### PR TITLE
Dashboards: Fix UPDATE_PANEL silently dropping panel links

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -161,6 +161,29 @@ describe('InspectJsonTab', () => {
     expect(tab.isEditable()).toBe(false);
   });
 
+  it('falls back to the transformed frames when the source has produced none', async () => {
+    const { tab, panel } = await buildTestScene();
+
+    // Unlike the snapshot path, which would rather write no frames than frames its transformations
+    // already ran over, this tab always shows something.
+    const transformer = panel.state.$data as SceneDataTransformer;
+    transformer.state.$data!.setState({ data: undefined });
+    transformer.setState({
+      data: {
+        state: LoadingState.Done,
+        series: [
+          toDataFrame({ name: 'transformed', fields: [{ name: 'value', type: FieldType.number, values: [1] }] }),
+        ],
+        timeRange: getDefaultTimeRange(),
+      },
+    });
+
+    tab.onChangeSource({ value: 'data-frames' });
+
+    const obj = JSON.parse(tab.state.jsonText);
+    expect(obj[0].schema.name).toBe('transformed');
+  });
+
   it('Can update model', async () => {
     const { tab, panel, scene } = await buildTestScene();
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -6,7 +6,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import {
   type SceneComponentProps,
-  SceneDataTransformer,
   sceneGraph,
   type SceneGridItemStateLike,
   SceneGridLayout,
@@ -40,6 +39,7 @@ import {
   getLibraryPanelBehavior,
   getPanelIdForVizPanel,
   getQueryRunnerFor,
+  getSourceDataProvider,
   isLibraryPanel,
 } from '../utils/utils';
 import { isGridLayoutItemKind, isPanelKindV2 } from '../v2schema/validation';
@@ -404,12 +404,11 @@ function getJsonText(show: ShowContent, panel: VizPanel): string {
       const dataProvider = sceneGraph.getData(panel);
 
       if (dataProvider.state.data) {
-        // Get raw untransformed data
-        if (dataProvider instanceof SceneDataTransformer && dataProvider.state.$data?.state.data) {
-          objToStringify = getPanelDataFrames(dataProvider.state.$data!.state.data);
-        } else {
-          objToStringify = getPanelDataFrames(dataProvider.state.data);
-        }
+        // Raw untransformed data when it is available, otherwise whatever the panel actually has —
+        // this tab always shows something, unlike the snapshot path, which would rather show nothing
+        // than frames its transformations already ran over.
+        const sourceData = getSourceDataProvider(dataProvider)?.state.data;
+        objToStringify = getPanelDataFrames(sourceData ?? dataProvider.state.data);
       }
       break;
     }

--- a/public/app/features/dashboard-scene/mutation-api/commands/listPanels.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/listPanels.ts
@@ -14,10 +14,10 @@
 import type * as z from 'zod';
 
 import { type DataFrame, type DataQueryError, LoadingState } from '@grafana/data';
-import { sceneGraph, SceneDataTransformer, type SceneObject, type VizPanel } from '@grafana/scenes';
+import { sceneGraph, type SceneObject, type VizPanel } from '@grafana/scenes';
 
 import { getElements } from '../../serialization/layoutSerializers/utils';
-import { getVizPanelKeyForPanelId } from '../../utils/utils';
+import { getSourceDataProvider, getVizPanelKeyForPanelId } from '../../utils/utils';
 import type {
   FrameSchema,
   FieldSchema,
@@ -74,8 +74,7 @@ function getPanelRuntimeStatus(vizPanel: VizPanel): PanelRuntimeStatus | undefin
     return undefined;
   }
 
-  const innerProvider = dataProvider instanceof SceneDataTransformer ? dataProvider.state.$data : dataProvider;
-  const panelData = (innerProvider ?? dataProvider)?.state?.data;
+  const panelData = (getSourceDataProvider(dataProvider) ?? dataProvider).state?.data;
 
   if (!panelData) {
     return { loadingState: LoadingState.Loading, hasError: false, hasNoData: false };
@@ -141,8 +140,7 @@ function getDataFrameSchema(vizPanel: VizPanel): FrameSchema[] | undefined {
     return undefined;
   }
 
-  const innerProvider = dataProvider instanceof SceneDataTransformer ? dataProvider.state.$data : dataProvider;
-  const panelData = (innerProvider ?? dataProvider)?.state?.data;
+  const panelData = (getSourceDataProvider(dataProvider) ?? dataProvider).state?.data;
 
   if (!panelData?.series || !Array.isArray(panelData.series)) {
     return undefined;

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -12,11 +12,13 @@ import { config } from '@grafana/runtime';
 import { SceneDataNode, SceneDataTransformer, sceneGraph, type VizPanel } from '@grafana/scenes';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
 import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { DashboardMutationClient } from '../DashboardMutationClient';
 import type { PanelElementEntry, PanelElementsData, MutationResult } from '../types';
@@ -821,6 +823,11 @@ describe('Panel mutation commands', () => {
 
       const elementName = await addPanel(client, 'Transform Panel');
 
+      // The field is documented as "Replace all transformations", so the panel has to start with one
+      // for the assertion to tell replacing apart from appending.
+      const seeded = scene.state.body.getVizPanels()[0].state.$data;
+      (seeded as SceneDataTransformer).setState({ transformations: [{ id: 'reduce', options: {} }] });
+
       const result = await client.execute({
         type: 'UPDATE_PANEL',
         payload: {
@@ -857,13 +864,16 @@ describe('Panel mutation commands', () => {
       // means it silently skipped the update. Asserted rather than guarded: a conditional read lets
       // that failure mode pass as a green test.
       expect(dataProvider).toBeInstanceOf(SceneDataTransformer);
-      expect((dataProvider as SceneDataTransformer).state.transformations[0]).toMatchObject({
-        id: 'limit',
-        disabled: false,
-        filter: { id: 'byName', options: 'temperature' },
-        topic: DataTopic.Series,
-        options: { limitField: 10 },
-      });
+      // Length first: without it, appending to the seeded `reduce` would leave index 0 correct.
+      expect((dataProvider as SceneDataTransformer).state.transformations).toEqual([
+        {
+          id: 'limit',
+          disabled: false,
+          filter: { id: 'byName', options: 'temperature' },
+          topic: DataTopic.Series,
+          options: { limitField: 10 },
+        },
+      ]);
     });
 
     it('updates panel description', async () => {
@@ -902,6 +912,51 @@ describe('Panel mutation commands', () => {
       expect(result.success).toBe(true);
       const body = scene.state.body as unknown as DefaultGridLayoutManager;
       expect(body.getVizPanels()[0].state.displayMode).toBe('transparent');
+    });
+
+    /**
+     * `spec.links` is written by finding the panel's `VizPanelLinks` among its `titleItems`. There are
+     * two shapes in the wild: `getDefaultVizPanel` (every UI "add panel" entry point) builds the holder
+     * with no `rawLinks` key at all, while every deserialization path passes one. ADD_PANEL goes through
+     * `buildVizPanel`, so these tests swap the holder explicitly rather than relying on the helper.
+     */
+    describe('panel links', () => {
+      const runbook = { title: 'Runbook', url: 'https://example.com/runbook' };
+
+      async function updateLinksOn(titleItems: VizPanelLinks[]) {
+        const scene = buildPanelScene();
+        const client = new DashboardMutationClient(scene);
+        const elementName = await addPanel(client, 'Links Panel');
+
+        const panel = scene.state.body.getVizPanels().find((p) => p.state.title === 'Links Panel')!;
+        panel.setState({ titleItems });
+
+        const result = await client.execute({
+          type: 'UPDATE_PANEL',
+          payload: { element: { name: elementName }, panel: { kind: 'Panel', spec: { links: [runbook] } } },
+        });
+
+        return { result, panel };
+      }
+
+      it('sets links on a panel built by getDefaultVizPanel, whose holder has no rawLinks key', async () => {
+        const { result, panel } = await updateLinksOn([new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })]);
+
+        expect(result.success).toBe(true);
+        expect(dashboardSceneGraph.getPanelLinks(panel)?.state.rawLinks).toEqual([runbook]);
+      });
+
+      it('replaces the links on a panel deserialized with an existing rawLinks array', async () => {
+        const { result, panel } = await updateLinksOn([
+          new VizPanelLinks({
+            rawLinks: [{ title: 'Old', url: 'https://example.com/old' }],
+            menu: new VizPanelLinksMenu({}),
+          }),
+        ]);
+
+        expect(result.success).toBe(true);
+        expect(dashboardSceneGraph.getPanelLinks(panel)?.state.rawLinks).toEqual([runbook]);
+      });
     });
 
     it('changes plugin type via vizConfig.group', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -1,5 +1,6 @@
 import {
   DataQueryErrorType,
+  DataTopic,
   FieldType,
   getDefaultTimeRange,
   LoadingState,
@@ -852,18 +853,17 @@ describe('Panel mutation commands', () => {
       expect(result.success).toBe(true);
       const body = scene.state.body as unknown as DefaultGridLayoutManager;
       const dataProvider = body.getVizPanels()[0].state.$data;
-      expect(dataProvider).toBeDefined();
-      if (dataProvider && 'state' in dataProvider) {
-        const transformerState = dataProvider.state as { transformations?: Array<Record<string, unknown>> };
-        expect(transformerState.transformations).toBeDefined();
-        expect(transformerState.transformations![0]).toMatchObject({
-          id: 'limit',
-          disabled: false,
-          filter: { id: 'byName', options: 'temperature' },
-          topic: 'series',
-          options: { limitField: 10 },
-        });
-      }
+      // The command only writes transformations to a `SceneDataTransformer`, so anything else here
+      // means it silently skipped the update. Asserted rather than guarded: a conditional read lets
+      // that failure mode pass as a green test.
+      expect(dataProvider).toBeInstanceOf(SceneDataTransformer);
+      expect((dataProvider as SceneDataTransformer).state.transformations[0]).toMatchObject({
+        id: 'limit',
+        disabled: false,
+        filter: { id: 'byName', options: 'temperature' },
+        topic: DataTopic.Series,
+        options: { limitField: 10 },
+      });
     });
 
     it('updates panel description', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -19,6 +19,7 @@ import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getElements, panelQueryKindToSceneQuery } from '../../serialization/layoutSerializers/utils';
 import { transformDataTopic } from '../../serialization/transformToV2TypesUtils';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getQueryRunnerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
 import { serializeResultLayoutItem } from './panelSerialization';
@@ -41,19 +42,6 @@ function mergeReplacingArrays(
   });
 }
 
-interface RawLinksHolder {
-  state: { rawLinks: unknown };
-  setState: (state: Record<string, unknown>) => void;
-}
-
-function hasRawLinks(item: unknown): item is RawLinksHolder {
-  if (!item || typeof item !== 'object' || !('state' in item) || !('setState' in item)) {
-    return false;
-  }
-  const { state } = item;
-  return typeof state === 'object' && state !== null && 'rawLinks' in state && typeof item.setState === 'function';
-}
-
 export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
   name: 'UPDATE_PANEL',
   description: payloads.updatePanel.description ?? '',
@@ -68,6 +56,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
 
     try {
       const { element, panel } = payload;
+      const warnings: string[] = [];
       const elementName = element.name;
       const spec = panel?.spec;
 
@@ -100,14 +89,14 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
         }
 
         if (spec.links !== undefined) {
-          const titleItems = vizPanel.state.titleItems;
-          if (Array.isArray(titleItems)) {
-            for (const item of titleItems) {
-              if (hasRawLinks(item)) {
-                item.setState({ rawLinks: spec.links });
-                break;
-              }
-            }
+          // Same lookup the serializer reads links back through, so writer and reader agree on which
+          // object holds them. A duck-type on `rawLinks` would miss the holder `getDefaultVizPanel`
+          // builds, which omits the key until something writes it.
+          const panelLinks = dashboardSceneGraph.getPanelLinks(vizPanel);
+          if (panelLinks) {
+            panelLinks.setState({ rawLinks: spec.links });
+          } else {
+            warnings.push('links ignored: this panel has no links holder in its titleItems.');
           }
         }
 
@@ -152,12 +141,14 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
           }
 
           if (dataSpec.transformations !== undefined && dataPipeline instanceof SceneDataTransformer) {
+            // Spread rather than enumerate, matching the mapper in `layoutSerializers/utils.ts`: a field
+            // added to `transformationKindSchema.spec` then reaches the scene from both paths instead of
+            // being silently dropped here. `topic` is restated because the schema types it as a string
+            // union and the scene wants the `DataTopic` enum.
             const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
               id: t.group,
-              disabled: t.spec.disabled,
-              filter: t.spec.filter,
+              ...t.spec,
               topic: transformDataTopic(t.spec.topic),
-              options: t.spec.options,
             }));
             dataPipeline.setState({ transformations });
             dataPipeline.reprocessTransformations();
@@ -225,6 +216,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
             newValue: updatedElement,
           },
         ],
+        warnings: warnings.length > 0 ? warnings : undefined,
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -11,12 +11,14 @@ import { mergeWith, cloneDeep, isArray } from 'lodash';
 import type * as z from 'zod';
 
 import { type FieldConfigSource } from '@grafana/data';
+import { SceneDataTransformer } from '@grafana/scenes';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getElements, panelQueryKindToSceneQuery } from '../../serialization/layoutSerializers/utils';
+import { transformDataTopic } from '../../serialization/transformToV2TypesUtils';
 import { getQueryRunnerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
 import { serializeResultLayoutItem } from './panelSerialization';
@@ -39,12 +41,6 @@ function mergeReplacingArrays(
   });
 }
 
-interface DataTransformerLike {
-  state: { transformations?: unknown[]; $data?: unknown };
-  setState: (state: { transformations?: unknown[] }) => void;
-  reprocessTransformations: () => void;
-}
-
 interface RawLinksHolder {
   state: { rawLinks: unknown };
   setState: (state: Record<string, unknown>) => void;
@@ -56,15 +52,6 @@ function hasRawLinks(item: unknown): item is RawLinksHolder {
   }
   const { state } = item;
   return typeof state === 'object' && state !== null && 'rawLinks' in state && typeof item.setState === 'function';
-}
-
-function isDataTransformer(data: unknown): data is DataTransformerLike {
-  if (!data || typeof data !== 'object' || !('state' in data)) {
-    return false;
-  }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const state = (data as DataTransformerLike).state;
-  return typeof state === 'object' && Array.isArray(state?.transformations);
 }
 
 export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
@@ -164,12 +151,12 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
             queryRunner.runQueries();
           }
 
-          if (dataSpec.transformations !== undefined && isDataTransformer(dataPipeline)) {
+          if (dataSpec.transformations !== undefined && dataPipeline instanceof SceneDataTransformer) {
             const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
               id: t.group,
               disabled: t.spec.disabled,
               filter: t.spec.filter,
-              topic: t.spec.topic,
+              topic: transformDataTopic(t.spec.topic),
               options: t.spec.options,
             }));
             dataPipeline.setState({ transformations });

--- a/public/app/features/dashboard-scene/serialization/shared/snapshotData.test.ts
+++ b/public/app/features/dashboard-scene/serialization/shared/snapshotData.test.ts
@@ -15,7 +15,7 @@ describe('getSnapshotSourceData', () => {
   it('reads a provider that is not a transformer directly', () => {
     const queryResult = new SceneDataNode({ data: panelData('raw') });
 
-    expect(getSnapshotSourceData(queryResult)).toBe(queryResult.state.data);
+    expect(getSnapshotSourceData(queryResult)?.series[0].name).toBe('raw');
   });
 
   it('reads a transformer’s source rather than its own output', () => {

--- a/public/app/features/dashboard-scene/serialization/shared/snapshotData.test.ts
+++ b/public/app/features/dashboard-scene/serialization/shared/snapshotData.test.ts
@@ -1,0 +1,37 @@
+import { getDefaultTimeRange, LoadingState, type PanelData, toDataFrame } from '@grafana/data';
+import { SceneDataNode, SceneDataTransformer } from '@grafana/scenes';
+
+import { getSnapshotSourceData } from './snapshotData';
+
+function panelData(frameName: string): PanelData {
+  return {
+    state: LoadingState.Done,
+    series: [toDataFrame({ name: frameName, fields: [] })],
+    timeRange: getDefaultTimeRange(),
+  };
+}
+
+describe('getSnapshotSourceData', () => {
+  it('reads a provider that is not a transformer directly', () => {
+    const queryResult = new SceneDataNode({ data: panelData('raw') });
+
+    expect(getSnapshotSourceData(queryResult)).toBe(queryResult.state.data);
+  });
+
+  it('reads a transformer’s source rather than its own output', () => {
+    const queryResult = new SceneDataNode({ data: panelData('raw') });
+    const transformer = new SceneDataTransformer({ $data: queryResult, transformations: [] });
+    transformer.setState({ data: panelData('transformed') });
+
+    expect(getSnapshotSourceData(transformer)?.series[0].name).toBe('raw');
+  });
+
+  it('returns nothing for a transformer with no source, rather than its transformed output', () => {
+    const transformer = new SceneDataTransformer({ transformations: [] });
+    transformer.setState({ data: panelData('transformed') });
+
+    // A snapshot is written alongside the panel's transformations, so transformed frames here would
+    // run them a second time on open. No frames is recoverable; silently wrong frames is not.
+    expect(getSnapshotSourceData(transformer)).toBeUndefined();
+  });
+});

--- a/public/app/features/dashboard-scene/serialization/shared/snapshotData.ts
+++ b/public/app/features/dashboard-scene/serialization/shared/snapshotData.ts
@@ -1,0 +1,19 @@
+import { type PanelData } from '@grafana/data';
+import { type SceneDataProvider, SceneDataTransformer } from '@grafana/scenes';
+
+/**
+ * The data a snapshot captures for a panel: the query result, before anything transformed it. Both
+ * the v1 and v2 serializers write it into a `GrafanaQueryType.Snapshot` query alongside the panel's
+ * transformations — so capturing transformed frames here would make opening the snapshot run them a
+ * second time, over data they had already been applied to.
+ *
+ * A transformer holds its own output in `state.data`, which makes it the one provider that cannot be
+ * read directly. It carries its source in `$data`; a transformer without one resolves through the
+ * scene graph instead, but that shape cannot reach a serializer — `getQueryRunnerFor` recurses
+ * forever on it — so the snapshot gets no frames rather than the transformed ones.
+ */
+export function getSnapshotSourceData(dataProvider: SceneDataProvider): PanelData | undefined {
+  const source = dataProvider instanceof SceneDataTransformer ? dataProvider.state.$data : dataProvider;
+
+  return source?.state.data;
+}

--- a/public/app/features/dashboard-scene/serialization/shared/snapshotData.ts
+++ b/public/app/features/dashboard-scene/serialization/shared/snapshotData.ts
@@ -1,5 +1,7 @@
 import { type PanelData } from '@grafana/data';
-import { type SceneDataProvider, SceneDataTransformer } from '@grafana/scenes';
+import { type SceneDataProvider } from '@grafana/scenes';
+
+import { getSourceDataProvider } from '../../utils/utils';
 
 /**
  * The data a snapshot captures for a panel: the query result, before anything transformed it. Both
@@ -13,7 +15,5 @@ import { type SceneDataProvider, SceneDataTransformer } from '@grafana/scenes';
  * forever on it — so the snapshot gets no frames rather than the transformed ones.
  */
 export function getSnapshotSourceData(dataProvider: SceneDataProvider): PanelData | undefined {
-  const source = dataProvider instanceof SceneDataTransformer ? dataProvider.state.$data : dataProvider;
-
-  return source?.state.data;
+  return getSourceDataProvider(dataProvider)?.state.data;
 }

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.ts
@@ -57,6 +57,7 @@ import {
 import { GRAFANA_DATASOURCE_REF } from './const';
 import { dataLayersToAnnotations } from './dataLayersToAnnotations';
 import { sceneVariablesSetToVariables } from './sceneVariablesSetToVariables';
+import { getSnapshotSourceData } from './shared/snapshotData';
 
 export function transformSceneToSaveModel(scene: DashboardScene, isSnapshot = false): Dashboard {
   const state = scene.state;
@@ -342,11 +343,7 @@ function vizPanelDataToPanel(
   if (dataProvider && isSnapshot) {
     panel.datasource = GRAFANA_DATASOURCE_REF;
 
-    let data = getPanelDataFrames(dataProvider.state.data);
-    if (dataProvider instanceof SceneDataTransformer) {
-      // For transformations the non-transformed data is snapshoted
-      data = getPanelDataFrames(dataProvider.state.$data!.state.data);
-    }
+    const data = getPanelDataFrames(getSnapshotSourceData(dataProvider));
 
     panel.targets = [
       {

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -68,6 +68,7 @@ import { getLibraryPanelBehavior, getPanelIdForVizPanel, getQueryRunnerFor, isLi
 import { type DSReferencesMapping } from './DashboardSceneSerializer';
 import { transformV1ToV2AnnotationQuery } from './annotations';
 import { sceneVariablesSetToSchemaV2Variables } from './sceneVariablesSetToVariables';
+import { getSnapshotSourceData } from './shared/snapshotData';
 import { buildTimeSettingsSpec } from './shared/timeSettings';
 import { colorIdEnumToColorIdV2, transformCursorSynctoEnum } from './transformToV2TypesUtils';
 // FIXME: This is temporary to avoid creating partial types for all the new schema, it has some performance implications, but it's fine for now
@@ -453,10 +454,7 @@ export function getVizPanelQueries(
       return queries;
     }
 
-    let snapshotData = getPanelDataFrames(dataProvider.state.data);
-    if (dataProvider instanceof SceneDataTransformer) {
-      snapshotData = getPanelDataFrames(dataProvider.state.$data!.state.data);
-    }
+    const snapshotData = getPanelDataFrames(getSnapshotSourceData(dataProvider));
 
     const snapshotQuery: DataQueryKind = {
       kind: 'DataQuery',

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -7,6 +7,7 @@ import {
   type CustomVariable,
   LocalValueVariable,
   type MultiValueVariable,
+  type SceneDataProvider,
   SceneDataTransformer,
   sceneGraph,
   type SceneObject,
@@ -260,6 +261,18 @@ export function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQu
   }
 
   return undefined;
+}
+
+/**
+ * The provider holding untransformed results. A `SceneDataTransformer` keeps its own output in
+ * `state.data`, which makes it the one provider that cannot be read directly; it carries its source
+ * in `$data`.
+ *
+ * Returns undefined for a transformer with no source, leaving the choice between "raw or nothing"
+ * and "raw, else whatever ran" to the caller — snapshots need the former, display the latter.
+ */
+export function getSourceDataProvider(dataProvider: SceneDataProvider): SceneDataProvider | undefined {
+  return dataProvider instanceof SceneDataTransformer ? dataProvider.state.$data : dataProvider;
 }
 
 export function getDashboardSceneFor(sceneObject: SceneObject): DashboardScene {


### PR DESCRIPTION
**What is this feature?**

Two things, both found while consolidating how the codebase asks a panel for its
*untransformed* data:

1. **A bug fix.** `UPDATE_PANEL` with `spec.links` silently did nothing on any panel
   added through the UI, while still returning `success: true`.
2. **A refactor.** Five copies of the "which provider holds the untransformed frames"
   unwrap, across four files, collapse into one helper — which is what surfaced the bug
   and forced a decision on one edge case in the snapshot path.

The two halves are independent: no shared files, no ordering between them.

**Why do we need this feature?**

**`UPDATE_PANEL` silently discarded `spec.links`.** `hasRawLinks` gated on `'rawLinks' in state`, but `getDefaultVizPanel()` builds `VizPanelLinks` with no `rawLinks` key — so links were dropped on every UI-added panel while the command still returned `success: true`. No test covered it: every deserialization path passes `rawLinks:` explicitly, and ADD_PANEL goes through `buildVizPanel`. It now uses the same `getPanelLinks()` lookup the serializer reads links back through.

**Both snapshot copies asserted `$data!`, which a transformer need not have.** The helper answers `undefined` there: a snapshot is stored alongside the panel's transformations, so transformed frames would run them twice on open. No frames beats silently wrong frames.

**`DataTransformerLike` matched anything with a `state.transformations` array** and typed `topic` as `unknown`. `instanceof` is the same runtime check with the real type behind it, which is what lets `topic` go through `transformDataTopic`.

**Who is this feature for?**

Maintainers, plus anyone driving `UPDATE_PANEL` with `spec.links` against a UI-created panel.

**Special notes for your reviewer:**

- `transformDataTopic` is type hygiene, not a fix — a runtime identity for every value the schema admits; absent stays absent.
- The transformation mapper spreads rather than enumerates, matching `layoutSerializers/utils.ts`, so new `transformationKindSchema.spec` fields aren't dropped here. Not shared with it — zod-parsed vs. wire-format inputs would need casts.
- `getSourceDataProvider` returns the *provider*, so the caller picks the fallback: `listPanels` and the JSON inspector want "raw, else transformed", the serializers want "raw or nothing" (the inspector's is now explicit and tested).
- Two tests were tightened where they couldn't fail (appending passed as replacing; an expectation that re-stated the production formula); both verified red.
- `UPDATE_PANEL` can now return warnings, following `addPanel.ts`.

Fixes #

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
