### PR TITLE
Access control: Prevent managed role creation races

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/queries/role_insert.sql
+++ b/pkg/registry/apis/iam/resourcepermission/queries/role_insert.sql
@@ -6,4 +6,4 @@ VALUES (
     {{ .Arg .Name }},
     {{ .Arg .Now }},
     {{ .Arg .Now }}
-)
+){{ if eq .DialectName "mysql" }} ON DUPLICATE KEY UPDATE uid = IF(org_id = VALUES(org_id) AND name = VALUES(name), uid, NULL){{ else if or (eq .DialectName "postgres") (eq .DialectName "sqlite") }} ON CONFLICT (org_id, name) DO NOTHING{{ end }}

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/datasourcek8s"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 )
@@ -262,18 +264,30 @@ func (s *ResourcePermSqlBackend) createAndAssignManagedRole(ctx context.Context,
 		return 0, err
 	}
 
-	_, err = tx.Exec(ctx, insertRoleQuery, args...)
+	result, err := tx.Exec(ctx, insertRoleQuery, args...)
 	if err != nil {
 		s.logger.Error("could not insert new role", "orgID", orgID, "roleName", assignment.RoleName, "error", err.Error())
 		return 0, fmt.Errorf("could not insert new role: %w", err)
 	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("could not determine whether managed role was inserted: %w", err)
+	}
+	inserted := rows == 1
 
 	var roleID int64
 	idQuery := fmt.Sprintf("SELECT id FROM %s WHERE org_id = ? AND name = ?", dbHelper.Table("role"))
+	if dbHelper.DB.GetDialect().DriverName() != migrator.SQLite {
+		idQuery += " FOR UPDATE"
+	}
 	err = tx.Get(ctx, &roleID, idQuery, orgID, assignment.RoleName)
 	if err != nil {
 		s.logger.Error("could not retrieve id of created role", "orgID", orgID, "roleName", assignment.RoleName, "error", err.Error())
 		return 0, fmt.Errorf("could not retrieve id of created role: %w", err)
+	}
+
+	if !inserted {
+		return roleID, nil
 	}
 
 	assignQuery, args, err := buildInsertAssignmentQuery(dbHelper, orgID, roleID, assignment)
@@ -413,6 +427,9 @@ func (s *ResourcePermSqlBackend) buildRbacAssignments(ctx context.Context, ns ty
 			return nil, fmt.Errorf("unknown permission kind: %q: %w", perm.Kind, errInvalidSpec)
 		}
 	}
+	slices.SortStableFunc(assignments, func(a, b rbacAssignmentCreate) int {
+		return strings.Compare(a.RoleName, b.RoleName)
+	})
 
 	return assignments, nil
 }

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,7 +20,10 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	legacyresourcepermissions "github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
@@ -513,6 +517,91 @@ func TestIntegration_ResourcePermSqlBackend_CreateResourcePermission(t *testing.
 		require.Equal(t, "folders:uid:fold1", permission.Scope)
 		require.Equal(t, "folders:admin", permission.Action)
 	})
+}
+
+func TestIntegration_ResourcePermSqlBackend_ConcurrentLegacyRoleCreation(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if !db.IsTestDbMySQL() {
+		t.Skip("MySQL regression test")
+	}
+
+	store := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+	sqlHelper := &legacysql.LegacyDatabaseHelper{
+		DB:    store,
+		Table: func(name string) string { return name },
+	}
+	backend := ProvideStorageBackend(func(context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return sqlHelper, nil
+	}, NewMappersRegistry())
+	legacyStore := legacyresourcepermissions.NewStore(setting.NewCfg(), store, featuremgmt.WithFeatures())
+
+	for orgID := int64(100); orgID < 120; orgID++ {
+		folderName := fmt.Sprintf("folder-%d", orgID)
+		resourcePerm := &v0alpha1.ResourcePermission{
+			ObjectMeta: metav1.ObjectMeta{Name: "folder.grafana.app-folders-" + folderName, Namespace: fmt.Sprintf("org-%d", orgID)},
+			Spec: v0alpha1.ResourcePermissionSpec{
+				Resource: v0alpha1.ResourcePermissionspecResource{
+					ApiGroup: "folder.grafana.app",
+					Resource: "folders",
+					Name:     folderName,
+				},
+				Permissions: []v0alpha1.ResourcePermissionspecPermission{
+					{Kind: v0alpha1.ResourcePermissionSpecPermissionKindBasicRole, Name: "Viewer", Verb: "view"},
+					{Kind: v0alpha1.ResourcePermissionSpecPermissionKindBasicRole, Name: "Editor", Verb: "edit"},
+				},
+			},
+		}
+		grn, err := splitResourceName(resourcePerm.Name)
+		require.NoError(t, err)
+		mapper, err := backend.getResourceMapper(grn.Group, grn.Resource)
+		require.NoError(t, err)
+
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := backend.createResourcePermission(context.Background(), sqlHelper, types.NamespaceInfo{
+				Value: fmt.Sprintf("org-%d", orgID),
+				OrgID: orgID,
+			}, mapper, grn, resourcePerm)
+			errs <- err
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := legacyStore.SetResourcePermissions(context.Background(), orgID, []legacyresourcepermissions.SetResourcePermissionsCommand{
+				{
+					BuiltinRole: "Viewer",
+					SetResourcePermissionCommand: legacyresourcepermissions.SetResourcePermissionCommand{
+						Actions:           []string{"datasources:query"},
+						Resource:          "datasources",
+						ResourceID:        fmt.Sprintf("datasource-%d", orgID),
+						ResourceAttribute: "uid",
+					},
+				},
+				{
+					BuiltinRole: "Editor",
+					SetResourcePermissionCommand: legacyresourcepermissions.SetResourcePermissionCommand{
+						Actions:           []string{"datasources:query"},
+						Resource:          "datasources",
+						ResourceID:        fmt.Sprintf("datasource-%d", orgID),
+						ResourceAttribute: "uid",
+					},
+				},
+			}, legacyresourcepermissions.ResourceHooks{})
+			errs <- err
+		}()
+
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+	}
 }
 
 func TestIntegration_ResourcePermSqlBackend_UpdateResourcePermission(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/testdata/mysql--role_insert-insert_role.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/mysql--role_insert-insert_role.sql
@@ -6,4 +6,4 @@ VALUES (
     'managed:builtins:editor:1:permissions',
     '2025-08-27 21:35:00',
     '2025-08-27 21:35:00'
-)
+) ON DUPLICATE KEY UPDATE uid = IF(org_id = VALUES(org_id) AND name = VALUES(name), uid, NULL)

--- a/pkg/registry/apis/iam/resourcepermission/testdata/postgres--role_insert-insert_role.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/postgres--role_insert-insert_role.sql
@@ -6,4 +6,4 @@ VALUES (
     'managed:builtins:editor:1:permissions',
     '2025-08-27 21:35:00',
     '2025-08-27 21:35:00'
-)
+) ON CONFLICT (org_id, name) DO NOTHING

--- a/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--role_insert-insert_role.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--role_insert-insert_role.sql
@@ -6,4 +6,4 @@ VALUES (
     'managed:builtins:editor:1:permissions',
     '2025-08-27 21:35:00',
     '2025-08-27 21:35:00'
-)
+) ON CONFLICT (org_id, name) DO NOTHING

--- a/pkg/services/accesscontrol/resourcepermissions/store.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store.go
@@ -3,6 +3,7 @@ package resourcepermissions
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -250,10 +252,23 @@ func (s *store) SetResourcePermissions(
 	defer span.End()
 
 	var err error
-	var permissions []accesscontrol.ResourcePermission
+	type indexedCommand struct {
+		index   int
+		command SetResourcePermissionsCommand
+	}
+	orderedCommands := make([]indexedCommand, 0, len(commands))
+	for i, cmd := range commands {
+		orderedCommands = append(orderedCommands, indexedCommand{index: i, command: cmd})
+	}
+	slices.SortStableFunc(orderedCommands, func(a, b indexedCommand) int {
+		return strings.Compare(managedRoleName(a.command), managedRoleName(b.command))
+	})
+
+	permissionsByIndex := make(map[int]accesscontrol.ResourcePermission, len(commands))
 
 	err = s.sql.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
-		for _, cmd := range commands {
+		for _, indexed := range orderedCommands {
+			cmd := indexed.command
 			var p *accesscontrol.ResourcePermission
 			if cmd.User.ID != 0 {
 				p, err = s.setUserResourcePermission(sess, orgID, cmd.User, cmd.SetResourcePermissionCommand, hooks.User)
@@ -266,14 +281,32 @@ func (s *store) SetResourcePermissions(
 				return err
 			}
 			if p != nil {
-				permissions = append(permissions, *p)
+				permissionsByIndex[indexed.index] = *p
 			}
 		}
 
 		return nil
 	})
 
+	permissions := make([]accesscontrol.ResourcePermission, 0, len(permissionsByIndex))
+	for i := range commands {
+		if permission, ok := permissionsByIndex[i]; ok {
+			permissions = append(permissions, permission)
+		}
+	}
+
 	return permissions, err
+}
+
+func managedRoleName(cmd SetResourcePermissionsCommand) string {
+	switch {
+	case cmd.User.ID != 0:
+		return accesscontrol.ManagedUserRoleName(cmd.User.ID)
+	case cmd.TeamID != 0:
+		return accesscontrol.ManagedTeamRoleName(cmd.TeamID)
+	default:
+		return accesscontrol.ManagedBuiltInRoleName(cmd.BuiltinRole)
+	}
 }
 
 type roleAdder func(roleID int64) error
@@ -653,6 +686,9 @@ func (s *store) builtInRoleAdder(sess *db.Session, orgID int64, builtinRole stri
 func (s *store) getOrCreateManagedRole(sess *db.Session, orgID int64, name string, add roleAdder) (*accesscontrol.Role, error) {
 	role := accesscontrol.Role{OrgID: orgID, Name: name}
 	has, err := sess.Where("org_id = ? AND name = ?", orgID, name).Get(&role)
+	if err != nil {
+		return nil, err
+	}
 
 	// If managed role does not exist, create it and add it to user/team/builtin
 	if !has {
@@ -669,20 +705,65 @@ func (s *store) getOrCreateManagedRole(sess *db.Session, orgID int64, name strin
 			Updated: time.Now(),
 		}
 
-		if _, err := sess.Insert(&role); err != nil {
+		inserted, err := s.insertManagedRole(sess, &role)
+		if err != nil {
 			return nil, err
 		}
 
-		if err := add(role.ID); err != nil {
+		has, err = s.getManagedRoleAfterInsert(sess, orgID, name, &role)
+		if err != nil {
 			return nil, err
 		}
-	}
+		if !has {
+			return nil, fmt.Errorf("managed role not found after insert")
+		}
 
-	if err != nil {
-		return nil, err
+		if inserted {
+			if err := add(role.ID); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return &role, nil
+}
+
+func (s *store) getManagedRoleAfterInsert(sess *db.Session, orgID int64, name string, role *accesscontrol.Role) (bool, error) {
+	query := fmt.Sprintf("SELECT * FROM %s WHERE org_id = ? AND name = ?", s.sql.Quote("role"))
+	if s.sql.GetDialect().DriverName() != migrator.SQLite {
+		query += " FOR UPDATE"
+	}
+	return sess.SQL(query, orgID, name).Get(role)
+}
+
+func (s *store) insertManagedRole(sess *db.Session, role *accesscontrol.Role) (bool, error) {
+	table := s.sql.Quote("role")
+	query := fmt.Sprintf(
+		"INSERT INTO %s (org_id, name, uid, version, created, updated) VALUES (?, ?, ?, ?, ?, ?)",
+		table,
+	)
+
+	switch s.sql.GetDialect().DriverName() {
+	case migrator.MySQL:
+		// Only suppress the expected org/name conflict. A collision on the globally unique UID
+		// takes the NULL branch and remains an error because uid is not nullable.
+		query += " ON DUPLICATE KEY UPDATE uid = IF(org_id = VALUES(org_id) AND name = VALUES(name), uid, NULL)"
+	case migrator.Postgres, migrator.SQLite:
+		query += " ON CONFLICT (org_id, name) DO NOTHING"
+	default:
+		result, err := sess.Insert(role)
+		return err == nil && result == 1, err
+	}
+
+	result, err := sess.Exec(query, role.OrgID, role.Name, role.UID, role.Version, role.Created, role.Updated)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
 }
 
 func generateNewRoleUID(sess *db.Session, orgID int64) (string, error) {

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -3,6 +3,7 @@ package resourcepermissions
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -357,6 +358,52 @@ func TestIntegrationStore_SetResourcePermissions(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestIntegrationStore_SetResourcePermissionsConcurrentRoleCreation(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	store, _, _ := setupTestEnv(t)
+	commands := func(resourceID string, roles ...string) []SetResourcePermissionsCommand {
+		result := make([]SetResourcePermissionsCommand, 0, len(roles))
+		for _, role := range roles {
+			result = append(result, SetResourcePermissionsCommand{
+				BuiltinRole: role,
+				SetResourcePermissionCommand: SetResourcePermissionCommand{
+					Actions:           []string{"datasources:query"},
+					Resource:          "datasources",
+					ResourceID:        resourceID,
+					ResourceAttribute: "uid",
+				},
+			})
+		}
+		return result
+	}
+
+	for orgID := int64(100); orgID < 120; orgID++ {
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		for _, cmds := range [][]SetResourcePermissionsCommand{
+			commands(fmt.Sprintf("folder-%d", orgID), "Editor", "Viewer"),
+			commands(fmt.Sprintf("datasource-%d", orgID), "Viewer", "Editor"),
+		} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_, err := store.SetResourcePermissions(context.Background(), orgID, cmds, ResourceHooks{})
+				errs <- err
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Prevents concurrent resource-permission writers from failing when they create the same managed roles.

The legacy and App Platform permission backends now create managed roles atomically, reuse a concurrently created role, and process role assignments in a stable order. Dialect-specific role insertion remains in the ResourcePermission SQL template.

**Why do we need this feature?**

Parallel provisioning on a fresh organization can cause both permission backends to observe a missing managed role and attempt to insert it. On MySQL this produces duplicate-key errors and can deadlock when transactions create the Editor and Viewer roles in different orders.

**Who is this feature for?**

Users provisioning folders, data sources, service accounts, and other resources concurrently, including through Terraform.

**Which issue(s) does this PR fix?**:

Fixes #130923

**Special notes for your reviewer:**

The regression tests cover concurrent legacy writers and concurrent legacy/App Platform writers. The cross-backend test is MySQL-specific because it targets the reported duplicate-key and deadlock behavior.

Tested with:

- `go test -p=1 ./pkg/services/accesscontrol/resourcepermissions ./pkg/registry/apis/iam/resourcepermission -count=1` (SQLite, 421 tests)
- `GRAFANA_TEST_DB=mysql MYSQL_HOST=<host> go test -p=1 ./pkg/services/accesscontrol/resourcepermissions ./pkg/registry/apis/iam/resourcepermission -count=1` (MySQL 8.0.43, 422 tests)
- `git diff --check`

Please check that:

- [x] It works as expected from a user's perspective.
- [x] This change does not introduce a pre-GA feature or require a feature toggle.
- [x] This internal concurrency fix does not require documentation or a What's New entry.
