### PR TITLE
fix(unified-storage): fall back to [database] migration_locking for source-table locks

### DIFF
--- a/pkg/storage/unified/migrations/service.go
+++ b/pkg/storage/unified/migrations/service.go
@@ -45,7 +45,15 @@ func ProvideUnifiedStorageMigrationService(
 	registry *MigrationRegistry,
 	gcGate *resource.GCGate,
 ) contract.UnifiedStorageMigrationService {
-	lockingEnabled := cfg.Raw.Section("unified_storage").Key("migration_locking").MustBool(true)
+	// Fall back to the [database] migration_locking setting when [unified_storage]
+	// does not explicitly configure it, so that a single migration_locking=false in
+	// the database section also disables source-table locking (fixes #131361).
+	var lockingEnabled bool
+	if unifiedSec := cfg.Raw.Section("unified_storage"); unifiedSec.HasKey("migration_locking") {
+		lockingEnabled = unifiedSec.Key("migration_locking").MustBool(true)
+	} else {
+		lockingEnabled = cfg.Raw.Section("database").Key("migration_locking").MustBool(true)
+	}
 	if !lockingEnabled {
 		logger.Warn("unified_storage.migration_locking is disabled; source tables are NOT locked " +
 			"during migration and legacy tables are NOT renamed. Concurrent writes may be missed " +

--- a/pkg/storage/unified/migrations/service_test.go
+++ b/pkg/storage/unified/migrations/service_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -63,6 +64,75 @@ func TestUnifiedStorageMigrationServiceImpl_Run_SkipsMigrations(t *testing.T) {
 			require.Equal(t, 0, fake.migrateCalled)
 			require.True(t, gate.Wait(context.Background(), make(chan struct{})),
 				"expected Run to release the GC gate on the skip path")
+		})
+	}
+}
+func TestProvideUnifiedStorageMigrationService_LockingFallbackToDatabaseSection(t *testing.T) {
+	tests := []struct {
+		name             string
+		configureDB      func(cfg *setting.Cfg)
+		configureUnified func(cfg *setting.Cfg)
+		wantNoopLocker   bool
+	}{
+		{
+			name: "database migration_locking=false, no unified_storage section -> noop locker",
+			configureDB: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("database").Key("migration_locking").SetValue("false")
+			},
+			configureUnified: nil,
+			wantNoopLocker:   true,
+		},
+		{
+			name: "database migration_locking=true, no unified_storage section -> mysql locker (FakeDB default)",
+			configureDB: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("database").Key("migration_locking").SetValue("true")
+			},
+			configureUnified: nil,
+			wantNoopLocker:   false,
+		},
+		{
+			name: "unified_storage migration_locking=false explicit, database true -> noop locker",
+			configureDB: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("database").Key("migration_locking").SetValue("true")
+			},
+			configureUnified: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("unified_storage").Key("migration_locking").SetValue("false")
+			},
+			wantNoopLocker: true,
+		},
+		{
+			name: "unified_storage migration_locking=true explicit, database false -> mysql locker",
+			configureDB: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("database").Key("migration_locking").SetValue("false")
+			},
+			configureUnified: func(cfg *setting.Cfg) {
+				cfg.Raw.Section("unified_storage").Key("migration_locking").SetValue("true")
+			},
+			wantNoopLocker: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := setting.NewCfg()
+			tt.configureDB(cfg)
+			if tt.configureUnified != nil {
+				tt.configureUnified(cfg)
+			}
+
+			svc := ProvideUnifiedStorageMigrationService(
+				&fakeUnifiedMigrator{},
+				nil,
+				cfg,
+				dbtest.NewFakeDB(),
+				nil,
+				nil,
+				nil,
+				resource.NewGCGate(),
+			)
+			impl := svc.(*UnifiedStorageMigrationServiceImpl)
+			_, isNoop := impl.tableLocker.(*noopTableLocker)
+			require.Equal(t, tt.wantNoopLocker, isNoop, "expected noop locker status mismatch")
 		})
 	}
 }


### PR DESCRIPTION
### What this PR does

Fixes #131361 — `migration_locking: false` in the `[database]` config section has no effect in 13.2 during unified storage migration.

### Root cause

`ProvideUnifiedStorageMigrationService` read `migration_locking` exclusively from the `[unified_storage]` ini section, defaulting to `true` when unset. A user who sets `migration_locking=false` in the `[database]` section (the documented location in `conf/defaults.ini`) still got the MySQL/Postgres source-table locker during unified storage migration, which issues `LOCK TABLES ... READ` / `LOCK TABLE ... IN SHARE MODE` and fails on databases without LOCK privileges.

### Fix

When `[unified_storage]` does not explicitly configure `migration_locking`, fall back to the `[database]` section value. Explicit `[unified_storage]` configuration still takes precedence.

- `pkg/storage/unified/migrations/service.go` — fallback logic in `ProvideUnifiedStorageMigrationService`
- `pkg/storage/unified/migrations/service_test.go` — 4 new unit tests covering both sections and precedence

### Validation

All 4 unit test cases pass with `dbtest.NewFakeDB()` (integration-suite independent, no DB required).

Signed commit follows Grafana contribution guidelines.