### PR TITLE
Folder: add bare-minimum folder-controller operator skeleton

### DIFF
--- a/pkg/operators/folder/config.go
+++ b/pkg/operators/folder/config.go
@@ -1,0 +1,77 @@
+package folder
+
+import (
+	"fmt"
+
+	"github.com/grafana/authlib/authn"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+
+	"github.com/grafana/grafana/pkg/clientauth"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// buildDynamicClient builds a dynamic client for the folder apiserver from
+// [operator] and [grpc_client_authentication] settings:
+//
+// [operator]
+// folders_server_url =
+// tls_insecure =
+// [grpc_client_authentication]
+// token =
+// token_exchange_url =
+func buildDynamicClient(cfg *setting.Cfg) (dynamic.Interface, error) {
+	operatorSec := cfg.SectionWithEnvOverrides("operator")
+
+	serverURL := operatorSec.Key("folders_server_url").String()
+	if serverURL == "" {
+		return nil, fmt.Errorf("folders_server_url is required in [operator] section")
+	}
+
+	tlsConfig := rest.TLSClientConfig{
+		Insecure: operatorSec.Key("tls_insecure").MustBool(false),
+	}
+
+	tokenExchangeClient, err := buildTokenExchangeClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token exchange client: %w", err)
+	}
+
+	restConfig := &rest.Config{
+		APIPath: "/apis",
+		Host:    serverURL,
+		WrapTransport: clientauth.NewStaticTokenExchangeTransportWrapper(
+			tokenExchangeClient,
+			folderGVR.Group,
+			clientauth.WildcardNamespace,
+		),
+		TLSClientConfig: tlsConfig,
+		RateLimiter:     flowcontrol.NewFakeAlwaysRateLimiter(),
+	}
+
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return dynClient, nil
+}
+
+func buildTokenExchangeClient(cfg *setting.Cfg) (*authn.TokenExchangeClient, error) {
+	gRPCAuth := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+
+	token := gRPCAuth.Key("token").String()
+	if token == "" {
+		return nil, fmt.Errorf("token is required in [grpc_client_authentication] section")
+	}
+	tokenExchangeURL := gRPCAuth.Key("token_exchange_url").String()
+	if tokenExchangeURL == "" {
+		return nil, fmt.Errorf("token_exchange_url is required in [grpc_client_authentication] section")
+	}
+
+	return authn.NewTokenExchangeClient(authn.TokenExchangeConfig{
+		TokenExchangeURL: tokenExchangeURL,
+		Token:            token,
+	})
+}

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/server"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 var folderGVR = schema.GroupVersionResource{
@@ -68,10 +66,4 @@ func RunFolderController(ctx context.Context, deps server.OperatorDependencies) 
 	deps.HealthNotifier.SetNotReady()
 	logger.Info("folder controller shutting down")
 	return nil
-}
-
-func buildDynamicClient(cfg *setting.Cfg) (dynamic.Interface, error) {
-	// TODO: build a *rest.Config for the folder apiserver (TLS + token
-	// exchange) and return dynamic.NewForConfig(restConfig).
-	panic("not implemented")
 }

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
@@ -32,9 +33,10 @@ var folderGVR = schema.GroupVersionResource{
 // RunFolderController watches Folder objects and logs deletion events.
 // This is a bare skeleton: no workqueue, no retries, no finalizers.
 //
-// The delta source is NATS when [nats] is enabled, otherwise an apiserver
-// watch — usinformer.Informer picks between them transparently, so the
-// DeleteFunc handler below is unaffected either way.
+// The delta source is NATS-backed when [nats] is enabled — falling back to
+// re-list-only if the live subscription can't open, rather than blocking
+// readiness on it — otherwise a plain apiserver watch, matching the pattern
+// in pkg/registry/apis/provisioning/informer's delta sources.
 func RunFolderController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -46,20 +48,7 @@ func RunFolderController(ctx context.Context, deps server.OperatorDependencies) 
 		return err
 	}
 
-	subscriber := nats.ProvideSubscriber(nats.ProvideNATSConfig(deps.Config, nil), deps.Registerer)
-
-	newObject := func(ns, name string) runtime.Object {
-		return &folderv1.Folder{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
-	}
-	list := func(ctx context.Context) ([]runtime.Object, int64, error) {
-		return listAllPages(ctx, func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-			return dynClient.Resource(folderGVR).Namespace("").List(ctx, opts)
-		})
-	}
-
-	inf := usinformer.NewInformer(subscriber, folderGVR, "", 10*time.Minute, queueGroup, nil, newObject, list)
-
-	reg, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handler := cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
 			accessor, err := utils.MetaAccessor(obj)
 			if err != nil {
@@ -70,12 +59,39 @@ func RunFolderController(ctx context.Context, deps server.OperatorDependencies) 
 				"namespace", accessor.GetNamespace(),
 				"name", accessor.GetName())
 		},
-	})
-	if err != nil {
-		return err
 	}
 
-	go inf.Run(ctx.Done())
+	subscriber := nats.ProvideSubscriber(nats.ProvideNATSConfig(deps.Config, nil), deps.Registerer)
+
+	var reg cache.ResourceEventHandlerRegistration
+	if nats.Enabled(subscriber) {
+		newObject := func(ns, name string) runtime.Object {
+			return &folderv1.Folder{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+		}
+		list := func(ctx context.Context) ([]runtime.Object, int64, error) {
+			return listAllPages(ctx, func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+				return dynClient.Resource(folderGVR).Namespace("").List(ctx, opts)
+			})
+		}
+
+		inf := usinformer.NewInformer(subscriber, folderGVR, "", 10*time.Minute, queueGroup, nil, newObject, list)
+		inf.AllowDegradedStart()
+
+		reg, err = inf.AddEventHandler(handler)
+		if err != nil {
+			return err
+		}
+		go inf.Run(ctx.Done())
+	} else {
+		factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 10*time.Minute, "", nil)
+		informer := factory.ForResource(folderGVR).Informer()
+
+		reg, err = informer.AddEventHandler(handler)
+		if err != nil {
+			return err
+		}
+		factory.Start(ctx.Done())
+	}
 
 	if !cache.WaitForCacheSync(ctx.Done(), reg.HasSynced) {
 		logger.Error("failed to sync folder informer cache")

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -15,8 +15,8 @@ import (
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/nats"
-	usinformer "github.com/grafana/grafana/pkg/storage/unified/informer"
 	"github.com/grafana/grafana/pkg/server"
+	usinformer "github.com/grafana/grafana/pkg/storage/unified/informer"
 )
 
 // queueGroup is the NATS queue group this controller's subscription joins, so

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -17,7 +17,7 @@ import (
 
 var folderGVR = schema.GroupVersionResource{
 	Group:    "folder.grafana.app",
-	Version:  "v1beta1",
+	Version:  "v1",
 	Resource: "folders",
 }
 

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -7,13 +7,21 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 
+	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/nats"
+	usinformer "github.com/grafana/grafana/pkg/storage/unified/informer"
 	"github.com/grafana/grafana/pkg/server"
 )
+
+// queueGroup is the NATS queue group this controller's subscription joins, so
+// each live notification reaches only one replica.
+const queueGroup = "folder-controller"
 
 var folderGVR = schema.GroupVersionResource{
 	Group:    "folder.grafana.app",
@@ -23,6 +31,10 @@ var folderGVR = schema.GroupVersionResource{
 
 // RunFolderController watches Folder objects and logs deletion events.
 // This is a bare skeleton: no workqueue, no retries, no finalizers.
+//
+// The delta source is NATS when [nats] is enabled, otherwise an apiserver
+// watch — usinformer.Informer picks between them transparently, so the
+// DeleteFunc handler below is unaffected either way.
 func RunFolderController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
@@ -34,10 +46,20 @@ func RunFolderController(ctx context.Context, deps server.OperatorDependencies) 
 		return err
 	}
 
-	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 10*time.Minute, "", nil)
-	informer := factory.ForResource(folderGVR).Informer()
+	subscriber := nats.ProvideSubscriber(nats.ProvideNATSConfig(deps.Config, nil), deps.Registerer)
 
-	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	newObject := func(ns, name string) runtime.Object {
+		return &folderv1.Folder{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+	}
+	list := func(ctx context.Context) ([]runtime.Object, int64, error) {
+		return listAllPages(ctx, func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			return dynClient.Resource(folderGVR).Namespace("").List(ctx, opts)
+		})
+	}
+
+	inf := usinformer.NewInformer(subscriber, folderGVR, "", 10*time.Minute, queueGroup, nil, newObject, list)
+
+	reg, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj any) {
 			accessor, err := utils.MetaAccessor(obj)
 			if err != nil {
@@ -53,8 +75,9 @@ func RunFolderController(ctx context.Context, deps server.OperatorDependencies) 
 		return err
 	}
 
-	factory.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+	go inf.Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), reg.HasSynced) {
 		logger.Error("failed to sync folder informer cache")
 		return ctx.Err()
 	}

--- a/pkg/operators/folder/controller.go
+++ b/pkg/operators/folder/controller.go
@@ -1,0 +1,77 @@
+package folder
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/server"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var folderGVR = schema.GroupVersionResource{
+	Group:    "folder.grafana.app",
+	Version:  "v1beta1",
+	Resource: "folders",
+}
+
+// RunFolderController watches Folder objects and logs deletion events.
+// This is a bare skeleton: no workqueue, no retries, no finalizers.
+func RunFolderController(ctx context.Context, deps server.OperatorDependencies) error {
+	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})).With("logger", "folder-controller")
+	logger.Info("starting folder controller")
+
+	dynClient, err := buildDynamicClient(deps.Config)
+	if err != nil {
+		return err
+	}
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, 10*time.Minute, "", nil)
+	informer := factory.ForResource(folderGVR).Informer()
+
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj any) {
+			accessor, err := utils.MetaAccessor(obj)
+			if err != nil {
+				logger.Error("folder delete event: failed to read object", "error", err)
+				return
+			}
+			logger.Info("folder deleted",
+				"namespace", accessor.GetNamespace(),
+				"name", accessor.GetName())
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	factory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		logger.Error("failed to sync folder informer cache")
+		return ctx.Err()
+	}
+
+	logger.Info("folder controller is ready")
+	deps.HealthNotifier.SetReady()
+
+	<-ctx.Done()
+	deps.HealthNotifier.SetNotReady()
+	logger.Info("folder controller shutting down")
+	return nil
+}
+
+func buildDynamicClient(cfg *setting.Cfg) (dynamic.Interface, error) {
+	// TODO: build a *rest.Config for the folder apiserver (TLS + token
+	// exchange) and return dynamic.NewForConfig(restConfig).
+	panic("not implemented")
+}

--- a/pkg/operators/folder/list.go
+++ b/pkg/operators/folder/list.go
@@ -1,0 +1,38 @@
+package folder
+
+import (
+	"context"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/pager"
+)
+
+// listAllPages reads every page of a LIST, following continue tokens, and
+// returns the resource version the snapshot was read at.
+func listAllPages(ctx context.Context, page func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error)) ([]runtime.Object, int64, error) {
+	var listRV int64
+	capture := func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		obj, err := page(ctx, opts)
+		if err == nil && listRV == 0 {
+			if acc, aerr := meta.ListAccessor(obj); aerr == nil {
+				if rv, perr := strconv.ParseInt(acc.GetResourceVersion(), 10, 64); perr == nil {
+					listRV = rv
+				}
+			}
+		}
+		return obj, err
+	}
+	p := pager.New(capture)
+	p.FullListIfExpired = false
+	var out []runtime.Object
+	if err := p.EachListItem(ctx, metav1.ListOptions{Limit: 500}, func(obj runtime.Object) error {
+		out = append(out, obj)
+		return nil
+	}); err != nil {
+		return nil, 0, err
+	}
+	return out, listRV, nil
+}

--- a/pkg/operators/register.go
+++ b/pkg/operators/register.go
@@ -1,11 +1,18 @@
 package operators
 
 import (
+	"github.com/grafana/grafana/pkg/operators/folder"
 	"github.com/grafana/grafana/pkg/operators/provisioning"
 	"github.com/grafana/grafana/pkg/server"
 )
 
 func init() {
+	server.RegisterOperator(server.Operator{
+		Name:        "folder-controller",
+		Description: "Watch folders and log deletion events",
+		RunFunc:     folder.RunFolderController,
+	})
+
 	// Provisioning Operators
 	server.RegisterOperator(server.Operator{
 		Name:        "provisioning-repo",


### PR DESCRIPTION
Adds a first-cut `folder-controller` operator: watches Folder deletions and logs them. 

Scaffolding only. No workqueue, retries, or finalizers yet.

- Watches `folder.grafana.app/v1` Folders, logs on delete.
- NATS-backed watch when enabled, with degraded-start fallback to apiserver watch otherwise.
- Token-exchange auth against the folder apiserver.
- Registered as operator `folder-controller`.

No behavior change for existing operators.
