### PR TITLE
Docs: fix outdated CLA link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ To edit or write technical content, refer to [Contribute to our documentation](/
 
 #### Contributor License Agreement (CLA)
 
-Before we can accept your pull request, you need to [sign our CLA](https://grafana.com/docs/grafana/latest/developers/cla/). If you haven't, our CLA assistant prompts you to when you create your pull request.
+Before we can accept your pull request, you need to [sign our CLA](https://grafana.com/docs/grafana/latest/developer-resources/contribute/cla/). If you haven't, our CLA assistant prompts you to when you create your pull request.
 
 ## Where do I go from here?
 


### PR DESCRIPTION
## Problem

The CLA link in `CONTRIBUTING.md` points to an outdated path:

https://grafana.com/docs/grafana/latest/developers/cla/ → 404

Current location:

https://grafana.com/docs/grafana/latest/developer-resources/contribute/cla/ → 200

Fixes #130760

## Change

Single-line docs fix in `CONTRIBUTING.md` (line 129): update the CLA URL to the new path `developer-resources/contribute/cla`.

## Why this approach

Minimal docs correction; no code or behavior change. Verified via `curl -I` that the old URL 404s and the new URL 200s. Matches the website's current structure.

## Testing

```text
command: curl -sI https://grafana.com/docs/grafana/latest/developers/cla/ | head -n1
result: HTTP/2 404

command: curl -sI https://grafana.com/docs/grafana/latest/developer-resources/contribute/cla/ | head -n1
result: HTTP/2 200

command: git diff --check
result: clean

command: verify CONTRIBUTING.md renders correctly (no markdown lint errors)
result: pass
```

## Documentation and release impact

- [x] User-facing documentation updated (CONTRIBUTING.md)
- [ ] Changelog needed — docs-only, no code
- [x] No migration impact

## Review notes

- Follow-up: none
- Security: no

## AI disclosure

Muse Spark assisted in identifying the correct URL and drafting the fix. All changes manually reviewed and verified.
