### PR TITLE
Docs: fix broken Service Graph anchor in Tempo config docs

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
@@ -16,6 +16,7 @@ title: Additional settings
 weight: 700
 aliases:
   - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#additional-settings
+  - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#service-graph
 ---
 
 # Additional settings


### PR DESCRIPTION
## Problem

The link at `https://github.com/grafana/grafana/blob/main/docs/sources/datasources/tempo/configure-tempo-data-source.md?plain=1#L296` doesn't go anywhere.

Reproduction: Click the “Service Graph documentation” link at `https://grafana.com/docs/grafana/next/datasources/tempo/configure-tempo-data-source/#service-graph` — it 404s.

The `configure-tempo-data-source` page was split from a single `configure-tempo-data-source.md` file into a directory (`_index.md` + `additional-settings.md`). The `## Service graph` section now lives at `configure-tempo-data-source/additional-settings/#service-graph`, but no alias was left for the old anchor `.../configure-tempo-data-source/#service-graph`.

Fixes #105556

## Change

Adds an alias for the old anchor in `docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md`:

```yaml
aliases:
  - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#additional-settings
  - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#service-graph
```

Hugo will generate a redirect from the old URL to the new location.

## Why this approach

The `additional-settings` page is the new home for the Service Graph section (line 30 `## Service graph`). Adding an alias preserves the old deep link without duplicating content and matches how other moved sections are handled (e.g., `#additional-settings` alias already exists).

## Testing

```text
command: git diff --check
result: clean

command: hugo alias check (via docs build)
result: alias added, no other changes, markdown lint ok
```

## Documentation and release impact

- [x] User-facing documentation updated (alias)
- [ ] Changelog — docs-only

## Review notes

- Follow-up: none
- Security: no

## AI disclosure

Muse Spark assisted in analysis and fix drafting; all changes reviewed and tested manually. Co-authored-by trailers included for Pair Extraordinaire.

Co-authored-by: Muse Spark <muse-spark@users.noreply.github.com>
Co-authored-by: Aryan Singh K <70511529+aryansk@users.noreply.github.com>
