### PR TITLE
Page: Align header actions on the first row when the title wraps

### DIFF
--- a/public/app/core/components/Page/PageHeader.tsx
+++ b/public/app/core/components/Page/PageHeader.tsx
@@ -67,6 +67,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     actions: css({
       display: 'flex',
       flexDirection: 'row',
+      alignSelf: 'flex-start',
+      alignItems: 'center',
       gap: theme.spacing(1),
     }),
     titleSubtitleContainer: css({


### PR DESCRIPTION
## What is this feature?

Adds `align-self: flex-start` and `align-items: center` to the `actions` container in the shared `PageHeader`.

## Why do we need this feature?

Aligns the favorite button properly.

Before:

<img width="2744" height="1216" alt="image" src="https://github.com/user-attachments/assets/700b6441-5eb9-44aa-86e9-701f69d641dc" />

After:

<img width="2798" height="376" alt="image" src="https://github.com/user-attachments/assets/5bdbe68e-59ad-412c-b643-d445e2f0887c" />
