### PR TITLE
logsTablePanelNG: move to GA

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1308,7 +1308,7 @@ export interface FeatureToggles {
   inlineLogDetailsNoScrolls?: boolean;
   /**
   * Enables the logs tableNG panel to replace existing tableRT
-  * @default false
+  * @default true
   */
   logsTablePanelNG?: boolean;
   /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -885,10 +885,10 @@ export const useFlagLibraryelementsKubernetesLibraryPanels = (options?: ReactFla
  *
  * **Details:**
  * - flag key: `logsTablePanelNG`
- * - default value: `false`
+ * - default value: `true`
  */
 export const useFlagLogsTablePanelNG = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("logsTablePanelNG", false, options).value;
+  return useFlag("logsTablePanelNG", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2662,10 +2662,10 @@ var (
 		{
 			Name:         "logsTablePanelNG",
 			Description:  "Enables the logs tableNG panel to replace existing tableRT",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStageGeneralAvailability,
 			Owner:        grafanaObservabilityLogsSquad,
 			HideFromDocs: true,
-			Expression:   "false",
+			Expression:   "true",
 			Generate:     Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -308,7 +308,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,flameGraphWithCallTree,preview,@grafana/observability-traces-and-profiling,false,false,true
 2026-08-12,flameGraph.tableNg,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-05-22,inlineLogDetailsNoScrolls,experimental,@grafana/observability-logs,false,false,true
-2026-05-22,logsTablePanelNG,experimental,@grafana/observability-logs,false,false,true
+2026-05-22,logsTablePanelNG,GA,@grafana/observability-logs,false,false,true
 2026-05-22,plugins.useMTPluginSettings,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-05-22,splashScreen,preview,@grafana/grafana-frontend-platform,false,false,true
 2026-05-22,streamingForwardTeamHeadersTempo,privatePreview,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4555,19 +4555,19 @@
     {
       "metadata": {
         "name": "logsTablePanelNG",
-        "resourceVersion": "1782158134143",
+        "resourceVersion": "1787654578695",
         "creationTimestamp": "2026-05-22T09:03:04Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-06-22 19:55:34.143374 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-08-25 10:42:58.695317 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables the logs tableNG panel to replace existing tableRT",
-        "stage": "experimental",
+        "stage": "GA",
         "codeowner": "@grafana/observability-logs",
         "frontend": true,
         "hideFromDocs": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {

--- a/public/app/features/explore/Logs/Logs.test.tsx
+++ b/public/app/features/explore/Logs/Logs.test.tsx
@@ -33,7 +33,27 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   reportInteraction: (interactionName: string, properties?: Record<string, unknown> | undefined) =>
     reportInteraction(interactionName, properties),
+  getAppEvents: jest.fn(() => ({
+    publish: jest.fn(),
+  })),
+  getDataSourceSrv: jest.fn(() => ({
+    get: () => Promise.resolve(null),
+  })),
+  usePluginLinks: jest.fn().mockReturnValue({
+    links: [],
+    isLoading: false,
+  }),
 }));
+
+// Mock TableNG to disable virtualization, otherwise the lack of viewport in our testing env will cause the table to only render a single column
+jest.mock('@grafana/ui/unstable', () => {
+  const actual = jest.requireActual('@grafana/ui/unstable');
+  const MockTableNG = actual.TableNG;
+  return {
+    ...actual,
+    TableNG: (props: ComponentProps<typeof MockTableNG>) => <MockTableNG {...props} enableVirtualization={false} />,
+  };
+});
 
 const createAndCopyShortLink = jest.fn();
 jest.mock('app/core/utils/shortLinks', () => ({
@@ -509,15 +529,15 @@ describe('Logs', () => {
       const logsSection = screen.getByRole('radio', { name: 'Table' });
       await userEvent.click(logsSection);
 
-      const table = screen.getByTestId('logRowsTable');
-      expect(table).toBeInTheDocument();
+      expect(await screen.findByText('Selected fields')).toBeInTheDocument();
+      expect(screen.queryByTestId('logRowsTable')).not.toBeInTheDocument();
     });
 
     it('should use default state from localstorage - table', async () => {
       localStorage.setItem(visualisationTypeKey, 'table');
       setup({});
-      const table = await screen.findByTestId('logRowsTable');
-      expect(table).toBeInTheDocument();
+      expect(await screen.findByText('Selected fields')).toBeInTheDocument();
+      expect(screen.queryByTestId('logRowsTable')).not.toBeInTheDocument();
     });
 
     it('should use default state from localstorage - logs', async () => {
@@ -532,8 +552,8 @@ describe('Logs', () => {
       const logsSection = screen.getByRole('radio', { name: 'Table' });
       await userEvent.click(logsSection);
 
-      const table = screen.getByTestId('logRowsTable');
-      expect(table).toBeInTheDocument();
+      expect(await screen.findByText('Selected fields')).toBeInTheDocument();
+      expect(screen.queryByTestId('logRowsTable')).not.toBeInTheDocument();
     });
   });
   describe('with table panel visualisation', () => {
@@ -561,7 +581,6 @@ describe('Logs', () => {
 
       setBooleanFlags({
         logsPanelControls: true,
-        logsTablePanelNG: false,
       });
     });
 
@@ -577,31 +596,11 @@ describe('Logs', () => {
           },
         },
       });
-      await waitFor(() => expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument());
-      expect(screen.getByTestId('logRowsTable')).toBeInTheDocument();
+      expect(await screen.findByText('Selected fields')).toBeInTheDocument();
+      expect(screen.queryByTestId('logRowsTable')).not.toBeInTheDocument();
     });
 
     it('should show logs', async () => {
-      setup({
-        panelState: {
-          logs: {
-            visualisationType: 'logs',
-          },
-        },
-      });
-
-      await waitFor(() => expect(screen.getByRole('button', { name: /download/i })).toBeInTheDocument());
-      const logs = await screen.findByTestId('logRows');
-      expect(logs).toBeInTheDocument();
-      expect(screen.getByText('log message 3')).toBeVisible();
-    });
-
-    it('should show logs when logsPanelControls is enabled and logsTablePanelNG is true', async () => {
-      setBooleanFlags({
-        logsPanelControls: true,
-        logsTablePanelNG: true,
-      });
-
       setup({
         panelState: {
           logs: {

--- a/public/app/plugins/panel/logstable/suggestions.test.ts
+++ b/public/app/plugins/panel/logstable/suggestions.test.ts
@@ -22,14 +22,23 @@ jest.mock('@grafana/runtime/internal', () => {
 });
 
 describe('logstable suggestions', () => {
-  beforeAll(() => {
-    mockGetBooleanValue.mockImplementation((key, defaultValue) =>
-      key === FlagKeys.LogsTablePanelNG ? true : defaultValue
-    );
+  afterEach(() => {
+    mockGetBooleanValue.mockImplementation((key, defaultValue) => defaultValue);
   });
 
-  afterAll(() => {
-    mockGetBooleanValue.mockImplementation((key, defaultValue) => defaultValue);
+  it('does not suggest logs table when the feature flag is off', () => {
+    mockGetBooleanValue.mockImplementation((key, defaultValue) =>
+      key === FlagKeys.LogsTablePanelNG ? false : defaultValue
+    );
+
+    const dataSummary = getPanelDataSummary([
+      createDataFrame({
+        meta: { preferredVisualisationType: 'logs' },
+        fields: [{ name: 'line', type: FieldType.string, values: ['a', 'b', 'c'] }],
+      }),
+    ]);
+
+    expect(logstableSuggestionsSupplier(dataSummary)).toBeUndefined();
   });
 
   it('does not suggest logs table for non-log data', () => {

--- a/public/app/plugins/panel/logstable/suggestions.ts
+++ b/public/app/plugins/panel/logstable/suggestions.ts
@@ -25,7 +25,7 @@ function getTableSuggestionScore(dataSummary: PanelDataSummary): VisualizationSu
 export const logstableSuggestionsSupplier: VisualizationSuggestionsSupplier<Options, TableFieldConfig> = (
   dataSummary
 ) => {
-  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.LogsTablePanelNG, false)) {
+  if (!getFeatureFlagClient().getBooleanValue(FlagKeys.LogsTablePanelNG, true)) {
     return;
   }
   const score = getTableSuggestionScore(dataSummary);


### PR DESCRIPTION
Fully enabled in Cloud since August 3rd, replicate the change in OSS.