### PR TITLE
Unified search: fail trash queries when indexing is disabled

### DIFF
--- a/pkg/registry/apis/search/README.md
+++ b/pkg/registry/apis/search/README.md
@@ -249,6 +249,7 @@ The sampled path already exists: when per-item authorization runs after ranking,
 - **400 Bad Request**: the request could not be understood. Malformed JSON, an unknown top-level key, an empty body, more than one JSON object, a missing namespace, or `namespace=*`. Searching across namespaces is not supported.
 - **405 Method Not Allowed**: the kind is served, but has no search endpoint. It declares no search fields, it opted out, or it is cluster-scoped. No route is mounted, so the router answers before any search code runs.
 - **404 Not Found**: the resource itself is not served by this apiserver.
+- **503 Service Unavailable** (`/trash` only): the index does not keep deleted documents because indexing them is disabled, or because the index still needs to be rebuilt after indexing was enabled.
 
 ## 7. Authorization
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2515,10 +2515,14 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 	textQuery := b.buildTextQuery(searchrequest, req)
 	expirationThreshold := int64(0)
 	if req.IsDeleted {
-		// An index built before deleted documents were being kept holds none, so trash
-		// would read as empty when it is really unavailable until the index rebuilds.
-		if !b.keepsDeletedDocuments && b.wantsDeletedDocuments {
-			return nil, resource.NewServiceUnavailableError("trash is not available for this resource until its search index has been rebuilt")
+		// An index that does not keep deleted documents cannot distinguish an empty
+		// trash from unavailable trash, so fail instead of returning a misleading result.
+		if !b.keepsDeletedDocuments {
+			message := "trash is not available for this resource because indexing deleted documents is disabled"
+			if b.wantsDeletedDocuments {
+				message = "trash is not available for this resource until its search index has been rebuilt"
+			}
+			return nil, resource.NewServiceUnavailableError(message)
 		}
 		if t, ok := b.trashRetention.expirationThreshold(b.key.Group, b.key.Resource, time.Now()); ok {
 			expirationThreshold = t

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -943,8 +943,9 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 		Resource:  "dashboards",
 	}
 	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:          t.TempDir(),
-		FileThreshold: threshold, // use in-memory for tests
+		Root:                  t.TempDir(),
+		FileThreshold:         threshold, // use in-memory for tests
+		IndexDeletedDocuments: true,
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),
@@ -1281,10 +1282,11 @@ func newTestDashboardsIndexPostRankWithConfig(t testing.TB, size int64, cfg sear
 		Resource:  "dashboards",
 	}
 	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:                 t.TempDir(),
-		FileThreshold:        threshold, // use in-memory for tests
-		PostRankAuthzEnabled: true,
-		PostRankAuthz:        cfg,
+		Root:                  t.TempDir(),
+		FileThreshold:         threshold, // use in-memory for tests
+		IndexDeletedDocuments: true,
+		PostRankAuthzEnabled:  true,
+		PostRankAuthz:         cfg,
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -951,6 +952,44 @@ func TestBleveSearchRequestDefaultSortIncludesNameTieBreaker(t *testing.T) {
 			assert.Contains(t, errResult.Message, `facet "tagValues" has a negative limit`)
 		}
 	})
+}
+
+func TestBleveTrashSearchFailsWhenDeletedDocumentsAreNotIndexed(t *testing.T) {
+	tests := []struct {
+		name                  string
+		wantsDeletedDocuments bool
+		message               string
+	}{
+		{
+			name:    "indexing is disabled",
+			message: "trash is not available for this resource because indexing deleted documents is disabled",
+		},
+		{
+			name:                  "index is awaiting rebuild",
+			wantsDeletedDocuments: true,
+			message:               "trash is not available for this resource until its search index has been rebuilt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := &bleveIndex{
+				fields:                resource.StandardSearchFields(),
+				searchFields:          newKindSearchFields(nil, "", "", nil),
+				wantsDeletedDocuments: tc.wantsDeletedDocuments,
+			}
+			searchReq, errResult := idx.toBleveSearchRequest(t.Context(), &resourcepb.ResourceSearchRequest{
+				Options:   &resourcepb.ListOptions{},
+				Limit:     10,
+				IsDeleted: true,
+			}, nil, false, nil)
+
+			require.Nil(t, searchReq)
+			require.NotNil(t, errResult)
+			assert.Equal(t, int32(http.StatusServiceUnavailable), errResult.Code)
+			assert.Equal(t, tc.message, errResult.Message)
+		})
+	}
 }
 
 // TestBleveSortCapabilityCheck covers both the counting and the rejecting mode.

--- a/pkg/storage/unified/search/bleve_trash_retention_test.go
+++ b/pkg/storage/unified/search/bleve_trash_retention_test.go
@@ -118,8 +118,9 @@ func newTrashRetentionIndex(t testing.TB, group, res string, retention search.Tr
 	t.Helper()
 
 	backend, err := search.NewBleveBackend(search.BleveOptions{
-		Root:          t.TempDir(),
-		FileThreshold: 5,
+		Root:                  t.TempDir(),
+		FileThreshold:         5,
+		IndexDeletedDocuments: true,
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource(group, res): search.DashboardSearchFieldsProviderForTest(),
 		}),


### PR DESCRIPTION
## What

Return 503 from `/trash` when the search index does not retain deleted documents. This prevents disabled indexing from appearing as an empty trash result.

Keep the existing error for indexes that still need rebuilding.