### PR TITLE
Alerting: commit pending query options on toggletip close, not just blur

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { type GrafanaTheme2, type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -8,7 +8,12 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { TimeRangeLabel } from '../TimeRangeLabel';
 
-import { type AlertQueryOptions, MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+import {
+  type AlertQueryOptions,
+  type QueryOptionFieldHandle,
+  MaxDataPointsOption,
+  MinIntervalOption,
+} from './QueryWrapper';
 
 export interface QueryOptionsProps {
   query: AlertQuery;
@@ -28,6 +33,8 @@ export const QueryOptions = ({
   const styles = useStyles2(getStyles);
 
   const [showOptions, setShowOptions] = useState(false);
+  const maxDataPointsRef = useRef<QueryOptionFieldHandle>(null);
+  const minIntervalRef = useRef<QueryOptionFieldHandle>(null);
 
   const separator = <span>, </span>;
 
@@ -44,12 +51,26 @@ export const QueryOptions = ({
                 />
               </InlineField>
             )}
-            <MaxDataPointsOption options={queryOptions} onChange={(options) => onChangeQueryOptions(options, index)} />
-            <MinIntervalOption options={queryOptions} onChange={(options) => onChangeQueryOptions(options, index)} />
+            <MaxDataPointsOption
+              ref={maxDataPointsRef}
+              options={queryOptions}
+              onChange={(options) => onChangeQueryOptions(options, index)}
+            />
+            <MinIntervalOption
+              ref={minIntervalRef}
+              options={queryOptions}
+              onChange={(options) => onChangeQueryOptions(options, index)}
+            />
           </div>
         }
         closeButton={true}
         placement="bottom-start"
+        onClose={() => {
+          // Commit any pending edits before the toggletip (and its inputs) unmount - clicking
+          // outside can otherwise close it before the input's onBlur commits the value.
+          maxDataPointsRef.current?.flush();
+          minIntervalRef.current?.flush();
+        }}
       >
         <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
           <Trans i18nKey="alerting.query-options.button-options">Options</Trans>{' '}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import * as React from 'react';
-import { type ChangeEvent, useState } from 'react';
+import { type ChangeEvent, forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import {
@@ -221,18 +221,23 @@ export const EmptyQueryWrapper = ({ children }: React.PropsWithChildren<{}>) => 
   return <div className={styles.wrapper}>{children}</div>;
 };
 
-export function MaxDataPointsOption({
-  options,
-  onChange,
-}: {
+// Exposes a way for the parent to force the pending input value to be committed. This is needed
+// because the options are shown inside a `Toggletip` that gets dismissed (and its content
+// unmounted) on outside click, which can happen before the input's `onBlur` has a chance to
+// commit the value - silently discarding the edit. See https://github.com/grafana/grafana/issues/111664
+export interface QueryOptionFieldHandle {
+  flush: () => void;
+}
+
+export const MaxDataPointsOption = forwardRef<QueryOptionFieldHandle, {
   options: AlertQueryOptions;
   onChange: (options: AlertQueryOptions) => void;
-}) {
+}>(({ options, onChange }, ref) => {
   const value = options.maxDataPoints ?? '';
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const maxDataPointsNumber = parseInt(event.target.value, 10);
-
+  const commit = (rawValue: string) => {
+    const maxDataPointsNumber = parseInt(rawValue, 10);
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
 
     if (maxDataPoints !== options.maxDataPoints) {
@@ -242,6 +247,16 @@ export function MaxDataPointsOption({
       });
     }
   };
+
+  useImperativeHandle(ref, () => ({
+    flush: () => {
+      if (inputRef.current) {
+        commit(inputRef.current.value);
+      }
+    },
+  }));
+
+  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => commit(event.target.value);
 
   return (
     <InlineField
@@ -253,6 +268,7 @@ export function MaxDataPointsOption({
       )}
     >
       <Input
+        ref={inputRef}
         type="number"
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
@@ -262,26 +278,34 @@ export function MaxDataPointsOption({
       />
     </InlineField>
   );
-}
+});
+MaxDataPointsOption.displayName = 'MaxDataPointsOption';
 
-export function MinIntervalOption({
-  options,
-  onChange,
-}: {
+export const MinIntervalOption = forwardRef<QueryOptionFieldHandle, {
   options: AlertQueryOptions;
   onChange: (options: AlertQueryOptions) => void;
-}) {
+}>(({ options, onChange }, ref) => {
   const value = options.minInterval ?? '';
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const minInterval = event.target.value;
-    if (minInterval !== value) {
+  const commit = (rawValue: string) => {
+    if (rawValue !== value) {
       onChange({
         ...options,
-        minInterval,
+        minInterval: rawValue,
       });
     }
   };
+
+  useImperativeHandle(ref, () => ({
+    flush: () => {
+      if (inputRef.current) {
+        commit(inputRef.current.value);
+      }
+    },
+  }));
+
+  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => commit(event.target.value);
 
   return (
     <InlineField
@@ -295,6 +319,7 @@ export function MinIntervalOption({
       }
     >
       <Input
+        ref={inputRef}
         type="text"
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
@@ -304,7 +329,8 @@ export function MinIntervalOption({
       />
     </InlineField>
   );
-}
+});
+MinIntervalOption.displayName = 'MinIntervalOption';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({


### PR DESCRIPTION
## What is this feature?

Fixes #111664.

On the alert edit/creation page, opening the query "Options" toggletip and changing the interval or max data points value, then clicking *outside* the toggletip to close it, silently discards the edit instead of saving it.

## Root cause

The options live inside a `Toggletip` (floating-ui based). Clicking outside triggers `useDismiss`, which unmounts the toggletip's content - including the `<Input>` for interval/max data points - and this can happen before the input's native `blur` has fully propagated to React's synthetic `onBlur`, where the value was being committed. The edit is lost with no error or indication anything went wrong.

## Fix

`MaxDataPointsOption`/`MinIntervalOption` now expose a `flush()` imperative handle (via `forwardRef` + `useImperativeHandle`) backed by a ref to their underlying input. `QueryOptions` calls `flush()` on both from `Toggletip`'s `onClose` callback, which fires synchronously before the unmounting render is committed - so the pending value is always saved, regardless of whether native blur completed in time.

`onBlur` behavior (tabbing between fields, etc.) is unchanged.

## Test plan

- Manually verified: open Options tooltip on an alert query, change "Interval", click outside the tooltip to close it -> value is now saved (previously reverted).
- Same for "Max data points".
- Verified tabbing between fields (onBlur path) still commits as before.