### PR TITLE
Keys API: add the list-keys handler and routes

### DIFF
--- a/pkg/registry/apis/keys/handler.go
+++ b/pkg/registry/apis/keys/handler.go
@@ -1,0 +1,257 @@
+// Package keys serves the keys-only list endpoint, at
+// POST /apis/{group}/{version}/{resource}/list-keys.
+//
+// It reads identities out of unified storage without fetching object bodies, so a
+// controller can take a state-of-the-world snapshot cheaply. Cluster-scoped: one
+// call covers every namespace, so the caller's identity must cover them too.
+//
+// POST rather than GET because GET would permanently shadow an object of that
+// name, and nothing is registered for POST on {resource}/{name}.
+package keys
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/errhttp"
+)
+
+// ListOptions is small, so anything larger is a client bug or an attack.
+const maxRequestBody = 1 << 20 // 1 MiB
+
+type kindRef struct {
+	group    string
+	version  string
+	resource string
+	kind     string
+}
+
+type Handler struct {
+	store  resourcepb.ResourceStoreClient
+	tracer trace.Tracer
+	log    log.Logger
+}
+
+func NewHandler(store resourcepb.ResourceStoreClient, tracer trace.Tracer) *Handler {
+	return &Handler{
+		store:  store,
+		tracer: tracer,
+		log:    log.New("grafana-apiserver.keys"),
+	}
+}
+
+// ListKeysFor returns the POST handler for one kind's keys endpoint.
+//
+// The response is a PartialObjectMetadataList carrying only namespace, name,
+// resourceVersion and the grafana.app/folder annotation. Nothing from the object
+// body is available, since no body is read — which is why this is its own endpoint
+// rather than content negotiation on the normal list, where clients are promised
+// complete metadata.
+//
+// Reconciling against this plus an event stream converges only if the caller:
+//
+//  1. Compares per-key resourceVersion, never a single global one. Versions are
+//     assigned before commit, so a write can be missing from a snapshot while
+//     carrying a version below that snapshot's.
+//  2. Treats deletions as observable only by diffing a full snapshot, arbitrated
+//     by the list's resourceVersion. They are absent from the list, not tombstoned.
+//  3. Treats events as a latency optimization. They may be dropped, and the server
+//     never reports that a resource version aged out; the relist is what converges.
+//
+// Known limitation: this always reads unified storage, so for a resource still
+// served from legacy (dual-write mode 0-2) the result can be empty or stale while
+// the normal list returns real data.
+func (h *Handler) ListKeysFor(kind kindRef) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, span := h.tracer.Start(r.Context(), "keys.v1.listKeys", trace.WithAttributes(
+			attribute.String("keys.group", kind.group),
+			attribute.String("keys.version", kind.version),
+			attribute.String("keys.resource", kind.resource),
+		))
+		defer span.End()
+
+		if err := requireClusterWideServiceIdentity(ctx); err != nil {
+			errhttp.Write(ctx, err, w)
+			return
+		}
+
+		opts, err := decodeListOptions(r)
+		if err != nil {
+			errhttp.Write(ctx, err, w)
+			return
+		}
+
+		req := &resourcepb.ListRequest{
+			KeysOnly:      true,
+			Limit:         opts.Limit,
+			NextPageToken: opts.Continue,
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Group:    kind.group,
+					Resource: kind.resource,
+				},
+			},
+		}
+
+		if opts.ResourceVersion != "" {
+			rv, err := strconv.ParseInt(opts.ResourceVersion, 10, 64)
+			if err != nil {
+				errhttp.Write(ctx, apierrors.NewBadRequest(
+					fmt.Sprintf("invalid resourceVersion: %q", opts.ResourceVersion)), w)
+				return
+			}
+			req.ResourceVersion = rv
+		}
+
+		res, err := h.store.List(ctx, req)
+		// AsErrorResult reads the structured result off the gRPC status details, so
+		// the reason and code survive the wire instead of collapsing to Internal.
+		if err != nil {
+			errhttp.Write(ctx, resource.GetError(resource.AsErrorResult(err)), w)
+			return
+		}
+		// The backend also reports failures in the payload, not only as a transport error.
+		if res.GetError() != nil {
+			errhttp.Write(ctx, resource.GetError(res.GetError()), w)
+			return
+		}
+
+		writeJSON(w, keysResults(res))
+	}
+}
+
+// requireClusterWideServiceIdentity accepts only the service identity. The read
+// it performs is cluster-wide, so only the "*" namespace is allowed.
+func requireClusterWideServiceIdentity(ctx context.Context) error {
+	info, ok := claims.AuthInfoFrom(ctx)
+	if !ok || info == nil {
+		return apierrors.NewUnauthorized("no identity found for request")
+	}
+	if !identity.IsServiceIdentity(ctx) {
+		return apierrors.NewForbidden(
+			schema.GroupResource{}, "",
+			fmt.Errorf("listing keys is only available to the service identity, got %q", info.GetIdentityType()),
+		)
+	}
+	if ns := info.GetNamespace(); ns != "*" {
+		return apierrors.NewForbidden(
+			schema.GroupResource{}, "",
+			fmt.Errorf("listing keys is cluster-wide and requires an identity scoped to %q, got %q", "*", ns),
+		)
+	}
+	return nil
+}
+
+// Refused rather than ignored: silently dropping a selector would hand the caller
+// an unfiltered list.
+type unsupportedListOption struct {
+	name string
+	set  func(*metav1.ListOptions) bool
+}
+
+var unsupportedListOptions = []unsupportedListOption{
+	{"labelSelector", func(o *metav1.ListOptions) bool { return o.LabelSelector != "" }},
+	{"fieldSelector", func(o *metav1.ListOptions) bool { return o.FieldSelector != "" }},
+	{"watch", func(o *metav1.ListOptions) bool { return o.Watch }},
+	{"allowWatchBookmarks", func(o *metav1.ListOptions) bool { return o.AllowWatchBookmarks }},
+	{"sendInitialEvents", func(o *metav1.ListOptions) bool { return o.SendInitialEvents != nil }},
+	{"timeoutSeconds", func(o *metav1.ListOptions) bool { return o.TimeoutSeconds != nil }},
+	{"resourceVersionMatch", func(o *metav1.ListOptions) bool { return o.ResourceVersionMatch != "" }},
+}
+
+// An empty body means all defaults.
+func decodeListOptions(r *http.Request) (*metav1.ListOptions, error) {
+	opts := &metav1.ListOptions{}
+
+	body := http.MaxBytesReader(nil, r.Body, maxRequestBody)
+	dec := json.NewDecoder(body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(opts); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("invalid request body: %s", err))
+		}
+		return opts, nil
+	}
+	// Anything after the first value means the caller sent more than one.
+	if err := dec.Decode(&json.RawMessage{}); !errors.Is(err, io.EOF) {
+		return nil, apierrors.NewBadRequest("request body must contain a single JSON object")
+	}
+
+	if opts.Kind != "" && opts.Kind != "ListOptions" {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected kind ListOptions, got %q", opts.Kind))
+	}
+	if opts.Limit < 0 {
+		return nil, apierrors.NewBadRequest("limit must not be negative")
+	}
+
+	for _, opt := range unsupportedListOptions {
+		if opt.set(opts) {
+			return nil, apierrors.NewBadRequest(
+				fmt.Sprintf("%s is not supported when listing keys", opt.name))
+		}
+	}
+
+	return opts, nil
+}
+
+// The list's resourceVersion is the snapshot every page is taken at; callers need
+// it to arbitrate list-versus-event races. See ListKeysFor.
+func keysResults(res *resourcepb.ListResponse) *metav1.PartialObjectMetadataList {
+	apiVersion := metav1.SchemeGroupVersion.String()
+	out := &metav1.PartialObjectMetadataList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       "PartialObjectMetadataList",
+		},
+		ListMeta: metav1.ListMeta{
+			Continue:        res.GetNextPageToken(),
+			ResourceVersion: strconv.FormatInt(res.GetResourceVersion(), 10),
+		},
+		Items: make([]metav1.PartialObjectMetadata, 0, len(res.GetItems())),
+	}
+
+	// Identical for every item.
+	itemType := metav1.TypeMeta{APIVersion: apiVersion, Kind: "PartialObjectMetadata"}
+
+	for _, item := range res.GetItems() {
+		partial := metav1.PartialObjectMetadata{
+			TypeMeta: itemType,
+			ObjectMeta: metav1.ObjectMeta{
+				// Per item: the list spans namespaces, so the caller cannot infer it.
+				Namespace:       item.GetNamespace(),
+				Name:            item.GetName(),
+				ResourceVersion: strconv.FormatInt(item.GetResourceVersion(), 10),
+			},
+		}
+		// Absent rather than empty, so "no folder" stays distinguishable.
+		if folder := item.GetFolder(); folder != "" {
+			partial.Annotations = map[string]string{utils.AnnoKeyFolder: folder}
+		}
+		out.Items = append(out.Items, partial)
+	}
+
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, obj any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(obj)
+}

--- a/pkg/registry/apis/keys/handler_test.go
+++ b/pkg/registry/apis/keys/handler_test.go
@@ -1,0 +1,363 @@
+package keys
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	claims "github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// Records the request, so a test can assert on what the handler sent.
+type fakeStore struct {
+	resourcepb.ResourceStoreClient
+
+	calls []*resourcepb.ListRequest
+	rsp   *resourcepb.ListResponse
+	err   error
+}
+
+func (f *fakeStore) List(_ context.Context, req *resourcepb.ListRequest, _ ...grpc.CallOption) (*resourcepb.ListResponse, error) {
+	f.calls = append(f.calls, req)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.rsp != nil {
+		return f.rsp, nil
+	}
+	return &resourcepb.ListResponse{ResourceVersion: 1}, nil
+}
+
+const (
+	testGroup    = "dashboard.grafana.app"
+	testVersion  = "v1beta1"
+	testResource = "dashboards"
+	testKind     = "Dashboard"
+)
+
+func testKind_() kindRef {
+	return kindRef{group: testGroup, version: testVersion, resource: testResource, kind: testKind}
+}
+
+// The identity a controller gets from identity.WithServiceIdentity, built the
+// same way so the test cannot drift from it.
+func serviceIdentity() *identity.StaticRequester {
+	_, requester := identity.WithServiceIdentity(context.Background(), 1)
+	return requester.(*identity.StaticRequester)
+}
+
+// Drives the handler as the apiserver would for a cluster-scoped route: no
+// namespace in the context.
+func do(t *testing.T, store *fakeStore, ident claims.AuthInfo, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	h := NewHandler(store, noop.NewTracerProvider().Tracer("test"))
+
+	var reader *strings.Reader
+	if body == "" {
+		reader = strings.NewReader("")
+	} else {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/list-keys", reader)
+
+	ctx := req.Context()
+	if ident != nil {
+		ctx = claims.WithAuthInfo(ctx, ident)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ListKeysFor(testKind_())(rec, req.WithContext(ctx))
+	return rec
+}
+
+func TestListKeys_ProjectsOntoPartialObjectMetadataList(t *testing.T) {
+	store := &fakeStore{rsp: &resourcepb.ListResponse{
+		ResourceVersion: 4242,
+		NextPageToken:   "next-please",
+		Items: []*resourcepb.ResourceWrapper{
+			{Namespace: "ns-one", Name: "aaa", Folder: "folder-a", ResourceVersion: 11},
+			{Namespace: "ns-two", Name: "bbb", ResourceVersion: 22},
+		},
+	}}
+
+	rec := do(t, store, serviceIdentity(), `{"limit":2}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Decoded with the real type, not just JSON that looks like one.
+	var got metav1.PartialObjectMetadataList
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	assert.Equal(t, "PartialObjectMetadataList", got.Kind)
+	assert.Equal(t, "meta.k8s.io/v1", got.APIVersion)
+
+	assert.Equal(t, "4242", got.ResourceVersion)
+	assert.Equal(t, "next-please", got.Continue)
+
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "ns-one", got.Items[0].Namespace)
+	assert.Equal(t, "aaa", got.Items[0].Name)
+	assert.Equal(t, "11", got.Items[0].ResourceVersion)
+	assert.Equal(t, map[string]string{utils.AnnoKeyFolder: "folder-a"}, got.Items[0].Annotations)
+
+	// No folder stays absent rather than becoming an empty annotation.
+	assert.Equal(t, "ns-two", got.Items[1].Namespace)
+	assert.Equal(t, "bbb", got.Items[1].Name)
+	assert.Equal(t, "22", got.Items[1].ResourceVersion)
+	assert.Empty(t, got.Items[1].Annotations)
+
+	require.Len(t, store.calls, 1)
+	sent := store.calls[0]
+	assert.True(t, sent.KeysOnly, "the handler must set keys_only or it reads whole objects")
+	assert.Equal(t, int64(2), sent.Limit)
+	assert.Equal(t, testGroup, sent.Options.Key.Group)
+	assert.Equal(t, testResource, sent.Options.Key.Resource)
+	assert.Empty(t, sent.Options.Key.Namespace,
+		"a cluster-scoped list must not pin a namespace, or it silently covers only one")
+}
+
+// ListOptions fields must reach the store request unchanged, and an absent body
+// must mean defaults rather than an error.
+func TestListKeys_TranslatesListOptions(t *testing.T) {
+	for name, tc := range map[string]struct {
+		body      string
+		wantLimit int64
+		wantToken string
+		wantRV    int64
+	}{
+		"empty body means defaults": {body: ""},
+		"limit only":                {body: `{"limit":5}`, wantLimit: 5},
+		"continue token":            {body: `{"continue":"tok"}`, wantToken: "tok"},
+		"resource version":          {body: `{"resourceVersion":"999"}`, wantRV: 999},
+		"all three": {
+			body:      `{"continue":"tok","resourceVersion":"999","limit":5}`,
+			wantLimit: 5, wantToken: "tok", wantRV: 999,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeStore{}
+			rec := do(t, store, serviceIdentity(), tc.body)
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+			require.Len(t, store.calls, 1)
+			sent := store.calls[0]
+			assert.True(t, sent.KeysOnly)
+			assert.Equal(t, tc.wantLimit, sent.Limit)
+			assert.Equal(t, tc.wantToken, sent.NextPageToken)
+			assert.Equal(t, tc.wantRV, sent.ResourceVersion)
+		})
+	}
+}
+
+// Silently ignoring a selector would hand a reconciliation loop an unfiltered
+// list, so this is a trust boundary rather than input tidiness.
+func TestListKeys_RejectsUnsupportedListOptions(t *testing.T) {
+	for name, body := range map[string]string{
+		"labelSelector":        `{"labelSelector":"team=a"}`,
+		"fieldSelector":        `{"fieldSelector":"metadata.name=x"}`,
+		"watch":                `{"watch":true}`,
+		"allowWatchBookmarks":  `{"allowWatchBookmarks":true}`,
+		"sendInitialEvents":    `{"sendInitialEvents":true}`,
+		"timeoutSeconds":       `{"timeoutSeconds":30}`,
+		"resourceVersionMatch": `{"resourceVersionMatch":"Exact"}`,
+		"negative limit":       `{"limit":-1}`,
+		"unknown field":        `{"nonsense":true}`,
+		"wrong kind":           `{"kind":"SearchQuery"}`,
+		"bad resourceVersion":  `{"resourceVersion":"not-a-number"}`,
+		"two objects":          `{}{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeStore{}
+			rec := do(t, store, serviceIdentity(), body)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+			assert.Empty(t, store.calls, "a rejected request must not reach the store")
+		})
+	}
+}
+
+// Asserting the store was never called matters more than the status code: it is
+// what shows the gate runs before any read.
+func TestListKeys_ServiceIdentitiesOnly(t *testing.T) {
+	withType := func(typ claims.IdentityType) claims.AuthInfo {
+		ident := serviceIdentity()
+		ident.Type = typ
+		return ident
+	}
+
+	cases := map[string]struct {
+		ident      claims.AuthInfo
+		wantStatus int
+	}{
+		"no identity at all": {ident: nil, wantStatus: http.StatusUnauthorized},
+	}
+	cases["allowed: service identity"] = struct {
+		ident      claims.AuthInfo
+		wantStatus int
+	}{ident: serviceIdentity(), wantStatus: http.StatusOK}
+
+	// The sharp case: an access policy is the right type, so only the UID
+	// distinguishes the service identity from any other token.
+	other := serviceIdentity()
+	other.UserUID = "some-other-policy"
+	cases["refused: another access policy"] = struct {
+		ident      claims.AuthInfo
+		wantStatus int
+	}{ident: other, wantStatus: http.StatusForbidden}
+
+	for _, typ := range []claims.IdentityType{
+		claims.TypeServiceAccount,
+		claims.TypeUser,
+		claims.TypeAPIKey,
+		claims.TypeAnonymous,
+		claims.TypeRenderService,
+		claims.TypeUnauthenticated,
+		claims.TypeProvisioning,
+		claims.TypePublic,
+		claims.TypeEmpty,
+	} {
+		cases["refused: "+string(typ)] = struct {
+			ident      claims.AuthInfo
+			wantStatus int
+		}{ident: withType(typ), wantStatus: http.StatusForbidden}
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeStore{}
+			rec := do(t, store, tc.ident, `{}`)
+			require.Equal(t, tc.wantStatus, rec.Code, rec.Body.String())
+
+			if tc.wantStatus == http.StatusOK {
+				assert.Len(t, store.calls, 1)
+				return
+			}
+			assert.Empty(t, store.calls, "a refused caller must not reach the store")
+		})
+	}
+}
+
+// The read is cluster-wide, so only a caller scoped to every namespace may make
+// it. A narrower one would otherwise reach the resource server and fail partway
+// with a namespace mismatch over a partial page instead of a clean refusal.
+func TestListKeys_RequiresWildcardNamespaceScope(t *testing.T) {
+	for name, tc := range map[string]struct {
+		namespace  string
+		wantStatus int
+	}{
+		"all namespaces":                {"*", http.StatusOK},
+		"single tenant service account": {"default", http.StatusForbidden},
+		"multi tenant stack":            {"stacks-1234", http.StatusForbidden},
+		"org scoped":                    {"org-3", http.StatusForbidden},
+		"unscoped":                      {"", http.StatusForbidden},
+		// The case the wildcard check exists for: WithProvisioningIdentity also
+		// satisfies IsServiceIdentity, but is scoped to one namespace.
+		"provisioning identity": {"stacks-1234", http.StatusForbidden},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeStore{}
+			ident := serviceIdentity()
+			ident.Namespace = tc.namespace
+
+			rec := do(t, store, ident, `{}`)
+			require.Equal(t, tc.wantStatus, rec.Code, rec.Body.String())
+
+			if tc.wantStatus != http.StatusOK {
+				assert.Empty(t, store.calls, "a refused caller must not reach the store")
+				return
+			}
+			require.Len(t, store.calls, 1)
+			assert.Empty(t, store.calls[0].Options.Key.Namespace)
+		})
+	}
+}
+
+// The backend reports failures in the payload as well as over the transport, so
+// both have to become an HTTP status rather than a 200 with no items.
+func TestListKeys_SurfacesErrors(t *testing.T) {
+	for name, tc := range map[string]struct {
+		store    *fakeStore
+		wantCode int
+		exact    bool
+	}{
+		"payload error": {
+			store: &fakeStore{rsp: &resourcepb.ListResponse{
+				Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "nope"},
+			}},
+			wantCode: http.StatusBadRequest,
+		},
+		"transport error": {
+			store:    &fakeStore{err: fmt.Errorf("boom")},
+			wantCode: http.StatusInternalServerError,
+		},
+		// A gRPC status carries the real result in its details; flattening the
+		// error instead would report this as a 500.
+		"grpc status details": {
+			store:    &fakeStore{err: grpcStatusWithResult(http.StatusBadRequest, "Invalid", "bad selector")},
+			wantCode: http.StatusBadRequest,
+			exact:    true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := do(t, tc.store, serviceIdentity(), `{}`)
+			if tc.exact {
+				require.Equal(t, tc.wantCode, rec.Code, rec.Body.String())
+				return
+			}
+			assert.GreaterOrEqual(t, rec.Code, tc.wantCode, rec.Body.String())
+			assert.NotEqual(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// Mirrors how the resource server reports a failure over gRPC: a status whose
+// details carry the structured ErrorResult.
+func grpcStatusWithResult(code int32, reason, msg string) error {
+	st, err := status.New(codes.InvalidArgument, msg).WithDetails(
+		&resourcepb.ErrorResult{Code: code, Reason: reason, Message: msg},
+	)
+	if err != nil {
+		panic(err)
+	}
+	return st.Err()
+}
+
+// Items from many namespaces come back in one page, each carrying its own.
+func TestListKeys_ReportsPerItemNamespace(t *testing.T) {
+	store := &fakeStore{rsp: &resourcepb.ListResponse{
+		ResourceVersion: 7,
+		Items: []*resourcepb.ResourceWrapper{
+			{Namespace: "ns-one", Name: "aaa", ResourceVersion: 1},
+			{Namespace: "ns-two", Name: "bbb", ResourceVersion: 2},
+			{Namespace: "ns-two", Name: "ccc", ResourceVersion: 3},
+		},
+	}}
+
+	rec := do(t, store, serviceIdentity(), `{}`)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var got metav1.PartialObjectMetadataList
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 3)
+
+	byName := map[string]string{}
+	for _, item := range got.Items {
+		byName[item.Name] = item.Namespace
+	}
+	assert.Equal(t, map[string]string{"aaa": "ns-one", "bbb": "ns-two", "ccc": "ns-two"}, byName)
+}

--- a/pkg/registry/apis/keys/route.go
+++ b/pkg/registry/apis/keys/route.go
@@ -1,0 +1,153 @@
+package keys
+
+import (
+	"net/http"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/util"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	commonv0 "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	grafanaauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
+)
+
+// ConfigSection and ConfigKey name the ini setting that turns the endpoint on.
+// The endpoint is permanent; the gate is not.
+const (
+	ConfigSection = "grafana-apiserver"
+	ConfigKey     = "enable_keys_api"
+)
+
+const componentPrefix = "#/components/schemas/"
+
+// Standard meta.k8s.io/v1 types, so there is no envelope to define or generate.
+var (
+	listOptionsModel = metav1.ListOptions{}.OpenAPIModelName()
+	partialListModel = metav1.PartialObjectMetadataList{}.OpenAPIModelName()
+)
+
+// Route is an endpoint to mount. Deliberately not builder.APIRouteHandler: more
+// than one host mounts this handler, so the mapping belongs to each host.
+type Route struct {
+	Path    string
+	Spec    *spec3.PathProps
+	Handler http.HandlerFunc
+
+	// Components Spec references. They travel with the route because the types
+	// belong to a different group than the one serving.
+	Schemas map[string]spec.Schema
+}
+
+// ListKeysRoute returns the cluster-scoped list-keys route.
+func (h *Handler) ListKeysRoute(group, version, resourceName, kindName string) Route {
+	kind := kindRef{group: group, version: version, resource: resourceName, kind: kindName}
+	return Route{
+		Path:    resourceName + "/" + grafanaauthorizer.ListKeysPathSegment,
+		Spec:    listKeysRouteSpec(kindName, version),
+		Handler: h.ListKeysFor(kind),
+		Schemas: metaSchemas(listOptionsModel, partialListModel),
+	}
+}
+
+// The version is part of the name because the endpoint is mounted on every served
+// version and operation IDs must stay unique once the specs are merged. Starts
+// with a Kubernetes verb so the route builder does not prefix one.
+func listKeysOperationID(kindName, version string) string {
+	return "list" + kindName + "Keys" + capitalize(version)
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func listKeysRouteSpec(kindName, version string) *spec3.PathProps {
+	return &spec3.PathProps{
+		Post: &spec3.Operation{
+			OperationProps: spec3.OperationProps{
+				Tags:        []string{"Keys"},
+				OperationId: listKeysOperationID(kindName, version),
+				Description: "List " + kindName + " keys across all namespaces: namespace, name, " +
+					"folder and resourceVersion only, with no object bodies. Requires a service " +
+					"identity scoped to all namespaces.",
+				RequestBody: &spec3.RequestBody{
+					RequestBodyProps: spec3.RequestBodyProps{
+						Required: false,
+						Description: "A ListOptions carrying limit, continue and resourceVersion. " +
+							"Selectors, watch and timeouts are rejected: they cannot be evaluated " +
+							"without reading objects.",
+						Content: jsonContent(listOptionsModel),
+					},
+				},
+				Responses: &spec3.Responses{
+					ResponsesProps: spec3.ResponsesProps{
+						StatusCodeResponses: map[int]*spec3.Response{
+							200: {
+								ResponseProps: spec3.ResponseProps{
+									Description: "A PartialObjectMetadataList in which only namespace, name, " +
+										"resourceVersion and the grafana.app/folder annotation are populated.",
+									Content: jsonContent(partialListModel),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// Generated dependencies come as either Go import paths or names already
+// converted by OpenAPIModelName; converting an already-converted name reverses it.
+func friendly(name string) string {
+	if strings.Contains(name, "/") {
+		return util.ToRESTFriendlyName(name)
+	}
+	return name
+}
+
+func schemaRef(goName string) spec.Ref {
+	return spec.MustCreateRef(componentPrefix + friendly(goName))
+}
+
+// Each group version's spec is self-contained, so the components have to travel
+// with the route. Dependencies are followed rather than listed because a missing
+// one renders as an empty model with no error.
+func metaSchemas(roots ...string) map[string]spec.Schema {
+	defs := commonv0.GetOpenAPIDefinitions(schemaRef)
+
+	out := map[string]spec.Schema{}
+	queue := append([]string{}, roots...)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+
+		if _, seen := out[friendly(name)]; seen {
+			continue
+		}
+		def, ok := defs[name]
+		if !ok {
+			continue
+		}
+		out[friendly(name)] = def.Schema
+		queue = append(queue, def.Dependencies...)
+	}
+
+	return out
+}
+
+func jsonContent(goName string) map[string]*spec3.MediaType {
+	return map[string]*spec3.MediaType{
+		"application/json": {
+			MediaTypeProps: spec3.MediaTypeProps{
+				Schema: &spec.Schema{
+					SchemaProps: spec.SchemaProps{Ref: schemaRef(goName)},
+				},
+			},
+		},
+	}
+}

--- a/pkg/registry/apis/keys/route_test.go
+++ b/pkg/registry/apis/keys/route_test.go
@@ -1,0 +1,94 @@
+package keys
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func testRoute(t *testing.T) Route {
+	t.Helper()
+	h := NewHandler(&fakeStore{}, noop.NewTracerProvider().Tracer("test"))
+	return h.ListKeysRoute(testGroup, testVersion, testResource, testKind)
+}
+
+func TestListKeysRoute_Shape(t *testing.T) {
+	r := testRoute(t)
+
+	assert.Equal(t, "dashboards/list-keys", r.Path)
+	require.NotNil(t, r.Handler)
+
+	require.NotNil(t, r.Spec)
+	require.NotNil(t, r.Spec.Post, "the endpoint is a POST")
+	assert.Nil(t, r.Spec.Get)
+	assert.Nil(t, r.Spec.Put)
+	assert.Nil(t, r.Spec.Patch)
+	assert.Nil(t, r.Spec.Delete)
+
+	op := r.Spec.Post.OperationProps
+	assert.Equal(t, "listDashboardKeysV1beta1", op.OperationId)
+	// Cluster-scoped: no namespace in the path to describe.
+	assert.Empty(t, op.Parameters)
+
+	// Accepted but not required: every field has a default.
+	require.NotNil(t, op.RequestBody)
+	assert.False(t, op.RequestBody.Required)
+	assert.Contains(t, op.RequestBody.Content, "application/json")
+
+	require.NotNil(t, op.Responses)
+	ok := op.Responses.StatusCodeResponses[200]
+	require.NotNil(t, ok)
+	assert.Contains(t, ok.Content, "application/json")
+}
+
+// Each group version's document is self-contained, so referenced components have
+// to travel with the route. A missing one renders as an empty model with no error.
+func TestListKeysRoute_PublishesReferencedSchemas(t *testing.T) {
+	r := testRoute(t)
+	require.NotEmpty(t, r.Schemas)
+
+	for _, want := range []string{
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ListOptions",
+		"io.k8s.apimachinery.pkg.apis.meta.v1.PartialObjectMetadataList",
+		// Reached transitively.
+		"io.k8s.apimachinery.pkg.apis.meta.v1.PartialObjectMetadata",
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+		"io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+	} {
+		assert.Contains(t, r.Schemas, want)
+	}
+
+	// Every $ref the spec emits must be one of the published components.
+	bodyRef := r.Spec.Post.RequestBody.Content["application/json"].Schema.Ref.String()
+	respRef := r.Spec.Post.Responses.StatusCodeResponses[200].Content["application/json"].Schema.Ref.String()
+	for _, ref := range []string{bodyRef, respRef} {
+		require.True(t, len(ref) > len(componentPrefix), "unexpected ref %q", ref)
+		assert.Contains(t, r.Schemas, ref[len(componentPrefix):])
+	}
+}
+
+// Pins how the apiserver parses the path: a create on an object named
+// "list-keys", which the authorizer restates as a list.
+func TestListKeysRoute_ParsesAsClusterScopedNamedCreate(t *testing.T) {
+	f := &request.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("apis"),
+		GrouplessAPIPrefixes: sets.NewString(),
+	}
+	path := "/apis/" + testGroup + "/" + testVersion + "/" + testRoute(t).Path
+
+	req, err := http.NewRequest(http.MethodPost, path, nil)
+	require.NoError(t, err)
+	info, err := f.NewRequestInfo(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "create", info.Verb)
+	assert.Equal(t, testResource, info.Resource)
+	assert.Equal(t, "list-keys", info.Name)
+	assert.Empty(t, info.Namespace, "cluster-scoped: no namespace in the path")
+	assert.Empty(t, info.Subresource, "a subresource would be a different endpoint")
+}

--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -83,11 +83,25 @@ func (a *GrafanaAuthorizer) Unregister(gv schema.GroupVersion) {
 	delete(a.apis, gv.String())
 }
 
+// ListKeysPathSegment is the final segment of the list-keys endpoint.
+const ListKeysPathSegment = "list-keys"
+
+// IsListKeysRequest reports whether attr is a call to a kind's list-keys endpoint.
+//
+// Exported because the multi-tenant apiserver has its own chain and has to apply
+// the same rule.
+func IsListKeysRequest(attr authorizer.Attributes) bool {
+	if !attr.IsResourceRequest() || attr.GetVerb() != "create" || attr.GetSubresource() != "" {
+		return false
+	}
+	return attr.GetName() == ListKeysPathSegment
+}
+
 // Authorize implements authorizer.Authorizer.
 func (a *GrafanaAuthorizer) Authorize(ctx context.Context, attr authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	// Restated before the chain, not inside one link: the org role authorizer
 	// allows a viewer to list but not to create.
-	if IsSearchRequest(attr) {
+	if IsSearchRequest(attr) || IsListKeysRequest(attr) {
 		attr = AsReadAttributes(attr)
 	}
 	return a.auth.Authorize(ctx, attr)

--- a/pkg/services/apiserver/auth/authorizer/authorizer_test.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer_test.go
@@ -1,0 +1,80 @@
+package authorizer
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+)
+
+// Keys is cluster-scoped, so its path carries no namespace.
+const listKeysPath = "/apis/dashboard.grafana.app/v0alpha1/dashboards/list-keys"
+
+func TestIsListKeysRequest(t *testing.T) {
+	post := attributesFor(t, http.MethodPost, listKeysPath)
+	require.Equal(t, "create", post.GetVerb())
+	require.Equal(t, "dashboards", post.GetResource())
+	require.Equal(t, ListKeysPathSegment, post.GetName())
+	assert.True(t, IsListKeysRequest(post))
+
+	// Creating a dashboard posts to the collection, so it carries no name and
+	// must not be mistaken for a keys list.
+	create := attributesFor(t, http.MethodPost, "/apis/dashboard.grafana.app/v0alpha1/dashboards")
+	require.Empty(t, create.GetName())
+	assert.False(t, IsListKeysRequest(create))
+
+	// An object may legitimately carry the name, and is only ever reached with a
+	// non-create verb.
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		assert.False(t, IsListKeysRequest(attributesFor(t, method, listKeysPath)), "method %s", method)
+	}
+
+	// A subresource named list-keys is a different endpoint and not ours.
+	sub := attributesFor(t, http.MethodPost, base+"/my-dash/list-keys")
+	require.Equal(t, "list-keys", sub.GetSubresource())
+	assert.False(t, IsListKeysRequest(sub))
+
+	// Search and trash are handled by IsSearchRequest, not this one.
+	assert.False(t, IsListKeysRequest(attributesFor(t, http.MethodPost, searchPath)))
+	assert.False(t, IsListKeysRequest(attributesFor(t, http.MethodPost, trashPath)))
+}
+
+func TestAsReadAttributes_ListKeys(t *testing.T) {
+	read := AsReadAttributes(attributesFor(t, http.MethodPost, listKeysPath))
+
+	// Listing keys reads the kind, so it must not demand permission to create it.
+	assert.Equal(t, "list", read.GetVerb())
+	assert.True(t, read.IsReadOnly())
+	// "list-keys" was a path segment, not an object.
+	assert.Empty(t, read.GetName())
+
+	assert.Equal(t, "dashboard.grafana.app", read.GetAPIGroup())
+	assert.Equal(t, "v0alpha1", read.GetAPIVersion())
+	assert.Equal(t, "dashboards", read.GetResource())
+	// Cluster-scoped, so there is no namespace to carry.
+	assert.Empty(t, read.GetNamespace())
+	assert.True(t, read.IsResourceRequest())
+}
+
+// The org role authorizer allows a viewer to list but not to create, which is why
+// the restatement has to happen before the chain.
+func TestGrafanaAuthorizer_ViewerMayListKeysButNotCreate(t *testing.T) {
+	var seen []string
+	recorder := authorizer.AuthorizerFunc(
+		func(_ context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+			seen = append(seen, attr.GetVerb())
+			return authorizer.DecisionNoOpinion, "", nil
+		})
+
+	a := &GrafanaAuthorizer{auth: recorder}
+
+	_, _, err := a.Authorize(context.Background(), attributesFor(t, http.MethodPost, listKeysPath))
+	require.NoError(t, err)
+	_, _, err = a.Authorize(context.Background(), attributesFor(t, http.MethodPost, listPath))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"list", "create"}, seen)
+}


### PR DESCRIPTION
**What is this feature?**

The HTTP layer for the keys-only list endpoint, at two scopes:

```
POST /apis/{group}/{version}/{resource}/list-keys                         # cluster-wide
POST /apis/{group}/{version}/namespaces/{namespace}/{resource}/list-keys
```

Request and response are standard `meta.k8s.io/v1` types that already carry OpenAPI definitions: `ListOptions` in, `PartialObjectMetadataList` out. No new API group, no new kinds, no generated schema. Each item carries `namespace`, `name`, `resourceVersion` and the `grafana.app/folder` annotation, and `ListMeta` carries `continue` plus the snapshot `resourceVersion`, so `client-go` pagination works unmodified.

This is part 2 of 3. Part 1 (#131304) added `keys_only` to the storage layer and is merged. **The routes are not mounted yet** - mounting and the config gate are part 3 - so nothing serves this after merging.

Paired with grafana/grafana-enterprise#13293, which carries the same branch name.

**Why do we need this feature?**

A controller reconciling against unified storage otherwise has to issue a full LIST and transfer every object body, then discard the spec and status it never reads. At high cardinality that is avoidable storage and network cost. Part 1 made the read cheap; this exposes it over HTTP for callers that reach Grafana through the API server rather than in-process.

Both scopes exist because #132447 taught storage to accept a namespaced `keys_only` list, on the grounds that requiring a cluster-wide request broadens access unnecessarily. Exposing only the cluster-wide form would have contradicted that.

**Who is this feature for?**

Controllers and operators reconciling namespaced resource collections. Access is restricted to the service identity, so it does not serve end users.

**Which issue(s) does this PR fix?**:

Tracked in https://github.com/grafana/search-and-storage-team/issues/936. Deliberately not using `Fixes`: this is part 2 of 3, so the issue should stay open until part 3 lands.

**Special notes for your reviewer:**

Design points worth the attention:

- **POST rather than GET.** A literal path segment outranks `{name}` in the router, so `GET .../{resource}/keys` would permanently shadow an object named `keys`. Object names are not knowable at mount time, so that could be neither detected up front nor undone later without breaking clients. Nothing is registered for POST on `{resource}/{name}`.
- **The namespace comes from the path, not the body**, so it stays visible to the authorization chain and the audit log. An absent or wildcard namespace is refused: a wildcard would reach the backend as a namespace literally named `*`, and cluster-wide reads have their own route.
- **Only the cluster-wide route is identity-gated.** It requires `identity.IsServiceIdentity` scoped to `*`, since it spans every namespace and a narrower caller would be authorized per item and get a partial page alongside a namespace mismatch rather than a clean refusal. The namespaced route has no gate of its own: it returns a strict subset of what a normal LIST in that namespace returns, over the same per-item `FilterAuthorized`, the chain has already required `list` on the kind, and storage checks the namespace against the caller. Gating it would have withheld a cheaper form of data the caller can already obtain, and would have admitted only loopback callers, who can use the in-process client instead.
- **`IsListKeysRequest` is its own predicate**, not another case in `IsSearchRequest`, because this is not a search endpoint and the two can diverge. Kubernetes parses the request as a create on an object named `list-keys`, so without the restatement a caller would need permission to *create* the kind. The enterprise PR extends the same rule to the multi-tenant chain, behind that file's route-ownership guard, and must land before list-keys is enabled in MT.
- **`ListOptions` is an allowlist, not a denylist.** Quietly dropping a selector would hand back an unfiltered list, a correctness bug in a reconciliation loop rather than a cosmetic one. Fields unknown to the struct are refused at decode by `DisallowUnknownFields`; fields known but unhandled are caught by a test that reflects over `metav1.ListOptions` and asserts each one is either honored or refused by name. That test exists because `ShardSelector` was in neither bucket and was being silently dropped.

Testing: the identity gate is table-driven over every `IdentityType` and namespace scope and asserts the store is never called on refusal, which is what shows the gate runs before any read. Each gate was verified by mutation, so removing it fails exactly its own cases.

Please check that:
- [ ] It works as expected from a user's perspective. **Not yet reachable** - the routes are mounted in part 3, so there is no user-facing surface to exercise in this PR. Part 1 was verified end to end against a single-tenant instance.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Gated by `[grafana-apiserver] enable_keys_api`, default off and deliberately absent from `conf/defaults.ini`. The gate is wired in part 3.
- [ ] The docs are updated. **Not applicable** - service-identity only, no end-user surface, so not a What's New candidate.

