### PR TITLE
Preferences: Allow unknown dashboard to be clearable

### DIFF
--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -45,6 +45,18 @@ describe('DashboardPicker', () => {
         })
       );
     });
+
+    it('should render an unknown current value that can be cleared when clearable', async () => {
+      const onChange = jest.fn();
+      const { user } = render(
+        <DashboardPicker value="unknown-dashboard-uid" isClearable onChange={onChange} showUnknown />
+      );
+
+      await screen.findByText('Unknown dashboard (unknown-dashboard-uid)');
+      await user.click(await screen.findByRole('button', { name: 'Clear value' }));
+
+      expect(onChange).toHaveBeenCalledWith(undefined);
+    });
   });
 
   xdescribe('dashboard v2 (v2beta1 API)', () => {

--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -80,19 +80,9 @@ describe('DashboardPicker', () => {
           dashboard: { uid: folderA_dashbdD.item.uid, title: folderA_dashbdD.item.title },
           meta: { folderTitle: folderA.item.title, folderUid: folderA.item.uid },
         });
-      const mockedDashboardApi: Awaited<ReturnType<typeof dashboardApi.getDashboardAPI>> = {
-        getDashboardDTO,
-        saveDashboard: jest.fn(),
-        deleteDashboard: jest.fn(),
-        listDashboardHistory: jest.fn(),
-        getDashboardHistoryVersions: jest.fn(),
-        restoreDashboardVersion: jest.fn(),
-        listDeletedDashboards: jest.fn(),
-        getDeletedDashboard: jest.fn(),
-        getDashboard: jest.fn(),
-        restoreDashboard: jest.fn(),
-      };
-      const apiSpy = jest.spyOn(dashboardApi, 'getDashboardAPI').mockResolvedValue(mockedDashboardApi);
+      const apiSpy = jest
+        .spyOn(dashboardApi, 'getDashboardAPI')
+        .mockResolvedValue({ getDashboardDTO } as unknown as Awaited<ReturnType<typeof dashboardApi.getDashboardAPI>>);
 
       const { rerender } = render(<DashboardPicker value={unknownUid} showUnknown />);
 

--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
+import * as dashboardApi from 'app/features/dashboard/api/dashboard_api';
 
 import { DashboardPicker } from './DashboardPicker';
 
@@ -11,6 +12,17 @@ setBackendSrv(backendSrv);
 setupMockServer();
 
 const [_, { folderA, folderA_dashbdD }] = getFolderFixtures();
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
 
 describe('DashboardPicker', () => {
   describe('using app platform', () => {
@@ -56,6 +68,45 @@ describe('DashboardPicker', () => {
       await user.click(await screen.findByRole('button', { name: 'Clear value' }));
 
       expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should ignore stale unknown fallback when value changes to another dashboard', async () => {
+      const unknownUid = 'deleted-dashboard-uid';
+      const pendingUnknown = createDeferred<never>();
+      const getDashboardDTO = jest
+        .fn()
+        .mockImplementationOnce(() => pendingUnknown.promise)
+        .mockResolvedValueOnce({
+          dashboard: { uid: folderA_dashbdD.item.uid, title: folderA_dashbdD.item.title },
+          meta: { folderTitle: folderA.item.title, folderUid: folderA.item.uid },
+        });
+      const mockedDashboardApi: Awaited<ReturnType<typeof dashboardApi.getDashboardAPI>> = {
+        getDashboardDTO,
+        saveDashboard: jest.fn(),
+        deleteDashboard: jest.fn(),
+        listDashboardHistory: jest.fn(),
+        getDashboardHistoryVersions: jest.fn(),
+        restoreDashboardVersion: jest.fn(),
+        listDeletedDashboards: jest.fn(),
+        getDeletedDashboard: jest.fn(),
+        getDashboard: jest.fn(),
+        restoreDashboard: jest.fn(),
+      };
+      const apiSpy = jest.spyOn(dashboardApi, 'getDashboardAPI').mockResolvedValue(mockedDashboardApi);
+
+      const { rerender } = render(<DashboardPicker value={unknownUid} showUnknown />);
+
+      rerender(<DashboardPicker value={folderA_dashbdD.item.uid} showUnknown />);
+
+      expect(await screen.findByText(`${folderA.item.title}/${folderA_dashbdD.item.title}`)).toBeInTheDocument();
+
+      pendingUnknown.reject(new Error('not found'));
+
+      await waitFor(() => {
+        expect(screen.queryByText(`Unknown dashboard (${unknownUid})`)).not.toBeInTheDocument();
+      });
+
+      apiSpy.mockRestore();
     });
   });
 

--- a/public/app/core/components/Select/DashboardPicker.tsx
+++ b/public/app/core/components/Select/DashboardPicker.tsx
@@ -2,6 +2,7 @@ import debounce from 'debounce-promise';
 import { forwardRef, useCallback, useEffect, useState } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { type AsyncSelectProps, AsyncSelect } from '@grafana/ui';
 import { AnnoKeyFolder, AnnoKeyFolderTitle } from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -13,6 +14,7 @@ import { type DashboardDTO } from 'app/types/dashboard';
 interface Props extends Omit<AsyncSelectProps<DashboardPickerDTO>, 'value' | 'onChange' | 'loadOptions' | ''> {
   value?: DashboardPickerDTO['uid'];
   onChange?: (value?: DashboardPickerDTO) => void;
+  showUnknown?: boolean;
 }
 
 export type DashboardPickerDTO = Pick<DashboardQueryResult, 'uid' | 'name'> &
@@ -42,7 +44,7 @@ const getDashboards = debounce(findDashboards, 250, { leading: true });
 
 // TODO: this component should provide a way to apply different filters to the search APIs
 export const DashboardPicker = forwardRef<HTMLElement, Props>(
-  ({ value, onChange, placeholder = 'Select dashboard', noOptionsMessage = 'No dashboards found', ...props }, ref) => {
+  ({ value, onChange, placeholder, noOptionsMessage, showUnknown, ...props }, ref) => {
     const [current, setCurrent] = useState<SelectableValue<DashboardPickerDTO>>();
 
     // This is required because the async select does not match the raw uid value
@@ -55,36 +57,49 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
       (async () => {
         // value was manually changed from outside or we are rendering for the first time.
         // We need to fetch dashboard information.
-        const api = await getDashboardAPI();
-        const dto = await api.getDashboardDTO(value, undefined);
+        try {
+          const api = await getDashboardAPI();
+          const dto = await api.getDashboardDTO(value, undefined);
 
-        if (isDashboardV2Resource(dto)) {
-          setCurrent({
-            value: {
-              uid: dto.metadata.name,
-              name: dto.spec.title,
-              folderTitle: dto.metadata.annotations?.[AnnoKeyFolderTitle],
-              folderUid: dto.metadata.annotations?.[AnnoKeyFolder],
-            },
-            label: formatLabel(dto.metadata.annotations?.[AnnoKeyFolder], dto.spec.title),
-          });
-        } else {
-          if (dto.dashboard) {
+          if (isDashboardV2Resource(dto)) {
             setCurrent({
               value: {
-                uid: dto.dashboard.uid,
-                name: dto.dashboard.title,
-                folderTitle: dto.meta.folderTitle,
-                folderUid: dto.meta.folderUid,
+                uid: dto.metadata.name,
+                name: dto.spec.title,
+                folderTitle: dto.metadata.annotations?.[AnnoKeyFolderTitle],
+                folderUid: dto.metadata.annotations?.[AnnoKeyFolder],
               },
-              label: formatLabel(dto.meta?.folderTitle, dto.dashboard.title),
+              label: formatLabel(dto.metadata.annotations?.[AnnoKeyFolder], dto.spec.title),
+            });
+          } else {
+            if (dto.dashboard) {
+              setCurrent({
+                value: {
+                  uid: dto.dashboard.uid,
+                  name: dto.dashboard.title,
+                  folderTitle: dto.meta.folderTitle,
+                  folderUid: dto.meta.folderUid,
+                },
+                label: formatLabel(dto.meta?.folderTitle, dto.dashboard.title),
+              });
+            }
+          }
+        } catch {
+          if (showUnknown) {
+            const name = t('dashboard-picker.unknown-dashboard', 'Unknown dashboard ({{uid}})', { uid: value });
+            setCurrent({
+              value: {
+                uid: value,
+                name,
+              },
+              label: name,
             });
           }
         }
       })();
       // we don't need to rerun this effect every time `current` changes
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value]);
+    }, [value, showUnknown]);
 
     const onPicked = useCallback(
       (sel: SelectableValue<DashboardPickerDTO>) => {
@@ -98,8 +113,8 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
       <AsyncSelect
         loadOptions={getDashboards}
         onChange={onPicked}
-        placeholder={placeholder}
-        noOptionsMessage={noOptionsMessage}
+        placeholder={placeholder ?? t('dashboard-picker.placeholder', 'Select dashboard')}
+        noOptionsMessage={noOptionsMessage ?? t('dashboard-picker.no-options', 'No dashboards found')}
         value={current}
         defaultOptions={true}
         {...props}

--- a/public/app/core/components/Select/DashboardPicker.tsx
+++ b/public/app/core/components/Select/DashboardPicker.tsx
@@ -1,5 +1,5 @@
 import debounce from 'debounce-promise';
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 
 import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -46,6 +46,7 @@ const getDashboards = debounce(findDashboards, 250, { leading: true });
 export const DashboardPicker = forwardRef<HTMLElement, Props>(
   ({ value, onChange, placeholder, noOptionsMessage, showUnknown, ...props }, ref) => {
     const [current, setCurrent] = useState<SelectableValue<DashboardPickerDTO>>();
+    const abortRef = useRef<AbortController | null>(null);
 
     // This is required because the async select does not match the raw uid value
     // We can not use a simple Select because the dashboard search should not return *everything*
@@ -53,6 +54,14 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
       if (!value || value === current?.value?.uid) {
         return;
       }
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+      const setCurrentIfLatest = (next: SelectableValue<DashboardPickerDTO>) => {
+        if (!abortController.signal.aborted) {
+          setCurrent(next);
+        }
+      };
 
       (async () => {
         // value was manually changed from outside or we are rendering for the first time.
@@ -62,7 +71,7 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
           const dto = await api.getDashboardDTO(value, undefined);
 
           if (isDashboardV2Resource(dto)) {
-            setCurrent({
+            setCurrentIfLatest({
               value: {
                 uid: dto.metadata.name,
                 name: dto.spec.title,
@@ -73,7 +82,7 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
             });
           } else {
             if (dto.dashboard) {
-              setCurrent({
+              setCurrentIfLatest({
                 value: {
                   uid: dto.dashboard.uid,
                   name: dto.dashboard.title,
@@ -87,7 +96,7 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
         } catch {
           if (showUnknown) {
             const name = t('dashboard-picker.unknown-dashboard', 'Unknown dashboard ({{uid}})', { uid: value });
-            setCurrent({
+            setCurrentIfLatest({
               value: {
                 uid: value,
                 name,
@@ -97,12 +106,17 @@ export const DashboardPicker = forwardRef<HTMLElement, Props>(
           }
         }
       })();
+
+      return () => {
+        abortController.abort();
+      };
       // we don't need to rerun this effect every time `current` changes
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value, showUnknown]);
 
     const onPicked = useCallback(
       (sel: SelectableValue<DashboardPickerDTO>) => {
+        abortRef.current?.abort();
         setCurrent(sel);
         onChange?.(sel?.value);
       },

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -210,6 +210,7 @@ export const SharedPreferences = memo((props: Props) => {
               onChange={(v) => handleDashboardChanged(v?.uid ?? '')}
               defaultOptions={true}
               isClearable={true}
+              showUnknown={true}
               placeholder={t('shared-preferences.fields.home-dashboard-placeholder', 'Default dashboard')}
               inputId="home-dashboard-select"
             />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6870,6 +6870,11 @@
       "title": "There are no dashboard links added yet"
     }
   },
+  "dashboard-picker": {
+    "no-options": "No dashboards found",
+    "placeholder": "Select dashboard",
+    "unknown-dashboard": "Unknown dashboard ({{uid}})"
+  },
   "dashboard-prompt": {
     "datasource-entry": {
       "generate-dashboard": "Generate dashboard"


### PR DESCRIPTION
**What is this feature?**

When an unknown (deleted) dashboard is set as the homepage, allow it to be cleared from the preference directly.

**Why do we need this feature?**

Previously, if you had an unknown (deleted) dashboard set as the homepage, the preferences UI would show that you had the default dashboard set when that was not the case. To actually clear the stored preference, you would need to save a new dashboard as the homepage preference, and then clear that.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/support-escalations/issues/23893

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
