### PR TITLE
TraceView: Expand attribute plugin cross-sell promos

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
@@ -1,4 +1,12 @@
-import { groupAttributesByCategory, isDatabaseAttribute, SERVICE_CATEGORY_ID } from './attributeCategories';
+import {
+  groupAttributesByCategory,
+  isDatabaseAttribute,
+  isFrontendObservabilityAttribute,
+  isKnowledgeGraphAttribute,
+  isKubernetesAttribute,
+  isServiceAttribute,
+  SERVICE_CATEGORY_ID,
+} from './attributeCategories';
 
 describe('isDatabaseAttribute', () => {
   it.each(['db.system', 'db.statement', 'db_name', 'DB.operation'])('matches %s', (key) => {
@@ -8,6 +16,52 @@ describe('isDatabaseAttribute', () => {
   it.each(['http.method', 'service.name', 'dbc.something', 'database.system'])('does not match %s', (key) => {
     expect(isDatabaseAttribute(key)).toBe(false);
   });
+});
+
+describe('isServiceAttribute', () => {
+  it.each(['service.name', 'service.namespace', 'service_name'])('matches %s', (key) => {
+    expect(isServiceAttribute(key)).toBe(true);
+  });
+
+  it.each(['k8s.pod.name', 'db.system', 'session.id'])('does not match %s', (key) => {
+    expect(isServiceAttribute(key)).toBe(false);
+  });
+});
+
+describe('isKubernetesAttribute', () => {
+  it.each(['k8s.cluster.name', 'k8s.pod.name', 'k8s_pod_name', 'container.id'])('matches %s', (key) => {
+    expect(isKubernetesAttribute(key)).toBe(true);
+  });
+
+  it.each(['service.name', 'container.name', 'db.system'])('does not match %s', (key) => {
+    expect(isKubernetesAttribute(key)).toBe(false);
+  });
+});
+
+describe('isFrontendObservabilityAttribute', () => {
+  it.each(['session.id', 'session_id', 'gf.feo11y.app.id', 'app_id', 'app_name', 'browser.name'])(
+    'matches %s',
+    (key) => {
+      expect(isFrontendObservabilityAttribute(key)).toBe(true);
+    }
+  );
+
+  it.each(['service.name', 'k8s.pod.name', 'http.method'])('does not match %s', (key) => {
+    expect(isFrontendObservabilityAttribute(key)).toBe(false);
+  });
+});
+
+describe('isKnowledgeGraphAttribute', () => {
+  it.each(['service.name', 'service.namespace', 'service_name'])('matches %s', (key) => {
+    expect(isKnowledgeGraphAttribute(key)).toBe(true);
+  });
+
+  it.each(['k8s.cluster.name', 'k8s.pod.name', 'db.system', 'session.id', 'http.method'])(
+    'does not match %s',
+    (key) => {
+      expect(isKnowledgeGraphAttribute(key)).toBe(false);
+    }
+  );
 });
 
 describe('groupAttributesByCategory', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
@@ -255,11 +255,7 @@ export function isKubernetesAttribute(key: string): boolean {
 
 /** Returns true when an attribute key matches Frontend Observability session / app attributes. */
 export function isFrontendObservabilityAttribute(key: string): boolean {
-  return (
-    matchesPrefixes(key, ['browser', 'device', 'session', 'gf.feo11y']) ||
-    key === 'app_id' ||
-    key === 'app_name'
-  );
+  return matchesPrefixes(key, ['browser', 'device', 'session', 'gf.feo11y']) || key === 'app_id' || key === 'app_name';
 }
 
 /** Returns true when an attribute key is linked from Knowledge Graph service entity extensions. */

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
@@ -243,6 +243,30 @@ export function isDatabaseAttribute(key: string): boolean {
   return matchesPrefixes(key, ['db']);
 }
 
+/** Returns true when an attribute key matches the OpenTelemetry `service.*` / `service_*` namespace. */
+export function isServiceAttribute(key: string): boolean {
+  return matchesPrefixes(key, ['service']);
+}
+
+/** Returns true when an attribute key matches Kubernetes-related trace resource attributes. */
+export function isKubernetesAttribute(key: string): boolean {
+  return matchesPrefixes(key, ['k8s']) || key === 'container.id';
+}
+
+/** Returns true when an attribute key matches Frontend Observability session / app attributes. */
+export function isFrontendObservabilityAttribute(key: string): boolean {
+  return (
+    matchesPrefixes(key, ['browser', 'device', 'session', 'gf.feo11y']) ||
+    key === 'app_id' ||
+    key === 'app_name'
+  );
+}
+
+/** Returns true when an attribute key is linked from Knowledge Graph service entity extensions. */
+export function isKnowledgeGraphAttribute(key: string): boolean {
+  return isServiceAttribute(key);
+}
+
 export function groupAttributesByCategory(
   attributes: TraceKeyValuePair[],
   sectionType: AttributeSectionType

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -464,7 +464,11 @@ export default function SpanDetail(props: SpanDetailProps) {
     spanID,
     spanStartTime: startTime,
   });
-  const promoGetter = useAttributePluginPromoGetter();
+  const promoAttributeKeys = useMemo(
+    () => [...tags.map((tag) => tag.key), ...(process.tags ?? []).map((tag) => tag.key)],
+    [tags, process.tags]
+  );
+  const promoGetter = useAttributePluginPromoGetter(promoAttributeKeys);
 
   const listOfContentCards = [];
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -3,9 +3,20 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { config, isAppPluginEnabled } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 
-import { isDatabaseAttribute } from '../attributeCategories';
+import {
+  isDatabaseAttribute,
+  isFrontendObservabilityAttribute,
+  isKnowledgeGraphAttribute,
+  isKubernetesAttribute,
+  isServiceAttribute,
+} from '../attributeCategories';
 
-import { getAttributePluginPromos, useAttributePluginPromoGetter } from './attributePluginPromos';
+import {
+  getAttributePluginPromos,
+  MAX_ATTRIBUTE_PLUGIN_PROMOS,
+  selectAttributeKeysForPromos,
+  useAttributePluginPromoGetter,
+} from './attributePluginPromos';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -40,6 +51,26 @@ describe('getAttributePluginPromos', () => {
     expect(isDatabaseAttribute('db.system')).toBe(true);
   });
 
+  it('includes promos for other observability apps with expected matchers on Cloud', () => {
+    config.namespace = 'stacks-12345';
+
+    const promos = getAttributePluginPromos();
+
+    expect(promos.find((promo) => promo.pluginId === 'grafana-kowalski-app')?.match('session.id')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-app-observability-app')?.match('service.name')).toBe(
+      true
+    );
+    expect(promos.find((promo) => promo.pluginId === 'grafana-k8s-app')?.match('k8s.pod.name')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-asserts-app')?.match('service.name')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-asserts-app')?.match('k8s.cluster.name')).toBe(false);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-k8s-app')?.match('k8s.cluster.name')).toBe(true);
+
+    expect(isFrontendObservabilityAttribute('session.id')).toBe(true);
+    expect(isServiceAttribute('service.name')).toBe(true);
+    expect(isKubernetesAttribute('k8s.pod.name')).toBe(true);
+    expect(isKnowledgeGraphAttribute('service.name')).toBe(true);
+  });
+
   it('omits Database Observability promo on on-prem', () => {
     config.namespace = 'default';
 
@@ -63,7 +94,7 @@ describe('useAttributePluginPromoGetter', () => {
   it('returns no promo while plugin metas are loading', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: true, error: undefined, value: undefined });
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system']));
 
     await waitFor(() => {
       expect(result.current('db.system')).toBeUndefined();
@@ -74,7 +105,7 @@ describe('useAttributePluginPromoGetter', () => {
   it('returns no promo when plugin metas are unavailable', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: new Error('failed'), value: undefined });
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system']));
 
     await waitFor(() => {
       expect(result.current('db.system')).toBeUndefined();
@@ -85,7 +116,7 @@ describe('useAttributePluginPromoGetter', () => {
   it('returns a promo when the matching plugin is not installed', async () => {
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system', 'http.method']));
 
     await waitFor(() => {
       expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
@@ -102,7 +133,7 @@ describe('useAttributePluginPromoGetter', () => {
     });
     mockIsAppPluginEnabled.mockResolvedValue(false);
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system']));
 
     await waitFor(() => {
       expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
@@ -118,7 +149,7 @@ describe('useAttributePluginPromoGetter', () => {
     });
     mockIsAppPluginEnabled.mockResolvedValue(true);
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system']));
 
     await waitFor(() => {
       expect(mockIsAppPluginEnabled).toHaveBeenCalledWith('grafana-dbo11y-app');
@@ -126,14 +157,102 @@ describe('useAttributePluginPromoGetter', () => {
     expect(result.current('db.system')).toBeUndefined();
   });
 
+  it('prefers Knowledge Graph when multiple plugins match the same attribute', async () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['service.name']));
+
+    await waitFor(() => {
+      expect(result.current('service.name')?.pluginId).toBe('grafana-asserts-app');
+    });
+  });
+
+  it('falls back to App O11y promo for service attributes when Knowledge Graph is active', async () => {
+    mockUseAppPluginMetas.mockReturnValue({
+      loading: false,
+      error: undefined,
+      value: [{ id: 'grafana-asserts-app' } as never],
+    });
+    mockIsAppPluginEnabled.mockImplementation(async (pluginId) => pluginId === 'grafana-asserts-app');
+
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['service.name']));
+
+    await waitFor(() => {
+      expect(result.current('service.name')?.pluginId).toBe('grafana-app-observability-app');
+    });
+  });
+
+  it('limits promos to MAX_ATTRIBUTE_PLUGIN_PROMOS attribute keys', async () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const keys = [
+      'service.name',
+      'service.namespace',
+      'db.system',
+      'db.statement',
+      'session.id',
+      'k8s.pod.name',
+      'k8s.cluster.name',
+    ];
+    const { result } = renderHook(() => useAttributePluginPromoGetter(keys));
+
+    await waitFor(() => {
+      expect(result.current('service.name')?.pluginId).toBe('grafana-asserts-app');
+    });
+
+    const promoted = keys.filter((key) => result.current(key) !== undefined);
+    expect(promoted).toHaveLength(MAX_ATTRIBUTE_PLUGIN_PROMOS);
+    expect(promoted).toEqual(['service.name', 'db.system', 'session.id']);
+    expect(result.current('k8s.pod.name')).toBeUndefined();
+    expect(result.current('service.namespace')).toBeUndefined();
+  });
+
   it('returns no promo on on-prem', async () => {
     config.namespace = 'default';
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
 
-    const { result } = renderHook(() => useAttributePluginPromoGetter());
+    const { result } = renderHook(() => useAttributePluginPromoGetter(['db.system']));
 
     await waitFor(() => {
       expect(result.current('db.system')).toBeUndefined();
     });
+  });
+});
+
+describe('selectAttributeKeysForPromos', () => {
+  const originalNamespace = config.namespace;
+
+  beforeEach(() => {
+    config.namespace = 'stacks-12345';
+  });
+
+  afterEach(() => {
+    config.namespace = originalNamespace;
+  });
+
+  it('selects at most one key per inactive plugin up to the max', () => {
+    const promos = getAttributePluginPromos();
+    const inactive = new Set(promos.map((promo) => promo.pluginId));
+
+    const selected = selectAttributeKeysForPromos(
+      ['service.name', 'service.version', 'db.system', 'db.name', 'session.id', 'k8s.pod.name'],
+      inactive,
+      promos
+    );
+
+    expect([...selected]).toEqual(['service.name', 'db.system', 'session.id']);
+  });
+
+  it('skips active plugins and fills remaining slots from lower-priority promos', () => {
+    const promos = getAttributePluginPromos();
+    const inactive = new Set(['grafana-dbo11y-app', 'grafana-k8s-app', 'grafana-app-observability-app']);
+
+    const selected = selectAttributeKeysForPromos(
+      ['service.name', 'db.system', 'k8s.pod.name', 'session.id'],
+      inactive,
+      promos
+    );
+
+    expect([...selected]).toEqual(['db.system', 'service.name', 'k8s.pod.name']);
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -263,11 +263,7 @@ describe('selectAttributeKeysForPromos', () => {
     const promos = getAttributePluginPromos();
     const inactive = new Set(promos.map((promo) => promo.pluginId));
 
-    const selected = selectAttributeKeysForPromos(
-      ['service.name', 'service.version', 'db.system'],
-      inactive,
-      promos
-    );
+    const selected = selectAttributeKeysForPromos(['service.name', 'service.version', 'db.system'], inactive, promos);
 
     expect(selected.get('service.name')?.pluginId).toBe('grafana-asserts-app');
     expect(selected.get('service.version')?.pluginId).toBe('grafana-app-observability-app');

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -207,6 +207,19 @@ describe('useAttributePluginPromoGetter', () => {
     expect(result.current('service.namespace')).toBeUndefined();
   });
 
+  it('assigns overlapping service keys to different inactive plugins', async () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const keys = ['service.name', 'service.version', 'db.system'];
+    const { result } = renderHook(() => useAttributePluginPromoGetter(keys));
+
+    await waitFor(() => {
+      expect(result.current('service.name')?.pluginId).toBe('grafana-asserts-app');
+    });
+    expect(result.current('service.version')?.pluginId).toBe('grafana-app-observability-app');
+    expect(result.current('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+  });
+
   it('returns no promo on on-prem', async () => {
     config.namespace = 'default';
     mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
@@ -240,7 +253,25 @@ describe('selectAttributeKeysForPromos', () => {
       promos
     );
 
-    expect([...selected]).toEqual(['service.name', 'db.system', 'session.id']);
+    expect([...selected.keys()]).toEqual(['service.name', 'db.system', 'session.id']);
+    expect(selected.get('service.name')?.pluginId).toBe('grafana-asserts-app');
+    expect(selected.get('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    expect(selected.get('session.id')?.pluginId).toBe('grafana-kowalski-app');
+  });
+
+  it('maps a second overlapping service key to App O11y, not Knowledge Graph', () => {
+    const promos = getAttributePluginPromos();
+    const inactive = new Set(promos.map((promo) => promo.pluginId));
+
+    const selected = selectAttributeKeysForPromos(
+      ['service.name', 'service.version', 'db.system'],
+      inactive,
+      promos
+    );
+
+    expect(selected.get('service.name')?.pluginId).toBe('grafana-asserts-app');
+    expect(selected.get('service.version')?.pluginId).toBe('grafana-app-observability-app');
+    expect(selected.get('db.system')?.pluginId).toBe('grafana-dbo11y-app');
   });
 
   it('skips active plugins and fills remaining slots from lower-priority promos', () => {
@@ -253,6 +284,9 @@ describe('selectAttributeKeysForPromos', () => {
       promos
     );
 
-    expect([...selected]).toEqual(['db.system', 'service.name', 'k8s.pod.name']);
+    expect([...selected.keys()]).toEqual(['db.system', 'service.name', 'k8s.pod.name']);
+    expect(selected.get('service.name')?.pluginId).toBe('grafana-app-observability-app');
+    expect(selected.get('db.system')?.pluginId).toBe('grafana-dbo11y-app');
+    expect(selected.get('k8s.pod.name')?.pluginId).toBe('grafana-k8s-app');
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
@@ -95,30 +95,32 @@ export function getAttributePluginPromos(): AttributePluginPromo[] {
  * Picks up to {@link MAX_ATTRIBUTE_PLUGIN_PROMOS} attribute keys to promote.
  * Walks promos in priority order and assigns at most one key per inactive plugin
  * so a span with many matching attrs does not become a wall of promo tips.
+ * Returns the promo that claimed each key so overlapping matchers (e.g. service.*)
+ * keep their assignment instead of collapsing to the first matching promo.
  */
 export function selectAttributeKeysForPromos(
   attributeKeys: readonly string[],
   inactivePluginIds: ReadonlySet<string>,
   promos: readonly AttributePluginPromo[],
   maxPromos = MAX_ATTRIBUTE_PLUGIN_PROMOS
-): Set<string> {
-  const selectedKeys = new Set<string>();
+): Map<string, AttributePluginPromo> {
+  const selectedPromos = new Map<string, AttributePluginPromo>();
 
   for (const promo of promos) {
-    if (selectedKeys.size >= maxPromos) {
+    if (selectedPromos.size >= maxPromos) {
       break;
     }
     if (!inactivePluginIds.has(promo.pluginId)) {
       continue;
     }
 
-    const matchingKey = attributeKeys.find((key) => !selectedKeys.has(key) && promo.match(key));
+    const matchingKey = attributeKeys.find((key) => !selectedPromos.has(key) && promo.match(key));
     if (matchingKey) {
-      selectedKeys.add(matchingKey);
+      selectedPromos.set(matchingKey, promo);
     }
   }
 
-  return selectedKeys;
+  return selectedPromos;
 }
 
 export type AttributePluginPromoGetter = (attributeKey: string) => AttributePluginPromo | undefined;
@@ -158,20 +160,12 @@ export function useAttributePluginPromoGetter(attributeKeys: readonly string[] =
     return inactive;
   }, [appMetas, metasLoading, promos]);
 
-  const allowedAttributeKeys = useMemo(() => {
+  const promosByAttributeKey = useMemo(() => {
     if (!inactivePluginIds) {
       return undefined;
     }
     return selectAttributeKeysForPromos(attributeKeys, inactivePluginIds, promos);
   }, [attributeKeys, inactivePluginIds, promos]);
 
-  return useCallback(
-    (attributeKey: string) => {
-      if (!inactivePluginIds || !allowedAttributeKeys?.has(attributeKey)) {
-        return undefined;
-      }
-      return promos.find((promo) => inactivePluginIds.has(promo.pluginId) && promo.match(attributeKey));
-    },
-    [allowedAttributeKeys, inactivePluginIds, promos]
-  );
+  return useCallback((attributeKey: string) => promosByAttributeKey?.get(attributeKey), [promosByAttributeKey]);
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
@@ -7,7 +7,13 @@ import { isAppPluginEnabled } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
-import { isDatabaseAttribute } from '../attributeCategories';
+import {
+  isDatabaseAttribute,
+  isFrontendObservabilityAttribute,
+  isKnowledgeGraphAttribute,
+  isKubernetesAttribute,
+  isServiceAttribute,
+} from '../attributeCategories';
 
 export type AttributePluginPromo = {
   pluginId: string;
@@ -16,6 +22,9 @@ export type AttributePluginPromo = {
   body: string;
   match: (attributeKey: string) => boolean;
 };
+
+/** Cap how many attribute rows can show a promo tip in one span detail view. */
+export const MAX_ATTRIBUTE_PLUGIN_PROMOS = 3;
 
 /**
  * Promos shown on attribute values when the related app plugin is not installed,
@@ -30,6 +39,16 @@ export function getAttributePluginPromos(): AttributePluginPromo[] {
 
   return [
     {
+      pluginId: 'grafana-asserts-app',
+      icon: 'asserts',
+      title: t('explore.trace-view.knowledge-graph-promo.title', 'See the full picture'),
+      body: t(
+        'explore.trace-view.knowledge-graph-promo.body',
+        'Knowledge Graph correlates services, infrastructure, and insights from your traces — helping you navigate from a span attribute to related entities and assertions.'
+      ),
+      match: isKnowledgeGraphAttribute,
+    },
+    {
       pluginId: 'grafana-dbo11y-app',
       icon: 'database-observability',
       title: t('explore.trace-view.database-observability-promo.title', 'Find slow queries faster'),
@@ -39,7 +58,67 @@ export function getAttributePluginPromos(): AttributePluginPromo[] {
       ),
       match: isDatabaseAttribute,
     },
+    {
+      pluginId: 'grafana-kowalski-app',
+      icon: 'frontend-observability',
+      title: t('explore.trace-view.frontend-observability-promo.title', 'Debug real user sessions'),
+      body: t(
+        'explore.trace-view.frontend-observability-promo.body',
+        'Frontend Observability links trace attributes to sessions, errors, and performance — so you can see what users experienced when a span ran.'
+      ),
+      match: isFrontendObservabilityAttribute,
+    },
+    {
+      pluginId: 'grafana-app-observability-app',
+      icon: 'application-observability',
+      title: t('explore.trace-view.application-observability-promo.title', 'Understand your services faster'),
+      body: t(
+        'explore.trace-view.application-observability-promo.body',
+        'Application Observability connects traces, metrics, and logs for each service — so you can spot regressions and drill into root cause.'
+      ),
+      match: isServiceAttribute,
+    },
+    {
+      pluginId: 'grafana-k8s-app',
+      icon: 'kubernetes',
+      title: t('explore.trace-view.kubernetes-promo.title', 'Drill into your cluster'),
+      body: t(
+        'explore.trace-view.kubernetes-promo.body',
+        'Kubernetes Monitoring turns trace attributes into navigation to clusters, namespaces, workloads, and pods — with metrics and health context in one place.'
+      ),
+      match: isKubernetesAttribute,
+    },
   ];
+}
+
+/**
+ * Picks up to {@link MAX_ATTRIBUTE_PLUGIN_PROMOS} attribute keys to promote.
+ * Walks promos in priority order and assigns at most one key per inactive plugin
+ * so a span with many matching attrs does not become a wall of promo tips.
+ */
+export function selectAttributeKeysForPromos(
+  attributeKeys: readonly string[],
+  inactivePluginIds: ReadonlySet<string>,
+  promos: readonly AttributePluginPromo[],
+  maxPromos = MAX_ATTRIBUTE_PLUGIN_PROMOS
+): Set<string> {
+  const selectedKeys = new Set<string>();
+
+  for (const promo of promos) {
+    if (selectedKeys.size >= maxPromos) {
+      break;
+    }
+    if (!inactivePluginIds.has(promo.pluginId)) {
+      continue;
+    }
+
+    const matchingKey = attributeKeys.find((key) => !selectedKeys.has(key) && promo.match(key));
+    if (matchingKey) {
+      selectedKeys.add(matchingKey);
+    }
+  }
+
+  return selectedKeys;
 }
 
 export type AttributePluginPromoGetter = (attributeKey: string) => AttributePluginPromo | undefined;
@@ -50,8 +129,9 @@ export type AttributePluginPromoGetter = (attributeKey: string) => AttributePlug
  * Returns no promo while status is loading or unavailable, to avoid a flash for activated plugins.
  * Installed status comes from bootdata metas (no request); enabled is only fetched for installed apps
  * to avoid 404s for plugins that aren't present.
+ * At most {@link MAX_ATTRIBUTE_PLUGIN_PROMOS} attribute keys from {@link attributeKeys} get a promo.
  */
-export function useAttributePluginPromoGetter(): AttributePluginPromoGetter {
+export function useAttributePluginPromoGetter(attributeKeys: readonly string[] = []): AttributePluginPromoGetter {
   const promos = useMemo(() => getAttributePluginPromos(), []);
   const { loading: metasLoading, value: appMetas } = useAppPluginMetas();
 
@@ -78,13 +158,20 @@ export function useAttributePluginPromoGetter(): AttributePluginPromoGetter {
     return inactive;
   }, [appMetas, metasLoading, promos]);
 
+  const allowedAttributeKeys = useMemo(() => {
+    if (!inactivePluginIds) {
+      return undefined;
+    }
+    return selectAttributeKeysForPromos(attributeKeys, inactivePluginIds, promos);
+  }, [attributeKeys, inactivePluginIds, promos]);
+
   return useCallback(
     (attributeKey: string) => {
-      if (!inactivePluginIds) {
+      if (!inactivePluginIds || !allowedAttributeKeys?.has(attributeKey)) {
         return undefined;
       }
       return promos.find((promo) => inactivePluginIds.has(promo.pluginId) && promo.match(attributeKey));
     },
-    [inactivePluginIds, promos]
+    [allowedAttributeKeys, inactivePluginIds, promos]
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9104,13 +9104,13 @@
         "body": "This trace was originally dropped by Adaptive Traces and has been restored. A restored trace is not included in TraceQL queries and can only be queried by trace ID. Please review the <2>documentation</2> for more details.",
         "title": "Trace restored by Adaptive Traces"
       },
-      "aria-label-copy": "Copy to clipboard",
-      "attribute-plugin-promo": {
-        "learn-more": "Learn more"
-      },
       "application-observability-promo": {
         "body": "Application Observability connects traces, metrics, and logs for each service — so you can spot regressions and drill into root cause.",
         "title": "Understand your services faster"
+      },
+      "aria-label-copy": "Copy to clipboard",
+      "attribute-plugin-promo": {
+        "learn-more": "Learn more"
       },
       "database-observability-promo": {
         "body": "Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9108,9 +9108,25 @@
       "attribute-plugin-promo": {
         "learn-more": "Learn more"
       },
+      "application-observability-promo": {
+        "body": "Application Observability connects traces, metrics, and logs for each service — so you can spot regressions and drill into root cause.",
+        "title": "Understand your services faster"
+      },
       "database-observability-promo": {
         "body": "Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.",
         "title": "Find slow queries faster"
+      },
+      "frontend-observability-promo": {
+        "body": "Frontend Observability links trace attributes to sessions, errors, and performance — so you can see what users experienced when a span ran.",
+        "title": "Debug real user sessions"
+      },
+      "knowledge-graph-promo": {
+        "body": "Knowledge Graph correlates services, infrastructure, and insights from your traces — helping you navigate from a span attribute to related entities and assertions.",
+        "title": "See the full picture"
+      },
+      "kubernetes-promo": {
+        "body": "Kubernetes Monitoring turns trace attributes into navigation to clusters, namespaces, workloads, and pods — with metrics and health context in one place.",
+        "title": "Drill into your cluster"
       },
       "no-data": "No data",
       "tooltip-copy-icon": "Copied"


### PR DESCRIPTION
**What is this feature?**

Expand attribute plugin cross-sell promos in the trace view.

**Why do we need this feature?**

Adds Cloud promos for Knowledge Graph, App O11y, Frontend O11y, and Kubernetes. Prefers KG for service.*, Kubernetes-only for k8s.*, and caps to 3 tips per span.

**Who is this feature for?**

Trace view users.

**Special notes for your reviewer:**

Part of https://github.com/grafana/grafana/issues/129072