### PR TITLE
Access: share SQL filter query fields

### DIFF
--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -32,10 +32,8 @@ type SQLFilter struct {
 	Args  []any
 }
 
-// AccessControlQueryFields returns whether a SQL filter allows all records and
-// the arguments needed to apply the filter.
-func AccessControlQueryFields(filter SQLFilter) (bool, []any) {
-	return strings.TrimSpace(filter.Where) == "1 = 1", filter.Args
+func (f SQLFilter) AllowsAllRecords() bool {
+	return f.Where == allowAllQuery.Where
 }
 
 // Filter creates a where clause to restrict the view of a query based on a users permissions

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -32,6 +32,12 @@ type SQLFilter struct {
 	Args  []any
 }
 
+// AccessControlQueryFields returns whether a SQL filter allows all records and
+// the arguments needed to apply the filter.
+func AccessControlQueryFields(filter SQLFilter) (bool, []any) {
+	return strings.TrimSpace(filter.Where) == "1 = 1", filter.Args
+}
+
 // Filter creates a where clause to restrict the view of a query based on a users permissions
 // Scopes that exists for all actions will be parsed and compared against the supplied sqlID
 // Prefix parameter is the prefix of the scope that we support (e.g. "users:id:")

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -35,6 +35,38 @@ func TestManagedPermissionsActionSetsFilter(t *testing.T) {
 	assert.Contains(t, filter, "'folders:admin'")
 }
 
+func TestAccessControlQueryFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		filter    accesscontrol.SQLFilter
+		accessAll bool
+		args      []any
+	}{
+		{
+			name:      "allows all records",
+			filter:    accesscontrol.SQLFilter{Where: " 1 = 1 ", Args: nil},
+			accessAll: true,
+		},
+		{
+			name:   "returns filtered record arguments",
+			filter: accesscontrol.SQLFilter{Where: " u.id IN (?, ?)", Args: []any{int64(1), int64(2)}},
+			args:   []any{int64(1), int64(2)},
+		},
+		{
+			name:   "denies all records",
+			filter: accesscontrol.SQLFilter{Where: " 1 = 0 "},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessAll, args := accesscontrol.AccessControlQueryFields(tt.filter)
+			require.Equal(t, tt.accessAll, accessAll)
+			require.Equal(t, tt.args, args)
+		})
+	}
+}
+
 type filterDatasourcesTestCase struct {
 	desc        string
 	sqlID       string

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -35,34 +35,39 @@ func TestManagedPermissionsActionSetsFilter(t *testing.T) {
 	assert.Contains(t, filter, "'folders:admin'")
 }
 
-func TestAccessControlQueryFields(t *testing.T) {
+func TestSQLFilterAllowsAllRecords(t *testing.T) {
 	tests := []struct {
-		name      string
-		filter    accesscontrol.SQLFilter
-		accessAll bool
-		args      []any
+		name        string
+		permissions []string
+		accessAll   bool
+		args        []any
 	}{
 		{
-			name:      "allows all records",
-			filter:    accesscontrol.SQLFilter{Where: " 1 = 1 ", Args: nil},
-			accessAll: true,
+			name:        "allows all records",
+			permissions: []string{"global.users:*"},
+			accessAll:   true,
 		},
 		{
-			name:   "returns filtered record arguments",
-			filter: accesscontrol.SQLFilter{Where: " u.id IN (?, ?)", Args: []any{int64(1), int64(2)}},
-			args:   []any{int64(1), int64(2)},
+			name:        "returns filtered record arguments",
+			permissions: []string{"global.users:id:1"},
+			args:        []any{int64(1)},
 		},
 		{
-			name:   "denies all records",
-			filter: accesscontrol.SQLFilter{Where: " 1 = 0 "},
+			name: "denies all records",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessAll, args := accesscontrol.AccessControlQueryFields(tt.filter)
-			require.Equal(t, tt.accessAll, accessAll)
-			require.Equal(t, tt.args, args)
+			filter, err := accesscontrol.Filter(&user.SignedInUser{
+				OrgID: 1,
+				Permissions: map[int64]map[string][]string{
+					1: {accesscontrol.ActionUsersRead: tt.permissions},
+				},
+			}, "u.id", "global.users:id:", accesscontrol.ActionUsersRead)
+			require.NoError(t, err)
+			assert.Equal(t, tt.accessAll, filter.AllowsAllRecords())
+			assert.Equal(t, tt.args, filter.Args)
 		})
 	}
 }

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -845,10 +845,6 @@ type searchOrgUsersQuery struct {
 
 func (q searchOrgUsersQuery) Validate() error { return nil }
 
-func accessControlQueryFields(filter accesscontrol.SQLFilter) (bool, []any) {
-	return strings.TrimSpace(filter.Where) == "1 = 1", filter.Args
-}
-
 func filteredHiddenUsers(requester identity.Requester, hiddenUsersMap map[string]struct{}) []string {
 	if requester != nil && requester.GetIsGrafanaAdmin() {
 		return nil
@@ -915,7 +911,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 			if err != nil {
 				return err
 			}
-			accessAll, accessUserIDs = accessControlQueryFields(acFilter)
+			accessAll, accessUserIDs = accesscontrol.AccessControlQueryFields(acFilter)
 		}
 
 		var hiddenUserLogins []string

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -911,7 +911,7 @@ func (ss *sqlStore) SearchOrgUsers(ctx context.Context, query *org.SearchOrgUser
 			if err != nil {
 				return err
 			}
-			accessAll, accessUserIDs = accesscontrol.AccessControlQueryFields(acFilter)
+			accessAll, accessUserIDs = acFilter.AllowsAllRecords(), acFilter.Args
 		}
 
 		var hiddenUserLogins []string

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -283,7 +283,7 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 		if err != nil {
 			return err
 		}
-		accessAll, accessTeamIDs := ac.AccessControlQueryFields(acFilter)
+		accessAll, accessTeamIDs := acFilter.AllowsAllRecords(), acFilter.Args
 
 		sorts := make([]string, 0, len(query.SortOpts))
 		for i := range query.SortOpts {
@@ -450,7 +450,7 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 		if err != nil {
 			return err
 		}
-		accessAll, accessTeamIDs := ac.AccessControlQueryFields(acFilter)
+		accessAll, accessTeamIDs := acFilter.AllowsAllRecords(), acFilter.Args
 
 		sqlQuery := getTeamsByUserQuery{
 			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
@@ -808,7 +808,7 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, dbHelper *legacysql.Leg
 		accessAll := true
 		var accessUserIDs []any
 		if acUserFilter != nil {
-			accessAll, accessUserIDs = ac.AccessControlQueryFields(*acUserFilter)
+			accessAll, accessUserIDs = acUserFilter.AllowsAllRecords(), acUserFilter.Args
 		}
 
 		sqlQuery := getTeamMembersQuery{

--- a/pkg/services/team/teamimpl/store.go
+++ b/pkg/services/team/teamimpl/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"text/template"
 	"time"
 
@@ -268,10 +267,6 @@ type searchTeamsQuery struct {
 
 func (q searchTeamsQuery) Validate() error { return nil }
 
-func accessControlQueryFields(filter ac.SQLFilter) (bool, []any) {
-	return strings.TrimSpace(filter.Where) == "1 = 1", filter.Args
-}
-
 func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
 	queryResult := team.SearchTeamQueryResult{
 		Teams: make([]*team.TeamDTO, 0),
@@ -288,7 +283,7 @@ func (ss *xormStore) Search(ctx context.Context, query *team.SearchTeamsQuery) (
 		if err != nil {
 			return err
 		}
-		accessAll, accessTeamIDs := accessControlQueryFields(acFilter)
+		accessAll, accessTeamIDs := ac.AccessControlQueryFields(acFilter)
 
 		sorts := make([]string, 0, len(query.SortOpts))
 		for i := range query.SortOpts {
@@ -455,7 +450,7 @@ func (ss *xormStore) GetByUser(ctx context.Context, query *team.GetTeamsByUserQu
 		if err != nil {
 			return err
 		}
-		accessAll, accessTeamIDs := accessControlQueryFields(acFilter)
+		accessAll, accessTeamIDs := ac.AccessControlQueryFields(acFilter)
 
 		sqlQuery := getTeamsByUserQuery{
 			SQLTemplate:     sqltemplate.New(dbHelper.DialectForDriver()),
@@ -813,7 +808,7 @@ func (ss *xormStore) getTeamMembers(ctx context.Context, dbHelper *legacysql.Leg
 		accessAll := true
 		var accessUserIDs []any
 		if acUserFilter != nil {
-			accessAll, accessUserIDs = accessControlQueryFields(*acUserFilter)
+			accessAll, accessUserIDs = ac.AccessControlQueryFields(*acUserFilter)
 		}
 
 		sqlQuery := getTeamMembersQuery{

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -835,7 +835,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			return err
 		}
 
-		accessAll, accessUserIDs := accesscontrol.AccessControlQueryFields(acFilter)
+		accessAll, accessUserIDs := acFilter.AllowsAllRecords(), acFilter.Args
 		joins, inFilters, whereFilters, err := buildSearchUserFilters(dbHelper, query.Filters)
 		if err != nil {
 			return err

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -835,7 +835,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			return err
 		}
 
-		accessAll := strings.TrimSpace(acFilter.Where) == "1 = 1"
+		accessAll, accessUserIDs := accesscontrol.AccessControlQueryFields(acFilter)
 		joins, inFilters, whereFilters, err := buildSearchUserFilters(dbHelper, query.Filters)
 		if err != nil {
 			return err
@@ -858,7 +858,7 @@ func (ss *sqlStore) Search(ctx context.Context, query *user.SearchUsersQuery) (*
 			Joins:         joins,
 			OrgID:         query.OrgID,
 			AccessAll:     accessAll,
-			AccessUserIDs: acFilter.Args,
+			AccessUserIDs: accessUserIDs,
 			QueryPattern:  searchQueryPattern(query.Query),
 			IsDisabled:    query.IsDisabled,
 			InFilters:     inFilters,


### PR DESCRIPTION
## Summary
- Promote the duplicated SQL filter-to-query-fields conversion into the shared accesscontrol package.
- Use the shared helper from orgimpl, teamimpl, and userimpl.
- Add focused coverage for allow-all, filtered, and deny-all results.

This PR addresses a review [comment](https://github.com/grafana/grafana/pull/131041#discussion_r3847298658) on #131041.