### PR TITLE
Button/RadioButton: Reduce left/right padding by 4px

### DIFF
--- a/packages/grafana-ui/src/components/Forms/commonStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/commonStyles.ts
@@ -98,7 +98,7 @@ export function getPropertiesForButtonSize(size: ComponentSize, theme: GrafanaTh
     case 'md':
     default:
       return {
-        padding: 2,
+        padding: 1.5,
         fontSize: theme.typography.size.md,
         height: theme.components.height.md,
       };


### PR DESCRIPTION
Problem

RadioButtonGroups are often ellipsed because the do not fit in the options side bar 

<img width="302" height="252" alt="Screenshot 2026-08-25 at 15 01 25" src="https://github.com/user-attachments/assets/b5f2aa05-678d-4fc9-9915-c848bf72c69d" />
<img width="304" height="215" alt="Screenshot 2026-08-25 at 15 01 28" src="https://github.com/user-attachments/assets/733e8010-e996-407a-b0c1-98c09401cce1" />

I think having 16px left/right padding on each value in a radiobutton is a bit much so wanted to reduce this to 12px, but this is sharing the same code / padding as normal `md` button. But figure reducing the padding or this button might also be a good thing (we are going to reduce the height soon anyway) .

Before: 
<img width="890" height="185" alt="Screenshot 2026-08-25 at 15 09 41" src="https://github.com/user-attachments/assets/18e713dc-4ce0-4b7e-897e-2ef4c6741804" />

After:
<img width="842" height="175" alt="Screenshot 2026-08-25 at 15 14 30" src="https://github.com/user-attachments/assets/100457cf-0386-4737-85fb-4492165580a4" />

Before:
<img width="313" height="478" alt="Screenshot 2026-08-25 at 15 15 52" src="https://github.com/user-attachments/assets/eaa9a23e-174b-4fd8-941b-bd4045b5d95a" />

After:
<img width="308" height="476" alt="Screenshot 2026-08-25 at 15 16 10" src="https://github.com/user-attachments/assets/0a654208-2a4b-4d1b-bc91-b8bde596bdca" />
