### PR TITLE
LogsLink: Rewrite Logs Drilldown links when in a Drilldown context

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -1180,21 +1180,32 @@ describe('isDrilldownContext', () => {
     ['grafana-lokiexplore-app', false],
     [undefined, false],
   ])('app %s → %s when the URL is not a drilldown app', (app, expected) => {
-    jest.spyOn(locationService, 'getLocation').mockReturnValue({ pathname: '/explore' } as Location);
+    jest.spyOn(locationService, 'getLocation').mockReturnValue({
+      pathname: '/explore',
+      search: '',
+      state: undefined,
+      hash: '',
+    });
     expect(isDrilldownContext(app)).toBe(expected);
   });
 
   it('treats the standalone Traces Drilldown URL as drilldown when panel context is unset', () => {
-    jest
-      .spyOn(locationService, 'getLocation')
-      .mockReturnValue({ pathname: '/a/grafana-exploretraces-app/explore' } as Location);
+    jest.spyOn(locationService, 'getLocation').mockReturnValue({
+      pathname: '/a/grafana-exploretraces-app/explore',
+      search: '',
+      state: undefined,
+      hash: '',
+    });
     expect(isDrilldownContext(undefined)).toBe(true);
   });
 
   it('treats the standalone Logs Drilldown URL as drilldown when panel context is unset', () => {
-    jest
-      .spyOn(locationService, 'getLocation')
-      .mockReturnValue({ pathname: '/a/grafana-lokiexplore-app/explore' } as Location);
+    jest.spyOn(locationService, 'getLocation').mockReturnValue({
+      pathname: '/a/grafana-lokiexplore-app/explore',
+      search: '',
+      state: undefined,
+      hash: '',
+    });
     expect(isDrilldownContext(undefined)).toBe(true);
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -13,7 +13,7 @@ import {
   store,
   toDataFrame,
 } from '@grafana/data';
-import { locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
+import { reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
 import {
   getDataSourceInstance,
@@ -676,42 +676,6 @@ describe('LogsLinkButton', () => {
     });
   });
 
-  it('uses the Open in Logs Drilldown extension path on a Traces Drilldown URL', async () => {
-    jest.spyOn(locationService, 'getLocation').mockReturnValue({
-      pathname: '/a/grafana-exploretraces-app/explore',
-      search: '',
-      state: undefined,
-      hash: '',
-    });
-    mockDatasourceReturningFrames([logsFrame], 'loki');
-    const interpolatedQuery: LokiQuery = {
-      refId: 'A',
-      datasource: { uid: 'logs-ds-uid', type: 'loki' },
-      expr: '{job="api"} |= "trace1"',
-    };
-    usePluginLinksMock.mockReturnValue({
-      isLoading: false,
-      links: [
-        {
-          id: '',
-          pluginId: 'grafana-lokiexplore-app',
-          path: '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid',
-          type: PluginExtensionTypes.link,
-          title: '',
-          description: '',
-        },
-      ],
-    });
-
-    render(
-      <LogsLinkButton linkModel={createProbingLinkModel(interpolatedQuery)} traceDatasourceUid={TRACE_DATASOURCE_UID} />
-    );
-
-    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid');
-    jest.mocked(locationService.getLocation).mockRestore();
-  });
-
   it('keeps the Explore href in a drilldown context when the extension does not return a path', async () => {
     mockDatasourceReturningFrames([logsFrame], 'loki');
     const interpolatedQuery: LokiQuery = {
@@ -1180,10 +1144,6 @@ describe('addNoSpanIdFallback', () => {
 });
 
 describe('isDrilldownContext', () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it.each([
     [CoreApp.Unknown, true],
     [CoreApp.Explore, false],
@@ -1191,33 +1151,7 @@ describe('isDrilldownContext', () => {
     ['grafana-exploretraces-app', false],
     ['grafana-lokiexplore-app', false],
     [undefined, false],
-  ])('app %s → %s when the URL is not a drilldown app', (app, expected) => {
-    jest.spyOn(locationService, 'getLocation').mockReturnValue({
-      pathname: '/explore',
-      search: '',
-      state: undefined,
-      hash: '',
-    });
+  ])('app %s → %s', (app, expected) => {
     expect(isDrilldownContext(app)).toBe(expected);
-  });
-
-  it('treats the standalone Traces Drilldown URL as drilldown when panel context is unset', () => {
-    jest.spyOn(locationService, 'getLocation').mockReturnValue({
-      pathname: '/a/grafana-exploretraces-app/explore',
-      search: '',
-      state: undefined,
-      hash: '',
-    });
-    expect(isDrilldownContext(undefined)).toBe(true);
-  });
-
-  it('treats the standalone Logs Drilldown URL as drilldown when panel context is unset', () => {
-    jest.spyOn(locationService, 'getLocation').mockReturnValue({
-      pathname: '/a/grafana-lokiexplore-app/explore',
-      search: '',
-      state: undefined,
-      hash: '',
-    });
-    expect(isDrilldownContext(undefined)).toBe(true);
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -9,6 +9,7 @@ import {
   EventBusSrv,
   type LinkModel,
   PluginExtensionPoints,
+  PluginExtensionTypes,
   store,
   toDataFrame,
 } from '@grafana/data';
@@ -645,8 +646,12 @@ describe('LogsLinkButton', () => {
       isLoading: false,
       links: [
         {
+          id: '',
           pluginId: 'grafana-lokiexplore-app',
           path: '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid',
+          type: PluginExtensionTypes.link,
+          title: '',
+          description: '',
         },
       ],
     });
@@ -672,9 +677,12 @@ describe('LogsLinkButton', () => {
   });
 
   it('uses the Open in Logs Drilldown extension path on a Traces Drilldown URL', async () => {
-    jest
-      .spyOn(locationService, 'getLocation')
-      .mockReturnValue({ pathname: '/a/grafana-exploretraces-app/explore' } as Location);
+    jest.spyOn(locationService, 'getLocation').mockReturnValue({
+      pathname: '/a/grafana-exploretraces-app/explore',
+      search: '',
+      state: undefined,
+      hash: '',
+    });
     mockDatasourceReturningFrames([logsFrame], 'loki');
     const interpolatedQuery: LokiQuery = {
       refId: 'A',
@@ -685,8 +693,12 @@ describe('LogsLinkButton', () => {
       isLoading: false,
       links: [
         {
+          id: '',
           pluginId: 'grafana-lokiexplore-app',
           path: '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid',
+          type: PluginExtensionTypes.link,
+          title: '',
+          description: '',
         },
       ],
     });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -2,14 +2,17 @@ import { of, throwError } from 'rxjs';
 import { act, render, screen, userEvent, waitFor } from 'test/test-utils';
 
 import {
+  CoreApp,
   type DataSourceApi,
   type DataSourceInstanceListItem,
   type DataSourceInstanceSettings,
+  EventBusSrv,
   type LinkModel,
+  PluginExtensionPoints,
   store,
   toDataFrame,
 } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
+import { locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { FlagKeys } from '@grafana/runtime/internal';
 import {
   getDataSourceInstance,
@@ -18,6 +21,7 @@ import {
 } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { setTestFlags } from '@grafana/test-utils/unstable';
+import { PanelContextProvider } from '@grafana/ui';
 import { type LokiQuery } from 'app/features/loki-helpers/types';
 
 import { getTraceToLogsSpanQuery, getTraceToLogsTraceQuery } from '../../logsLink';
@@ -27,6 +31,7 @@ import {
   addNoSpanIdFallback,
   getLogsButtonCTA,
   getLogsButtonTooltip,
+  isDrilldownContext,
   LOKI_DATASOURCE_MATCH_STORAGE_KEY_PREFIX,
   lokiQueryMatchStorageKey,
   LogsLinkButton,
@@ -36,6 +41,7 @@ import {
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   reportInteraction: jest.fn(),
+  usePluginLinks: jest.fn().mockReturnValue({ links: [], isLoading: false }),
 }));
 
 jest.mock('@grafana/runtime/unstable', () => ({
@@ -48,6 +54,7 @@ jest.mock('@grafana/runtime/unstable', () => ({
 const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
 const useDataSourceInstanceSettingsMock = jest.mocked(useDataSourceInstanceSettings);
 const useDataSourceInstanceListMock = jest.mocked(useDataSourceInstanceList);
+const usePluginLinksMock = jest.mocked(usePluginLinks);
 
 const DYNAMIC_TRACE_TO_LOGS_FLAG = 'grafana.dynamicTraceToLogs';
 
@@ -115,6 +122,7 @@ describe('LogsLinkButton', () => {
     store.delete(datasourceMatchKey());
     mockLokiDatasourceList(['logs-ds-uid']);
     useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+    usePluginLinksMock.mockReturnValue({ links: [], isLoading: false });
     // The presence check is gated behind this flag; enable it so most tests exercise the check.
     // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates.
     await act(async () => {
@@ -609,6 +617,109 @@ describe('LogsLinkButton', () => {
     );
     await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
   });
+
+  it('keeps an Explore href when not in a drilldown context', async () => {
+    mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: LokiQuery = {
+      refId: 'A',
+      datasource: { uid: 'logs-ds-uid', type: 'loki' },
+      expr: '{job="api"} |= "trace1"',
+    };
+
+    render(
+      <LogsLinkButton linkModel={createProbingLinkModel(interpolatedQuery)} traceDatasourceUid={TRACE_DATASOURCE_UID} />
+    );
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
+    expect(screen.getByRole('link')).toHaveAttribute('href', expect.stringContaining('/explore?left='));
+  });
+
+  it('uses the Open in Logs Drilldown extension path when the panel app is unknown', async () => {
+    mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: LokiQuery = {
+      refId: 'A',
+      datasource: { uid: 'logs-ds-uid', type: 'loki' },
+      expr: '{job="api"} |= "trace1"',
+    };
+    usePluginLinksMock.mockReturnValue({
+      isLoading: false,
+      links: [
+        {
+          pluginId: 'grafana-lokiexplore-app',
+          path: '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid',
+        },
+      ],
+    });
+
+    render(
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Unknown }}>
+        <LogsLinkButton
+          linkModel={createProbingLinkModel(interpolatedQuery)}
+          traceDatasourceUid={TRACE_DATASOURCE_UID}
+        />
+      </PanelContextProvider>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid');
+    expect(usePluginLinksMock).toHaveBeenCalledWith({
+      extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
+      context: expect.objectContaining({
+        targets: [expect.objectContaining({ datasource: { uid: 'logs-ds-uid', type: 'loki' } })],
+      }),
+      limitPerPlugin: 1,
+    });
+  });
+
+  it('uses the Open in Logs Drilldown extension path on a Traces Drilldown URL', async () => {
+    jest
+      .spyOn(locationService, 'getLocation')
+      .mockReturnValue({ pathname: '/a/grafana-exploretraces-app/explore' } as Location);
+    mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: LokiQuery = {
+      refId: 'A',
+      datasource: { uid: 'logs-ds-uid', type: 'loki' },
+      expr: '{job="api"} |= "trace1"',
+    };
+    usePluginLinksMock.mockReturnValue({
+      isLoading: false,
+      links: [
+        {
+          pluginId: 'grafana-lokiexplore-app',
+          path: '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid',
+        },
+      ],
+    });
+
+    render(
+      <LogsLinkButton linkModel={createProbingLinkModel(interpolatedQuery)} traceDatasourceUid={TRACE_DATASOURCE_UID} />
+    );
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/a/grafana-lokiexplore-app/explore?var-ds=logs-ds-uid');
+    jest.mocked(locationService.getLocation).mockRestore();
+  });
+
+  it('keeps the Explore href in a drilldown context when the extension does not return a path', async () => {
+    mockDatasourceReturningFrames([logsFrame], 'loki');
+    const interpolatedQuery: LokiQuery = {
+      refId: 'A',
+      datasource: { uid: 'logs-ds-uid', type: 'loki' },
+      expr: '{job="api"} |= "trace1"',
+    };
+
+    render(
+      <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Unknown }}>
+        <LogsLinkButton
+          linkModel={createProbingLinkModel(interpolatedQuery)}
+          traceDatasourceUid={TRACE_DATASOURCE_UID}
+        />
+      </PanelContextProvider>
+    );
+
+    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'false'));
+    expect(screen.getByRole('link')).toHaveAttribute('href', expect.stringContaining('/explore?left='));
+  });
 });
 
 describe('LogsLinkMenuItem', () => {
@@ -618,6 +729,7 @@ describe('LogsLinkMenuItem', () => {
     store.delete(datasourceMatchKey());
     mockLokiDatasourceList(['logs-ds-uid']);
     useDataSourceInstanceSettingsMock.mockReturnValue({ isLoading: false, settings: undefined });
+    usePluginLinksMock.mockReturnValue({ links: [], isLoading: false });
     // The presence check is gated behind this flag; enable it so most tests exercise the check.
     // Wrap in act() because setTestFlags fires OpenFeature events that trigger React state updates.
     await act(async () => {
@@ -1052,5 +1164,37 @@ describe('addNoSpanIdFallback', () => {
     expect(structured?.expr).not.toMatch(/span/i);
     expect(addNoSpanIdFallback(structured!)).toHaveLength(1);
     expect(addNoSpanIdFallback(lineContains!)).toHaveLength(1);
+  });
+});
+
+describe('isDrilldownContext', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    [CoreApp.Unknown, true],
+    [CoreApp.Explore, false],
+    [CoreApp.Dashboard, false],
+    ['grafana-exploretraces-app', false],
+    ['grafana-lokiexplore-app', false],
+    [undefined, false],
+  ])('app %s → %s when the URL is not a drilldown app', (app, expected) => {
+    jest.spyOn(locationService, 'getLocation').mockReturnValue({ pathname: '/explore' } as Location);
+    expect(isDrilldownContext(app)).toBe(expected);
+  });
+
+  it('treats the standalone Traces Drilldown URL as drilldown when panel context is unset', () => {
+    jest
+      .spyOn(locationService, 'getLocation')
+      .mockReturnValue({ pathname: '/a/grafana-exploretraces-app/explore' } as Location);
+    expect(isDrilldownContext(undefined)).toBe(true);
+  });
+
+  it('treats the standalone Logs Drilldown URL as drilldown when panel context is unset', () => {
+    jest
+      .spyOn(locationService, 'getLocation')
+      .mockReturnValue({ pathname: '/a/grafana-lokiexplore-app/explore' } as Location);
+    expect(isDrilldownContext(undefined)).toBe(true);
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -45,7 +45,6 @@ import {
 import { usePanelContext, useStyles2, DataLinkButton, Menu } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
 
-const TRACES_DRILLDOWN_APP_ID = 'grafana-exploretraces-app';
 const LOGS_DRILLDOWN_APP_ID = 'grafana-lokiexplore-app';
 
 /** Persists which Loki query variation found logs for a given trace + logs datasource pair. */
@@ -143,14 +142,11 @@ type LogsCheckResult = {
 };
 
 /**
- * Assume Drilldown when the app is unknown or resolve it via path name.
+ * Assume Drilldown when the app is unknown (Traces Drilldown and other plugins).
+ * For other contexts, app will be defined (CoreApp value) or undefined (Explore).
  */
 export function isDrilldownContext(app?: CoreApp | string): boolean {
-  if (app === CoreApp.Unknown) {
-    return true;
-  }
-  const pathname = locationService.getLocation()?.pathname ?? '';
-  return pathname.includes(`/a/${TRACES_DRILLDOWN_APP_ID}`) || pathname.includes(`/a/${LOGS_DRILLDOWN_APP_ID}`);
+  return app === CoreApp.Unknown;
 }
 
 /**

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -244,9 +244,10 @@ function useHasLogs(
     if (!match) {
       return linkModel;
     }
-    const drilldownPath = inDrilldown && dynamicTraceToLogsEnabled
-      ? pluginLinks.find((link) => link.pluginId === LOGS_DRILLDOWN_APP_ID)?.path
-      : undefined;
+    const drilldownPath =
+      inDrilldown && dynamicTraceToLogsEnabled
+        ? pluginLinks.find((link) => link.pluginId === LOGS_DRILLDOWN_APP_ID)?.path
+        : undefined;
     return rewriteLinkForMatch(linkModel, match, drilldownPath);
   }, [dynamicTraceToLogsEnabled, inDrilldown, linkModel, match, pluginLinks]);
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -210,7 +210,7 @@ function useHasLogs(
     // The trace view re-renders a lot on every event, including mouse over.
     // `query`/`timeRange` are intentionally omitted; their content is captured by the serialized keys.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryKey, timeRangeKey, isLoadingDsList, dsList, traceDatasourceUid, inDrilldown]);
+  }, [queryKey, timeRangeKey, isLoadingDsList, dsList, traceDatasourceUid, dynamicTraceToLogsEnabled]);
 
   useEffect(() => {
     if (presence !== 'absent' || !dynamicTraceToLogsEnabled) {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -143,7 +143,7 @@ type LogsCheckResult = {
 };
 
 /**
- * Asume Drilldown when the app is unknown or resolve it via path name.
+ * Assume Drilldown when the app is unknown or resolve it via path name.
  */
 export function isDrilldownContext(app?: CoreApp | string): boolean {
   if (app === CoreApp.Unknown) {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.tsx
@@ -23,9 +23,11 @@ import {
   type DataSourceInstanceSettings,
   type DataSourceJsonData,
   getDefaultTimeRange,
+  getTimeZone,
   type GrafanaTheme2,
   type LinkModel,
   locationUtil,
+  PluginExtensionPoints,
   serializeStateToUrlParam,
   store,
   type TimeRange,
@@ -33,15 +35,18 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getTraceToLogsOptions } from '@grafana/o11y-ds-frontend';
-import { locationService, reportInteraction } from '@grafana/runtime';
+import { locationService, reportInteraction, usePluginLinks } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient, useFlagGrafanaDynamicTraceToLogs } from '@grafana/runtime/internal';
 import {
   getDataSourceInstance,
   useDataSourceInstanceList,
   useDataSourceInstanceSettings,
 } from '@grafana/runtime/unstable';
-import { useStyles2, DataLinkButton, Menu } from '@grafana/ui';
+import { usePanelContext, useStyles2, DataLinkButton, Menu } from '@grafana/ui';
 import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
+
+const TRACES_DRILLDOWN_APP_ID = 'grafana-exploretraces-app';
+const LOGS_DRILLDOWN_APP_ID = 'grafana-lokiexplore-app';
 
 /** Persists which Loki query variation found logs for a given trace + logs datasource pair. */
 const LOKI_QUERY_MATCH_STORAGE_KEY_PREFIX = 'grafana.explore.traceToLogs.lokiQueryMatch';
@@ -138,6 +143,17 @@ type LogsCheckResult = {
 };
 
 /**
+ * Asume Drilldown when the app is unknown or resolve it via path name.
+ */
+export function isDrilldownContext(app?: CoreApp | string): boolean {
+  if (app === CoreApp.Unknown) {
+    return true;
+  }
+  const pathname = locationService.getLocation()?.pathname ?? '';
+  return pathname.includes(`/a/${TRACES_DRILLDOWN_APP_ID}`) || pathname.includes(`/a/${LOGS_DRILLDOWN_APP_ID}`);
+}
+
+/**
  * Runs the link's query against its datasource to determine whether
  * any logs exist for the span, so the button can be disabled when there is nothing to link to.
  *
@@ -151,8 +167,10 @@ function useHasLogs(
   traceDatasourceUid?: string
 ): { presence: LogsPresence; resolvedLinkModel: LinkModel } {
   const dynamicTraceToLogsEnabled = useFlagGrafanaDynamicTraceToLogs();
+  const { app } = usePanelContext();
+  const inDrilldown = isDrilldownContext(app);
   const [presence, setPresence] = useState<LogsPresence>('loading');
-  const [resolvedLinkModel, setResolvedLinkModel] = useState(linkModel);
+  const [match, setMatch] = useState<LogsCheckMatch | undefined>();
 
   const { query, alternativeQueries, timeRange } = linkModel.interpolatedParams ?? {};
 
@@ -175,10 +193,11 @@ function useHasLogs(
     const queries = Array.isArray(alternativeQueries) ? alternativeQueries : [query];
 
     setPresence('loading');
+    setMatch(undefined);
     const subscription = checkForLogsInQueries(queries, effectiveTimeRange, dsList, traceDatasourceUid).subscribe({
       next: (result) => {
         if (result.hasLogs && result.match) {
-          setResolvedLinkModel(rewriteLinkForMatch(linkModel, result.match));
+          setMatch(result.match);
           setPresence('present');
           reportPresence('present', result.match.refId);
           return;
@@ -195,7 +214,7 @@ function useHasLogs(
     // The trace view re-renders a lot on every event, including mouse over.
     // `query`/`timeRange` are intentionally omitted; their content is captured by the serialized keys.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queryKey, timeRangeKey, isLoadingDsList, dsList, traceDatasourceUid]);
+  }, [queryKey, timeRangeKey, isLoadingDsList, dsList, traceDatasourceUid, inDrilldown]);
 
   useEffect(() => {
     if (presence !== 'absent' || !dynamicTraceToLogsEnabled) {
@@ -203,6 +222,33 @@ function useHasLogs(
     }
     reportPresence('absent');
   }, [dynamicTraceToLogsEnabled, presence]);
+
+  const extensionContext = useMemo(() => {
+    if (!inDrilldown || !match) {
+      return undefined;
+    }
+    return {
+      targets: remapQueriesToDatasource([match.query], match.datasourceUid),
+      timeRange: (timeRange ?? getDefaultTimeRange()).raw,
+      timeZone: getTimeZone(),
+    };
+  }, [inDrilldown, match, timeRange]);
+
+  const { links: pluginLinks } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.ExploreToolbarAction,
+    context: extensionContext,
+    limitPerPlugin: 1,
+  });
+
+  const resolvedLinkModel = useMemo(() => {
+    if (!match) {
+      return linkModel;
+    }
+    const drilldownPath = inDrilldown && dynamicTraceToLogsEnabled
+      ? pluginLinks.find((link) => link.pluginId === LOGS_DRILLDOWN_APP_ID)?.path
+      : undefined;
+    return rewriteLinkForMatch(linkModel, match, drilldownPath);
+  }, [dynamicTraceToLogsEnabled, inDrilldown, linkModel, match, pluginLinks]);
 
   return { presence, resolvedLinkModel };
 }
@@ -382,10 +428,12 @@ function probeForMatchingQuery(
   );
 }
 
-function rewriteLinkForMatch(linkModel: LinkModel, match: LogsCheckMatch): LinkModel {
-  // Narrow Explore to the successful query variation (and datasource, when it differs from config).
+function rewriteLinkForMatch(linkModel: LinkModel, match: LogsCheckMatch, drilldownPath?: string): LinkModel {
+  // Narrow the destination to the successful query variation (and datasource, when it differs from config).
   const matchedQueries = remapQueriesToDatasource([match.query], match.datasourceUid);
-  const href = rebuildExploreHref(linkModel, matchedQueries, match.datasourceUid);
+  const href = drilldownPath
+    ? locationUtil.assureBaseUrl(drilldownPath)
+    : rebuildExploreHref(linkModel, matchedQueries, match.datasourceUid);
 
   return {
     ...linkModel,
@@ -395,7 +443,7 @@ function rewriteLinkForMatch(linkModel: LinkModel, match: LogsCheckMatch): LinkM
       query: matchedQueries[0],
     },
     // Original onClick closes over the configured datasource/queries; replace it so navigation
-    // uses the matched datasource and successful query variation.
+    // uses the matched datasource and successful query variation (or the Logs Drilldown extension path).
     onClick: linkModel.onClick
       ? (event) => {
           if (event?.preventDefault) {


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/130515

When we attempt different query combinations, we need to rewrite the link using the new parameters, and until now these links were being rewritten to point to Explore.

Any Traces Drilldown link that could be originally pointing to Logs Drilldown was mistakenly then pointing to Explore when this feature flag was on and a match was found.

Now, when we're in a Drilldown context and we have a matching query (and the extension is available), we reconstruct the link to Logs Drilldown.

### How to test

With `grafana.dynamicTraceToLogs` enabled and Traces that can correlate to logs
- Browse a trace in Explore. The link to logs should also open in Explore.
- Browse a trace in Traces Drilldown. The link to logs should open in Logs Drilldown.
- Browse a trace in embedded Traces Drilldown. The link to logs should open in Logs Drilldown.