### PR TITLE
OAuth: keep the stored token when a forced refresh is skipped

### DIFF
--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -177,12 +177,32 @@ func (o *Service) GetCurrentOAuthToken(ctx context.Context, usr identity.Request
 	token, err := o.TryTokenRefresh(ctx, usr, tokenRefreshMetadata)
 	if err != nil {
 		if errors.Is(err, ErrNoRefreshTokenFound) {
-			return persistedToken
+			// No refresh token is stored, and needTokenRefresh may already have
+			// cleared the access token of persistedToken while forcing the
+			// refresh attempt. Rebuild the token from storage so callers never
+			// observe an access token that was blanked.
+			if o.features.IsEnabledGlobally(featuremgmt.FlagImprovedExternalSessionHandling) {
+				return buildOAuthTokenFromExternalSession(externalSession)
+			}
+			return buildOAuthTokenFromAuthInfo(authInfo)
 		}
 
 		ctxLogger.Error("Failed to refresh OAuth token", "error", err)
 
 		return nil
+	}
+
+	// TryTokenRefresh returns (nil, nil) when it declines to refresh: the
+	// provider was not found or has refresh handling disabled. Nothing was
+	// mutated in that case, but needTokenRefresh may have cleared the access
+	// token on persistedToken to force the refresh attempt. Returning nil here
+	// would make datasource requests go out without credentials even though a
+	// usable token is stored, so rebuild the stored token instead.
+	if token == nil {
+		if o.features.IsEnabledGlobally(featuremgmt.FlagImprovedExternalSessionHandling) {
+			return buildOAuthTokenFromExternalSession(externalSession)
+		}
+		return buildOAuthTokenFromAuthInfo(authInfo)
 	}
 
 	return token

--- a/pkg/services/oauthtoken/oauth_token_test.go
+++ b/pkg/services/oauthtoken/oauth_token_test.go
@@ -1013,6 +1013,36 @@ func TestIntegration_GetCurrentOAuthToken(t *testing.T) {
 			},
 			expectedToken: unexpiredTokenWithoutRefreshWithIDToken,
 		},
+		{
+			desc:         "should return the stored auth info token when token refresh is disabled and only the id token has expired",
+			identity:     userIdentity,
+			sessionToken: &auth.UserToken{ExternalSessionId: 1},
+			setup: func(env *environment) {
+				env.authInfoService.On("GetAuthInfo", mock.Anything, mock.Anything).Return(&login.UserAuth{
+					AuthModule:        login.GenericOAuthModule,
+					OAuthAccessToken:  unexpiredToken.AccessToken,
+					OAuthRefreshToken: unexpiredToken.RefreshToken,
+					OAuthExpiry:       unexpiredToken.Expiry,
+					OAuthTokenType:    unexpiredToken.TokenType,
+					OAuthIdToken:      EXPIRED_ID_TOKEN,
+				}, nil)
+
+				env.sessionService.On("GetExternalSession", mock.Anything, int64(1)).Return(&auth.ExternalSession{
+					ID:          1,
+					UserID:      1234,
+					AuthModule:  login.GenericOAuthModule,
+					AccessToken: unexpiredToken.AccessToken,
+					ExpiresAt:   unexpiredToken.Expiry,
+				}, nil).Once()
+
+				env.socialService.ExpectedAuthInfoProvider = &social.OAuthInfo{
+					UseRefreshToken: false,
+				}
+			},
+			// Rebuilt from auth info exactly as stored; the expired id token
+			// rides along until the next login or refresh replaces it.
+			expectedToken: unexpiredToken.WithExtra(map[string]interface{}{"id_token": EXPIRED_ID_TOKEN}),
+		},
 		// Edge case, can only happen after the feature is enabled and logged in users don't have their external sessions set,
 		{
 			desc:         "should refresh token when the access token is expired and the external session was not found",
@@ -1351,6 +1381,34 @@ func TestIntegration_GetCurrentOAuthToken_WithExternalSessions(t *testing.T) {
 				}
 			},
 			expectedToken: unexpiredTokenWithoutRefreshWithIDToken,
+		},
+		{
+			desc:         "should return the stored token when token refresh is disabled and only the id token has expired",
+			identity:     userIdentity,
+			sessionToken: &auth.UserToken{ExternalSessionId: 1},
+			setup: func(env *environment) {
+				env.authInfoService.On("GetAuthInfo", mock.Anything, mock.Anything).Return(&login.UserAuth{
+					AuthModule: login.GenericOAuthModule,
+				}, nil)
+
+				env.sessionService.On("GetExternalSession", mock.Anything, int64(1)).Return(&auth.ExternalSession{
+					ID:           1,
+					UserID:       1234,
+					AuthModule:   login.GenericOAuthModule,
+					AccessToken:  unexpiredTokenWithIDToken.AccessToken,
+					RefreshToken: unexpiredTokenWithIDToken.RefreshToken,
+					ExpiresAt:    unexpiredTokenWithIDToken.Expiry,
+					IDToken:      EXPIRED_ID_TOKEN,
+				}, nil).Once()
+
+				env.socialService.ExpectedAuthInfoProvider = &social.OAuthInfo{
+					UseRefreshToken: false,
+				}
+			},
+			// The token is rebuilt exactly as stored: the access and refresh
+			// tokens are intact, while the expired id token is passed through
+			// unchanged until the next successful login or refresh replaces it.
+			expectedToken: unexpiredToken.WithExtra(map[string]interface{}{"id_token": EXPIRED_ID_TOKEN}),
 		},
 		{
 			desc:         "should not do token refresh if access token or id token have not expired yet",


### PR DESCRIPTION
**What is this feature?**

When a refresh cannot be performed, `GetCurrentOAuthToken` now returns the token as currently stored instead of returning nil (or a token whose access token was just blanked). A refresh that is attempted and fails still returns nil, as before.

**Why do we need this feature?**

`needTokenRefresh` clears the access token on the persisted token when the id token has expired, to force a refresh attempt. If that refresh then does not happen - no refresh token stored, or refresh handling disabled for the provider, which is the default for generic OAuth - callers received either an empty access token or nothing at all. Datasource requests with OAuth pass-through then went out with an empty or missing Authorization header, and backend datasources started returning 401s roughly one token lifetime after login (#103410). The same flow worked in v11.2 because the missing-refresh-token check happened before the access token was cleared; #96667 reordered those steps.

**Who is this feature for?**

Users behind generic OAuth SSO whose identity provider issues short-lived id tokens without refresh tokens, using backend datasources with OAuth pass-through enabled.

**Which issue(s) does this PR fix?**

Fixes #103410

**Special notes for your reviewer**

- `TryTokenRefresh` itself is untouched: its declined-refresh contract (`(nil, nil)`, no error) is pinned by existing tests and shared with the background sync path.
- The rebuilt token reflects storage exactly, including an expired id token when only the id token has expired - the access token is what datasource pass-through consumes.
- On transient provider-config lookup failures inside the refresh attempt, callers now proceed with the stored token until its real expiry rather than sending requests without credentials - strictly better than the previous header-less behavior, though the credential may be near expiry.
- Two regression cases added, one per feature-toggle state, mirroring the adjacent "token refresh is disabled" case but with an expired id token. Both fail on main without the production change and pass with it.
- Verified locally: full `pkg/services/oauthtoken` suite passes; consumer packages (`authn/clients`, `services/auth/...`) pass; the one failing test in `services/auth/jwt` (`TestIntegrationCustomRootCAJWKHTTPSClient`) also fails on clean upstream and is unrelated.
