### PR TITLE
Search: skip empty dashboard tags

### DIFF
--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -240,7 +240,12 @@ func readDashboardIter(jsonPath string, iter *jsoniter.Iterator, lookup Datasour
 					continue
 				}
 
-				dash.Tags = append(dash.Tags, iter.ReadString())
+				// An empty tag has nothing to search for or show, and it would still take a
+				// slot in the tag list a user picks from. The reader that indexes deleted
+				// dashboards skips it too, so both report the same tags for one dashboard.
+				if tag := iter.ReadString(); tag != "" {
+					dash.Tags = append(dash.Tags, tag)
+				}
 			}
 
 		case "links":

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -144,6 +144,30 @@ func TestReadV2PanelType(t *testing.T) {
 	assert.False(t, types["VizConfig"], "panel type must never be the literal VizConfig")
 }
 
+// An empty tag cannot be searched for or shown, and it would still take a slot in
+// the tag list a user picks from. Deleted dashboards are read by a different,
+// generic reader that already skips one, so both have to agree.
+func TestReadDashboardTags(t *testing.T) {
+	read := func(t *testing.T, tags string) []string {
+		t.Helper()
+		json := `{"metadata":{"name":"x"},"spec":{"title":"t","tags":` + tags + `}}`
+		dash, err := ReadDashboard(strings.NewReader(json), dsLookupForTests())
+		require.NoError(t, err)
+		return dash.Tags
+	}
+
+	t.Run("empty tags are skipped", func(t *testing.T) {
+		assert.Equal(t, []string{"prod", "team-a"}, read(t, `["prod","","team-a"]`))
+		assert.Empty(t, read(t, `[""]`))
+	})
+
+	// Whitespace is a tag a user can type and see, so it is kept: only a wholly
+	// empty string is dropped.
+	t.Run("other tags are kept as written", func(t *testing.T) {
+		assert.Equal(t, []string{"prod", " ", "prod"}, read(t, `["prod"," ","prod"]`))
+	})
+}
+
 // TestReadDashboardRecursionLimits ensures that maliciously deep nesting of `spec` or
 // `panels` is bounded so the parser cannot be driven into unbounded recursion.
 func TestReadDashboardRecursionLimits(t *testing.T) {


### PR DESCRIPTION
The dashboard reader kept an empty string as a tag. Tags can be faceted, so an empty one shows up as a blank entry in the tag list people filter by, and matches nothing when picked.

The generic reader used for deleted dashboards already skips it, so this keeps the two in agreement. Whitespace and duplicate tags are still kept as written.
