### PR TITLE
Navigation: Prefix nav item hrefs with the app subpath in breadcrumbs and tabs

### DIFF
--- a/public/app/core/components/Breadcrumbs/utils.test.ts
+++ b/public/app/core/components/Breadcrumbs/utils.test.ts
@@ -1,4 +1,4 @@
-import { type NavModelItem } from '@grafana/data';
+import { type GrafanaConfig, locationUtil, type NavModelItem } from '@grafana/data';
 
 import { buildBreadcrumbs } from './utils';
 
@@ -134,6 +134,62 @@ describe('breadcrumb utils', () => {
         { text: 'My section', href: '/my-section?from=1h&to=now' },
         { text: 'My page', href: '/my-page' },
       ]);
+    });
+
+    describe('with appSubUrl', () => {
+      beforeAll(() => {
+        locationUtil.initialize({
+          config: { appSubUrl: '/grafana' } as GrafanaConfig,
+          getVariablesUrlParams: jest.fn(),
+          getTimeRangeForUrl: jest.fn(),
+        });
+      });
+
+      afterAll(() => {
+        locationUtil.initialize({
+          config: { appSubUrl: '' } as GrafanaConfig,
+          getVariablesUrlParams: jest.fn(),
+          getTimeRangeForUrl: jest.fn(),
+        });
+      });
+
+      it('prefixes a bare nav url with the subpath exactly once', () => {
+        const sectionNav: NavModelItem = {
+          text: 'My section',
+          url: '/my-section',
+        };
+        expect(buildBreadcrumbs(sectionNav)).toEqual([{ text: 'My section', href: '/grafana/my-section' }]);
+      });
+
+      it('does not double-prefix a nav url that already carries the subpath', () => {
+        const sectionNav: NavModelItem = {
+          text: 'My section',
+          url: '/grafana/my-section',
+        };
+        expect(buildBreadcrumbs(sectionNav)).toEqual([{ text: 'My section', href: '/grafana/my-section' }]);
+      });
+
+      it('still matches the home nav and dedupes using the unprefixed nav urls', () => {
+        const pageNav: NavModelItem = {
+          text: 'My page',
+          url: '/my-page',
+          parentItem: {
+            text: 'My parent page',
+            url: '/home',
+          },
+        };
+        const sectionNav: NavModelItem = {
+          text: 'My section',
+          url: '/my-section',
+          parentItem: {
+            text: 'My parent section',
+            url: '/my-parent-section',
+          },
+        };
+        expect(buildBreadcrumbs(sectionNav, pageNav, mockHomeNav)).toEqual([
+          { text: 'My page', href: '/grafana/my-page' },
+        ]);
+      });
     });
   });
 });

--- a/public/app/core/components/Breadcrumbs/utils.ts
+++ b/public/app/core/components/Breadcrumbs/utils.ts
@@ -1,4 +1,4 @@
-import { type NavModelItem } from '@grafana/data';
+import { locationUtil, type NavModelItem } from '@grafana/data';
 
 import { type Breadcrumb } from './types';
 
@@ -39,10 +39,10 @@ export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelIte
       if (activeChildIndex > 0) {
         const activeChild = node.children?.[activeChildIndex];
         if (activeChild) {
-          crumbs.unshift({ text: activeChild.text, href: activeChild.url ?? '' });
+          crumbs.unshift({ text: activeChild.text, href: locationUtil.assureBaseUrl(activeChild.url ?? '') });
         }
       }
-      crumbs.unshift({ text: node.text, href: node.url ?? '' });
+      crumbs.unshift({ text: node.text, href: locationUtil.assureBaseUrl(node.url ?? '') });
     }
 
     if (node.parentItem) {

--- a/public/app/core/components/Page/PageTabs.test.tsx
+++ b/public/app/core/components/Page/PageTabs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { type NavModelItem } from '@grafana/data';
+import { type GrafanaConfig, locationUtil, type NavModelItem } from '@grafana/data';
 
 import { PageTabs } from './PageTabs';
 
@@ -18,5 +18,55 @@ describe('PageTabs', () => {
 
     render(<PageTabs navItem={navItem} />);
     expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('should render a tab with no url as a button with no href', () => {
+    const navItem: NavModelItem = {
+      text: 'My page',
+      children: [{ text: 'My tab' }],
+    };
+
+    render(<PageTabs navItem={navItem} />);
+    const tab = screen.getByRole('tab', { name: 'My tab' });
+    expect(tab.tagName).toBe('BUTTON');
+    expect(tab).not.toHaveAttribute('href');
+  });
+
+  describe('with appSubUrl', () => {
+    beforeAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/grafana' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    afterAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    it('prefixes a bare tab url with the subpath', () => {
+      const navItem: NavModelItem = {
+        text: 'My page',
+        children: [{ text: 'My tab', url: '/my-page/tab' }],
+      };
+
+      render(<PageTabs navItem={navItem} />);
+      expect(screen.getByRole('tab', { name: 'My tab' })).toHaveAttribute('href', '/grafana/my-page/tab');
+    });
+
+    it('does not double-prefix a tab url that already carries the subpath', () => {
+      const navItem: NavModelItem = {
+        text: 'My page',
+        children: [{ text: 'My tab', url: '/grafana/my-page/tab' }],
+      };
+
+      render(<PageTabs navItem={navItem} />);
+      expect(screen.getByRole('tab', { name: 'My tab' })).toHaveAttribute('href', '/grafana/my-page/tab');
+    });
   });
 });

--- a/public/app/core/components/Page/PageTabs.tsx
+++ b/public/app/core/components/Page/PageTabs.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
+import { locationUtil, type NavModelItem, type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, TabsBar, Tab, toIconName } from '@grafana/ui';
 
 export interface Props {
@@ -23,7 +23,7 @@ export function PageTabs({ navItem }: Props) {
                 key={`${child.url}-${index}`}
                 icon={icon}
                 counter={child.tabCounter}
-                href={child.url}
+                href={child.url ? locationUtil.assureBaseUrl(child.url) : undefined}
                 suffix={child.tabSuffix}
                 onChangeTab={child.onClick}
               />


### PR DESCRIPTION
## What this is

Part 1 of a 3-PR stack fixing #128972 (Connections → Data sources duplicates the subpath when Grafana is served under `root_url`/`serve_from_sub_path`). This PR contains the shared-renderer half of the fix; PR 2 (Connections landing page) and PR 3 (remaining bare anchors) stack on top of this one.

## Root cause

Grafana's SPA history is created with `basename: config.appSubUrl` (`packages/grafana-runtime/src/services/LocationService.tsx`), so any `href` handed to the router must have the subpath applied exactly once. But `PageTabs` and `buildBreadcrumbs` are the only renderers for every `pageNav`/breadcrumb in the app, and their inputs are permanently mixed: backend nav-tree urls already carry `appSubUrl` (`pkg/services/navtree/navtreeimpl/navtree.go`), while frontend-built `pageNav` urls are bare. Rendering either one straight into `href` is wrong for the other.

## Fix

Wrap the emitted `href` with `locationUtil.assureBaseUrl` (idempotent: `appSubUrl + stripBaseFromUrl(url)`) at the two render sites:
- `public/app/core/components/Breadcrumbs/utils.ts`
- `public/app/core/components/Page/PageTabs.tsx`

This closes the bug for every current and future `pageNav`/breadcrumb, rather than patching each producer individually.

## Testing

Added `describe('with appSubUrl', …)` cases to both `utils.test.ts` and `PageTabs.test.tsx` covering: a bare url gets prefixed once, an already-prefixed url is not double-prefixed, and (for breadcrumbs) the home-nav short-circuit and same-path dedupe still work with a subpath set.

```
yarn jest --no-watch --watchAll=false public/app/core/components/Breadcrumbs public/app/core/components/Page/PageTabs.test.tsx
yarn tsc --noEmit
```