### PR TITLE
Connections: Fix subpath doubling on the landing page cards

### DIFF
--- a/public/app/features/connections/Connections.test.tsx
+++ b/public/app/features/connections/Connections.test.tsx
@@ -2,6 +2,7 @@ import { type RenderResult, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render } from 'test/test-utils';
 
+import { type GrafanaConfig, locationUtil } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as api from 'app/features/datasources/api';
@@ -162,5 +163,48 @@ describe('Connections', () => {
     // We expect not to see the text that would be rendered by the core "Add new connection" page
     expect(screen.queryByText('Data sources')).not.toBeInTheDocument();
     expect(screen.queryByText('No results matching your query were found')).not.toBeInTheDocument();
+  });
+
+  describe('with appSubUrl', () => {
+    beforeAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/grafana' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    afterAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    test('still resolves card metadata when the nav tree urls already carry the subpath', async () => {
+      config.pluginAdminExternalManageEnabled = false;
+
+      const prefixedStore = configureStore({
+        navIndex: {
+          ...navIndex,
+          connections: {
+            ...navIndex.connections,
+            children: navIndex.connections.children?.map((child) => ({
+              ...child,
+              url: child.url ? `/grafana${child.url}` : child.url,
+            })),
+          },
+        },
+        plugins: getPluginsStateMock([]),
+      });
+
+      renderPage(ROUTES.Base, prefixedStore);
+
+      // Metadata lookup must strip the subpath before matching CardMetadata's bare keys,
+      // otherwise these OSS-specific overrides silently fall back to the raw nav item text/subtitle.
+      expect(await screen.findByText('Connect to a new data source')).toBeVisible();
+      expect(await screen.findByText('View configured data sources')).toBeVisible();
+    });
   });
 });

--- a/public/app/features/connections/pages/ConnectionsHomePage.tsx
+++ b/public/app/features/connections/pages/ConnectionsHomePage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 
-import { type GrafanaTheme2, type IconName, isIconName } from '@grafana/data';
+import { locationUtil, type GrafanaTheme2, type IconName, isIconName } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
@@ -31,7 +31,7 @@ export default function ConnectionsHomePage() {
   const cardsData = (navIndex['connections']?.children ?? [])
     .filter((item) => item.url)
     .map((item) => {
-      const meta = cardMetadata[item.url!];
+      const meta = cardMetadata[locationUtil.stripBaseFromUrl(item.url!)];
       return {
         ...item,
         text: meta?.text ?? item.text,

--- a/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.test.tsx
+++ b/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+
+import { type GrafanaConfig, locationUtil } from '@grafana/data';
+import { getCatalogPluginMock } from 'app/features/plugins/admin/mocks/mockHelpers';
+
+import { CardGrid, type CardGridItem } from './CardGrid';
+
+function buildItem(overrides: Partial<CardGridItem>): CardGridItem {
+  return getCatalogPluginMock(overrides);
+}
+
+describe('CardGrid', () => {
+  it('fires onClickItem', async () => {
+    const onClickItem = jest.fn();
+    const items = [buildItem({ id: 'test-ds', name: 'Test DS', url: '/connections/datasources/test-ds' })];
+
+    render(<CardGrid items={items} onClickItem={onClickItem} />);
+    screen.getByText('Test DS').click();
+
+    expect(onClickItem).toHaveBeenCalled();
+  });
+
+  it('renders a card with no href when the item has no url', () => {
+    const items = [buildItem({ id: 'no-url', name: 'No URL Plugin', url: undefined })];
+
+    render(<CardGrid items={items} />);
+    expect(screen.queryByRole('link', { name: 'No URL Plugin' })).not.toBeInTheDocument();
+  });
+
+  describe('with appSubUrl', () => {
+    beforeAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/grafana' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    afterAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    it('prefixes a bare datasource details url with the subpath', () => {
+      const items = [buildItem({ id: 'test-ds', name: 'Test DS', url: '/connections/datasources/test-ds' })];
+
+      render(<CardGrid items={items} />);
+      expect(screen.getByRole('link', { name: 'Test DS' })).toHaveAttribute(
+        'href',
+        '/grafana/connections/datasources/test-ds'
+      );
+    });
+
+    it('prefixes a bare app plugin url with the subpath', () => {
+      const items = [buildItem({ id: 'test-app', name: 'Test App', url: '/plugins/test-app' })];
+
+      render(<CardGrid items={items} />);
+      expect(screen.getByRole('link', { name: 'Test App' })).toHaveAttribute('href', '/grafana/plugins/test-app');
+    });
+  });
+});

--- a/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
+++ b/public/app/features/connections/tabs/ConnectData/CardGrid/CardGrid.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { locationUtil, type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { featureEnabled } from '@grafana/runtime';
@@ -88,7 +88,7 @@ export const CardGrid = ({ items, onClickItem }: CardGridProps) => {
           key={item.id}
           noMargin
           className={styles.card}
-          href={item.url}
+          href={item.url ? locationUtil.assureBaseUrl(item.url) : undefined}
           data-testid={selectors.pages.Connections.AddNewConnection.pluginCard(item.name)}
           onClick={(e) => {
             if (onClickItem) {

--- a/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
+++ b/public/app/features/connections/tabs/ConnectData/DataSourceTabs.test.tsx
@@ -2,7 +2,7 @@ import { type RenderResult, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render } from 'test/test-utils';
 
-import { LayoutModes, PluginType } from '@grafana/data';
+import { type GrafanaConfig, LayoutModes, locationUtil, PluginType } from '@grafana/data';
 import { setPluginLinksHook, setPluginComponentsHook, setPluginFunctionsHook } from '@grafana/runtime';
 import { setDatasourcePluginMetas } from '@grafana/runtime/internal';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -191,5 +191,31 @@ describe('DataSourceEditTabs', () => {
     expect(insightsTab).toBeInTheDocument();
     expect(insightsTab).toHaveTextContent('Insights');
     expect(insightsTab).toHaveAttribute('href', '/connections/datasources/edit/x/insights');
+  });
+
+  describe('with appSubUrl', () => {
+    beforeAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '/grafana' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    afterAll(() => {
+      locationUtil.initialize({
+        config: { appSubUrl: '' } as GrafanaConfig,
+        getVariablesUrlParams: jest.fn(),
+        getTimeRangeForUrl: jest.fn(),
+      });
+    });
+
+    it('prefixes the tab hrefs with the subpath exactly once', async () => {
+      const path = ROUTES.DataSourcesEdit.replace(':uid', mockDatasources[0].uid);
+      renderPage(path);
+
+      const permissionsTab = await screen.findByTestId('data-testid Tab Permissions');
+      expect(permissionsTab).toHaveAttribute('href', '/grafana/connections/datasources/edit/x/permissions');
+    });
   });
 });


### PR DESCRIPTION
## What this is

Part 2 of a 3-PR stack fixing #128972. Stacks on #131492 (merge that one first). This PR fixes the actual reported symptom: the Connections landing page.

## Root cause

Under a configured subpath, the backend nav tree hands `ConnectionsHomePage` a `Connections → Data sources` url that already carries `appSubUrl` (`pkg/services/navtree/navtreeimpl/navtree.go`). The page looked up per-card metadata (icon, copy) by that url against bare keys in `CardMetadata.ts`, so the lookup always missed and cards silently fell back to the raw nav item's text/icon. This was the last live gap behind the reported "duplicate subpath" symptom — the `PageCard` component itself that generates the link was already fixed on `main` by #130603, but nothing guarded that fix with a test, and the metadata lookup was still broken.

`CardGrid` (the "Add new connection" plugin/datasource cards) had the mirror-image bug: its urls are built bare (`ROUTES.DataSourcesDetails`, `/plugins/:id`), but rendered straight into a raw `href`, so they lost the subpath entirely rather than doubling it.

## Fix

- `ConnectionsHomePage.tsx`: strip the subpath before the `CardMetadata` lookup.
- `CardGrid.tsx`: apply the subpath once via `locationUtil.assureBaseUrl`.

## Testing

- New `CardGrid.test.tsx`: bare datasource/app-plugin urls get prefixed once under a subpath; `onClickItem` still fires; an item with no url renders without a link.
- Extended `Connections.test.tsx` with a subpath case asserting the OSS-specific card titles/subtitles (`CardMetadata`) still resolve when the nav tree's urls already carry the prefix.
- `DataSourceTabs.test.tsx` gets a subpath case too, exercising PR 1's `PageTabs` fix through the datasource-settings nav end-to-end.

```
yarn jest --no-watch --watchAll=false public/app/features/connections
yarn tsc --noEmit
```