### PR TITLE
Frontend: Resolve index page images from the asset public path

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -147,6 +147,12 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		return nil, err
 	}
 
+	// The bundlers copy public/img into whichever build directory they write, so these
+	// have to follow the build directory resolved above rather than a fixed path.
+	buildImage := func(name string) template.URL {
+		return template.URL(assets.ContentDeliveryURL + assets.PublicPath + "img/" + name) // #nosec G203 nosemgrep: go.lang.security.audit.net.unescaped-data-in-url.unescaped-data-in-url
+	}
+
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
 	hasEditPerm := hasAccess(ac.EvalAny(ac.EvalPermission(dashboards.ActionDashboardsCreate), ac.EvalPermission(folder.ActionFoldersCreate)))
 
@@ -189,12 +195,12 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		NewGrafanaVersionExists:             hs.grafanaUpdateChecker.UpdateAvailable(),
 		AppName:                             setting.ApplicationName,
 		AppNameBodyClass:                    "app-grafana",
-		FavIcon:                             template.URL(assets.ContentDeliveryURL + "public/build/img/fav32.png"),            // #nosec G203
-		AppleTouchIcon:                      template.URL(assets.ContentDeliveryURL + "public/build/img/apple-touch-icon.png"), // #nosec G203
+		FavIcon:                             buildImage("fav32.png"),
+		AppleTouchIcon:                      buildImage("apple-touch-icon.png"),
 		AppTitle:                            "Grafana",
 		NavTree:                             navTree,
 		Nonce:                               c.RequestNonce,
-		LoadingLogo:                         template.URL(assets.ContentDeliveryURL + "public/build/img/grafana_icon.svg"), // #nosec G203
+		LoadingLogo:                         buildImage("grafana_icon.svg"),
 		IsDevelopmentEnv:                    hs.Cfg.Env == setting.Dev,
 		Assets:                              assets,
 		RenderBindingSupported:              renderBindingSupported,

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -19,9 +19,9 @@
     ></script>
     [[end]]
 
-    <link rel="icon" id="grafana_favicon" type="image/png" href="[[.Assets.ContentDeliveryURL]]public/build/img/fav32.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="[[.Assets.ContentDeliveryURL]]public/build/img/apple-touch-icon.png" />
-    <link rel="mask-icon" href="[[.Assets.ContentDeliveryURL]]public/build/img/grafana_mask_icon.svg" color="#F05A28" />
+    <link rel="icon" id="grafana_favicon" type="image/png" href="[[.Assets.ContentDeliveryURL]][[.Assets.PublicPath]]img/fav32.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="[[.Assets.ContentDeliveryURL]][[.Assets.PublicPath]]img/apple-touch-icon.png" />
+    <link rel="mask-icon" href="[[.Assets.ContentDeliveryURL]][[.Assets.PublicPath]]img/grafana_mask_icon.svg" color="#F05A28" />
 
     [[range $asset := .Assets.CSSFiles]]
       <link rel="stylesheet" href="[[$asset.FilePath]]" />

--- a/pkg/services/frontend/index_test.go
+++ b/pkg/services/frontend/index_test.go
@@ -164,6 +164,7 @@ func TestFrontendService_WebAssets(t *testing.T) {
 		assert.Equal(t, 200, recorder.Code)
 		body := recorder.Body.String()
 		assert.Contains(t, body, "src=\"public/build/runtime.js\"")
+		assert.Contains(t, body, "href=\"public/build/img/fav32.png\"")
 		assert.NotContains(t, body, "window.__grafanaPreviewAssets")
 	})
 
@@ -237,6 +238,9 @@ func TestFrontendService_WebAssets(t *testing.T) {
 		assert.Contains(t, body, "src=\"public/build/rspack/app.js\" type=\"text/javascript\"")
 		assert.NotContains(t, body, "src=\"public/build/runtime.js\"")
 		assert.Contains(t, body, "// test boot stub for build/rspack")
+		// Static images are copied into the build directory, so they move with it.
+		assert.Contains(t, body, "href=\"public/build/rspack/img/fav32.png\"")
+		assert.NotContains(t, body, "href=\"public/build/img/fav32.png\"")
 	})
 
 	t.Run("should start without an rspack build and fail the request when the flag is on", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

The favicon, apple-touch-icon, mask-icon and boot logo are built from the resolved asset public path instead of a hardcoded `public/build/`.

**Why do we need this feature?**

They 404 whenever assets are served from anywhere other than `public/build`. The two index templates had also drifted: the frontend service pointed `mask-icon` at `public/build/img/`, core points at `public/img/`.

**Who is this feature for?**

Grafana developers.

**Which issue(s) does this PR fix?**:

Part of #129734, epic #128309. Same class as #131186 — a frontend site that resolves assets against a hardcoded `public/build`.

**Special notes for your reviewer:**

No behaviour change today. `PublicPath` is `public/build/`, so every URL is byte-identical.

The frontend service uses `[[.Assets.PublicPath]]` in the template rather than growing `FavIcon`-style fields. Per @joshhunt, core has those fields mainly so enterprise index-data hooks can override them, and the frontend service passes hooks a stub carrying only `BuildInfo` and `Licensing` — fields there would be unreachable.

Covered by `TestFrontendService_WebAssets`; the assertion fails if the template goes back to a literal path.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] ~If this is a pre-GA feature, it is behind a feature toggle.~ N/A
- [x] ~The docs are updated~ N/A

