### PR TITLE
Homepage: Point the Hosted Traces recommendation at the Alloy traces guide

### DIFF
--- a/public/app/features/home/solutions/telemetrySetup.test.ts
+++ b/public/app/features/home/solutions/telemetrySetup.test.ts
@@ -40,12 +40,12 @@ describe('getTelemetrySetupLink', () => {
     });
   });
 
-  it('uses Cloud instrumentation documentation for traces even when the setup guide is available', () => {
+  it('opens the in-app Pathfinder traces guide when the setup guide is available', () => {
     jest.mocked(contextSrv.hasRole).mockImplementation((role) => role === 'Admin');
 
     expect(getTelemetrySetupLink('traces', { setupGuideEnabled: true })).toEqual({
       action: 'Instrument traces',
-      href: 'https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/instrument-apps/',
+      href: '/a/grafana-pathfinder-app?doc=%2Fdocs%2Flearning-paths%2Fsend-traces-alloy%2F&source=homepage-recommendations',
       cta: 'learn_more',
     });
   });

--- a/public/app/features/home/solutions/telemetrySetup.ts
+++ b/public/app/features/home/solutions/telemetrySetup.ts
@@ -25,6 +25,11 @@ export const TELEMETRY_SETUP_DOCS = {
 
 const GRAFANA_CLOUD_DOCS_BASE_URL = 'https://grafana.com/docs/grafana-cloud';
 
+const PATHFINDER_PLUGIN_ID = 'grafana-pathfinder-app';
+/** "Send traces to Grafana Cloud using Alloy" learning path, opened in Grafana by Pathfinder. */
+const TRACES_GUIDE_DOC = encodeURIComponent('/docs/learning-paths/send-traces-alloy/');
+const TRACES_GUIDE_HREF = `/a/${PATHFINDER_PLUGIN_ID}?doc=${TRACES_GUIDE_DOC}&source=homepage-recommendations`;
+
 const setup: Record<
   TelemetryType,
   { action: () => string; guidePath?: string; cloudDocsHref: string; docsHref: string }
@@ -43,7 +48,7 @@ const setup: Record<
   },
   traces: {
     action: () => t('home.overview.available.traces.action', 'Instrument traces'),
-    cloudDocsHref: `${GRAFANA_CLOUD_DOCS_BASE_URL}/send-data/traces/set-up/instrument-apps/`,
+    cloudDocsHref: TRACES_GUIDE_HREF,
     docsHref: TELEMETRY_SETUP_DOCS.traces,
   },
 };
@@ -86,5 +91,7 @@ export function getTelemetrySetupLearnMore(
   capabilities: TelemetrySetupCapabilities
 ): SolutionLearnMore {
   const definition = setup[type];
-  return { href: capabilities.setupGuideEnabled ? definition.cloudDocsHref : definition.docsHref };
+  const href = capabilities.setupGuideEnabled ? definition.cloudDocsHref : definition.docsHref;
+  // cloudDocsHref may be an in-app path, so respect a non-root base URL. Absolute URLs pass through unchanged.
+  return { href: locationUtil.assureBaseUrl(href) };
 }


### PR DESCRIPTION
**What is this feature?**

The Hosted Traces recommendation on the growth homepage currently sends Cloud users to `grafana.com/docs/grafana-cloud/send-data/traces/set-up/instrument-apps/`. This changes that one destination to a Pathfinder deep link for the "Send traces to Grafana Cloud using Alloy" learning path:

```
/a/grafana-pathfinder-app?doc=%2Fdocs%2Flearning-paths%2Fsend-traces-alloy%2F&source=homepage-recommendations
```

The diff is one value in `telemetrySetup.ts`, plus a line in `getTelemetrySetupLearnMore` so a non-root `appSubUrl` is respected. `docsHref` is untouched: deployments without the setup-guide plugin still get the Tempo documentation.

I did not add a `guidePath` for traces. That branch is gated on Admin plus the setup-guide plugin, so it would reach far fewer users than the `learn_more` branch this link feeds.

**Why do we need this feature?**

This is a migration, not a new idea. That exact link already ships today.

`grafana-setupguide-app` at `src/feature/getting-started/data.tsx:106-116` carries a card titled "Send traces using Alloy" pointing at the same document with the same encoding. It lives on the legacy Get Started index, and that index is being replaced by this homepage — `grafana-setupguide-app` `CHANGELOG.md:11`, "redirect getting started to growth homepage" (#1389). So the link exists, it works, and its current home is going away. This carries it forward onto the surviving surface.

It also answers a question already asked on this surface. In the CTA thread Matt noted that two of the recommendation links still take the user out of app to the docs. `hosted-traces` is one of the two. The other is `enable-logs-k8s`, which I have left alone.

**The general question behind this specific PR**

All six Pathfinder walkthroughs on that legacy index are in the same position, not just traces: traces, Kubernetes, MySQL, k6, AWS, and a bundled first-dashboard guide. Where do those land when the index goes away? This PR moves one of them and does not decide anything for the other five. If there is a plan for them, I would rather follow it than keep opening one-link PRs.

**Two things I expect you to push back on, asked as questions**

1. The field is called `cloudDocsHref` and it would now hold a Pathfinder link rather than a documentation URL. That is a real naming mismatch and I have not renamed anything. Would you prefer a separate, differently-named field for in-app guide links, so `cloudDocsHref` keeps meaning "documentation URL"?

2. The link stays gated on the setup-guide plugin. `getTelemetrySetupLearnMore` picks `cloudDocsHref` only when `setupGuideEnabled` is true, so a user with Pathfinder installed but no setup-guide plugin still gets the external Tempo docs. That gate is inherited, not chosen. Is it the gate you want here, or should the Pathfinder link key off the Pathfinder plugin instead?

**Who is this feature for?**

Grafana Cloud users who land on the growth homepage with no traces in their stack and pick the Hosted Traces recommendation.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Draft on purpose. I would rather get an answer to the two questions above, and to the six-link question, than have this merged quietly.

- Tests: `telemetrySetup.test.ts` had a case named "uses Cloud instrumentation documentation for traces even when the setup guide is available", which asserted exactly the behaviour being changed. It is renamed and its expected href updated. The no-setup-guide fallback case and the `getTelemetrySetupCta('traces', ...) === null` case are unchanged and still pass, since no `guidePath` was added.
- `Recommendations.test.tsx` needs no change. It never enables the setup-guide plugin, so its Hosted Traces cases stay on the external Tempo fallback.
- `isExternal` is `/^https?:\/\//`, so the card now renders "Learn more" as an internal link with no external-link icon and no `target="_blank"`. That is the intended change in behaviour.
- `source=homepage-recommendations` is free-form Pathfinder attribution. It lets us measure opens originating here without an experiment inside this code.
- I have not run the frontend suite locally; CI on this PR is the verification.
