### PR TITLE
IAM: Cascade delete service account tokens

### DIFF
--- a/pkg/registry/apis/iam/legacy/delete_service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/delete_service_account_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM {{ .Ident .TokenTable }}
+WHERE org_id = {{ .Arg .Command.OrgID }}
+  AND service_account_id = {{ .Arg .Command.ServiceAccountID }}

--- a/pkg/registry/apis/iam/legacy/service_account.go
+++ b/pkg/registry/apis/iam/legacy/service_account.go
@@ -464,6 +464,23 @@ func (s *legacySQLStore) DeleteServiceAccount(ctx context.Context, ns claims.Nam
 			_ = rows.Close()
 		}
 
+		deleteTokensReq := newDeleteServiceAccountTokens(sql, &deleteServiceAccountTokensCommand{
+			OrgID:            ns.OrgID,
+			ServiceAccountID: userID,
+		})
+		if err := deleteTokensReq.Validate(); err != nil {
+			return err
+		}
+
+		deleteTokensQuery, err := sqltemplate.Execute(sqlDeleteServiceAccountTokensTemplate, deleteTokensReq)
+		if err != nil {
+			return fmt.Errorf("execute service account token delete template: %w", err)
+		}
+
+		if _, err := st.Exec(ctx, deleteTokensQuery, deleteTokensReq.GetArgs()...); err != nil {
+			return fmt.Errorf("failed to delete service account tokens: %w", err)
+		}
+
 		orgUserReq := newDeleteOrgUser(sql, userID)
 		if err := orgUserReq.Validate(); err != nil {
 			return err

--- a/pkg/registry/apis/iam/legacy/service_account_token.go
+++ b/pkg/registry/apis/iam/legacy/service_account_token.go
@@ -69,6 +69,11 @@ type DeleteServiceAccountTokenCommand struct {
 	ServiceAccountID int64
 }
 
+type deleteServiceAccountTokensCommand struct {
+	OrgID            int64
+	ServiceAccountID int64
+}
+
 // CreateServiceAccountTokenWithHashCommand stores a pre-generated hashed token in the legacy api_key table.
 type CreateServiceAccountTokenWithHashCommand struct {
 	TokenName         string // token name used as api_key.name
@@ -169,6 +174,32 @@ func (q deleteServiceAccountTokenQuery) Validate() error {
 
 func newDeleteServiceAccountToken(sql *legacysql.LegacyDatabaseHelper, cmd *DeleteServiceAccountTokenCommand) deleteServiceAccountTokenQuery {
 	return deleteServiceAccountTokenQuery{
+		SQLTemplate: sqltemplate.New(sql.DialectForDriver()),
+		TokenTable:  sql.Table("api_key"),
+		Command:     cmd,
+	}
+}
+
+var sqlDeleteServiceAccountTokensTemplate = mustTemplate("delete_service_account_tokens.sql")
+
+type deleteServiceAccountTokensQuery struct {
+	sqltemplate.SQLTemplate
+	TokenTable string
+	Command    *deleteServiceAccountTokensCommand
+}
+
+func (q deleteServiceAccountTokensQuery) Validate() error {
+	if q.Command.OrgID == 0 {
+		return fmt.Errorf("expected non zero org id")
+	}
+	if q.Command.ServiceAccountID == 0 {
+		return fmt.Errorf("expected non zero service account id")
+	}
+	return nil
+}
+
+func newDeleteServiceAccountTokens(sql *legacysql.LegacyDatabaseHelper, cmd *deleteServiceAccountTokensCommand) deleteServiceAccountTokensQuery {
+	return deleteServiceAccountTokensQuery{
 		SQLTemplate: sqltemplate.New(sql.DialectForDriver()),
 		TokenTable:  sql.Table("api_key"),
 		Command:     cmd,

--- a/pkg/registry/apis/iam/legacy/sql_test.go
+++ b/pkg/registry/apis/iam/legacy/sql_test.go
@@ -205,6 +205,12 @@ func TestIdentityQueries(t *testing.T) {
 		return &v
 	}
 
+	deleteServiceAccountTokens := func(cmd *deleteServiceAccountTokensCommand) sqltemplate.SQLTemplate {
+		v := newDeleteServiceAccountTokens(nodb, cmd)
+		v.SQLTemplate = mocks.NewTestingSQLTemplate()
+		return &v
+	}
+
 	mocks.CheckQuerySnapshots(t, mocks.TemplateTestSetup{
 		RootDir:        "testdata",
 		SQLTemplatesFS: sqlTemplatesFS,
@@ -907,6 +913,15 @@ func TestIdentityQueries(t *testing.T) {
 					Name: "delete_token_basic",
 					Data: deleteServiceAccountToken(&DeleteServiceAccountTokenCommand{
 						Name:             "my-token",
+						OrgID:            1,
+						ServiceAccountID: 42,
+					}),
+				},
+			},
+			sqlDeleteServiceAccountTokensTemplate: {
+				{
+					Name: "delete_service_account_tokens",
+					Data: deleteServiceAccountTokens(&deleteServiceAccountTokensCommand{
 						OrgID:            1,
 						ServiceAccountID: 42,
 					}),

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--delete_service_account_tokens-delete_service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--delete_service_account_tokens-delete_service_account_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM `grafana`.`api_key`
+WHERE org_id = 1
+  AND service_account_id = 42

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--delete_service_account_tokens-delete_service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--delete_service_account_tokens-delete_service_account_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM "grafana"."api_key"
+WHERE org_id = 1
+  AND service_account_id = 42

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--delete_service_account_tokens-delete_service_account_tokens.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--delete_service_account_tokens-delete_service_account_tokens.sql
@@ -1,0 +1,3 @@
+DELETE FROM "grafana"."api_key"
+WHERE org_id = 1
+  AND service_account_id = 42

--- a/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
+++ b/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -81,7 +82,7 @@ func TestIntegrationServiceAccountTokens(t *testing.T) {
 }
 
 // createServiceAccount is a test helper that creates a SA and returns its k8s name (UID).
-func createServiceAccount(t *testing.T, helper *apis.K8sTestHelper) string {
+func createServiceAccount(t *testing.T, helper *apis.K8sTestHelper, name string) string {
 	t.Helper()
 	ctx := context.Background()
 
@@ -91,13 +92,17 @@ func createServiceAccount(t *testing.T, helper *apis.K8sTestHelper) string {
 		GVR:       gvrServiceAccounts,
 	})
 
-	created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
+	obj := helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-create-v0.yaml")
+	obj.SetName(name)
+	require.NoError(t, unstructured.SetNestedField(obj.Object, name, "spec", "title"))
+
+	created, err := saClient.Resource.Create(ctx, obj, metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 
-	name := created.GetName()
-	require.NotEmpty(t, name)
-	return name
+	createdName := created.GetName()
+	require.NotEmpty(t, createdName)
+	return createdName
 }
 
 func tokensPath(ns, saName string) string {
@@ -129,24 +134,43 @@ func doServiceAccountTokenCascadeDeleteTests(t *testing.T, helper *apis.K8sTestH
 	}
 
 	t.Run("deleting a service account deletes its tokens", func(t *testing.T) {
-		saName := createServiceAccount(t, helper)
+		createServiceAccountWithCleanup := func(name string) string {
+			saName := createServiceAccount(t, helper, name)
+			t.Cleanup(func() {
+				_ = saClient.Resource.Delete(ctx, saName, metav1.DeleteOptions{})
+			})
+			return saName
+		}
+
+		saName := createServiceAccountWithCleanup("cascade-delete-sa")
 		require.Equal(t, http.StatusCreated, createToken(saName, "cascade-delete-token-1").Response.StatusCode)
 		require.Equal(t, http.StatusCreated, createToken(saName, "cascade-delete-token-2").Response.StatusCode)
 
+		bystanderSAName := createServiceAccountWithCleanup("cascade-delete-bystander-sa")
+		require.Equal(t, http.StatusCreated, createToken(bystanderSAName, "bystander-token").Response.StatusCode)
+
 		require.NoError(t, saClient.Resource.Delete(ctx, saName, metav1.DeleteOptions{}))
+
+		var bystanderToken getTokenResponse
+		bystanderRsp := apis.DoRequest(helper, apis.RequestParams{
+			User:   helper.Org1.Admin,
+			Method: http.MethodGet,
+			Path:   tokenPath(ns, bystanderSAName, "bystander-token"),
+		}, &bystanderToken)
+		require.Equal(t, http.StatusOK, bystanderRsp.Response.StatusCode)
+		require.Equal(t, "bystander-token", bystanderToken.Body.Title)
 
 		// Token names are unique within an organization, so recreating both names proves
 		// that the original rows were removed rather than merely hidden by owner deletion.
-		replacementSAName := createServiceAccount(t, helper)
+		replacementSAName := createServiceAccountWithCleanup("cascade-delete-replacement-sa")
 		require.Equal(t, http.StatusCreated, createToken(replacementSAName, "cascade-delete-token-1").Response.StatusCode)
 		require.Equal(t, http.StatusCreated, createToken(replacementSAName, "cascade-delete-token-2").Response.StatusCode)
-		require.NoError(t, saClient.Resource.Delete(ctx, replacementSAName, metav1.DeleteOptions{}))
 	})
 }
 
 func doServiceAccountTokenCRUDTests(t *testing.T, helper *apis.K8sTestHelper) {
 	ns := helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID())
-	saName := createServiceAccount(t, helper)
+	saName := createServiceAccount(t, helper, "test-sa-1")
 
 	t.Run("should create a token and receive the plaintext key", func(t *testing.T) {
 		body, err := json.Marshal(createTokenRequest{

--- a/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
+++ b/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
@@ -74,6 +74,7 @@ func TestIntegrationServiceAccountTokens(t *testing.T) {
 				},
 			})
 
+			doServiceAccountTokenCascadeDeleteTests(t, helper)
 			doServiceAccountTokenCRUDTests(t, helper)
 		})
 	}
@@ -105,6 +106,42 @@ func tokensPath(ns, saName string) string {
 
 func tokenPath(ns, saName, tokenName string) string {
 	return fmt.Sprintf("/apis/iam.grafana.app/v0alpha1/namespaces/%s/serviceaccounts/%s/tokens/%s", ns, saName, tokenName)
+}
+
+func doServiceAccountTokenCascadeDeleteTests(t *testing.T, helper *apis.K8sTestHelper) {
+	ctx := context.Background()
+	ns := helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID())
+	saClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: ns,
+		GVR:       gvrServiceAccounts,
+	})
+
+	createToken := func(saName, tokenName string) apis.K8sResponse[createTokenResponse] {
+		body, err := json.Marshal(createTokenRequest{TokenName: tokenName})
+		require.NoError(t, err)
+		return apis.DoRequest(helper, apis.RequestParams{
+			User:   helper.Org1.Admin,
+			Method: http.MethodPost,
+			Path:   tokensPath(ns, saName),
+			Body:   body,
+		}, &createTokenResponse{})
+	}
+
+	t.Run("deleting a service account deletes its tokens", func(t *testing.T) {
+		saName := createServiceAccount(t, helper)
+		require.Equal(t, http.StatusCreated, createToken(saName, "cascade-delete-token-1").Response.StatusCode)
+		require.Equal(t, http.StatusCreated, createToken(saName, "cascade-delete-token-2").Response.StatusCode)
+
+		require.NoError(t, saClient.Resource.Delete(ctx, saName, metav1.DeleteOptions{}))
+
+		// Token names are unique within an organization, so recreating both names proves
+		// that the original rows were removed rather than merely hidden by owner deletion.
+		replacementSAName := createServiceAccount(t, helper)
+		require.Equal(t, http.StatusCreated, createToken(replacementSAName, "cascade-delete-token-1").Response.StatusCode)
+		require.Equal(t, http.StatusCreated, createToken(replacementSAName, "cascade-delete-token-2").Response.StatusCode)
+		require.NoError(t, saClient.Resource.Delete(ctx, replacementSAName, metav1.DeleteOptions{}))
+	})
 }
 
 func doServiceAccountTokenCRUDTests(t *testing.T, helper *apis.K8sTestHelper) {


### PR DESCRIPTION
**What is this feature?**

Deletes all service account tokens from the legacy `api_key` table when their owning service account is deleted through the Kubernetes-style API.

The token deletion runs in the same transaction as the existing `org_user` and `user` deletions. SQL snapshots cover SQLite, MySQL, and PostgreSQL.

**Why do we need this feature?**

Deleting a service account through the Kubernetes-style API currently leaves its tokens behind. These orphaned tokens retain their organization-wide unique names and may remain usable.

Cascading the deletion ensures that removing a service account also removes its associated credentials whenever deletion includes the legacy store.

**Who is this feature for?**

Administrators managing service accounts through Grafana's Kubernetes-style APIs.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/identity-access-team/issues/2028

**Special notes for your reviewer:**

This change adds transactional token cleanup when service account deletion includes the legacy store (Modes 0–3), matching the existing legacy service account deletion behavior.

Unified-only cleanup for Modes 4–5 depends on https://github.com/grafana/identity-access-team/issues/2254. The current service account token API uses only the legacy token store.
