### PR TITLE
fix(OutsideRangePlugin): handle NULL time values in Zoom to data

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -26,6 +26,9 @@ export const OutsideRangePlugin = memo(({ config, onChangeTimeRange }: Threshold
    */
   const allValuesNullAtIndex = useCallback(
     (idx: number): boolean => {
+      if (data[0]?.[idx] == null) {
+        return true;
+      }
       for (let seriesIdx = 1; seriesIdx < data.length; seriesIdx++) {
         if (data[seriesIdx][idx] != null) {
           return false;
@@ -64,6 +67,10 @@ export const OutsideRangePlugin = memo(({ config, onChangeTimeRange }: Threshold
 
   let first = timeValues[i];
   let last = timeValues[j];
+
+  if (first == null || last == null || !Number.isFinite(first) || !Number.isFinite(last)) {
+    return null;
+  }
 
   // (StartA <= EndB) and (EndA >= StartB)
   if (first <= timeRange.max && last >= timeRange.min) {


### PR DESCRIPTION
Fix OutsideRangePlugin crash when time column contains NULLs.

Bug: allValuesNullAtIndex at OutsideRangePlugin.tsx:27-66 skipped only value-null rows, so i/j could land on index where timeValues[i] is null or undefined. That null was passed as {from: undefined, to: undefined} to onChangeTimeRange, causing TypeError on valueOf.

Fix: make allValuesNullAtIndex return true when timeValues[idx] is null or undefined so while loops skip NULL-time rows. Add defensive guard before dispatch: if first or last is null or not finite, return null instead of rendering button. Keeps State Timeline and Time Series from passing undefined range.

Evidence: reproduction with time [null,2000,3000,null] and values [1,2,3,4] shows buggy path passes null to onChangeTimeRange while fixed path correctly trims to [2000,3000]. Existing OutsideRangePlugin tests continue to pass.

Written in conjunction with my pair programmer Claude.