### PR TITLE
Alerting: Refactor useIsAutoSyncActive onto the shared Config-API helpers

### DIFF
--- a/public/app/features/alerting/unified/api/configApi.ts
+++ b/public/app/features/alerting/unified/api/configApi.ts
@@ -16,11 +16,7 @@ export const CONFIG_SINGLETON_NAME = 'default';
 
 type GetConfigQueryOptions = Parameters<typeof configApi.useGetConfigQuery>[1];
 
-/**
- * Auto-sync specific: the flag gate would be wrong for a consumer of some other Config field.
- * Wired up by a later PR in this migration's stack; not consumed yet.
- * @lintignore
- */
+/** Auto-sync specific: the flag gate would be wrong for a consumer of some other Config field. */
 export function useAutoSyncConfigQuery(options?: GetConfigQueryOptions) {
   const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
   const canReadConfig = contextSrv.hasPermission(AccessControlAction.ActionAlertingNotificationsConfigRead);

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.test.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.test.ts
@@ -1,100 +1,92 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
 
-import { type Config } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions } from '../mocks';
-import { setupAutoSyncConfig } from '../mocks/server/handlers/k8s/config.k8s';
+import { setupAutoSyncConfig, setupAutoSyncConfigAbsent } from '../mocks/server/handlers/k8s/config.k8s';
 
-import { resolveEffectiveSyncUid, useIsAutoSyncActive } from './useIsAutoSyncActive';
+import { useIsAutoSyncActive } from './useIsAutoSyncActive';
 
-const INI_UID = 'ini-mimir-uid';
-const SPEC_UID = 'spec-mimir-uid';
+const server = setupMswServer();
 
-function buildConfig(spec: Config['spec'], status: Config['status']): Config {
-  return {
-    apiVersion: 'notifications.alerting.grafana.app/v0alpha1',
-    kind: 'Config',
-    metadata: { name: 'default' },
-    spec,
-    status,
-  };
+function renderIsAutoSyncActive() {
+  return renderHook(() => useIsAutoSyncActive(), { wrapper: getWrapper({ renderWithRouter: true }) });
 }
 
-const notConfiguredCondition = {
-  type: 'ExternalAlertmanagerSynced',
-  status: 'Unknown',
-  reason: 'NotConfigured',
-  lastTransitionTime: '2026-01-01T00:00:00Z',
-} as const;
+async function settledResult() {
+  const { result } = renderIsAutoSyncActive();
+  await waitFor(() => expect(result.current.isLoading).toBe(false));
+  return result;
+}
 
-describe('resolveEffectiveSyncUid', () => {
-  it('returns the spec UID when only spec is set', () => {
-    const config = buildConfig({ externalAlertmanagerSync: { datasourceUid: SPEC_UID } }, {});
+testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
 
-    expect(resolveEffectiveSyncUid(config)).toBe(SPEC_UID);
-  });
-
-  it('returns the ini UID from status, which never reaches spec', () => {
-    const config = buildConfig({}, { externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' } });
-
-    expect(resolveEffectiveSyncUid(config)).toBe(INI_UID);
-  });
-
-  it('ignores an ini UID once the syncer reports NotConfigured', () => {
-    // The syncer keeps externalAlertmanagerSync as last-attempt context after sync stops, so the
-    // condition is the only thing that releases a stale ini reading.
-    const config = buildConfig(
-      {},
-      {
-        externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' },
-        conditions: [notConfiguredCondition],
-      }
-    );
-
-    expect(resolveEffectiveSyncUid(config)).toBeUndefined();
-  });
-
-  it('prefers the ini UID over spec, matching the backend resolution order', () => {
-    const config = buildConfig(
-      { externalAlertmanagerSync: { datasourceUid: SPEC_UID } },
-      { externalAlertmanagerSync: { datasourceUid: INI_UID, origin: 'ini' } }
-    );
-
-    expect(resolveEffectiveSyncUid(config)).toBe(INI_UID);
-  });
-
-  it('ignores an api-origin status, which lags spec', () => {
-    const config = buildConfig({}, { externalAlertmanagerSync: { datasourceUid: SPEC_UID, origin: 'api' } });
-
-    expect(resolveEffectiveSyncUid(config)).toBeUndefined();
-  });
-
-  it('returns undefined when the Config is unreadable', () => {
-    expect(resolveEffectiveSyncUid(undefined)).toBeUndefined();
-  });
+beforeEach(() => {
+  grantUserPermissions([AccessControlAction.ActionAlertingNotificationsConfigRead]);
 });
 
 describe('useIsAutoSyncActive', () => {
-  const server = setupMswServer();
+  it('reports active for an API-configured org', async () => {
+    setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
 
-  testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
-
-  beforeEach(() => {
-    grantUserPermissions([AccessControlAction.ActionAlertingNotificationsConfigRead]);
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(true);
   });
 
-  it('reports an ini-configured sync as active, using its datasource UID', async () => {
-    setupAutoSyncConfig(server, { statusUid: INI_UID, origin: 'ini' });
+  it('reports inactive when nothing is configured', async () => {
+    setupAutoSyncConfig(server);
 
-    const wrapper = getWrapper({ renderWithRouter: false });
-    const { result } = renderHook(() => useIsAutoSyncActive(), { wrapper });
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(false);
+  });
 
-    await waitFor(() => {
-      expect(result.current.isActive).toBe(true);
-    });
-    expect(result.current.datasourceUid).toBe(INI_UID);
+  it('reports inactive for a stale status UID left behind by a disabled sync', async () => {
+    setupAutoSyncConfig(server, { statusUid: 'mimir-uid' });
+
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('reports active for an operator-configured (ini) sync', async () => {
+    setupAutoSyncConfig(server, { statusUid: 'mimir-uid', origin: 'ini' });
+
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it('keeps reporting active for an ini sync whose last attempt failed', async () => {
+    // A check written against the condition's status rather than its reason would unblock imports here.
+    setupAutoSyncConfig(server, { statusUid: 'mimir-uid', origin: 'ini', syncedReason: 'MimirFetchFailed' });
+
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it('reports inactive once the worker stops resolving a removed ini key', async () => {
+    // Regression: trusting origin='ini' alone kept imports blocked forever, with no way to recover.
+    setupAutoSyncConfig(server, { statusUid: 'mimir-uid', origin: 'ini', syncedReason: 'NotConfigured' });
+
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('reports inactive when the singleton has not been seeded yet', async () => {
+    setupAutoSyncConfigAbsent(server);
+
+    const result = await settledResult();
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('skips the query, and reports inactive, without the read permission', async () => {
+    // The read would be a guaranteed 403, and imports must not be blocked by that.
+    grantUserPermissions([]);
+    const { requestSpy } = setupAutoSyncConfig(server, { specUid: 'mimir-uid' });
+
+    const result = await settledResult();
+
+    expect(requestSpy).not.toHaveBeenCalled();
+    expect(result.current.isActive).toBe(false);
   });
 });

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -1,66 +1,15 @@
-import { skipToken } from '@reduxjs/toolkit/query';
+import { useAutoSyncConfigQuery } from '../api/configApi';
+import { deriveSyncSource } from '../utils/autoSync';
 
-import { type Config, useGetConfigQuery } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
-import { config } from '@grafana/runtime';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
-
-// The per-org alerting Config resource is a singleton at this fixed name (backend
-// ConfigSingletonName).
-const CONFIG_SINGLETON_NAME = 'default';
-
-// Mirrors the syncer's condition contract (conditionTypeExternalAlertmanagerSynced and
-// conditionReasonNotConfigured in pkg/services/ngalert/notifier/external_am_syncer.go). The generated
-// client types both fields as plain strings, so nothing links these to the backend at compile time.
-const SYNCED_CONDITION_TYPE = 'ExternalAlertmanagerSynced';
-const REASON_NOT_CONFIGURED = 'NotConfigured';
-
-interface AutoSyncState {
+interface AutoSyncActiveState {
   isActive: boolean;
-  /** Datasource the org syncs from. Undefined while loading, when sync is off, or when the Config is unreadable. */
-  datasourceUid?: string;
   isLoading: boolean;
 }
 
-/**
- * The datasource UID the sync worker will actually use, resolved the way the backend does in
- * resolveExternalAMUIDForOrg: the operator ini override first, then the per-org spec.
- *
- * Status is ignored at the "api" origin because it holds the last sync attempt and lags — it stays
- * populated after sync is disabled and restarted, so it reports active when it isn't. The ini
- * override (unified_alerting.external_alertmanager_uid) is the exception: it never reaches spec, so
- * status is the only place it surfaces. A stale ini reading is released by the
- * ExternalAlertmanagerSynced/NotConfigured condition, which the syncer writes on the first tick after
- * sync stops (every alertmanager_config_poll_interval, default 1 minute) while deliberately keeping
- * externalAlertmanagerSync as last-attempt context.
- *
- * Residual gap: before the syncer's first tick status is empty, so an ini-configured sync is
- * invisible here. IsExternalAMSyncConfiguredForOrg on the convert endpoint stays the real guard.
- */
-export function resolveEffectiveSyncUid(orgConfig?: Config): string | undefined {
-  const lastAttempt = orgConfig?.status?.externalAlertmanagerSync;
-  const syncTurnedOff = orgConfig?.status?.conditions?.some(
-    (condition) => condition.type === SYNCED_CONDITION_TYPE && condition.reason === REASON_NOT_CONFIGURED
-  );
+// Fail-open: no data — loading, 404, 403, or a skipped query — derives no UID, so sync reads as
+// inactive. The convert endpoint's IsExternalAMSyncConfiguredForOrg check is the real safety net.
+export function useIsAutoSyncActive(): AutoSyncActiveState {
+  const { data, isLoading } = useAutoSyncConfigQuery();
 
-  if (lastAttempt?.origin === 'ini' && !syncTurnedOff && lastAttempt.datasourceUid) {
-    return lastAttempt.datasourceUid;
-  }
-  return orgConfig?.spec?.externalAlertmanagerSync?.datasourceUid;
-}
-
-// Reports whether external (Mimir/Cortex) Alertmanager sync is actively running for the org.
-//
-// Sourced from the per-org Config resource (notifications.alerting.grafana.app); see
-// resolveEffectiveSyncUid for how spec and status combine. Gated on the
-// ActionAlertingNotificationsConfigRead permission so non-admins who legitimately hold it are also
-// blocked while sync is active. Fail-open: while loading or on a 404/403 (resource absent or no read
-// access) data is undefined, so isActive is false; when the query is skipped (flag off or no read
-// access) isLoading is also false.
-export function useIsAutoSyncActive(): AutoSyncState {
-  const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
-  const canReadConfig = contextSrv.hasPermission(AccessControlAction.ActionAlertingNotificationsConfigRead);
-  const { data, isLoading } = useGetConfigQuery(flagOn && canReadConfig ? { name: CONFIG_SINGLETON_NAME } : skipToken);
-  const datasourceUid = resolveEffectiveSyncUid(data);
-  return { isActive: Boolean(datasourceUid), datasourceUid, isLoading };
+  return { isActive: Boolean(deriveSyncSource(data).uid), isLoading };
 }

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/config.k8s.ts
@@ -89,11 +89,7 @@ export function setupAutoSyncConfig(server: SetupServer, options: AutoSyncConfig
   return { requestSpy };
 }
 
-/**
- * 404 on both read and write: the sync worker has not seeded the singleton yet.
- * Wired up by a later PR in this migration's stack; not consumed yet.
- * @lintignore
- */
+/** 404 on both read and write: the sync worker has not seeded the singleton yet. */
 export function setupAutoSyncConfigAbsent(server: SetupServer) {
   const requestSpy = jest.fn();
   server.use(

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -447,10 +447,16 @@ describe('RuleListActions', () => {
       enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
     });
 
-    // Drive auto-sync state via the Config resource: useIsAutoSyncActive reads
-    // spec.externalAlertmanagerSync.datasourceUid, so specUid is the active-sync signal.
+    // Drive auto-sync state via the Config resource: for an API-configured org useIsAutoSyncActive
+    // reads spec.externalAlertmanagerSync.datasourceUid, so specUid is the active-sync signal.
     function mockAutoSync(uid?: string) {
       setupAutoSyncConfig(server, uid ? { specUid: uid } : {});
+    }
+
+    // An operator-configured sync leaves spec dormant — grafana.ini is authoritative and the UID
+    // surfaces only in status with origin='ini' — but sync is just as active.
+    function mockIniManagedAutoSync(uid: string) {
+      setupAutoSyncConfig(server, { statusUid: uid, origin: 'ini' });
     }
 
     async function findDisabledWizardItem(menu: HTMLElement) {
@@ -499,6 +505,24 @@ describe('RuleListActions', () => {
       const item = await findDisabledWizardItem(menu);
       expect(item).toHaveAttribute('aria-disabled', 'true');
       expect(item).not.toHaveAttribute('href');
+      expect(item).toHaveTextContent(/auto-sync/i);
+    });
+
+    it('disables "Import to Grafana Alerting" when sync is configured through grafana.ini', async () => {
+      grantUserRole(OrgRole.Editor);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+        AccessControlAction.ActionAlertingNotificationsConfigRead,
+      ]);
+      mockIniManagedAutoSync('mimir-uid');
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      const item = await findDisabledWizardItem(menu);
+      expect(item).toHaveAttribute('aria-disabled', 'true');
       expect(item).toHaveTextContent(/auto-sync/i);
     });
 


### PR DESCRIPTION
**What is this feature?**

Swaps the hook's own local resolveEffectiveSyncUid for the shared deriveSyncSource/utils/autoSync.ts helpers Stage A introduced, and useAutoSyncConfigQuery instead of a raw useGetConfigQuery call — a dedup, not a migration, since this hook already read the Config API. No other consumer references the removed resolveEffectiveSyncUid export.

**Why do we need this feature?**

Part of the API migration for the autosync api

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/alerting-squad/issues/1886

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
