### PR TITLE
DashboardScene: SceneDataTransformer no-restricted-syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -421,6 +421,20 @@ module.exports = [
     },
   },
   {
+    // Scoped to dashboard-scene because that is where a SceneDataTransformer becomes a panel's
+    // $data. Scenes built elsewhere (alerting insights, SceneApps) are not dashboard panels and
+    // construct their own transformers legitimately.
+    name: 'grafana/dashboard-scene-panel-data-transformer',
+    plugins: {
+      '@grafana': grafanaPlugin,
+    },
+    files: ['public/app/features/dashboard-scene/**/*.{ts,tsx}'],
+    ignores: [...commonTestIgnores],
+    rules: {
+      '@grafana/no-scene-data-transformer': 'error',
+    },
+  },
+  {
     name: 'grafana/i18n-plural-defaults',
     plugins: {
       '@grafana/i18n': grafanaI18nPlugin,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -423,7 +423,7 @@ module.exports = [
   {
     // Scoped to dashboard-scene because that is where a SceneDataTransformer becomes a panel's
     // $data. Scenes built elsewhere (alerting insights, SceneApps) are not dashboard panels and
-    // construct their own transformers legitimately.
+    // have no use for the panel plugin behaviour.
     name: 'grafana/dashboard-scene-panel-data-transformer',
     plugins: {
       '@grafana': grafanaPlugin,
@@ -431,7 +431,7 @@ module.exports = [
     files: ['public/app/features/dashboard-scene/**/*.{ts,tsx}'],
     ignores: [...commonTestIgnores],
     rules: {
-      '@grafana/no-scene-data-transformer': 'error',
+      '@grafana/require-panel-plugin-transformations-behaviour': 'error',
     },
   },
   {

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -357,3 +357,23 @@ const logger = createMonitoringLogger('features.my-area');
 import { getLogger } from '@grafana/runtime/unstable';
 const logger = getLogger('features.my-area');
 ```
+
+### `no-scene-data-transformer`
+
+Disallow `new SceneDataTransformer` under `public/app/features/dashboard-scene`. Use `createPanelDataTransformer` instead.
+
+Every transformer that sits between a dashboard panel and its queries has to carry `PanelPluginTransformationsBehaviour`, which is what runs the transformations a panel's plugin registers. A construction site that forgets it fails silently: the panel renders untransformed data with no error and nothing in state to notice. The factory owns `$behaviors` so the guarantee is unconditional.
+
+The rule is scoped to `dashboard-scene` (excluding tests) because that is where a `SceneDataTransformer` becomes a panel's `$data`. Scenes built elsewhere — the alerting insights scenes, plugin-authored SceneApps — are not dashboard panels and construct their own transformers legitimately.
+
+#### Examples
+
+```ts
+// Bad ❌ — missing PanelPluginTransformationsBehaviour
+import { SceneDataTransformer } from '@grafana/scenes';
+const $data = new SceneDataTransformer({ $data: queryRunner, transformations });
+
+// Good ✅
+import { createPanelDataTransformer } from 'app/features/dashboard-scene/utils/createPanelDataTransformer';
+const $data = createPanelDataTransformer({ $data: queryRunner, transformations });
+```

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -358,13 +358,15 @@ import { getLogger } from '@grafana/runtime/unstable';
 const logger = getLogger('features.my-area');
 ```
 
-### `no-scene-data-transformer`
+### `require-panel-plugin-transformations-behaviour`
 
-Disallow `new SceneDataTransformer` under `public/app/features/dashboard-scene`. Use `createPanelDataTransformer` instead.
+Require every `new SceneDataTransformer` under `public/app/features/dashboard-scene` to carry `PanelPluginTransformationsBehaviour` in `$behaviors`. `createPanelDataTransformer` does that for you.
 
-Every transformer that sits between a dashboard panel and its queries has to carry `PanelPluginTransformationsBehaviour`, which is what runs the transformations a panel's plugin registers. A construction site that forgets it fails silently: the panel renders untransformed data with no error and nothing in state to notice. The factory owns `$behaviors` so the guarantee is unconditional.
+That behaviour is what runs the transformations a panel's plugin registers, and a construction site that forgets it fails silently: the panel renders untransformed data with no error and nothing in state to notice.
 
-The rule is scoped to `dashboard-scene` (excluding tests) because that is where a `SceneDataTransformer` becomes a panel's `$data`. Scenes built elsewhere — the alerting insights scenes, plugin-authored SceneApps — are not dashboard panels and construct their own transformers legitimately.
+Only the omission is reported, so a call site with a reason to build the transformer itself still can — it just has to pass the behaviour. A `$behaviors` array assembled elsewhere (spread in from another object, say) can't be checked syntactically and is reported.
+
+The rule is scoped to `dashboard-scene` (excluding tests) because that is where a `SceneDataTransformer` becomes a panel's `$data`. Scenes built elsewhere — the alerting insights scenes, plugin-authored SceneApps — are not dashboard panels and have no use for the behaviour.
 
 #### Examples
 
@@ -376,4 +378,11 @@ const $data = new SceneDataTransformer({ $data: queryRunner, transformations });
 // Good ✅
 import { createPanelDataTransformer } from 'app/features/dashboard-scene/utils/createPanelDataTransformer';
 const $data = createPanelDataTransformer({ $data: queryRunner, transformations });
+
+// Also good ✅ — the behaviour passed by hand
+const $data = new SceneDataTransformer({
+  $data: queryRunner,
+  transformations,
+  $behaviors: [new PanelPluginTransformationsBehaviour()],
+});
 ```

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -88,5 +88,14 @@ module.exports = createNoRestrictedSyntax(
     ].join(', '),
     message:
       'getDataSourceSrv is being phased out in Grafana core. Use the async data source APIs from @grafana/runtime/unstable instead (getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList). See the migration guide https://github.com/grafana/grafana/issues/125083.',
+  },
+  {
+    name: 'no-scene-data-transformer',
+    selector: [
+      'NewExpression[callee.name="SceneDataTransformer"]',
+      'NewExpression[callee.property.name="SceneDataTransformer"]',
+    ].join(', '),
+    message:
+      "Build a panel's data transformer with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer. Constructing SceneDataTransformer directly omits PanelPluginTransformationsBehaviour, so the panel renders untransformed data with no error to notice.",
   }
 );

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -1,5 +1,12 @@
 const createNoRestrictedSyntax = require('eslint-no-restricted/syntax');
 
+// A `SceneDataTransformer` is only safe as a panel's `$data` if `PanelPluginTransformationsBehaviour`
+// is in its `$behaviors`. Matching the identifier anywhere under the property covers both the
+// behaviour constructed inline and one passed by reference; a `$behaviors` array assembled elsewhere
+// cannot be checked syntactically and is reported.
+const withoutPanelTransformationsBehaviour =
+  ':not(:has(Property[key.name="$behaviors"] Identifier[name="PanelPluginTransformationsBehaviour"]))';
+
 // This is a bit different - instead of defining a custom rule manually, we use
 // eslint-no-restricted to turn no-restricted-syntax config into actual eslint rules.
 // This gives them individual rule names for suppression and reporting.
@@ -90,12 +97,12 @@ module.exports = createNoRestrictedSyntax(
       'getDataSourceSrv is being phased out in Grafana core. Use the async data source APIs from @grafana/runtime/unstable instead (getDataSourceInstance, getDataSourceInstanceSettings, getDataSourceInstanceList). See the migration guide https://github.com/grafana/grafana/issues/125083.',
   },
   {
-    name: 'no-scene-data-transformer',
+    name: 'require-panel-plugin-transformations-behaviour',
     selector: [
-      'NewExpression[callee.name="SceneDataTransformer"]',
-      'NewExpression[callee.property.name="SceneDataTransformer"]',
+      `NewExpression[callee.name="SceneDataTransformer"]${withoutPanelTransformationsBehaviour}`,
+      `NewExpression[callee.property.name="SceneDataTransformer"]${withoutPanelTransformationsBehaviour}`,
     ].join(', '),
     message:
-      "Build a panel's data transformer with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer. Constructing SceneDataTransformer directly omits PanelPluginTransformationsBehaviour, so the panel renders untransformed data with no error to notice.",
+      "A dashboard panel's SceneDataTransformer has to carry PanelPluginTransformationsBehaviour in $behaviors, otherwise the transformations the panel's plugin registers never run and the panel renders untransformed data with no error to notice. Build it with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer, or pass the behaviour in $behaviors yourself.",
   }
 );

--- a/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
+++ b/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
@@ -14,14 +14,14 @@ const ruleTester = new RuleTester();
 
 const rule = noRestrictedSyntax.rules['no-direct-create-monitoring-logger'];
 const zodImportNamespaceRule = noRestrictedSyntax.rules['zod-import-namespace'];
-const noSceneDataTransformerRule = noRestrictedSyntax.rules['no-scene-data-transformer'];
+const panelTransformationsBehaviourRule = noRestrictedSyntax.rules['require-panel-plugin-transformations-behaviour'];
 
 const expectedMessage =
   'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.';
 const expectedZodImportMessage =
   "Zod imports must use exactly `import * as z from 'zod'` or `import type * as z from 'zod'`. Imports from zod subpaths are not allowed.";
-const expectedSceneDataTransformerMessage =
-  "Build a panel's data transformer with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer. Constructing SceneDataTransformer directly omits PanelPluginTransformationsBehaviour, so the panel renders untransformed data with no error to notice.";
+const expectedPanelTransformationsBehaviourMessage =
+  "A dashboard panel's SceneDataTransformer has to carry PanelPluginTransformationsBehaviour in $behaviors, otherwise the transformations the panel's plugin registers never run and the panel renders untransformed data with no error to notice. Build it with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer, or pass the behaviour in $behaviors yourself.";
 
 ruleTester.run('no-direct-create-monitoring-logger', rule, {
   valid: [
@@ -131,11 +131,27 @@ ruleTester.run('zod-import-namespace', zodImportNamespaceRule, {
   ],
 });
 
-ruleTester.run('no-scene-data-transformer', noSceneDataTransformerRule, {
+ruleTester.run('require-panel-plugin-transformations-behaviour', panelTransformationsBehaviourRule, {
   valid: [
     {
       name: 'the factory is the sanctioned construction path',
       code: `const $data = createPanelDataTransformer({ $data: queryRunner, transformations });`,
+    },
+    {
+      name: 'the behaviour constructed inline',
+      code: `const $data = new SceneDataTransformer({ transformations, $behaviors: [new PanelPluginTransformationsBehaviour()] });`,
+    },
+    {
+      name: 'the behaviour alongside others',
+      code: `const $data = new SceneDataTransformer({ $behaviors: [new DashboardDatasourceBehaviour(), new PanelPluginTransformationsBehaviour()] });`,
+    },
+    {
+      name: 'the behaviour passed by reference',
+      code: `const $data = new SceneDataTransformer({ $behaviors: [PanelPluginTransformationsBehaviour] });`,
+    },
+    {
+      name: 'construction through a namespace import carrying the behaviour',
+      code: `const $data = new scenes.SceneDataTransformer({ $behaviors: [new PanelPluginTransformationsBehaviour()] });`,
     },
     {
       name: 'importing the type is fine',
@@ -156,29 +172,42 @@ ruleTester.run('no-scene-data-transformer', noSceneDataTransformerRule, {
   ],
   invalid: [
     {
-      name: 'direct construction',
+      name: 'no behaviours at all',
       code: `const $data = new SceneDataTransformer({ $data: queryRunner, transformations });`,
-      errors: [{ message: expectedSceneDataTransformerMessage }],
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
     },
     {
       name: 'construction with no arguments',
       code: `const $data = new SceneDataTransformer();`,
-      errors: [{ message: expectedSceneDataTransformerMessage }],
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
+    },
+    {
+      name: 'an empty $behaviors array',
+      code: `const $data = new SceneDataTransformer({ transformations, $behaviors: [] });`,
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
+    },
+    {
+      name: 'other behaviours but not this one',
+      code: `const $data = new SceneDataTransformer({ $behaviors: [new DashboardDatasourceBehaviour()] });`,
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
+    },
+    {
+      name: 'a $behaviors array assembled elsewhere cannot be checked syntactically',
+      code: `const $data = new SceneDataTransformer({ ...state });`,
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
     },
     {
       name: 'construction through a namespace import',
       code: `import * as scenes from '@grafana/scenes'; const $data = new scenes.SceneDataTransformer({});`,
-      errors: [{ message: expectedSceneDataTransformerMessage }],
-    },
-    {
-      name: 'construction even when $behaviors is passed by hand',
-      code: `const $data = new SceneDataTransformer({ transformations, $behaviors: [new PanelPluginTransformationsBehaviour()] });`,
-      errors: [{ message: expectedSceneDataTransformerMessage }],
+      errors: [{ message: expectedPanelTransformationsBehaviourMessage }],
     },
     {
       name: 'each construction site is reported',
       code: `const a = new SceneDataTransformer({}); const b = new SceneDataTransformer({});`,
-      errors: [{ message: expectedSceneDataTransformerMessage }, { message: expectedSceneDataTransformerMessage }],
+      errors: [
+        { message: expectedPanelTransformationsBehaviourMessage },
+        { message: expectedPanelTransformationsBehaviourMessage },
+      ],
     },
   ],
 });

--- a/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
+++ b/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
@@ -14,11 +14,14 @@ const ruleTester = new RuleTester();
 
 const rule = noRestrictedSyntax.rules['no-direct-create-monitoring-logger'];
 const zodImportNamespaceRule = noRestrictedSyntax.rules['zod-import-namespace'];
+const noSceneDataTransformerRule = noRestrictedSyntax.rules['no-scene-data-transformer'];
 
 const expectedMessage =
   'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.';
 const expectedZodImportMessage =
   "Zod imports must use exactly `import * as z from 'zod'` or `import type * as z from 'zod'`. Imports from zod subpaths are not allowed.";
+const expectedSceneDataTransformerMessage =
+  "Build a panel's data transformer with createPanelDataTransformer from app/features/dashboard-scene/utils/createPanelDataTransformer. Constructing SceneDataTransformer directly omits PanelPluginTransformationsBehaviour, so the panel renders untransformed data with no error to notice.";
 
 ruleTester.run('no-direct-create-monitoring-logger', rule, {
   valid: [
@@ -124,6 +127,58 @@ ruleTester.run('zod-import-namespace', zodImportNamespaceRule, {
       name: 'namespace alias from zod subpath different from z is disallowed',
       code: "import * as zod from 'zod/v4';",
       errors: [{ message: expectedZodImportMessage }],
+    },
+  ],
+});
+
+ruleTester.run('no-scene-data-transformer', noSceneDataTransformerRule, {
+  valid: [
+    {
+      name: 'the factory is the sanctioned construction path',
+      code: `const $data = createPanelDataTransformer({ $data: queryRunner, transformations });`,
+    },
+    {
+      name: 'importing the type is fine',
+      code: `import { type SceneDataTransformerState } from '@grafana/scenes';`,
+    },
+    {
+      name: 'reading an existing transformer is fine',
+      code: `const transformations = panel.state.$data.state.transformations;`,
+    },
+    {
+      name: 'other scenes constructors are untouched',
+      code: `const $data = new SceneQueryRunner({ queries });`,
+    },
+    {
+      name: 'calling it without new is not a construction site',
+      code: `const isTransformer = (obj) => obj instanceof SceneDataTransformer;`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'direct construction',
+      code: `const $data = new SceneDataTransformer({ $data: queryRunner, transformations });`,
+      errors: [{ message: expectedSceneDataTransformerMessage }],
+    },
+    {
+      name: 'construction with no arguments',
+      code: `const $data = new SceneDataTransformer();`,
+      errors: [{ message: expectedSceneDataTransformerMessage }],
+    },
+    {
+      name: 'construction through a namespace import',
+      code: `import * as scenes from '@grafana/scenes'; const $data = new scenes.SceneDataTransformer({});`,
+      errors: [{ message: expectedSceneDataTransformerMessage }],
+    },
+    {
+      name: 'construction even when $behaviors is passed by hand',
+      code: `const $data = new SceneDataTransformer({ transformations, $behaviors: [new PanelPluginTransformationsBehaviour()] });`,
+      errors: [{ message: expectedSceneDataTransformerMessage }],
+    },
+    {
+      name: 'each construction site is reported',
+      code: `const a = new SceneDataTransformer({}); const b = new SceneDataTransformer({});`,
+      errors: [{ message: expectedSceneDataTransformerMessage }, { message: expectedSceneDataTransformerMessage }],
     },
   ],
 });

--- a/public/app/features/dashboard-scene/utils/createPanelDataTransformer.ts
+++ b/public/app/features/dashboard-scene/utils/createPanelDataTransformer.ts
@@ -17,6 +17,7 @@ import { PanelPluginTransformationsBehaviour } from '../scene/PanelPluginTransfo
  * module reaches back into through `DashboardDatasourceBehaviour`.
  */
 export function createPanelDataTransformer(state: Omit<SceneDataTransformerState, '$behaviors'>): SceneDataTransformer {
+  // eslint-disable-next-line @grafana/no-scene-data-transformer -- the one construction site the rule points at
   return new SceneDataTransformer({
     ...state,
     $behaviors: [new PanelPluginTransformationsBehaviour()],

--- a/public/app/features/dashboard-scene/utils/createPanelDataTransformer.ts
+++ b/public/app/features/dashboard-scene/utils/createPanelDataTransformer.ts
@@ -17,7 +17,6 @@ import { PanelPluginTransformationsBehaviour } from '../scene/PanelPluginTransfo
  * module reaches back into through `DashboardDatasourceBehaviour`.
  */
 export function createPanelDataTransformer(state: Omit<SceneDataTransformerState, '$behaviors'>): SceneDataTransformer {
-  // eslint-disable-next-line @grafana/no-scene-data-transformer -- the one construction site the rule points at
   return new SceneDataTransformer({
     ...state,
     $behaviors: [new PanelPluginTransformationsBehaviour()],


### PR DESCRIPTION
**What is this feature?**

Follow-up to https://github.com/grafana/grafana/pull/131174 to prevent accidental construction of SceneDataTransformer without the required behavior. 

Limited to dashboard-scene directory to avoid false positives in alerting code, which do not need to support panel transformations. 

**Why do we need this feature?**

To keep future developers from breaking the system transformations

**Who is this feature for?**

Dashboard developers

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
