### PR TITLE
AdHocTransformations: Contract - PoC

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.test.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.test.ts
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react';
+
+import { usePanelContext } from './PanelContext';
+
+describe('usePanelContext', () => {
+  // Hosts that render no PanelContextProvider at all — PanelRenderer, and so Explore, alerting
+  // rule previews and the visualization suggestion cards — fall back to this default. A panel
+  // feature-detects on the absence to decide whether to render an affordance that writes a
+  // transformation, so the members have to be missing here, not stubbed.
+  it('leaves the transformation members undefined when no provider is mounted', () => {
+    const { result } = renderHook(() => usePanelContext());
+
+    expect(result.current.transformations).toBeUndefined();
+    expect(result.current.onTransformationsChange).toBeUndefined();
+  });
+});

--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -9,6 +9,7 @@ import {
   type EventBus,
   EventBusSrv,
 } from '@grafana/data';
+import { type DataTransformerConfig } from '@grafana/schema';
 
 import { type AdHocFilterItem } from '../Table/types';
 
@@ -63,6 +64,36 @@ export interface PanelContext {
    * Used to apply multiple filters at once
    */
   onAddAdHocFilters?: (items: AdHocFilterItem[]) => void;
+
+  /**
+   * The panel's user-configured transformations, in pipeline order. Read live, so this is the
+   * current list on every render.
+   *
+   * Present only where a host persists transformations and the user may edit the dashboard. It is
+   * absent in Explore, alerting rule previews and visualization suggestion cards, which render
+   * through `PanelRenderer` and run no transformations at all — that absence is the signal a panel
+   * must not offer an affordance that writes one.
+   *
+   * Excludes transformations a plugin registered via `PanelPlugin.setSystemTransformations`: those
+   * are read-only and never persisted.
+   *
+   * @alpha
+   */
+  transformations?: DataTransformerConfig[];
+
+  /**
+   * Replaces the panel's user-configured transformations. The dashboard becomes dirty and the user
+   * saves or discards, exactly like `PanelProps.onFieldConfigChange`.
+   *
+   * Paired with {@link PanelContext.transformations}: both are present or neither is. Read that,
+   * derive the next list from it, pass the whole list back.
+   *
+   * Call this only from a user event handler — never from a render or an effect. A write re-runs the
+   * data pipeline, which re-renders the panel; writing on render would loop.
+   *
+   * @alpha
+   */
+  onTransformationsChange?: (transformations: DataTransformerConfig[]) => void;
 
   /**
    * Used by the panel header status popover to open the errors and notices view.


### PR DESCRIPTION
Two @alpha members a panel feature-detects on: `transformations` reads the panel's user-configured transformations, `onTransformationsChange` replaces them. Both are absent wherever the host cannot persist the write - PanelRenderer mounts no provider, so Explore, alerting rule previews and the suggestion cards see neither, which is the signal a panel must not draw the affordance.

Contract only; nothing sets them yet.

**What is this feature?**

PoC/YOLO

**Why do we need this feature?**

To estimate effort required for ad-hoc transforms after system transformations work

**Special notes for your reviewer:**
<details>

<summary>Plan summary</summary>

# Ad-hoc (panel-authored, user-editable) transformations

> **Summary for reviewers** — the section below is self-contained and free of implementation
> detail. Everything after the horizontal rule is the engineering plan.

## What we're building

A way for a visualization to create and update its own data transformations in response to a user
gesture, instead of only being able to change its own options and field config.

The motivating example: you drag a column header in a table and the column order sticks. Under the
hood that becomes an ordinary "Organize fields" transformation on the panel — the same one you could
have added by hand. Aggregating by a column (via "Group to nested tables") is the next candidate.

Two new capabilities are handed to a panel: read the panel's current transformations, and replace
them. A write behaves exactly like changing a field config today — the dashboard shows unsaved
changes, and the user saves or discards.

## Why this is not the system-transformations work already in flight

Those two efforts look adjacent and are actually opposites, which is worth being precise about
because it drives most of the design:

| | System transformations (already in review) | Ad-hoc transformations (this plan) |
|---|---|---|
| Who decides | The plugin, from the shape of the data | The user, from a gesture |
| Editable | No — read-only rows in the editor | Yes — a normal row the user can reorder, disable or delete |
| Saved to the dashboard | No — they never enter the saved list | Yes |
| Purpose | A prerequisite the panel needs to render at all | A convenience the user opted into |

Because ad-hoc transformations are just user transformations that happen to have been created by a
click, they slot into machinery that already exists. That is the single biggest reason this plan is
small: saving, dirty-state tracking, and both transformation editors need no changes whatsoever.

## The four decisions, and what they cost

1. **The API is a host capability, not a panel prop.** A panel has to know *before it draws a drag
   handle* whether the write can be persisted. Dashboards can persist; Explore, alert rule previews
   and the visualization suggestion cards cannot. Modelling it as a capability that is simply absent
   in those contexts makes that check natural, matches how "add an ad-hoc filter" already works, and
   avoids a dependency on an external package release that is currently holding up the sibling PR.
   The cost is discoverability: it does not sit next to the two change handlers a plugin author
   already knows.

2. **We are not recording which transformations the panel created.** Marking them would mean
   changing the dashboard's stored format, in two schema versions, across the frontend and backend.
   It buys an "added by the panel" badge and an exact ownership match. We're skipping it: a
   transformation the user produced by dragging *is* theirs, and treating it as ordinary is precisely
   what makes it editable and deletable — the whole point. The panel finds its own entry by
   convention instead. The one soft edge: if a user hand-adds a second Organize transformation after
   the panel's, the panel will edit that one. Acceptable, and revisitable if it bites.

3. **Three pull requests, not one.** The public API shape, the dashboard wiring, and the table UX
   have different reviewers and different risk profiles. Splitting them mirrors how the
   system-transformations work was reviewed, and it lets the API be argued about on its own.

4. **Reordering works while simply viewing a dashboard**, not only while editing it — consistent
   with resizing a table column today, which already marks a dashboard dirty. Users without edit
   rights never see the affordance at all.

## Sequencing and what lands when

- **PR 1 — the contract.** Two optional capabilities added to the panel-facing API, documented,
  marked experimental. Nothing observable changes.
- **PR 2 — the dashboard wiring.** Dashboards start offering the capability, behind an experimental
  feature flag. Still nothing user-visible, because no panel uses it yet.
- **PR 3 — the table.** Drag-to-reorder ships. This is the first thing a user can see, and the first
  real exercise of the API.

Worth noting: the system-transformations API shipped with no consumer at all — nothing in the
codebase calls it today. Including the table here means this API is proven end to end before it
becomes public.

## What could go wrong

- **The feature flag reads as "off" for logged-out users.** Not a problem here, since the feature
  already requires edit rights, but it is a trap worth knowing about for anything read-only.
- **A panel misusing the read capability could loop.** Reading transformations during rendering and
  writing them back would re-run the data pipeline, re-render, and repeat. The documented rule is to
  write only from a user event; the plan also makes the read cheap and stable so accidental misuse
  degrades rather than spins.
- **Ordering semantics with multiple query results.** The table shows one result set at a time but
  reordering is expressed by column name, so behaviour across several result sets needs explicit
  test coverage rather than assumption.
- **Editing a panel operates on a working copy.** Dragging inside the panel editor and then
  discarding should behave like any other discarded edit; it needs a deliberate manual check rather
  than being taken on trust.

## Open question worth an explicit answer

None blocking. The one judgement call likely to attract debate in review is decision 2 — whether
panel-created transformations should be distinguishable from hand-added ones. The plan argues no,
and the reversal cost is the schema change described above, so it is better contested now than
after PR 3.

## Update: the groundwork this builds on has changed, in our favour

This plan was first written against an earlier state of the in-flight system-transformations work.
That work has since been reshaped, and the reshaping makes this feature **simpler**, not harder. Two
changes mattered at the first re-read, and a third arrived with the one after it:

**The plugin's transformations no longer share a list with the user's.** They used to be inserted
into the same array and filtered back out at every point that read it — saving, dirty-state
tracking, both editors. Now the plugin supplies them on demand and they never enter that list at
all. The consequence for us is that the panel's stored transformation list is already exactly the
user's list, with nothing to separate out. A helper this plan previously needed — to extract the
user's entries and keep the result stable across renders — is no longer necessary at all, and one of
the risks below disappeared with it.

**Ownership tagging is no longer limited to a single owner.** An earlier constraint meant a second
kind of owner would have required an upstream change. That is no longer true. It does not change
decision 2 — that tagging is deliberately temporary and never saved, so it still cannot answer
"who created this transformation?" after a reload — but it does remove one of the arguments I had
been leaning on, and the decision now rests solely on the design intent of the tag rather than on
what is technically reachable.

**A third change, from the 2026-08-25 re-verification.** The stack has grown a PR *below* the
contract: #131427 replaces the open-coded `dataProvider instanceof SceneDataTransformer` lookups with
a shared helper in `utils/utils.ts`. That is the move PR 2 of this plan was going to make on the
side, so `getDataTransformerFor` is now a sibling of an accepted helper rather than a new idea
smuggled into a PR about something else.

None of the three affects decisions 1, 3 or 4. The engineering detail below has been updated
throughout; the section headed "Upstream drift" records precisely what moved, for anyone comparing
against an earlier read of this plan.

---

## Context

Panels like TableNG want to offer direct-manipulation UI that produces a real transformation: drag
a column header to reorder (an `organize` transform), aggregate by a column (a `groupToNestedTable`
transform). Today a panel can only write to its own `options` and `fieldConfig`
(`PanelProps.onOptionsChange` / `onFieldConfigChange`) — there is no way for a panel to author a
transformation.

The system-transformations work on this branch (`PanelPlugin.setSystemTransformations`,
`PanelPluginTransformationsBehaviour`, PRs #131154 / #131174 — the whole stack is tabled below)
deliberately does *not* solve this: those transforms are pull-based, data-derived, read-only, and
**never enter `state.transformations` at all** — Grafana registers them as a *supplier*, and scenes
resolves them per pass outside state.
Ad-hoc transforms are the inverse — push-based from a user gesture, user-editable in the
transformations tab, and persisted. They belong in `state.transformations`, which is now exactly the
user's list.

Outcome: a panel can read its user transformations and write a new list, the write becomes a pending
dashboard change exactly like `onFieldConfigChange`, and TableNG ships drag-to-reorder as the first
consumer.

</details>

<details>

<summary>Implementation plan</summary>


## Upstream drift, and the stack as it stands

Re-verified 2026-08-25 against these heads. Five PRs, all open, none merged:

| PR | Branch (`gtk-grafana/dataviz/system-transformation__…`) | Base | What it means for this plan |
|---|---|---|---|
| #131426 `13c68da755d` | `…replay-hook` | `main` | Nothing here depends on it — PanelEditNext replay fixes. Merges independently |
| #131427 `fb265006e80` | `…transformer-narrowing` | #131426 | `getSourceDataProvider` in `utils/utils.ts`: the precedent PR 2's helper follows |
| #131154 `fa5cf2252ee` | `…contract` | #131427 | `PanelPlugin.setSystemTransformations(supplier)` and its `@alpha` types |
| #131174 `3376bb4a1d6` | `…implementation` | #131154 | The behaviour, the scenes wrapper, both editors' read-only rows |
| #131191 `64b3805c8ce` | `…logs-table-poc` | #131174 | The first consumer — what PR 3 mirrors, for the read-only case |

scenes #1614 is at `40da41a2` (+1686/-25) and has not moved since 2026-08-24. The branch pins
`@grafana/scenes@8.17.0--canary.1614.32748973104.0`, the newest canary published for that PR — so
this time **the checkout, all five branch heads and the scenes PR agree**, and the local tree can be
read directly. That was not true a day ago and will not stay true for long.

**First reshaping**, between this plan's first draft and its second:

| Was | Now | Effect on this plan |
|---|---|---|
| `PanelDataTransformer`, a `SceneDataTransformer` subclass | Deleted. `utils/createPanelDataTransformer.ts` factory attaches `$behaviors: [new PanelPluginTransformationsBehaviour()]`; every panel transformer is a plain `SceneDataTransformer` | Never reference `PanelDataTransformer` or `instanceof` it. `getDataTransformerFor` returns `SceneDataTransformer` |
| Plugin entries tagged into `state.transformations`, filtered out by every reader | `setSystemTransformations({ origin: 'plugin', supplier })`; supplier-resolved entries never reach state | `state.transformations` **is** the user list |
| `getUserTransformations`, `splitSystemTransformations` | Deleted | **The `getUserTransformerConfigs` accessor and its `WeakMap` are no longer needed** |
| `transformSceneToSaveModel.ts` filtered before writing | Unfiltered: `panel.transformations = dataProvider.state.transformations` | Still no change needed, for a stronger reason |
| `DashboardSceneChangeTracker` diffed the user subset | Reverted to the plain "any non-`data` partial update is dirty" check | Still no change needed |
| `TransformationOrigin = 'plugin'`; `_combineTransformations` hardcoded that origin | `TransformationOrigin = string`, ordered by `_originOrder` | **Corrects a claim below**: a second origin no longer needs a scenes change |
| Resolution + memo lived in Grafana | `SceneDataTransformer.getResolvedSystemTransformations()` (no-arg, memoized per pass) in scenes; Grafana wraps it in `scene/systemTransformations.ts` | Caching precedent to cite is that wrapper, not the old class |
| — | `pluginTransformationsEnabled()` now exported from `scene/systemTransformations.ts` | `adHocTransformationsEnabled()` belongs beside it |
| `PanelDataPaneNext.tsx` mutators rewritten by #131174 | Not in the PR any more | Removes the "collides with #131174" risk |

**Second pass**, what moved on 2026-08-25:

| Was | Now | Effect on this plan |
|---|---|---|
| Nine files open-coded `dataProvider instanceof SceneDataTransformer` | #131427 extracted the *source-provider* half into `getSourceDataProvider` (`utils/utils.ts:276`); 19 sites across 16 files still open-code the narrowing | PR 2's helper lands beside it, in the file and the docblock style that PR just established |
| Serializers inlined `dataProvider.state.$data!.state.data` for snapshots | Both call `getSnapshotSourceData` (`serialization/shared/snapshotData.ts`) | Still no serializer change: this plan writes `state.transformations`, and #131427 rewrote the *snapshot* branch, not that one |
| System entries identified by convention | `isSystemTransformation` and `isTransformationFrom(origin)` are exported **values** on `@grafana/scenes` | `asConfigs` filters them explicitly instead of resting on the plugin tier happening to be supplier-only |
| `setUserTransformations` assumed to leave system entries alone | It partitions state by origin *and* drops any tagged entry from the incoming array before recombining | Strengthens writing through it: `setState` puts that filtering on the caller |
| `getResolvedSystemTransformations()` took no argument | `(series?: DataFrame[])`, defaulting to the frames the pipeline is running | No change — Grafana's wrapper still calls it no-arg, which is what shares the pipeline's memo |
| Neither transformations editor showed system entries | Both do: legacy tab via `panel-edit/systemTransformationDisplay.tsx`, PanelEditNext via `QueryEditor/Sidebar/Cards/SystemTransformationCards.tsx` | Still no editor change here — and manual step 6 now has something concrete to compare an ad-hoc row against |
| — | The five branches touch **none** of `setDashboardPanelContext.ts`, `PanelContext.ts`, `PanelDataPaneNext.tsx`, `Table/TableNG/*`, `features/table/utils.ts` or `panel/table/TablePanel.tsx` | Every file this plan edits is conflict-free against the whole stack |

## Decisions (confirmed)

1. **API lives on `PanelContext`, not `PanelProps`** (see comparison below). No `@grafana/scenes`
   change, so this is not blocked on a scenes release.
2. **No persisted provenance field.** The panel upserts the trailing config matching its transformer
   id. A persisted field would mean a dashboard-spec change (CUE + Go + v1 + v2 +
   `transformationCompat.ts` + two zod mirrors + both serializers) and is explicitly out of scope.
3. **Three PRs**: contract → dashboard plumbing → TableNG consumer.
4. **Writes work in view mode**, matching `onFieldConfigChange`; availability is gated on
   `DashboardScene.canEditDashboard()`.

## Why `PanelContext` over `PanelProps`

The obvious first instinct is `PanelProps`, alongside the other two change handlers. The evidence
points to `PanelContext`:

| | `PanelProps` (`@grafana/data`) | `PanelContext` (`@grafana/ui`) |
|---|---|---|
| Who constructs it | `@grafana/scenes` [`VizPanelRenderer.tsx:328-347`](https://github.com/grafana/scenes/blob/main/packages/scenes/src/components/VizPanel/VizPanelRenderer.tsx) | scenes `buildPanelContext()`, **but extensible by the host** via `VizPanelState.extendPanelContext` |
| Scenes release needed | **Yes** — a `VizPanel` method + renderer wiring, then a real release. Same blocker as #131174 (pinned to `8.17.0--canary.1614...`) | **No.** Everything lands in `setDashboardPanelContext.ts` |
| Non-dashboard hosts | `public/app/features/panel/components/PanelRenderer.tsx:30-33` passes no-op defaults, so the callback is *present but silently does nothing* in Explore / alerting previews / suggestion cards | `PanelRenderer` renders no `PanelContextProvider` at all, so the member is `undefined` — the panel feature-detects and hides the affordance |
| API stability | `@public` | `@alpha` wholesale (`PanelContext.ts:17`) |
| Precedent for this shape | `onOptionsChange`, `onFieldConfigChange` — always-present, panel-owned config | `onAddAdHocFilter`, `onUpdateData`, `canExecuteActions`, `canAddAnnotations` — host capabilities that may be absent |

The decider is the second and third rows. A panel *must* know whether a transformation write can be
persisted before it renders a drag handle; `PanelProps` has no off-switch for that, and
`onAddAdHocFilter` — the closest existing "panel mutates the dashboard model" feature — already
solved it on `PanelContext` with exactly the `!= null` idiom
([`BarChartPanel.tsx:179-189`](air-file://38g4p8gpb3thijc9pibm/Users/galen/projects/grafana/grafana/public/app/plugins/panel/barchart/BarChartPanel.tsx?type=file&root=%252F)).
`TablePanel.tsx:76-80` already mixes both seams in one component, so this is not a new inconsistency.

Cost accepted: worse discoverability than sitting next to `onOptionsChange`. Mitigated by docblocks
that cross-reference, and promotable to `PanelProps` later without breaking `PanelContext` consumers.

## Why no persisted provenance

Scenes' own `TransformationOrigin` docblock rules out reusing `origin`:

> The origin is runtime ownership only, so it never survives into a save model. A transformation
> promoted into the dashboard spec has to drop its origin […] which is why provenance that outlives
> promotion needs its own persisted field.

**Correction to an earlier draft of this plan:** it also argued that a second origin would need a
scenes change, because `_combineTransformations` hardcoded `system.plugin.*`. That is no longer true —
`TransformationOrigin` is now `string` and origins are combined in `_originOrder` sequence, so a
second origin is free. The argument above stands on its own, though: `origin` is *designed* to be
runtime-only and is stripped before persistence, so it cannot answer "who created this?" after a
reload no matter how many origins exist.

The alternative is a new persisted field, which touches `apps/dashboard/kinds/v2/dashboard_spec.cue`,
the v1 raw schema, regenerated Go/TS, `transformationCompat.ts`, both zod mirrors and both
serializers. That buys an "added by panel" badge and exact ownership.

It isn't needed: an ad-hoc transform genuinely *is* a user transformation — the user made the gesture
— and treating it as one is what makes it editable and deletable in the transformations tab, which is
the stated requirement. Ownership is recovered by upserting the **trailing** config whose `id`
matches. The one ambiguity (user hand-adds a second `organize` *after* the panel's) degrades to
"the panel edits that one instead", which is also a defensible result.

The payoff is large, and larger than in the first draft: **PR 2 needs no serializer, change-tracker
or transformations-editor changes at all.** Since the plugin tier moved to a supplier and left
`state.transformations`, `transformSceneToSaveModel.ts:340` writes that array through unfiltered,
`DashboardSceneChangeTracker` treats any non-`data` update to a transformer as dirty, and both
editors already render its entries as normal editable rows. An ad-hoc write is indistinguishable
from the transformations editor's own write, which is the point.

## PR split

Mirrors the stack above — contract, implementation, consumer. #131191 is the sibling to compare
against: it does the consumer job for a read-only transformation, which is the contrast a reviewer of
PR 3 will reach for.

| PR | Content | Reviewers |
|---|---|---|
| 1 — Contract | Two `@alpha` `PanelContext` members + docs + tests | API / dataviz |
| 2 — Implementation | `setDashboardPanelContext` wiring, graph helper, feature flag, tests | dashboards / scenes |
| 3 — Consumer | TableNG drag-to-reorder → `organize` | table owners |

PR 1 is small (~2 fields), but the API shape is the contentious part and #131154 showed the value of
discussing it alone. PR 3 is a user-visible UX change reviewed by different people than the dashboard
plumbing — that's the real seam.

---

# PR 1 — Contract

## File changes

**Modify** `packages/grafana-ui/src/components/PanelChrome/PanelContext.ts` — add two members to
`PanelContext` (interface at `:18-95`), near `onAddAdHocFilter` (`:55`):

```ts
/**
 * The panel's user-configured transformations, in pipeline order. Read live, so this is the
 * current list on every render.
 *
 * Present only where a host persists transformations and the user may edit the dashboard. It is
 * absent in Explore, alerting rule previews and visualization suggestion cards, which render
 * through `PanelRenderer` and run no transformations at all — that absence is the signal a panel
 * must not offer an affordance that writes one.
 *
 * Excludes transformations a plugin registered via `PanelPlugin.setSystemTransformations`: those
 * are read-only and never persisted.
 *
 * @alpha
 */
transformations?: DataTransformerConfig[];

/**
 * Replaces the panel's user-configured transformations. The dashboard becomes dirty and the user
 * saves or discards, exactly like `PanelProps.onFieldConfigChange`.
 *
 * Paired with {@link PanelContext.transformations}: both are present or neither is. Read that,
 * derive the next list from it, pass the whole list back.
 *
 * Call this only from a user event handler — never from a render or an effect. A write re-runs the
 * data pipeline, which re-renders the panel; writing on render would loop.
 *
 * @alpha
 */
onTransformationsChange?: (transformations: DataTransformerConfig[]) => void;
```

`DataTransformerConfig` comes from `@grafana/schema`, already a `@grafana/ui` dependency.

**Modify** `packages/grafana-ui/src/components/PanelChrome/PanelContext.test.ts` (**Create** if
absent) — assert the default `PanelContextRoot` value (`:97-100`) leaves both members `undefined`,
which is the contract non-dashboard hosts rely on.

No `index.ts` export change: `PanelContext` is already public
(`packages/grafana-ui/src/index.ts:181-184`). No api-extractor report exists in this repo — Levitate
(`.github/workflows/detect-breaking-changes-levitate.yml`) is the gate, and additive optional members
don't trip it.

## Acceptance criteria

- `yarn typecheck` passes.
- A panel can write `const { transformations, onTransformationsChange } = usePanelContext()` and both
  are typed `| undefined`.
- Levitate reports no breaking change on the PR.

---

# PR 2 — Dashboard implementation

## Approach

~15 lines in `setDashboardPanelContext.ts` plus one small graph helper. Nothing else.

The accessor-with-cache this section used to specify is **deleted from the plan**: since the plugin
tier moved to a supplier, `state.transformations` is already exactly the user's list and already a
stable reference between writes, so there is nothing to extract and nothing to memoize. Reuse
`filterDataTransformerConfigs` (`panel-edit/PanelEditNext/QueryEditor/utils.ts:84`, pre-existing on
main) for the `DataTransformerConfig[]` narrowing, returning the state array itself when nothing was
filtered so identity is preserved in the common case.

Filter `isSystemTransformation` in the same pass. The plugin tier registers only a supplier, so
nothing tagged reaches `state.transformations` today — but `setSystemTransformations` still accepts
concrete `prepend`/`append` arrays from any origin, and a narrow accessor is where that belongs once
rather than as a discovery later. It is a one-word addition now that scenes exports the predicate.

## File changes

**Modify** `public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts` — inside
`setDashboardPanelContext` (`:24`), after the `onAddAdHocFilters` block (`:204`):

```ts
// Gated at build time, not per call: the two members are absent when this dashboard can't take the
// write, which is how a panel knows not to render the affordance at all.
if (adHocTransformationsEnabled() && dashboard.canEditDashboard()) {
  // Read on access, like `app` above: the context is built once and cached on the VizPanel while
  // the transformation list changes underneath it.
  Object.defineProperty(context, 'transformations', {
    enumerable: true,
    configurable: true,
    get: () => {
      const transformer = getDataTransformerFor(vizPanel);
      return transformer ? asConfigs(transformer.state.transformations) : undefined;
    },
  });

  context.onTransformationsChange = (transformations) => {
    // setUserTransformations, not setState: it reprocesses the pipeline for us. A plain setState
    // needs an explicit reprocessTransformations() call — see PanelDataTransformationsTab:89-93 —
    // and it stays correct if any origin ever registers concrete entries into this array.
    getDataTransformerFor(vizPanel)?.setUserTransformations(transformations);
  };
}
```

`dashboard` is already in scope at `:25`. `adHocTransformationsEnabled()` belongs in
`scene/systemTransformations.ts` beside the existing `pluginTransformationsEnabled()`, same shape.

`asConfigs` is `filterDataTransformerConfigs`, an `isSystemTransformation` rejection, and a
same-length short-circuit returning the input array, so the getter's identity is stable in the case
that is currently the only one: nothing filtered out.

**On `setUserTransformations` vs `setState`**: nothing in Grafana calls it. Both editors and the
`UPDATE_PANEL` mutation command (`mutation-api/commands/updatePanel.ts:143`) write the array with
plain `setState`, following it with `reprocessTransformations()` or, in PanelEditNext's delete and
toggle paths, `runQueries()` — supplier-resolved entries no longer share the array, so nothing is
lost by writing it directly. What `setUserTransformations` still adds is the concrete case: it
partitions state by origin and drops any tagged entry from the array it is handed, so a caller cannot
clobber or persist one by accident, and it does the reprocess itself. Expect a reviewer to raise the
inconsistency — the answer is that the editors could equally move to it, not that this should move to
`setState`.

**Modify** `public/app/features/dashboard-scene/utils/utils.ts` — add
`getDataTransformerFor(sceneObject): SceneDataTransformer | undefined`, between `getQueryRunnerFor`
(`:250`) and `getSourceDataProvider` (`:276`). Same `state.$data ?? parent?.state.$data` lookup,
returning the transformer instead of walking past it. #131427 added that neighbour for the same
reason, so match its docblock rather than inventing a style; six sites across five files still
open-code this particular lookup, including `PanelDataTransformationsTab.getDataTransformer()`
(`:79-86`), which throws where this returns `undefined`.

**Modify** `pkg/services/featuremgmt/registry.go` — new toggle beside
`grafana.panelPluginTransformations` (`:3282-3288`, already on `main`; the stack does not add it):

```go
{
  Name:        "grafana.adHocTransformations",
  Description: "Let panels author user-editable transformations",
  Stage:       FeatureStageExperimental,
  Owner:       grafanaDatavizSquad,
  Expression:  "false",
  Generate:    Generate{React: true},
},
```

A separate flag, not a reuse of `grafana.panelPluginTransformations` — independent features on
independent rollouts. Then `make gen-feature-toggles` regenerates `toggles_gen.csv`,
`toggles_gen.json` and `packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts`.

**Modify** `public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts` — see
acceptance criteria.

**Unchanged, deliberately** — worth calling out in the PR description:

| Site | Why no change |
|---|---|
| `transformSceneToSaveModel.ts:340`, `transformSceneToSaveModelSchemaV2.ts:565` | write `state.transformations` through unfiltered; an ad-hoc entry is already included. #131427 rewrote the snapshot branch of both, not this one |
| `DashboardSceneChangeTracker.ts:75` | any non-`data` partial update to a transformer is already dirty |
| `PanelDataTransformationsTab.tsx`, `PanelDataPaneNext.tsx` | already render `state.transformations` as editable rows — now beside the read-only system rows #131174 adds, which is exactly the contrast this feature wants |
| `PanelModelCompatibilityWrapper.ts`, `InspectDataTab.tsx` | already count those entries |
| `createPanelDataTransformer.ts`, `PanelPluginTransformationsBehaviour.ts` | ad-hoc transforms need no behaviour and no new construction path |

## Implementation steps

1. `getDataTransformerFor` in `utils/utils.ts` + unit test.
2. Feature toggle in `registry.go`; `make gen-feature-toggles`.
3. Wire the two `PanelContext` members in `setDashboardPanelContext.ts`, with `asConfigs` local to
   that file until a second caller wants it.

## Acceptance criteria

- `context.transformations` and `context.onTransformationsChange` are both `undefined` when the flag
  is off; both defined when it is on and `canEditDashboard()` returns true; both `undefined` when it
  returns false.
- `context.transformations` returns the same array reference across two reads with no intervening
  state change, and a different one after a write.
- `context.transformations` on a panel whose plugin registers system transformations returns **only**
  the user's entries — which holds trivially now, so assert it as a regression test against the
  plugin tier ever moving back into `state.transformations`. Assert the non-trivial case in the same
  test: `transformer.setSystemTransformations({ origin: 'test', prepend: [config] })` *does* land in
  `state.transformations`, and that entry must be absent from the read and still present after a
  write.
- `onTransformationsChange` re-runs the pipeline: the panel's `data` emits again, and a panel whose
  plugin registers system transformations still has them applied afterwards (proves the write did not
  disturb the supplier).
- After `onTransformationsChange`, `DashboardSceneChangeTracker.isUpdatingPersistedState` returns
  `true` for the emitted event, and `transformSceneToSaveModel` / `transformSceneToSaveModelSchemaV2`
  both contain the new config.
- Writing a list deep-equal to the current one emits no state change (scenes'
  `haveEqualTransformations` guard).

---

# PR 3 — TableNG drag-to-reorder

## Approach

`@grafana/react-data-grid@7.0.0-beta.57` already supports this: `Column.draggable?: boolean` and
`DataGridProps.onColumnsReorder?: (sourceColumnKey, targetColumnKey) => void` (`lib/index.d.ts:51`,
`:383`). And the column `key` is already the field **display name**
(`render-hooks.tsx:543`), which is exactly the key space `organize`'s `indexByName` uses
(`order.ts:78`, via `getFieldDisplayName`). No new DnD layer.

## File changes

**Modify** `packages/grafana-ui/src/components/Table/TableNG/types.ts` — add to `BaseTableProps`
(`:110-152`), beside `onColumnResize` (`:123`):

```ts
/** Called with the full new column order, by field display name. Absence disables column dragging. */
onColumnReorder?: (displayNames: string[]) => void;
```

Passing the resolved full order rather than `(source, target)` keeps the grid's DnD detail out of the
panel and matches how `onColumnResize` hands over a finished value.

**Modify** `packages/grafana-ui/src/components/Table/TableNG/render-hooks.tsx` — in the column push
at `:541-549`, add `draggable: onColumnReorder != null`, so handles appear only when the host can
persist. Threaded through `ColumnBuildConfig`.

**Modify** `packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx` — wire
`onColumnsReorder` on `TableDataGrid` (`:310-321`), translating `(sourceKey, targetKey)` into the new
display-name order from the current column list and calling `onColumnReorder`.

**Modify** `public/app/features/table/utils.ts` — new export beside `onColumnResize` (`:24-63`) and
`onSortByChange` (`:69-77`), the established home for table write-back helpers:

```ts
/**
 * Persists a column reorder as an `organize` transformation, upserting the trailing config rather
 * than appending a new one per drag. Only `indexByName` is written: the user's own
 * exclude/rename/include options on that config are preserved.
 */
export function onColumnReorder(
  displayNames: string[],
  transformations: DataTransformerConfig[],
  onTransformationsChange: (transformations: DataTransformerConfig[]) => void
) { ... }
```

Merge rule: if the **last** entry has `id === DataTransformerID.organize`, replace its `indexByName`;
otherwise append `{ id: 'organize', options: { indexByName, excludeByName: {}, renameByName: {},
includeByName: {} } }` — all four keys, because `excludeByName` and `renameByName` are non-optional
on `OrganizeFieldsTransformerOptions` (`organize.ts:9-13`). `indexByName` is
`Object.fromEntries(displayNames.map((n, i) => [n, i]))`, the same shape
`OrganizeFieldsTransformerEditor.tsx:147-165` produces via `reorderToIndex`.

**Modify** `public/app/plugins/panel/table/TablePanel.tsx` — in the `TableNG` element (`:69-88`):

```tsx
onColumnReorder={
  panelContext.onTransformationsChange && panelContext.transformations
    ? (displayNames) =>
        onColumnReorder(displayNames, panelContext.transformations!, panelContext.onTransformationsChange!)
    : undefined
}
```

The `undefined` branch is what removes the drag handles in Explore, alerting previews, suggestion
cards, and for users without edit rights.

**Not modified**: `public/app/plugins/panel/logstable/TableNGWrap.tsx` (`:116-130`). It shares
`BaseTableProps` but simply doesn't pass `onColumnReorder`, so logs tables keep their current column
handling. That now reads as a choice rather than an omission: #131191 has that panel deriving its
columns from a *system* transformation, so a drag there reorders fields a read-only transformation
produced. A real question, and one to answer after this ships rather than inside it.

**Modify/Create** tests: `public/app/features/table/utils.test.ts` for the merge rule;
`public/app/plugins/panel/table/TablePanel.test.tsx` for the gating.

## Acceptance criteria

- Dragging a header calls `onTransformationsChange` exactly once with a list whose last entry is
  `{ id: 'organize', options: { indexByName: {...} } }` matching the dropped order.
- A second drag **updates that entry** — the list length does not grow.
- An existing trailing `organize` with `renameByName`/`excludeByName` set keeps both after a drag;
  only `indexByName` changes.
- With a non-`organize` trailing transformation (e.g. `reduce`), a drag appends a new `organize`
  *after* it, and its `options` include all four keys.
- Headers are not draggable when `panelContext.onTransformationsChange` is undefined.
- The resulting `organize` entry appears as a normal editable, deletable, disable-able row in both
  the transformations tab and PanelEditNext — no new editor code.

---

## Verification

```bash
# PR 1
yarn typecheck
yarn jest --no-watch packages/grafana-ui/src/components/PanelChrome/PanelContext

# PR 2
make gen-feature-toggles && git diff --exit-code   # generated files committed
yarn jest --no-watch public/app/features/dashboard-scene/scene/setDashboardPanelContext \
  public/app/features/dashboard-scene/utils/utils \
  public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker \
  public/app/features/dashboard-scene/serialization
go test ./pkg/services/featuremgmt/...

# PR 3
yarn jest --no-watch public/app/features/table public/app/plugins/panel/table \
  packages/grafana-ui/src/components/Table
yarn lint && yarn prettier:write
```

Manual, with `grafana.adHocTransformations` on (`make run` + `yarn start`), on a table panel:

1. Drag a column header → order changes, dashboard shows unsaved changes.
2. Panel edit → Transformations tab shows an editable "Organize fields by name" row; disable it →
   original order returns; delete it → row gone.
3. Drag twice more → still exactly one `organize` row.
4. Add a rename in that row, then drag again → the rename survives.
5. Save → reload → order persists. Check the JSON in Inspect → Panel JSON for both v1 and a
   v2-schema dashboard.
6. Repeat on a panel that also has a plugin-registered system transform (flag
   `grafana.panelPluginTransformations` on too) → the read-only rows stay at the edges, the
   `organize` row stays in the editable list, and the saved JSON contains only the `organize`.
7. Open the same query in Explore and as a visualization suggestion → no drag handles.
8. As a viewer without edit rights → no drag handles.
9. Flag off → no drag handles, `usePanelContext()` has neither member.

## Risks

- **Feature flag is OpenFeature-only (`Generate{React: true}`), and OpenFeature reads every flag as
  `false` for anonymous users.** Public/anonymous dashboards would silently lose the affordance.
  Harmless here because `canEditDashboard()` already excludes them, but the same pattern in a
  read-only feature would be a silent outage. Assert the flag-off path in tests rather than assuming
  it.
- **`context.transformations` identity churn.** Largely defused by the upstream reshaping — the getter
  now returns `state.transformations` itself in the common case — but the short-circuit in `asConfigs`
  is what preserves that, and dropping it reintroduces a per-render allocation that a panel using the
  value as an effect dep would spin on. The identity-stability test is the guard, and the "only from
  an event handler" docblock remains load-bearing regardless.
- **Two `organize` transforms if the user hand-adds one after the panel's.** The trailing-match rule
  then edits the user's config instead of the panel's. Accepted (see rationale above) — a persisted
  provenance field is the fix if this shows up in practice.
- **`organize` reorders by display name across *all* frames** (`order.ts` maps over `data`), while
  the table's frame picker shows one. Names absent from a frame sort to `MAX_SAFE_INTEGER` and keep
  relative order, so other frames are effectively unaffected — but this is untested behavior for the
  multi-frame table and belongs in PR 3's tests. Note `organize.isApplicable` returns `NotPossible`
  for `data.length > 1`; that is a suggestion-UI signal only, not a runtime guard.
- **Panel edit writes go to the edit clone.** `extendPanelContext` is a plain state field copied by
  `clone()`, and `_panelContext` is a private field so it rebuilds against the clone. Same behavior
  as `onFieldConfigChange`, but the "drag in panel edit, then discard" path needs an explicit manual
  check. scenes now clones `_suppliers` and `_originOrder` with the transformer, so the clone resolves
  the same system transformations as the original — the ad-hoc write is the half still unexercised.
- **Four dependency PRs are open, and the stack gained one after this plan was written.** #131174 was
  reshaped once (the subclass became a behaviour, the plugin tier left `state.transformations`), and
  #131427 appeared underneath it. scenes #1614 has settled — unchanged since 2026-08-24, and the
  branch pin is its newest canary — so the drift tables are accurate as of 2026-08-25 and cheap to
  re-check: compare the five head SHAs above, and re-read only what moved. The part most likely to
  move next is whether the concrete `prepend`/`append` form survives at all; the plugin tier no longer
  uses it, and if it goes, `setUserTransformations` collapses into `setState` and both the write and
  `asConfigs` simplify.


</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
