### PR TITLE
AdHocTransformations: Implementation - PoC

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -96,6 +96,7 @@ declare module "@openfeature/core" {
     | "rawPrometheus.tableNg"
     | "datasources.queryGateway"
     | "grafana.panelPluginTransformations"
+    | "grafana.adHocTransformations"
     | "tracesDrilldown.useValueTypeFiltering"
     | "grafana.dashboardsAutoHeightPanels"
     | "grafana.dashboardAutoGridDefault";

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -59,6 +59,8 @@ export const FlagKeys = {
   FlameGraphWithCallTree: "flameGraphWithCallTree",
   /** Enables global and folder-scoped dashboard variables via dashboard.grafana.app */
   GlobalDashboardVariables: "globalDashboardVariables",
+  /** Let panels author user-editable transformations */
+  GrafanaAdHocTransformations: "grafana.adHocTransformations",
   /** Uses the hybrid (lexical + semantic) search endpoint as the dashboard search backend in the command palette */
   GrafanaCmdkHybridSearch: "grafana.cmdkHybridSearch",
   /** Enables custom dashboard templates for enterprise */
@@ -444,6 +446,17 @@ export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptio
  */
 export const useFlagGlobalDashboardVariables = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("globalDashboardVariables", false, options).value;
+};
+
+/**
+ * Let panels author user-editable transformations
+ *
+ * **Details:**
+ * - flag key: `grafana.adHocTransformations`
+ * - default value: `false`
+ */
+export const useFlagGrafanaAdHocTransformations = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.adHocTransformations", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3287,6 +3287,14 @@ var (
 			Generate:    Generate{React: true},
 		},
 		{
+			Name:        "grafana.adHocTransformations",
+			Description: "Let panels author user-editable transformations",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaDatavizSquad,
+			Expression:  "false",
+			Generate:    Generate{React: true},
+		},
+		{
 			Name:         "tracesDrilldown.useValueTypeFiltering",
 			Description:  "Enables value type filtering in Traces Drilldown",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -382,6 +382,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-08-12,rawPrometheus.tableNg,experimental,@grafana/data-sources-plugins,false,false,true
 2026-08-11,datasources.queryGateway,experimental,@grafana/data-sources-plugins,false,false,false
 2026-08-17,grafana.panelPluginTransformations,experimental,@grafana/dataviz-squad,false,false,true
+2026-08-25,grafana.adHocTransformations,experimental,@grafana/dataviz-squad,false,false,true
 2026-08-18,tracesDrilldown.useValueTypeFiltering,experimental,@grafana/observability-traces-and-profiling,false,false,true
 2026-08-18,grafana.dashboardsAutoHeightPanels,experimental,@grafana/dashboards-squad,false,false,true
 2026-08-13,grafana.dashboardAutoGridDefault,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2852,6 +2852,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.adHocTransformations",
+        "resourceVersion": "1787690577581",
+        "creationTimestamp": "2026-08-25T20:42:57Z"
+      },
+      "spec": {
+        "description": "Let panels author user-editable transformations",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.assetSriChecks",
         "resourceVersion": "1782832293915",
         "creationTimestamp": "2026-05-22T09:03:04Z",

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -1,20 +1,38 @@
+import { waitFor } from '@testing-library/react';
+
 import {
   type AdHocVariableModel,
   CoreApp,
   EventBusSrv,
+  getDefaultTimeRange,
   type GroupByVariableModel,
+  LoadingState,
   type Scope,
+  standardTransformersRegistry,
+  toDataFrame,
   type VariableModel,
 } from '@grafana/data';
 import { type BackendSrv, config, setBackendSrv } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
-import { GroupByVariable, sceneGraph, SceneQueryRunner } from '@grafana/scenes';
+import {
+  GroupByVariable,
+  SceneDataNode,
+  type SceneDataTransformer,
+  sceneGraph,
+  SceneObjectStateChangedEvent,
+  SceneQueryRunner,
+} from '@grafana/scenes';
+import { type DataTransformerConfig } from '@grafana/schema';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
+import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
 import { isAnnotationApiAvailable } from '../../annotations/isAnnotationApiAvailable';
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
+import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
-import { findVizPanelByKey, getQueryRunnerFor } from '../utils/utils';
+import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { activateFullSceneTree } from '../utils/test-utils';
+import { findVizPanelByKey, getDataTransformerFor, getQueryRunnerFor } from '../utils/utils';
 
 import { getAdHocFilterVariableFor, setDashboardPanelContext } from './setDashboardPanelContext';
 
@@ -565,6 +583,175 @@ describe('setDashboardPanelContext', () => {
       expect(variable.state.filters).toEqual([]);
     });
   });
+
+  describe('ad-hoc transformations', () => {
+    /** Puts `level` in front of `time`, so a run is visible in the output field order. */
+    const reorder: DataTransformerConfig = {
+      id: 'organize',
+      options: { indexByName: { level: 0, time: 1, msg: 2 }, excludeByName: {}, renameByName: {} },
+    };
+
+    beforeAll(() => {
+      standardTransformersRegistry.setInit(getStandardTransformers);
+    });
+
+    function stubAdHocFlag(enabled: boolean) {
+      getBooleanValueFn.mockImplementation((key: string, defaultValue: boolean) =>
+        key === FlagKeys.GrafanaAdHocTransformations ? enabled : defaultValue
+      );
+    }
+
+    function buildScene(options: SceneOptions = {}) {
+      const scene = buildTestScene({ dashboardCanEdit: true, ...options });
+
+      return { ...scene, transformer: getDataTransformerFor(scene.vizPanel)! };
+    }
+
+    /** Stands a data node in for the query runner, so the pipeline has frames without a datasource. */
+    function feedFrames(transformer: SceneDataTransformer) {
+      transformer.setState({
+        $data: new SceneDataNode({
+          data: {
+            state: LoadingState.Done,
+            series: [
+              toDataFrame({
+                fields: [
+                  { name: 'time', values: [1] },
+                  { name: 'level', values: ['info'] },
+                  { name: 'msg', values: ['hello'] },
+                ],
+              }),
+            ],
+            timeRange: getDefaultTimeRange(),
+          },
+        }),
+      });
+    }
+
+    /** Field names of the first output frame. */
+    const fieldNames = (transformer: SceneDataTransformer) =>
+      transformer.state.data?.series[0]?.fields.map((f) => f.name);
+
+    it.each([
+      { desc: 'the feature flag is off', enabled: false, dashboardCanEdit: true },
+      { desc: 'the dashboard cannot be edited', enabled: true, dashboardCanEdit: false },
+    ])('leaves both members undefined when $desc', ({ enabled, dashboardCanEdit }) => {
+      stubAdHocFlag(enabled);
+
+      const { context } = buildScene({ dashboardCanEdit });
+
+      expect(context.transformations).toBeUndefined();
+      expect(context.onTransformationsChange).toBeUndefined();
+    });
+
+    it("reads the panel's saved transformations", () => {
+      stubAdHocFlag(true);
+
+      const { context } = buildScene({ panelTransformations: [reorder] });
+
+      expect(context.transformations).toEqual([reorder]);
+    });
+
+    it('returns undefined once the panel provider is no longer a transformer', () => {
+      stubAdHocFlag(true);
+      const { context, vizPanel } = buildScene();
+
+      expect(context.transformations).toEqual([]);
+
+      // The context is built once and cached on the panel while `$data` can be replaced under it, as
+      // picking a datasource for a new panel does
+      vizPanel.setState({ $data: new SceneQueryRunner({ queries: [{ refId: 'A' }], runQueriesMode: 'manual' }) });
+
+      expect(context.transformations).toBeUndefined();
+    });
+
+    it('applies a written transformation to the frames the panel renders', async () => {
+      stubAdHocFlag(true);
+      const { context, transformer } = buildScene();
+      feedFrames(transformer);
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(fieldNames(transformer)).toEqual(['time', 'level', 'msg']);
+      });
+
+      context.onTransformationsChange!([reorder]);
+
+      await waitFor(() => {
+        expect(fieldNames(transformer)).toEqual(['level', 'time', 'msg']);
+      });
+      expect(context.transformations).toEqual([reorder]);
+    });
+
+    it("keeps another origin's transformation out of the read and running after a write", async () => {
+      stubAdHocFlag(true);
+      const { context, transformer } = buildScene();
+      feedFrames(transformer);
+      // A provider registering concrete entries, which is what would end up sharing state.transformations
+      transformer.setSystemTransformations({
+        origin: 'test',
+        append: [{ id: 'organize', options: { excludeByName: { msg: true }, renameByName: {} } }],
+      });
+      activateFullSceneTree(transformer);
+
+      await waitFor(() => {
+        expect(fieldNames(transformer)).toEqual(['time', 'level']);
+      });
+      expect(context.transformations).toEqual([]);
+
+      context.onTransformationsChange!([reorder]);
+
+      // Reordered by the write, and `msg` is still dropped by the other origin's entry
+      await waitFor(() => {
+        expect(fieldNames(transformer)).toEqual(['level', 'time']);
+      });
+      expect(context.transformations).toEqual([reorder]);
+      expect(transformer.state.transformations).toHaveLength(2);
+    });
+
+    it('returns the same array across reads and a new one after a write', () => {
+      stubAdHocFlag(true);
+      const { context } = buildScene({ panelTransformations: [reorder] });
+
+      // A panel using this as an effect dep re-runs the effect on every render if the identity churns
+      const first = context.transformations;
+
+      expect(context.transformations).toBe(first);
+
+      context.onTransformationsChange!([]);
+
+      expect(context.transformations).toEqual([]);
+      expect(context.transformations).not.toBe(first);
+    });
+
+    it('makes the dashboard dirty and lands the config in the save model', () => {
+      stubAdHocFlag(true);
+      const { context, scene, vizPanel } = buildScene();
+      const events: SceneObjectStateChangedEvent[] = [];
+      vizPanel.subscribeToEvent(SceneObjectStateChangedEvent, (event) => events.push(event));
+
+      context.onTransformationsChange!([reorder]);
+
+      const writes = events.filter((event) =>
+        Object.prototype.hasOwnProperty.call(event.payload.partialUpdate ?? {}, 'transformations')
+      );
+
+      expect(writes).toHaveLength(1);
+      expect(DashboardSceneChangeTracker.isUpdatingPersistedState(writes[0])).toBe(true);
+      expect(transformSceneToSaveModel(scene).panels?.[0]).toMatchObject({ transformations: [reorder] });
+    });
+
+    it('writes nothing when the list matches the one already configured', () => {
+      stubAdHocFlag(true);
+      const { context, vizPanel } = buildScene({ panelTransformations: [reorder] });
+      const events: SceneObjectStateChangedEvent[] = [];
+      vizPanel.subscribeToEvent(SceneObjectStateChangedEvent, (event) => events.push(event));
+
+      context.onTransformationsChange!([{ ...reorder, options: { ...reorder.options } }]);
+
+      expect(events).toEqual([]);
+    });
+  });
 });
 
 interface SceneOptions {
@@ -577,6 +764,7 @@ interface SceneOptions {
   existingGroupByVariable?: boolean;
   groupByDatasourceUid?: string;
   panelDatasourceUndefined?: boolean;
+  panelTransformations?: DataTransformerConfig[];
 }
 
 function buildTestScene(options: SceneOptions) {
@@ -626,6 +814,7 @@ function buildTestScene(options: SceneOptions) {
           id: 4,
           datasource: { uid: 'my-ds-uid', type: 'prometheus' },
           targets: [],
+          transformations: options.panelTransformations,
         },
       ],
       templating: {

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -2,24 +2,35 @@ import { AnnotationChangeEvent, type AnnotationEventUIModel, CoreApp, type DataF
 import { reportInteraction } from '@grafana/runtime';
 import { getDatasourcePluginMeta } from '@grafana/runtime/internal';
 import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
-import { AdHocFiltersVariable, dataLayers, sceneGraph, sceneUtils, type VizPanel } from '@grafana/scenes';
-import { type DataSourceRef } from '@grafana/schema';
+import {
+  AdHocFiltersVariable,
+  dataLayers,
+  isSystemTransformation,
+  sceneGraph,
+  type SceneDataTransformation,
+  sceneUtils,
+  type VizPanel,
+} from '@grafana/scenes';
+import { type DataSourceRef, type DataTransformerConfig } from '@grafana/schema';
 import { type AdHocFilterItem, type PanelContext } from '@grafana/ui';
 import { FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { annotationServer } from 'app/features/annotations/api';
 import { InspectTab } from 'app/features/inspector/types';
 
 import { openPanelInspector } from '../inspect/panelInspectorOpener';
+import { filterDataTransformerConfigs } from '../panel-edit/PanelEditNext/QueryEditor/utils';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getDatasourceFromQueryRunner } from '../utils/getDatasourceFromQueryRunner';
 import {
   getDashboardSceneFor,
+  getDataTransformerFor,
   getPanelIdForVizPanel,
   getQueryRunnerFor,
   isNewPanelQueryErrorsUIEnabled,
 } from '../utils/utils';
 
 import { type DashboardScene } from './DashboardScene';
+import { adHocTransformationsEnabled } from './systemTransformations';
 
 export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelContext) {
   const dashboard = getDashboardSceneFor(vizPanel);
@@ -203,6 +214,27 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     }
   };
 
+  // Gated at build time rather than per call: both members are absent when this dashboard cannot
+  // take the write, which is how a panel knows not to render the affordance at all.
+  if (adHocTransformationsEnabled() && dashboard.canEditDashboard()) {
+    // Read on access, like `app` above: the context is built once and cached on the VizPanel while
+    // the transformation list changes underneath it.
+    Object.defineProperty(context, 'transformations', {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        const transformer = getDataTransformerFor(vizPanel);
+        return transformer ? asConfigs(transformer.state.transformations) : undefined;
+      },
+    });
+
+    context.onTransformationsChange = (transformations) => {
+      // setUserTransformations rather than setState: it reprocesses the pipeline itself, and it drops
+      // origin-tagged entries from the array it is handed instead of letting a caller persist one.
+      getDataTransformerFor(vizPanel)?.setUserTransformations(transformations);
+    };
+  }
+
   context.canExecuteActions = () => {
     const dashboard = getDashboardSceneFor(vizPanel);
     return dashboard.canEditDashboard();
@@ -220,6 +252,31 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
   if (isNewPanelQueryErrorsUIEnabled()) {
     context.onOpenInspector = () => openPanelInspector(vizPanel, InspectTab.ErrorsAndNotices);
   }
+}
+
+/** Keyed on the state array, which scenes replaces on every write. */
+const configsByTransformations = new WeakMap<SceneDataTransformation[], DataTransformerConfig[]>();
+
+/**
+ * The panel's transformations in the shape `PanelContext.transformations` promises: configs only,
+ * since a panel can do nothing with a custom operator, and nothing carrying an origin, which belongs
+ * to the provider that registered it and is never persisted.
+ *
+ * Memoized because the getter is read on every render: a panel using the value as an effect dep, or
+ * comparing it to decide whether to re-derive, needs repeat reads between writes to be the same array.
+ */
+function asConfigs(transformations: SceneDataTransformation[]): DataTransformerConfig[] {
+  const cached = configsByTransformations.get(transformations);
+
+  if (cached) {
+    return cached;
+  }
+
+  const configs = filterDataTransformerConfigs(transformations.filter((t) => !isSystemTransformation(t)));
+
+  configsByTransformations.set(transformations, configs);
+
+  return configs;
 }
 
 /**

--- a/public/app/features/dashboard-scene/scene/systemTransformations.ts
+++ b/public/app/features/dashboard-scene/scene/systemTransformations.ts
@@ -23,6 +23,15 @@ export function pluginTransformationsEnabled(): boolean {
   return getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaPanelPluginTransformations, false);
 }
 
+/**
+ * Whether panels may author transformations of their own. Independent of
+ * {@link pluginTransformationsEnabled}: those are the plugin's read-only ones, these are the user's,
+ * written from a gesture and saved with the dashboard.
+ */
+export function adHocTransformationsEnabled(): boolean {
+  return getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaAdHocTransformations, false);
+}
+
 /** Keyed on what scenes returned, which is memoized per pass — see {@link getResolvedSystemTransformations}. */
 const unwrappedByResolved = new WeakMap<ResolvedSceneTransformations, ResolvedSystemTransformations>();
 

--- a/public/app/features/dashboard-scene/utils/utils.test.ts
+++ b/public/app/features/dashboard-scene/utils/utils.test.ts
@@ -22,12 +22,14 @@ import { RowItem } from '../scene/layout-rows/RowItem';
 import { TabItem } from '../scene/layout-tabs/TabItem';
 import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';
 
+import { createPanelDataTransformer } from './createPanelDataTransformer';
 import { activateFullSceneTree } from './test-utils';
 import {
   isValidLibraryPanelRef,
   hasLibraryPanelsInV1Dashboard,
   getLayoutForObject,
   forceRenderChildren,
+  getDataTransformerFor,
 } from './utils';
 
 setPluginImportUtils({
@@ -546,6 +548,42 @@ describe('utils', () => {
 
       expect(layout).toBe(autoGrid);
       expect(layout).toBeInstanceOf(AutoGridLayoutManager);
+    });
+  });
+
+  describe('getDataTransformerFor', () => {
+    // Manual mode keeps the runner from issuing real requests; these tests only care about which
+    // provider the lookup lands on.
+    const buildTransformer = () =>
+      createPanelDataTransformer({
+        $data: new SceneQueryRunner({ queries: [{ refId: 'A' }], runQueriesMode: 'manual' }),
+        transformations: [{ id: 'organize', options: {} }],
+      });
+
+    it("returns the transformer holding the panel's own transformations", () => {
+      const transformer = buildTransformer();
+      const panel = new VizPanel({ pluginId: 'timeseries', $data: transformer });
+
+      expect(getDataTransformerFor(panel)).toBe(transformer);
+    });
+
+    it('falls back to the provider on the grid item, as a repeated panel has', () => {
+      const transformer = buildTransformer();
+      const item = new DashboardGridItem({ body: new VizPanel({ pluginId: 'timeseries' }), $data: transformer });
+
+      expect(getDataTransformerFor(item.state.body)).toBe(transformer);
+    });
+
+    it('returns undefined for a panel running its own queries untransformed, even below a transformer', () => {
+      const panel = new VizPanel({
+        pluginId: 'timeseries',
+        $data: new SceneQueryRunner({ queries: [{ refId: 'A' }], runQueriesMode: 'manual' }),
+      });
+      const item = new DashboardGridItem({ body: panel, $data: buildTransformer() });
+
+      // The point of the narrow lookup: a write must land on the panel's own transformations, never
+      // on a provider it happens to sit under
+      expect(getDataTransformerFor(item.state.body)).toBeUndefined();
     });
   });
 });

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -266,6 +266,24 @@ export function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQu
 }
 
 /**
+ * The panel's own transformer, the provider that holds `state.transformations`. Uses the same lookup
+ * as {@link getQueryRunnerFor} — the object's own `$data`, else its parent's — and stops there, so a
+ * caller gets the panel's transformations rather than those of a provider shared higher up the graph.
+ *
+ * Returns undefined for a panel whose data does not run through a transformer, which is what a
+ * caller offering a write should treat as "not available here" rather than an error.
+ */
+export function getDataTransformerFor(sceneObject: SceneObject | undefined): SceneDataTransformer | undefined {
+  if (!sceneObject) {
+    return undefined;
+  }
+
+  const dataProvider = sceneObject.state.$data ?? sceneObject.parent?.state.$data;
+
+  return dataProvider instanceof SceneDataTransformer ? dataProvider : undefined;
+}
+
+/**
  * The provider holding untransformed results. A `SceneDataTransformer` keeps its own output in
  * `state.data`, which makes it the one provider that cannot be read directly; it carries its source
  * in `$data`.


### PR DESCRIPTION
PoC/YOLO

Also adds the `grafana.adHocTransformations` flag, which needs to get split out into new PR