### PR TITLE
Remote Cache: fix entries getting stuck after a clock correction

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -41,9 +41,13 @@ func (dc *databaseCache) Run(ctx context.Context) error {
 func (dc *databaseCache) internalRunGC() {
 	err := dc.SQLStore.WithDbSession(context.Background(), func(session *db.Session) error {
 		now := getTime().Unix()
-		sql := `DELETE FROM cache_data WHERE (? - created_at) >= expires AND expires <> 0`
+		// Future-stamped rows only age out once real time catches up
+		// with their timestamp, which for a large clock skew means
+		// effectively never; drop them too so a backwards correction
+		// recovers immediately.
+		sql := `DELETE FROM cache_data WHERE expires <> 0 AND ((? - created_at) >= expires OR created_at > ?)`
 
-		_, err := session.Exec(sql, now)
+		_, err := session.Exec(sql, now, now)
 		return err
 	})
 
@@ -67,7 +71,11 @@ func (dc *databaseCache) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 
 		if cacheHit.Expires > 0 {
-			existedButExpired := getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires
+			// A negative age means the row was written while the clock was
+			// ahead (e.g. a VM booted with skewed time). Treat it as expired
+			// instead of serving it until real time reaches its timestamp.
+			age := getTime().Unix() - cacheHit.CreatedAt
+			existedButExpired := age < 0 || age >= cacheHit.Expires
 			if existedButExpired {
 				err = dc.Delete(ctx, key) // ignore this error since we will return `ErrCacheItemNotFound` anyway
 				if err != nil {

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -79,4 +80,85 @@ func TestIntegrationSecondSet(t *testing.T) {
 
 	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
+}
+
+// A machine that ran with its clock ahead writes rows stamped in the future.
+// Once the clock is corrected those rows must be treated as stale instead of
+// waiting unreachable time until real time catches up with created_at,
+// otherwise poisoned entries (e.g. cached id tokens issued under the skewed
+// clock) keep being served and fail verification on every use.
+func TestIntegrationGetTreatsEntriesStampedInTheFutureAsExpired(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	dc := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	obj := []byte("stale-after-clock-correction")
+
+	t.Cleanup(func() { getTime = time.Now })
+
+	// Write while the clock is two months ahead.
+	getTime = func() time.Time { return time.Now().AddDate(0, 2, 0) }
+	require.NoError(t, dc.Set(context.Background(), "skewed-key", obj, time.Hour))
+
+	// Clock corrected: real now sits before the row's created_at, so the
+	// elapsed-time expiry check can never fire. The entry must be reported
+	// as missing (and dropped) instead of being served forever.
+	getTime = time.Now
+	_, err := dc.Get(context.Background(), "skewed-key")
+	require.ErrorIs(t, err, ErrCacheItemNotFound)
+
+	// With the stale row gone a fresh write becomes readable immediately.
+	fresh := []byte("fresh")
+	require.NoError(t, dc.Set(context.Background(), "skewed-key", fresh, time.Hour))
+	got, err := dc.Get(context.Background(), "skewed-key")
+	require.NoError(t, err)
+	assert.Equal(t, fresh, got)
+
+	// Entries that never expire are untouched by clock corrections.
+	getTime = func() time.Time { return time.Now().AddDate(0, 2, 0) }
+	require.NoError(t, dc.Set(context.Background(), "never-expire-skewed", obj, 0))
+	getTime = time.Now
+	got, err = dc.Get(context.Background(), "never-expire-skewed")
+	require.NoError(t, err)
+	assert.Equal(t, obj, got)
+}
+
+func TestIntegrationGarbageCollectionRemovesEntriesStampedInTheFuture(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	dc := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	t.Cleanup(func() { getTime = time.Now })
+
+	rowCount := func(key string) int64 {
+		var count int64
+		err := sqlstore.WithDbSession(context.Background(), func(session *db.Session) error {
+			var err error
+			count, err = session.Where("cache_key= ?", key).Count(&CacheData{})
+			return err
+		})
+		require.NoError(t, err)
+		return count
+	}
+
+	// Write while the clock is two months ahead, then correct it.
+	getTime = func() time.Time { return time.Now().AddDate(0, 2, 0) }
+	require.NoError(t, dc.Set(context.Background(), "gc-skewed", []byte("stale"), time.Hour))
+	getTime = time.Now
+
+	require.Equal(t, int64(1), rowCount("gc-skewed"))
+
+	dc.internalRunGC()
+
+	assert.Equal(t, int64(0), rowCount("gc-skewed"))
 }


### PR DESCRIPTION
Fixes #121015

**Problem**

When a machine runs with its clock ahead (e.g. a VM that booted with skewed time before NTP fixed it), anything the database remote-cache backend wrote during that window carries a `created_at` timestamp in the future. After the clock is corrected, `Get()` computes a *negative* age for those rows, so the expiry check never fires and they are served until real time reaches their timestamp — months in practice.

The reporter hit this through internal id tokens: they're cached in the remote cache (`pkg/services/auth/idimpl`), and tokens issued under the skewed clock fail verification with *"token issued in the future"* on every use, so pages stayed broken even though the clock itself had long been fixed.

**Root cause**

Two spots share the same blind spot in `pkg/infra/remotecache/database_storage.go`:

- `Get()`: `getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires` is false for any negative age.
- `internalRunGC()`: `(now - created_at) >= expires` likewise never matches a future `created_at`, so untouched rows aren't cleaned either.

**Fix**

- `Get()`: treat a negative age as expired (same delete-and-report-missing path as normal expiry).
- GC: also delete rows where `created_at > now`.

Together this makes the backend self-heal after a clock correction: the first read drops the poisoned entry, and the next write replaces it with one created under the corrected clock. Entries with `expires = 0` (never expire) are deliberately untouched.

**Testing**

New integration tests in `database_storage_test.go`, using the existing package clock stub:

- An entry written under a fake clock two months ahead is reported missing after correction, and a fresh rewrite is readable again.
- A never-expire entry written under the same skew stays readable (pins the `expires = 0` semantics).
- GC removes a future-stamped row (asserted via a direct row count).

Both defect-focused tests **fail against the unfixed code** (verified by reverting the production file with tests in place) and pass with the fix; full package suite, `go vet`, and `gofmt` are clean. Verified locally on SQLite; the MySQL/Postgres shards were not run locally, but the GC change is plain arithmetic/comparison SQL with dialect-interpolated placeholders.

**Potential risks**

- With a small benign forward-skew, slightly-fresh entries may now be deleted early — that surfaces as a cache miss (consumers regenerate), which we judged acceptable versus keeping un-verifiable auth material cached.
- Only the database backend is affected: redis/memcached use native relative TTLs and don't store wall-clock stamps.

Continuity note: #125052 proposed the same direction but closed unmerged via stale-bot without review; this applies that idea with GC coverage and regression tests for the recovery path.
