### PR TITLE
Search API: add an All filter operator, and document how In combines values

### DIFF
--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
@@ -2841,7 +2841,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -3141,7 +3141,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
@@ -984,7 +984,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1284,7 +1284,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
@@ -4032,7 +4032,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4332,7 +4332,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
@@ -3858,7 +3858,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4158,7 +4158,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
@@ -6964,7 +6964,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -7264,7 +7264,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
@@ -1085,7 +1085,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1321,7 +1321,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
@@ -1085,7 +1085,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1321,7 +1321,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -5123,7 +5123,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -5359,7 +5359,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
@@ -3873,7 +3873,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4109,7 +4109,7 @@
         }
       },
       "WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/apis/search/v0alpha1/types.go
+++ b/pkg/apis/search/v0alpha1/types.go
@@ -31,7 +31,7 @@ const (
 //
 // All node types are modelled so the schema is future-proof, but v1 only
 // accepts a narrow subset (top-level single leaf or a single and of leaves;
-// text, filter and range leaves; In/NotIn filter operators). Everything else is
+// text, filter and range leaves; In/NotIn/All filter operators). Everything else is
 // rejected with 422 Unprocessable Entity by the validation layer. exists is
 // sketched for a future version and always rejected today.
 //
@@ -72,7 +72,9 @@ type TextPredicate struct {
 // +k8s:deepcopy-gen=true
 type FilterPredicate struct {
 	Field string `json:"field"`
-	// Operator is "In" or "NotIn" in v1.
+	// Operator is "In", "NotIn" or "All" in v1. "In" matches any of the values,
+	// "NotIn" excludes all of them, and "All" requires the field to hold every
+	// value, which only a field holding a list of values can do.
 	Operator string   `json:"operator"`
 	Values   []string `json:"values"`
 }

--- a/pkg/apis/search/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/search/v0alpha1/zz_generated.openapi.go
@@ -97,7 +97,7 @@ func schema_pkg_apis_search_v0alpha1_FilterPredicate(ref common.ReferenceCallbac
 					},
 					"operator": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Operator is \"In\" or \"NotIn\" in v1.",
+							Description: "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -651,7 +651,7 @@ func schema_pkg_apis_search_v0alpha1_WhereNode(ref common.ReferenceCallback) com
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+				Description: "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"and": {

--- a/pkg/registry/apis/search/README.md
+++ b/pkg/registry/apis/search/README.md
@@ -98,7 +98,7 @@ Capabilities:
 
 | Capability | What it allows |
 | --- | --- |
-| `filter` | Exact matching on a value or set of values: `In` and `NotIn`. |
+| `filter` | Exact matching on a value or set of values: `In`, `NotIn` and `All`. `In` matches **any** of the values, `All` requires **every** one (see [Requiring every value](#requiring-every-value)). |
 | `text` | Free-text search over the field's tokens. |
 | `partial` | Substring matching. Requires `text`. Costs index size. |
 | `sort` | The field may be named in `sort`. |
@@ -185,10 +185,41 @@ In practice that means when your kind graduates from `v1beta1` to `v1`, the URL 
 **`where`** is a predicate tree. Today it accepts either a single leaf, or a single `and` of leaves. Leaf types:
 
 - `text`: the free-text query, the thing a user types into a search box. `value` is required. `text.fields` says which fields to match it against, defaulting to `title`, and each field named there needs the `text` capability. At most one text leaf. Omitting `text` is fine and common: the query then matches on the other leaves alone, results come back ordered by `name` rather than by relevance, and no `score` is returned.
-- `filter`: `field`, `operator` (`In` or `NotIn`), `values`. Values are always strings, whatever the field's type: a boolean field takes `"true"` or `"false"`, a number is written out. `*` in a value is rejected.
+- `filter`: `field`, `operator` (`In`, `NotIn` or `All`), `values`. `In` matches **any** of the values, `NotIn` excludes all of them, and `All` requires the field to hold **every** value, see [Requiring every value](#requiring-every-value). Values are always strings, whatever the field's type: a boolean field takes `"true"` or `"false"`, a number is written out. `*` in a value is rejected.
 - `range`: numeric fields only, and the field must declare `filter`. There is no separate range capability, so a field you cannot filter is also a field you cannot range over. `gt`/`gte`/`lt`/`lte`, at least one bound, and you cannot combine `gt` with `gte` or `lt` with `lte`. On an `int64` field bounds must be whole numbers.
 
 Omitting `where` matches everything of that kind in the namespace, subject to authorization.
+
+#### Requiring every value
+
+`In` with several values is an OR: this returns dashboards tagged `prod`, or `eu-west`, or both.
+
+```json
+{ "filter": { "field": "tags", "operator": "In", "values": ["prod", "eu-west"] } }
+```
+
+`All` requires **both**:
+
+```json
+{ "filter": { "field": "tags", "operator": "All", "values": ["prod", "eu-west"] } }
+```
+
+One filter leaf per value inside an `and` means the same thing and stays valid:
+
+```json
+{
+  "where": {
+    "and": [
+      { "filter": { "field": "tags", "operator": "In", "values": ["prod"] } },
+      { "filter": { "field": "tags", "operator": "In", "values": ["eu-west"] } }
+    ]
+  }
+}
+```
+
+`All` only means something on a field that holds a list of values, such as `tags` or `ownerReferences`. On a field holding a single value, such as `folder`, `All` with more than one value can never match, so it is rejected with 422 rather than returning an empty result. With exactly one value `All` and `In` mean the same thing, on any field.
+
+`In` is the shape people get wrong, because dashboard live search behaves the other way round: the old `/api/search` path sends its `tag` parameters as a single requirement that the backend combines with AND (`pkg/registry/apis/dashboard/search.go`). So a UI tag filter ported from live search to this endpoint keeps the same request shape and quietly changes meaning, from "has all these tags" to "has any of them".
 
 `or`, `not` and `exists` are in the schema for later and rejected today.
 
@@ -245,7 +276,7 @@ The sampled path already exists: when per-item authorization runs after ranking,
 
 ## 6. Errors
 
-- **422 Unprocessable Entity**: the request parsed but is not valid. A field your kind does not declare, a field missing the capability the request needs, an unsupported operator, a `not`/`or`/`exists` node, a second text leaf. The response body names the offending field path.
+- **422 Unprocessable Entity**: the request parsed but is not valid. A field your kind does not declare, a field missing the capability the request needs, an unsupported operator, `All` with several values on a field holding a single value, a `not`/`or`/`exists` node, a second text leaf. The response body names the offending field path.
 - **400 Bad Request**: the request could not be understood. Malformed JSON, an unknown top-level key, an empty body, more than one JSON object, a missing namespace, or `namespace=*`. Searching across namespaces is not supported.
 - **405 Method Not Allowed**: the kind is served, but has no search endpoint. It declares no search fields, it opted out, or it is cluster-scoped. No route is mounted, so the router answers before any search code runs.
 - **404 Not Found**: the resource itself is not served by this apiserver.

--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -327,10 +327,17 @@ func validateLeaf(n *searchv0.WhereNode, key string, fs *fieldSet, p *field.Path
 						errs = append(errs, field.Invalid(fp.Child("values").Index(i), v, err.Error()))
 					}
 				}
+				// A field holding one value cannot hold two, so this would always come
+				// back empty and the caller would have no way to tell that apart from
+				// nothing matching.
+				if f.Operator == "All" && len(f.Values) > 1 && !def.Array {
+					errs = append(errs, field.Invalid(fp.Child("operator"), f.Operator,
+						fmt.Sprintf("All with several values requires a field holding a list of values; %q holds a single value", f.Field)))
+				}
 			}
 		}
-		if f.Operator != "In" && f.Operator != "NotIn" {
-			errs = append(errs, field.NotSupported(fp.Child("operator"), f.Operator, []string{"In", "NotIn"}))
+		if f.Operator != "In" && f.Operator != "NotIn" && f.Operator != "All" {
+			errs = append(errs, field.NotSupported(fp.Child("operator"), f.Operator, []string{"In", "NotIn", "All"}))
 		}
 		if len(f.Values) == 0 {
 			errs = append(errs, field.Required(fp.Child("values"), "at least one value is required"))
@@ -609,8 +616,16 @@ func applyText(req *resourcepb.ResourceSearchRequest, t *searchv0.TextPredicate)
 
 func filterRequirement(f *searchv0.FilterPredicate) *resourcepb.Requirement {
 	op := "in"
-	if f.Operator == "NotIn" {
+	switch f.Operator {
+	case "NotIn":
 		op = "notin"
+	case "All":
+		// The backend combines several values of "=" with AND, which is what All
+		// asks for. A single value stays on the "in" path so All and In agree on it,
+		// including on title, where only "in" matches exactly.
+		if len(f.Values) > 1 {
+			op = string(selection.Equals)
+		}
 	}
 	return &resourcepb.Requirement{Key: f.Field, Operator: op, Values: f.Values}
 }

--- a/pkg/registry/apis/search/translate_test.go
+++ b/pkg/registry/apis/search/translate_test.go
@@ -278,6 +278,15 @@ func TestTranslateSearchQuery_ValidationErrors(t *testing.T) {
 			wantField: "where.filter.operator",
 		},
 		{
+			// A field holding one value cannot hold two, so this can never match. An
+			// empty result would not tell the caller that.
+			name: "All with several values on a field holding a single value",
+			mutate: func(q *searchv0.SearchQuery) {
+				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "folder", Operator: "All", Values: []string{"a", "b"}}}
+			},
+			wantField: "where.filter.operator",
+		},
+		{
 			name: "filter wildcard value",
 			mutate: func(q *searchv0.SearchQuery) {
 				q.Where = &searchv0.WhereNode{Filter: &searchv0.FilterPredicate{Field: "folder", Operator: "In", Values: []string{"a*"}}}
@@ -642,6 +651,67 @@ func TestTranslateSearchQuery_ContinueToken(t *testing.T) {
 	req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
 	require.Empty(t, errs)
 	assert.Equal(t, []string{"cursor-value"}, req.SearchAfter)
+}
+
+// All asks the field to hold every value, which the backend expresses as "=".
+func TestTranslateSearchQuery_FilterAll(t *testing.T) {
+	t.Run("several values on a list field", func(t *testing.T) {
+		q := searchQuery(&searchv0.WhereNode{
+			Filter: &searchv0.FilterPredicate{Field: "tags", Operator: "All", Values: []string{"prod", "eu-west"}},
+		})
+		req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+		require.Empty(t, errs)
+		require.Len(t, req.Options.Fields, 1)
+		assert.Equal(t, "tags", req.Options.Fields[0].Key)
+		assert.Equal(t, "=", req.Options.Fields[0].Operator)
+		assert.Equal(t, []string{"prod", "eu-west"}, req.Options.Fields[0].Values)
+	})
+
+	t.Run("one value means the same as In", func(t *testing.T) {
+		q := searchQuery(&searchv0.WhereNode{
+			Filter: &searchv0.FilterPredicate{Field: "folder", Operator: "All", Values: []string{"platform"}},
+		})
+		req, errs := TranslateSearchQuery(q, dashboardsGVR, "default", testProvider())
+		require.Empty(t, errs)
+		require.Len(t, req.Options.Fields, 1)
+		assert.Equal(t, "in", req.Options.Fields[0].Operator)
+	})
+}
+
+// Tags on trash are what prompted All, so check the shared validators give it
+// there too.
+func TestTranslateTrashQuery_FilterAll(t *testing.T) {
+	t.Run("several tags", func(t *testing.T) {
+		q := trashQuery(&searchv0.WhereNode{
+			Filter: &searchv0.FilterPredicate{Field: trashFieldTags, Operator: "All", Values: []string{"prod", "team-a"}},
+		})
+		req, errs := TranslateTrashQuery(q, dashboardsGVR, "default")
+		require.Empty(t, errs)
+		require.Len(t, req.Options.Fields, 1)
+		assert.Equal(t, "=", req.Options.Fields[0].Operator)
+		assert.Equal(t, []string{"prod", "team-a"}, req.Options.Fields[0].Values)
+	})
+
+	t.Run("several folders is rejected", func(t *testing.T) {
+		q := trashQuery(&searchv0.WhereNode{
+			Filter: &searchv0.FilterPredicate{Field: trashFieldFolder, Operator: "All", Values: []string{"a", "b"}},
+		})
+		req, errs := TranslateTrashQuery(q, dashboardsGVR, "default")
+		assert.Nil(t, req)
+		require.NotEmpty(t, errs)
+		assert.Equal(t, "where.filter.operator", errs[0].Field)
+		assert.Contains(t, errs[0].Detail, trashFieldFolder)
+	})
+
+	t.Run("one tag means the same as In", func(t *testing.T) {
+		q := trashQuery(&searchv0.WhereNode{
+			Filter: &searchv0.FilterPredicate{Field: trashFieldTags, Operator: "All", Values: []string{"prod"}},
+		})
+		req, errs := TranslateTrashQuery(q, dashboardsGVR, "default")
+		require.Empty(t, errs)
+		require.Len(t, req.Options.Fields, 1)
+		assert.Equal(t, "in", req.Options.Fields[0].Operator)
+	})
 }
 
 // Boolean and numeric filters reach the backend as the strings it parses back,

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -3399,7 +3399,11 @@ func (b *bleveIndex) usesExactTermFilter(key string) bool {
 	return ok && kf.filterable
 }
 
-// Convert a "requirement" into a bleve query
+// Convert a "requirement" into a bleve query.
+//
+// Combining rules for several values: "=" is an AND, so the field must hold
+// every value, while "in" is an OR, so at least one is enough. The numeric path
+// (numberOrBoolSetQuery) follows the same rules.
 func (b *bleveIndex) requirementQuery(req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
 	// Boolean and numeric fields are indexed in their native form, which a term
 	// or match query cannot reach, so they take a separate path.
@@ -3492,8 +3496,7 @@ func numberOrBoolQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query
 	}
 }
 
-// Combining rules follow the string path: "=" with several values is an AND,
-// "in" is an OR.
+// Combining rules follow the string path, see requirementQuery.
 func numberOrBoolSetQuery(nb numberOrBoolField, req *resourcepb.Requirement) (query.Query, *resourcepb.ErrorResult) {
 	op := selection.Operator(req.Operator)
 	if op == selection.DoubleEquals && len(req.Values) != 1 {

--- a/pkg/tests/apis/dashboard/searchapi_test.go
+++ b/pkg/tests/apis/dashboard/searchapi_test.go
@@ -87,6 +87,24 @@ func TestIntegrationSearchAPI(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	// One dashboard carries both tags and one only the first, so the difference
+	// between "any of these tags" and "all of them" shows up in the results.
+	tags := map[string][]any{
+		"searchapi-tags-both": {"prod", "eu-west"},
+		"searchapi-tags-prod": {"prod"},
+	}
+	for name, list := range tags {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"spec": map[string]any{"title": name, "schemaVersion": 41, "tags": list},
+		}}
+		obj.SetName(name)
+		obj.SetAPIVersion(gvr.GroupVersion().String())
+		obj.SetKind("Dashboard")
+		obj.SetAnnotations(map[string]string{utils.AnnoKeyFolder: folderUID})
+		_, err := admin.Resource.Create(ctx, obj, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
 	// Per-item authorization decides what a non-admin sees, so a viewer granted
 	// View on the folder gets the dashboards in it.
 	t.Run("a viewer sees what they were granted", func(t *testing.T) {
@@ -192,6 +210,63 @@ func TestIntegrationSearchAPI(t *testing.T) {
 		assert.Equal(t, "folders", item.Resource.Resource)
 		assert.Equal(t, "Folder", item.Resource.Kind)
 		assert.Equal(t, folderUID, item.Resource.Name)
+	})
+
+	// All is the only way to ask for every value in one leaf; In asks for any of
+	// them, which is the mistake this operator exists to prevent.
+	t.Run("All requires every value", func(t *testing.T) {
+		all, code := search(t, ctx, helper.Org1.Admin, gvr, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{
+				Filter: &searchV0.FilterPredicate{Field: "tags", Operator: "All", Values: []string{"prod", "eu-west"}},
+			},
+			Limit: 10,
+		})
+		require.Equal(t, http.StatusOK, code)
+		assert.Equal(t, []string{"searchapi-tags-both"}, names(all))
+
+		// One leaf per value inside an and is the older way to write the same thing,
+		// and stays valid.
+		perLeaf, code := search(t, ctx, helper.Org1.Admin, gvr, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{And: []searchV0.WhereNode{
+				{Filter: &searchV0.FilterPredicate{Field: "tags", Operator: "In", Values: []string{"prod"}}},
+				{Filter: &searchV0.FilterPredicate{Field: "tags", Operator: "In", Values: []string{"eu-west"}}},
+			}},
+			Limit: 10,
+		})
+		require.Equal(t, http.StatusOK, code)
+		assert.Equal(t, names(all), names(perLeaf))
+
+		anyValue, code := search(t, ctx, helper.Org1.Admin, gvr, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{
+				Filter: &searchV0.FilterPredicate{Field: "tags", Operator: "In", Values: []string{"prod", "eu-west"}},
+			},
+			Limit: 10,
+		})
+		require.Equal(t, http.StatusOK, code)
+		assert.ElementsMatch(t, []string{"searchapi-tags-both", "searchapi-tags-prod"}, names(anyValue))
+	})
+
+	t.Run("All with one value behaves like In", func(t *testing.T) {
+		all, code := search(t, ctx, helper.Org1.Admin, gvr, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{
+				Filter: &searchV0.FilterPredicate{Field: "tags", Operator: "All", Values: []string{"eu-west"}},
+			},
+			Limit: 10,
+		})
+		require.Equal(t, http.StatusOK, code)
+		assert.Equal(t, []string{"searchapi-tags-both"}, names(all))
+	})
+
+	// A folder holds one value, so asking for two can never match. Rejecting it is
+	// better than an empty result the caller cannot explain.
+	t.Run("rejects All with several values on a field holding a single value", func(t *testing.T) {
+		_, code := search(t, ctx, helper.Org1.Admin, gvr, searchV0.SearchQuery{
+			Where: &searchV0.WhereNode{
+				Filter: &searchV0.FilterPredicate{Field: "folder", Operator: "All", Values: []string{folderUID, "other"}},
+			},
+			Limit: 10,
+		})
+		assert.Equal(t, http.StatusUnprocessableEntity, code)
 	})
 
 	// A malformed body cannot be validated at all, so it is a bad request.

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -3141,7 +3141,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -3463,7 +3463,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
@@ -1093,7 +1093,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1415,7 +1415,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
@@ -4432,7 +4432,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4754,7 +4754,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
@@ -4249,7 +4249,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4571,7 +4571,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
@@ -7613,7 +7613,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -7935,7 +7935,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
@@ -1215,7 +1215,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1470,7 +1470,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
@@ -1215,7 +1215,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -1470,7 +1470,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -5783,7 +5783,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -6038,7 +6038,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {

--- a/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
@@ -4197,7 +4197,7 @@
             "default": ""
           },
           "operator": {
-            "description": "Operator is \"In\" or \"NotIn\" in v1.",
+            "description": "Operator is \"In\", \"NotIn\" or \"All\" in v1. \"In\" matches any of the values, \"NotIn\" excludes all of them, and \"All\" requires the field to hold every value, which only a field holding a list of values can do.",
             "type": "string",
             "default": ""
           },
@@ -4452,7 +4452,7 @@
         }
       },
       "com.github.grafana.grafana.pkg.apis.search.v0alpha1.WhereNode": {
-        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
+        "description": "WhereNode is a single node of the where tree. Exactly one field must be set; the set field names the node's type. Combinators (and/or/not) compose other nodes, leaves (text/filter/range/exists) are terminal predicates.\n\nAll node types are modelled so the schema is future-proof, but v1 only accepts a narrow subset (top-level single leaf or a single and of leaves; text, filter and range leaves; In/NotIn/All filter operators). Everything else is rejected with 422 Unprocessable Entity by the validation layer. exists is sketched for a future version and always rejected today.",
         "type": "object",
         "properties": {
           "and": {


### PR DESCRIPTION
The search API only had `In` and `NotIn`. `In` matches any of its values, so a caller who needs every value had to send one filter leaf per value and let the surrounding `and` combine them. Tag filters are the common case for that, and it already caught out a frontend change that sent two selected tags as one `In` leaf and got dashboards carrying either tag.

`All` says it in one leaf:

```json
{ "filter": { "field": "tags", "operator": "All", "values": ["prod", "eu-west"] } }
```

It maps onto the `=` requirement the backend already combines with AND, so there is no new query building and no index rebuild. Additive: an unrecognised operator was already a 422, and one leaf per value stays valid. It works on `/trash` too, which is where tags prompted this.

`All` with more than one value on a field that holds a single value can never match, and the backend answers that with an empty result rather than an error. That is rejected with a 422 naming the field. With one value, `All` and `In` mean the same thing.

Named `All` rather than `=` because `In` and `NotIn` are Kubernetes selector operators, where `key=value` is single-value equality, not "holds all of these".

The README now says `In` matches any of the values and `All` requires every one, with examples, and points out the asymmetry that caused the original mistake: the old dashboard search endpoint combines its `tag` parameters with AND, so a tag filter ported to the new envelope keeps its shape and changes meaning.

**Why `no-check-unified-storage-compatibility`:** the server-side change here is a relocated code comment with no behaviour attached. The operator is client-side only and translates to `=`, which the storage server has supported for a long time, so any mix of versions works.
