### PR TITLE
Provisioning: Name the provisioningExport feature flag in disabled-job warnings

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -72,7 +72,7 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	if !enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
-		return jobs.AsWarning(errors.New("export functionality is disabled"))
+		return jobs.AsWarning(errors.New("push jobs require the provisioningExport feature flag"))
 	}
 
 	logger := logging.FromContext(ctx).With("options", options)

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -1294,7 +1294,7 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 			name:       "export job fails when feature flag is disabled",
 			enabled:    false,
 			wantErr:    true,
-			wantErrMsg: "export functionality is disabled",
+			wantErrMsg: "push jobs require the provisioningExport feature flag",
 		},
 		{
 			name:    "export job proceeds when enabled",
@@ -1364,7 +1364,7 @@ func TestExportWorker_ConfigurationDisabled(t *testing.T) {
 				// It may fail later due to minimal mocks, but the configuration check passed
 				if err != nil {
 					// Job failed due to mocking, not configuration - that's okay
-					assert.NotContains(t, err.Error(), "functionality is disabled")
+					assert.NotContains(t, err.Error(), "provisioningExport")
 				}
 			}
 		})

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -51,7 +51,7 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 	if !enabled {
 		// A disabled feature is an expected configuration state, not a failure:
 		// complete the job in a warning state so it is not logged or alerted as an error.
-		return jobs.AsWarning(errors.New("migrate functionality is disabled"))
+		return jobs.AsWarning(errors.New("migrate jobs require the provisioningExport feature flag"))
 	}
 
 	logger := logging.FromContext(ctx).With("options", options)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -171,7 +171,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 			name:       "migrate job fails when feature flag is disabled",
 			enabled:    false,
 			wantErr:    true,
-			wantErrMsg: "migrate functionality is disabled",
+			wantErrMsg: "migrate jobs require the provisioningExport feature flag",
 		},
 		{
 			name:    "migrate job proceeds when enabled",
@@ -229,7 +229,7 @@ func TestMigrationWorker_ConfigurationDisabled(t *testing.T) {
 				// It may fail later due to minimal mocks, but the configuration check passed
 				if err != nil {
 					// Job failed due to mocking, not configuration - that's okay
-					assert.NotContains(t, err.Error(), "functionality is disabled")
+					assert.NotContains(t, err.Error(), "provisioningExport")
 				}
 			}
 		})


### PR DESCRIPTION
**What is this feature?**

When the `provisioningExport` feature flag is off, the migrate and push workers complete the job in a
warning state. The warning text said only `migrate functionality is disabled` (or `export
functionality is disabled`). This changes both to name the flag, reusing the wording the API layer
already uses:

- `migrate jobs require the provisioningExport feature flag`
- `push jobs require the provisioningExport feature flag`

**Why do we need this feature?**

The message an operator actually sees does not say which configuration turned the feature off.

`jobs.go` already rejects both job types up front with a message that names the flag, but that check
only applies at creation time. A job queued before the flag changed still reaches the worker — and
that is exactly the case where someone is reading job status to work out why nothing happened. The
comment above that API check says the intent is "so the API user gets a clear error at creation time
instead of a job that is created only to complete as a no-op"; this makes the other path just as
clear.

I hit this on a self-hosted 13.2.0 instance while migrating an existing Grafana into Git Sync. The
job finished in ~140ms with `migrate functionality is disabled` and no indication of which toggle was
responsible; finding `FlagProvisioningExport` meant reading the source.

**Who is this feature for?**

Operators of self-hosted Grafana adopting Git Sync, where `provisioningExport` is off by default and
migrate is the supported way to take ownership of existing dashboards.

**Which issue(s) does this PR fix?**:

None — reporting and fixing together.

**Special notes for your reviewer:**

Two negative assertions in the worker tests matched on the old wording, which no longer appears
anywhere in the tree, so they would have silently stopped testing anything. They now match on the
flag name instead.

`go test ./pkg/registry/apis/provisioning/jobs/migrate/... ./pkg/registry/apis/provisioning/jobs/export/...`
passes locally.

No docs or feature-toggle changes: this is warning text only, behaviour is unchanged.
