### PR TITLE
Card: Improve styling for selectable cards

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -8,6 +8,7 @@ import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { getFocusStyles } from '../../themes/mixins';
+import { RadioButtonDot } from '../Forms/RadioButtonList/RadioButtonDot';
 
 import { CardContainer, type CardContainerProps, getCardContainerStyles } from './CardContainer';
 
@@ -131,6 +132,7 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
   };
   const optionLabel = t('grafana-ui.card.option', 'option');
   const headingId = useId();
+  const radioId = useId();
   const hasHeadingContent = React.Children.count(children) > 0;
 
   return (
@@ -146,13 +148,12 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
       ) : (
         <span id={headingId}>{children}</span>
       )}
-      {/* Input must be readonly because we are providing a value for the checked prop with no onChange handler */}
       {isSelected !== undefined && (
-        <input
+        <RadioButtonDot
           {...(hasHeadingContent ? { 'aria-labelledby': headingId } : { 'aria-label': optionLabel })}
-          type="radio"
+          id={radioId}
+          name={radioId}
           checked={isSelected}
-          readOnly
         />
       )}
     </div>
@@ -174,8 +175,8 @@ const getHeadingStyles = (theme: GrafanaTheme2) => ({
     lineHeight: theme.typography.body.lineHeight,
     color: theme.colors.text.primary,
     fontWeight: theme.typography.fontWeightMedium,
-    '& input[readonly]': {
-      cursor: 'inherit',
+    '& input': {
+      pointerEvents: 'none',
     },
   }),
   linkHack: css({

--- a/packages/grafana-ui/src/components/Forms/RadioButtonList/RadioButtonDot.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonList/RadioButtonDot.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -12,7 +12,7 @@ export interface RadioButtonDotProps<T>
   checked?: boolean;
   value?: T;
   disabled?: boolean;
-  label: React.ReactNode;
+  label?: React.ReactNode;
   description?: string;
   onChange?: (id: string) => void;
 }
@@ -31,7 +31,7 @@ export const RadioButtonDot = <T extends string | number | readonly string[]>({
   const styles = useStyles2(getStyles);
 
   return (
-    <label title={description} className={styles.label}>
+    <label title={description} className={cx(styles.label, { [styles.labelWithoutContent]: !label && !description })}>
       <input
         {...props}
         id={id}
@@ -43,10 +43,12 @@ export const RadioButtonDot = <T extends string | number | readonly string[]>({
         className={styles.input}
         onChange={() => onChange && onChange(id)}
       />
-      <div>
-        {label}
-        {description && <div className={styles.description}>{description}</div>}
-      </div>
+      {(label || description) && (
+        <div>
+          {label}
+          {description && <div className={styles.description}>{description}</div>}
+        </div>
+      )}
     </label>
   );
 };
@@ -102,6 +104,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gridTemplateColumns: `${theme.spacing(2)} auto`,
     gap: theme.spacing(1),
     cursor: 'pointer',
+  }),
+  labelWithoutContent: css({
+    gridTemplateColumns: theme.spacing(2),
+    gap: 0,
   }),
   description: css({
     fontSize: theme.typography.size.sm,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- switches to use a `RadioButtonDot` instead of a native radio button input
- see slack context [here](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1787728222803529)

|  | before | after |
| --- | --- | --- |
| visual refresh off | <img width="1219" height="349" alt="image" src="https://github.com/user-attachments/assets/87ac05ec-e7c7-441f-9067-8dfc4d3ab119" /> | <img width="1201" height="326" alt="image" src="https://github.com/user-attachments/assets/a9418e23-0897-45b2-8076-551c5b1faa54" /> |
| visual refresh on | <img width="1203" height="325" alt="image" src="https://github.com/user-attachments/assets/50ff1b71-4484-49ce-a6c6-0bf75ea9cb17" /> | <img width="1198" height="323" alt="image" src="https://github.com/user-attachments/assets/09935e31-bb29-49b4-ad02-3887e4bfa57f" /> |

**Why do we need this feature?**

- better styling when used in visual refresh

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana-frontend-platform/issues/165?reload=1

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
