### PR TITLE
Alerting: Add trusted producer alert UI support

### DIFF
--- a/public/app/features/alerting/unified/AlertGroups.test.tsx
+++ b/public/app/features/alerting/unified/AlertGroups.test.tsx
@@ -3,6 +3,7 @@ import { render, waitFor, waitForElementToBeRemoved } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -13,6 +14,7 @@ import { AlertmanagerProvider } from './state/AlertmanagerContext';
 import { DataSourceType } from './utils/datasource';
 
 const server = setupMswServer();
+const originalProducerAPIToggle = config.featureToggles.alertingAlertsProducerAPI;
 
 const dataSources = {
   am: mockDataSource({
@@ -63,6 +65,7 @@ describe('AlertGroups', () => {
 
   afterEach(() => {
     server.resetHandlers();
+    config.featureToggles.alertingAlertsProducerAPI = originalProducerAPIToggle;
   });
 
   it('loads and shows groups', async () => {
@@ -188,6 +191,40 @@ describe('AlertGroups', () => {
     renderAmNotifications();
     await waitFor(() => {
       expect(ui.group.getAll()).toHaveLength(1);
+    });
+  });
+
+  it('shows trusted producer alerts by default', async () => {
+    config.featureToggles.alertingAlertsProducerAPI = true;
+    mockAlertGroupsResponse([
+      mockAlertGroup({
+        labels: {},
+        alerts: [mockAlertmanagerAlert({ labels: { grafana_alert_source: 'producer_a' } })],
+      }),
+    ]);
+
+    renderAmNotifications();
+
+    expect(await ui.group.findAll()).toHaveLength(1);
+  });
+
+  it('filters all trusted producer sources without naming a specific product', async () => {
+    config.featureToggles.alertingAlertsProducerAPI = true;
+    const requests: Request[] = [];
+    server.use(
+      http.get('/api/alertmanager/:datasourceUid/api/v2/alerts/groups', ({ request }) => {
+        requests.push(request);
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { user } = renderAmNotifications();
+    await user.click(await byRole('button', { name: 'Producer alerts' }).find());
+
+    await waitFor(() => {
+      expect(
+        requests.some((request) => new URL(request.url).searchParams.get('filter') === 'grafana_alert_source=~".+"')
+      ).toBe(true);
     });
   });
 

--- a/public/app/features/alerting/unified/components/alert-groups/AlertDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertDetails.test.tsx
@@ -114,6 +114,26 @@ describe('AlertDetails', () => {
     });
   });
 
+  describe('See source button — trusted producer', () => {
+    it('uses a source-agnostic label and does not require rule read permission', () => {
+      const amSource = setupGrafanaAlertmanager();
+      grantUserPermissions([GRAFANA_AM_VISIBILITY_PERMISSION]);
+      const alert = mockAlertmanagerAlert({
+        status: { state: AlertState.Active, silencedBy: [], inhibitedBy: [] },
+        labels: { grafana_alert_source: 'producer_a' },
+        generatorURL: 'https://producer.example.com/findings/123',
+      });
+
+      renderAlertDetails(alert, amSource);
+
+      expect(screen.getByRole('link', { name: /see source/i })).toHaveAttribute(
+        'href',
+        'https://producer.example.com/findings/123'
+      );
+      expect(screen.queryByRole('link', { name: /watcher/i })).not.toBeInTheDocument();
+    });
+  });
+
   describe('See source button — external source', () => {
     it('always shows See source button regardless of rule read permission', () => {
       const amSource = setupMimirAlertmanager();

--- a/public/app/features/alerting/unified/components/alert-groups/AlertDetails.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertDetails.tsx
@@ -24,8 +24,9 @@ export const AlertDetails = ({ alert, alertManagerSourceName }: AmNotificationsA
   // For Grafana Managed alerts the Generator URL redirects to the alert rule edit page, so update permission is required
   // For external alert manager the Generator URL redirects to an external service which we don't control
   const isGrafanaSource = isGrafanaRulesSource(alertManagerSourceName);
+  const isTrustedProducer = Boolean(alert.labels.grafana_alert_source);
   const viewRuleAbility = useGlobalRuleAbility(RuleAction.View);
-  const isSeeSourceButtonEnabled = isGrafanaSource ? isGranted(viewRuleAbility) : true;
+  const isSeeSourceButtonEnabled = isTrustedProducer || (isGrafanaSource ? isGranted(viewRuleAbility) : true);
   const canCreateSilence = isGranted(useSilenceAbility({ action: SilenceAction.Create }));
   const canUpdateSilence = isGranted(useSilenceAbility({ action: SilenceAction.Update }));
 
@@ -57,7 +58,7 @@ export const AlertDetails = ({ alert, alertManagerSourceName }: AmNotificationsA
         )}
         {isSeeSourceButtonEnabled && alert.generatorURL && (
           <LinkButton className={styles.button} href={alert.generatorURL} icon={'chart-line'} size={'sm'}>
-            {isGrafanaSource
+            {isGrafanaSource && !isTrustedProducer
               ? t('alerting.alert-details.button-see-rule', 'See alert rule')
               : t('alerting.alert-details.button-see-source', 'See source')}
           </LinkButton>

--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroupFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroupFilter.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { type AlertState, type AlertmanagerGroup } from 'app/plugins/datasource/alertmanager/types';
@@ -23,6 +24,7 @@ export const AlertGroupFilter = ({ groups }: Props) => {
   const [queryParams, setQueryParams] = useQueryParams();
   const { groupBy = [], queryString, alertState, receivers = [] } = getFiltersFromUrlParams(queryParams);
   const matcherFilterKey = `matcher-${filterKey}`;
+  const producerAlertsQuery = 'grafana_alert_source=~".+"';
 
   const styles = useStyles2(getStyles);
 
@@ -48,6 +50,16 @@ export const AlertGroupFilter = ({ groups }: Props) => {
             defaultQueryString={queryString}
             onFilterChange={(value) => setQueryParams({ queryString: value ? value : null })}
           />
+          {config.featureToggles.alertingAlertsProducerAPI && (
+            <Button
+              size="sm"
+              variant="secondary"
+              fill={queryString === producerAlertsQuery ? 'solid' : 'outline'}
+              onClick={() => setQueryParams({ queryString: producerAlertsQuery })}
+            >
+              <Trans i18nKey="alerting.alert-group-filter.producer-alerts">Producer alerts</Trans>
+            </Button>
+          )}
           <GroupBy
             groups={groups}
             groupBy={groupBy}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -419,7 +419,8 @@
       "duration": "for {{time}}"
     },
     "alert-group-filter": {
-      "clear-filters": "Clear filters"
+      "clear-filters": "Clear filters",
+      "producer-alerts": "Producer alerts"
     },
     "alert-groups": {
       "body-grafana-alerted-delivered": "Grafana is configured to send alerts to external alertmanagers only. No alerts are expected to be available here for the selected Alertmanager.",


### PR DESCRIPTION
## What

Adds frontend support for trusted producer alerts:

- Shows producer alerts in Alert groups by default
- Adds a **Producer alerts** filter that narrows the list to alerts carrying `grafana_alert_source`
- Shows **See source** for producer alerts and links to their `generatorURL` without requiring alert-rule read permission

This PR is stacked on backend PR #131558 and contains only frontend changes.

## Why

Producer alerts are alert instances rather than Grafana-managed alert rules. They should remain visible alongside other alerts by default, while still being easy to isolate, and their details should link back to the producing system instead of a nonexistent alert rule.

## Verification

- `yarn jest --no-watch public/app/features/alerting/unified/AlertGroups.test.tsx --runInBand`
- `yarn jest --no-watch public/app/features/alerting/unified/components/alert-groups/AlertDetails.test.tsx --runInBand`
- ESLint on the changed TypeScript files
- Prettier on the changed frontend files
