### PR TITLE
TraceView: use real app value in app prop

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -22,7 +22,7 @@ import { getTraceToLogsOptions, type TraceToMetricsData, type TraceToProfilesDat
 import { config, getTemplateSrv, reportInteraction, useAppPluginInstalled } from '@grafana/runtime';
 import { useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
-import { useStyles2 } from '@grafana/ui';
+import { usePanelContext, useStyles2 } from '@grafana/ui';
 import { getTimeZone } from 'app/features/profile/state/selectors';
 import { useDispatch, useSelector } from 'app/types/store';
 
@@ -107,6 +107,7 @@ export function TraceView(props: Props) {
   const { removeHoverIndentGuideId, addHoverIndentGuideId, hoverIndentGuideIds } = useHoverIndentGuide();
   const { viewRange, updateViewRangeTime, updateNextViewRangeTime } = useViewRange();
   const { expandOne, collapseOne, childrenToggle, collapseAll, childrenHiddenIDs, expandAll } = useChildrenState();
+  const { app = CoreApp.Unknown } = usePanelContext();
 
   const criticalPath = useMemo(() => memoizedTraceCriticalPath(traceProp), [traceProp]);
   const { value: isAdaptiveTracesAppInstalled } = useAppPluginInstalled(ADAPTIVE_TRACES_APP_PLUGIN_ID);
@@ -292,7 +293,7 @@ export function TraceView(props: Props) {
             datasourceName={datasourceName}
             datasourceUid={datasourceUid}
             setHeaderHeight={setHeaderHeight}
-            app={exploreId ? CoreApp.Explore : CoreApp.Unknown}
+            app={exploreId ? CoreApp.Explore : app}
             updateNextViewRangeTime={updateNextViewRangeTime}
             updateViewRangeTime={updateViewRangeTime}
             viewRange={viewRange}
@@ -344,7 +345,7 @@ export function TraceView(props: Props) {
             redrawListView={redrawListView}
             setRedrawListView={setRedrawListView}
             timeRange={props.timeRange}
-            app={exploreId ? CoreApp.Explore : CoreApp.Unknown}
+            app={exploreId ? CoreApp.Explore : app}
           />
         </>
       ) : (

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -16,6 +16,7 @@ import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/
 import userEvent from '@testing-library/user-event';
 
 import {
+  CoreApp,
   type IconName,
   type LinkModel,
   MutableDataFrame,
@@ -103,6 +104,7 @@ const setup = (
 
   const viewRangeTime: [number, number] = [0, 0];
   const defaultProps = {
+    app: CoreApp.Unknown,
     trace,
     timeZone: '',
     search: DEFAULT_SPAN_FILTERS,

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -72,7 +72,7 @@ import { useTraceAdHocFiltersController } from './useTraceAdHocFiltersController
 export type TracePageHeaderProps = {
   trace: Trace | null;
   data: DataFrame;
-  app?: CoreApp;
+  app: CoreApp | string;
   timeZone: TimeZone;
   search: TraceSearchProps;
   setSearch: (newSearch: TraceSearchProps) => void;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/LogsLink.test.tsx
@@ -721,7 +721,7 @@ describe('LogsLinkMenuItem', () => {
     );
 
     await waitFor(() => expect(getDataSourceInstanceMock).toHaveBeenCalled());
-    expect(screen.getByRole('menuitem')).toBeEnabled();
+    await waitFor(() => expect(screen.getByRole('menuitem')).toBeEnabled());
   });
 
   it('keeps the item disabled when the presence check errors', async () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/SpanDetailLinkButtons.tsx
@@ -42,7 +42,7 @@ export type Props = {
   datasourceUid: string;
   timeRange: TimeRange;
   createSpanLink?: SpanLinkFunc;
-  app: CoreApp;
+  app: CoreApp | string;
   focusSpanLink: LinkModel;
 };
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -296,7 +296,7 @@ export type SpanDetailProps = {
   setTraceFlameGraphs: (flameGraphs: TraceFlameGraphs) => void;
   setRedrawListView: (redraw: {}) => void;
   timeRange: TimeRange;
-  app: CoreApp;
+  app: CoreApp | string;
 };
 
 export default function SpanDetail(props: SpanDetailProps) {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { type CoreApp, type GrafanaTheme2, type LinkModel, type TimeRange, type TraceLog } from '@grafana/data';
 import { type TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { type TimeZone } from '@grafana/schema';
-import { stylesFactory, withTheme2 } from '@grafana/ui';
+import { stylesFactory, useStyles2 } from '@grafana/ui';
 
 import { type SpanLinkFunc } from '../types/links';
 import { type TraceSpan, type TraceSpanReference } from '../types/trace';
@@ -106,7 +106,6 @@ export type SpanDetailRowProps = {
   hoverIndentGuideIds: Set<string>;
   addHoverIndentGuideId: (spanID: string) => void;
   removeHoverIndentGuideId: (spanID: string) => void;
-  theme: GrafanaTheme2;
   createSpanLink?: SpanLinkFunc;
   focusedSpanId?: string;
   createFocusSpanLink: (traceId: string, spanId: string) => LinkModel;
@@ -117,7 +116,7 @@ export type SpanDetailRowProps = {
   setTraceFlameGraphs: (flameGraphs: TraceFlameGraphs) => void;
   setRedrawListView: (redraw: {}) => void;
   timeRange: TimeRange;
-  app: CoreApp;
+  app: CoreApp | string;
 };
 
 const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
@@ -139,7 +138,6 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
     traceStartTime,
     traceDuration,
     traceName,
-    theme,
     createSpanLink,
     focusedSpanId,
     createFocusSpanLink,
@@ -156,7 +154,7 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
     visibleSpanIds,
   } = props;
 
-  const styles = getStyles(theme);
+  const styles = useStyles2(getStyles);
 
   return (
     <TimelineRow>
@@ -209,7 +207,6 @@ const UnthemedSpanDetailRow = React.memo<SpanDetailRowProps>((props) => {
     </TimelineRow>
   );
 });
-
 UnthemedSpanDetailRow.displayName = 'UnthemedSpanDetailRow';
 
-export default withTheme2(UnthemedSpanDetailRow);
+export default UnthemedSpanDetailRow;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/VirtualizedTraceView.tsx
@@ -115,7 +115,7 @@ type TVirtualizedTraceViewOwnProps = {
   redrawListView: {};
   setRedrawListView: (redraw: {}) => void;
   timeRange: TimeRange;
-  app: CoreApp;
+  app: CoreApp | string;
 };
 
 export type VirtualizedTraceViewProps = TVirtualizedTraceViewOwnProps & TTraceTimeline;

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -119,7 +119,7 @@ export type TProps = {
   redrawListView: {};
   setRedrawListView: (redraw: {}) => void;
   timeRange: TimeRange;
-  app: CoreApp;
+  app: CoreApp | string;
 };
 
 const NUM_TICKS = 5;


### PR DESCRIPTION
This PR fixes the current binary condition where the component can be in Explore or in an Unknown context. When the TraceView is used as a visualization, there is a defined [CoreApp | string](https://github.com/grafana/grafana/blob/4665520e85048e1005b046be8a689c3816e12200/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts#L27) that can be used and provide the real context.

Without this, any user of this prop can get an inaccurate value.

Before:

<img width="1866" height="440" alt="Before" src="https://github.com/user-attachments/assets/e58d9f9e-276f-490f-8075-544d049c8041" />

After:

<img width="1871" height="742" alt="After 3" src="https://github.com/user-attachments/assets/bae0f78f-7576-4bab-a734-df485f37c93c" />

<img width="1877" height="685" alt="After 2" src="https://github.com/user-attachments/assets/9ebc0742-b51c-45f3-b7f4-3a8540c8faf5" />

<img width="1875" height="432" alt="After 1" src="https://github.com/user-attachments/assets/6cc44133-b906-4cd9-b75a-47b6a1bb45da" />

Other changes:
- Use the memoized useStyles2 in SpanDetailRow.