### PR TITLE
unify grpc error handling in folder validation

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -525,12 +525,8 @@ func getChildrenBatch(ctx context.Context, searcher resourcepb.ResourceIndexClie
 		Limit:  limit,
 		Offset: offset,
 	})
-	if err != nil {
+	if err := resource.ErrorFromResponse(resp.GetError(), err); err != nil {
 		return nil, false, fmt.Errorf("failed to search folders: %w", err)
-	}
-
-	if resp.Error != nil {
-		return nil, false, fmt.Errorf("search error: %s", resp.Error.Message)
 	}
 
 	if resp.Results == nil || len(resp.Results.Rows) == 0 {
@@ -569,12 +565,8 @@ func validateOnDelete(ctx context.Context,
 	}
 
 	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
-	if err != nil {
+	if err := resource.ErrorFromResponse(resp.GetError(), err); err != nil {
 		return err
-	}
-
-	if resp != nil && resp.Error != nil {
-		return fmt.Errorf("could not verify if folder is empty: %v", resp.Error)
 	}
 
 	if resp.Stats == nil {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -566,7 +566,7 @@ func validateOnDelete(ctx context.Context,
 
 	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
 	if err := resource.ErrorFromResponse(resp.GetError(), err); err != nil {
-		return fmt.Errorf("could not verify if folder is empty: %v", err)
+		return fmt.Errorf("could not verify if folder is empty: %w", err)
 	}
 
 	if resp.Stats == nil {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -566,7 +566,7 @@ func validateOnDelete(ctx context.Context,
 
 	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
 	if err := resource.ErrorFromResponse(resp.GetError(), err); err != nil {
-		return err
+		return fmt.Errorf("could not verify if folder is empty: %v", err)
 	}
 
 	if resp.Stats == nil {


### PR DESCRIPTION
Read possible embedded ErrorResult from grpc error details.

This is one of many PRs on the topic, see https://github.com/grafana/grafana/pull/131038 and https://github.com/grafana/grafana/pull/131258 for more information.
