### PR TITLE
PanelEditor: Fix options pane not resizable beyond the preview's content width

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react';
+
+import { useSnappingSplitter } from './useSnappingSplitter';
+
+// `useSplitter` is deliberately not mocked, so these assert the override against the real styles.
+describe('useSnappingSplitter', () => {
+  it('lets the primary pane shrink in pixel mode so the other pane can be dragged wider', () => {
+    const { result } = renderHook(() =>
+      useSnappingSplitter({ direction: 'row', usePixels: true, initialSize: 330, collapseBelowPixels: 150 })
+    );
+
+    expect(result.current.primaryProps.style.minWidth).toBe(0);
+  });
+
+  it('leaves the primary pane floored at its content width in flex mode', () => {
+    const { result } = renderHook(() =>
+      useSnappingSplitter({ direction: 'row', initialSize: 0.5, collapseBelowPixels: 150 })
+    );
+
+    expect(result.current.primaryProps.style.minWidth).toBe('min-content');
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.ts
+++ b/public/app/features/dashboard-scene/panel-edit/splitter/useSnappingSplitter.ts
@@ -120,6 +120,13 @@ export function useSnappingSplitter({
   secondaryProps.style.minWidth = 'unset';
   secondaryProps.style.minHeight = 'unset';
 
+  if (usePixels) {
+    // Otherwise this pane can only grow until the primary one hits its `min-content` floor. A literal 0
+    // is required: `unset` resolves to `auto`, still the content minimum for a flex item whose own
+    // overflow is visible.
+    primaryProps.style[direction === 'row' ? 'minWidth' : 'minHeight'] = 0;
+  }
+
   if (state.snapSize) {
     if (usePixels) {
       secondaryProps.style.flexBasis = `${state.snapSize}px`;


### PR DESCRIPTION
## What this PR does

In panel edit the options pane can be dragged narrower but not wider. It stops as soon as the visualization preview reaches its intrinsic content width, so for a panel whose preview has a wide content min-width the pane barely widens at all.

`useSplitter` floors both panes at `min-width: min-content`. `useSnappingSplitter` lifts that floor only on the pixel-sized pane (the options pane), never on the primary one, so the primary never gives. `measureElement` then probes the achievable width with the floor still in force, and the resulting `dims.maxWidth` becomes a hard cap on the drag.

This lets the primary pane shrink when the splitter runs in pixel mode. Only the panel editor passes `usePixels: true` (`PanelEditorRenderer.tsx`, `PanelEditNext/hooks.ts`), so every flex-mode consumer is untouched.

A literal `0` is load-bearing here and `unset` would not be equivalent: on a flex item `unset` resolves to `auto`, which is still the content-based minimum unless the item's own overflow is hidden, and the primary pane's is visible. That is the same reason the pane beside it already pairs `minWidth: 'unset'` with `overflow: 'hidden'`.

## Measured

Headless Chromium at a 2560px viewport, reproducing the flex structure the two hooks emit and running `measureElement`'s `flex-grow: 100` probe. Widest the options pane can reach, with a 1400px-wide preview:

| primary pane `min-width` | max options pane width |
|---|---|
| `min-content` (before) | 1152px |
| `unset` | 1152px |
| `0` (this PR) | 2530px |

## Testing

- New `useSnappingSplitter.test.ts` deliberately does **not** mock `useSplitter`, so it asserts the override against the real styles. Swapping the fix for `unset` fails 3 of its 4 cases.
- Manually: open a panel in edit mode, drag the options-pane divider left. It now expands past the preview's content width. Collapse below the snap threshold, the expand affordance, and double-click reset all still behave as before.

## Note

https://github.com/grafana/grafana/pull/125773 already contains this change as one part of a larger query-editor refactor, and has been approved since 10 Aug. This PR carries only the behaviour fix so it is small enough to backport to 13.2.x on its own. Happy to close it in favour of that one if that PR merges and can be backported as-is.

## Reviewer Checklist

- [x] Tests are added where applicable
- [ ] Code pulled and tested
