### PR TITLE
Search: correct what deleted_rv is for

### DIFF
--- a/pkg/registry/apis/search/translate.go
+++ b/pkg/registry/apis/search/translate.go
@@ -716,7 +716,7 @@ func trashReturnFields(fields []string) []string {
 	if len(fields) == 0 {
 		fields = []string{trashFieldTitle, trashFieldFolder, trashFieldDeletedBy, trashFieldDeletionTime}
 	}
-	// deleted_rv is mandatory in the response; it drives restore.
+	// Always returned, so a client can restore from a trash hit without a second read.
 	if !slices.Contains(fields, trashFieldDeletedRV) {
 		fields = append(fields, trashFieldDeletedRV)
 	}

--- a/pkg/storage/unified/resource/standard_search_fields.go
+++ b/pkg/storage/unified/resource/standard_search_fields.go
@@ -134,7 +134,7 @@ func TrashSearchFieldDefinitions() []SearchFieldDefinition {
 		},
 		// A string, unlike deletion_time: resource versions are snowflake ids around
 		// 1.8e18, where a float64 can only represent multiples of 256, so a number
-		// would come back rounded. Restore submits this value, so it has to be exact.
+		// would come back rounded. It has to stay exact to be usable for a restore.
 		{
 			Name:         SEARCH_FIELD_DELETED_RV,
 			Type:         SearchFieldTypeString,


### PR DESCRIPTION
Two comments said `deleted_rv` drives restore, which reads as though something already does. Nothing in tree restores with it: the dashboards UI re-fetches the object by name and posts it back.

They now say what the field is for — it is always returned so a client can restore from a trash hit without a second read, and it stays a string so the value is exact enough to do that. A resource version is around 1.8e18 and a float64 can only represent multiples of 256, so a number would come back rounded.

Comments only, no behaviour change. It spans the API layer and unified storage because the same claim appears in both, hence the label.
