### PR TITLE
Advisor: Report the error when a datasource health check cannot run

### DIFF
--- a/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
@@ -2,6 +2,7 @@ package datasourcecheck
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 
@@ -135,6 +136,37 @@ func TestCheck_Run(t *testing.T) {
 		assert.Len(t, failures, 1)
 		assert.Equal(t, "health-check", failures[0].StepID)
 		assert.Contains(t, *failures[0].MoreInfo, "test message")
+	})
+
+	t.Run("should report the error when the datasource health check cannot run", func(t *testing.T) {
+		datasources := []*datasources.DataSource{
+			{UID: "valid-uid-1", Type: "prometheus", Name: "Prometheus"},
+		}
+
+		mockDatasourceSvc := &MockDatasourceSvc{dss: datasources}
+		mockPluginContextProvider := &MockPluginContextProvider{pCtx: backend.PluginContext{}}
+		// No result, only an error: the failure must still say what went wrong.
+		mockPluginClient := &MockPluginClient{err: errors.New("404: Plugin not found")}
+		mockPluginRepo := &MockPluginRepo{plugins: []repo.PluginInfo{
+			{ID: 1, Slug: "prometheus", Status: "active"},
+		}}
+		mockPluginStore := &MockPluginStore{exists: true}
+
+		check := &check{
+			DatasourceSvc: mockDatasourceSvc,
+			PluginRepo:    mockPluginRepo,
+			PluginStore:   mockPluginStore,
+			healthChecker: &checks.HealthCheckerImpl{
+				PluginContextProvider: mockPluginContextProvider,
+				PluginClient:          mockPluginClient,
+			},
+		}
+
+		failures, err := runChecks(check)
+		assert.NoError(t, err)
+		assert.Len(t, failures, 1)
+		assert.Equal(t, "health-check", failures[0].StepID)
+		assert.Contains(t, *failures[0].MoreInfo, "404: Plugin not found")
 	})
 
 	t.Run("should skip health check when datasource plugin is frontend-only", func(t *testing.T) {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
@@ -73,6 +73,10 @@ func (s *healthCheckStep) Run(ctx context.Context, log logging.Logger, obj *advi
 		moreInfo := ""
 		if resp != nil {
 			moreInfo = fmt.Sprintf("Status: %s\nMessage: %s\nJSONDetails: %s", resp.Status, resp.Message, resp.JSONDetails)
+		} else if err != nil {
+			// Without this, a health check that could not run at all reports a failure
+			// with no information, as the error is otherwise only logged.
+			moreInfo = fmt.Sprintf("Error: %s", err)
 		}
 		return []advisor.CheckReportFailure{checks.NewCheckReportFailureWithMoreInfo(
 			advisor.CheckReportFailureSeverityHigh,


### PR DESCRIPTION
## What

Include the error in a health-check failure's `moreInfo` when `CheckHealth` returns an error and no result.

## Why

`healthCheckStep.Run` enters its failure branch on `err != nil || (resp != nil && resp.Status != OK)`, but only builds `moreInfo` from `resp`:

```go
moreInfo := ""
if resp != nil {
	moreInfo = fmt.Sprintf("Status: %s\nMessage: %s\nJSONDetails: %s", resp.Status, resp.Message, resp.JSONDetails)
}
```

When the check could not run at all, `resp` is nil, so `moreInfo` stays empty. The error is logged and then discarded, and the report gets a `severity: high` failure with a "Fix me" link and no message, status or details — nothing the reader can act on, and nothing to distinguish it from any other failure.

Encountered on a real report, where a datasource failed with a completely empty `moreInfo` and the cause was only recoverable from backend logs.

The errors that reach this branch are not exotic. The escapes above it cover `ErrMethodNotImplemented`, `ErrPluginUnavailable` and `ErrPluginNotRegistered`; anything else lands here. In multi-tenant that includes plugin-resolution failures, transport errors reaching the datasource API server or the per-tenant runner, and an uninitialised health checker.

## How

An `else if err != nil` branch that formats the error. Deliberately `else if` rather than always appending: both current `HealthChecker` implementations return a nil result whenever they return an error, and this keeps the existing `moreInfo` format byte-identical for every failure that has a result.

## Tests

New case in `TestCheck_Run` using the existing `MockPluginClient.err` field. Verified it fails without the fix with `"" does not contain "404: Plugin not found"`, which is exactly the reported symptom.