### PR TITLE
Provisioning: Trace operator reconcile loops and job history

### DIFF
--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -47,6 +47,11 @@ func RunConnectionController(ctx context.Context, deps server.OperatorDependenci
 		return fmt.Errorf("failed to get health metrics recorder: %w", err)
 	}
 
+	tracer, err := controllerCfg.Tracer()
+	if err != nil {
+		return fmt.Errorf("failed to get tracer: %w", err)
+	}
+
 	// The connection delta source and the getter it backs.
 	connSource, connGetter := informer.NewConnectionDeltaSource(controllerCfg.natsSubscriber, provisioningClient, controllerCfg.ResyncInterval())
 	connController := controller.NewConnectionController(
@@ -60,6 +65,7 @@ func RunConnectionController(ctx context.Context, deps server.OperatorDependenci
 		controllerCfg.ResyncInterval(),
 		controllerCfg.DrainTimeout(),
 		controllerCfg.Registry(),
+		tracer,
 		nats.Enabled(controllerCfg.natsSubscriber),
 	)
 

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -269,7 +269,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 
 	// The worker loop carries no active span, so this opens a fresh trace per
 	// reconcile whose children show where the reconcile spends its time.
-	ctx, span := cc.tracer.Start(ctx, "provisioning.controller.reconcile_connection",
+	ctx, span := cc.tracer.Start(ctx, "provisioning.controller.reconcile",
 		trace.WithAttributes(
 			attribute.String("connection.namespace", namespace),
 			attribute.String("connection.name", name),
@@ -311,7 +311,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	hasSpecChanged := conn.Generation != conn.Status.ObservedGeneration
 	shouldCheckHealth := cc.healthChecker.ShouldCheckHealth(conn)
 
-	buildCtx, buildSpan := cc.tracer.Start(ctx, "provisioning.controller.build_connection", connSpanAttrs(conn))
+	buildCtx, buildSpan := cc.tracer.Start(ctx, "provisioning.controller.build", connSpanAttrs(conn))
 	c, err := cc.connectionFactory.Build(buildCtx, conn)
 	buildSpan.End()
 	if err != nil {
@@ -378,7 +378,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	if isTokenConnection && shouldRefreshToken {
 		logger.Info("generating connection token")
 
-		tokenCtx, tokenSpan := cc.tracer.Start(ctx, "provisioning.controller.generate_connection_token", connSpanAttrs(conn))
+		tokenCtx, tokenSpan := cc.tracer.Start(ctx, "provisioning.controller.generate_token", connSpanAttrs(conn))
 		token, tokenOps, err := cc.generateConnectionToken(tokenCtx, tokenConn)
 		tokenSpan.End()
 		if err != nil {

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -155,6 +155,17 @@ func connectionResourceVersion(obj any) string {
 	return ""
 }
 
+// connSpanAttrs returns the resource-identifying attributes stamped on every
+// reconcile child span, so a span is self-describing in isolation (e.g. a
+// health_check or apply_status span says which connection it concerns) rather
+// than only via its parent.
+func connSpanAttrs(conn *provisioning.Connection) trace.SpanStartOption {
+	return trace.WithAttributes(
+		attribute.String("connection.name", conn.GetName()),
+		attribute.String("connection.namespace", conn.GetNamespace()),
+	)
+}
+
 // Run starts the ConnectionController. The onStarted callback is invoked once
 // all workers have been launched, before blocking on ctx.Done().
 func (cc *ConnectionController) Run(ctx context.Context, workerCount int, onStarted func(), onShutdown func()) {
@@ -267,7 +278,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	defer span.End()
 	defer func() {
 		if err != nil {
-			tracing.Error(span, err)
+			_ = tracing.Error(span, err)
 		}
 	}()
 
@@ -300,7 +311,9 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	hasSpecChanged := conn.Generation != conn.Status.ObservedGeneration
 	shouldCheckHealth := cc.healthChecker.ShouldCheckHealth(conn)
 
-	c, err := cc.connectionFactory.Build(ctx, conn)
+	buildCtx, buildSpan := cc.tracer.Start(ctx, "provisioning.controller.build_connection", connSpanAttrs(conn))
+	c, err := cc.connectionFactory.Build(buildCtx, conn)
+	buildSpan.End()
 	if err != nil {
 		// The token references a stored secret that could not be decrypted (e.g. an
 		// orphaned reference whose secret was deleted). Regenerate it from the private
@@ -365,7 +378,9 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	if isTokenConnection && shouldRefreshToken {
 		logger.Info("generating connection token")
 
-		token, tokenOps, err := cc.generateConnectionToken(ctx, tokenConn)
+		tokenCtx, tokenSpan := cc.tracer.Start(ctx, "provisioning.controller.generate_connection_token", connSpanAttrs(conn))
+		token, tokenOps, err := cc.generateConnectionToken(tokenCtx, tokenConn)
+		tokenSpan.End()
 		if err != nil {
 			logger.Error("failed to generate connection token", "error", err)
 			return err
@@ -387,7 +402,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	}
 
 	// Handle health checks using the health checker
-	healthCtx, healthSpan := cc.tracer.Start(ctx, "provisioning.controller.health_check")
+	healthCtx, healthSpan := cc.tracer.Start(ctx, "provisioning.controller.health_check", connSpanAttrs(conn))
 	healthResult, err := cc.healthChecker.RefreshHealthWithPatchOps(healthCtx, conn)
 	healthSpan.End()
 	if err != nil {
@@ -420,6 +435,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	if len(patchOperations) > 0 {
 		// Update fieldErrors from test results
 		patchCtx, patchSpan := cc.tracer.Start(ctx, "provisioning.controller.apply_status",
+			connSpanAttrs(conn),
 			trace.WithAttributes(attribute.Int("patch.operations", len(patchOperations))),
 		)
 		err := cc.statusPatcher.Patch(patchCtx, conn, patchOperations...)

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -18,6 +20,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/informer"
 	usinformer "github.com/grafana/grafana/pkg/storage/unified/informer"
 )
@@ -58,6 +61,7 @@ type ConnectionController struct {
 	healthChecker     ConnectionHealthCheckerInterface
 	connectionFactory connection.Factory
 	tokenMetrics      *connectionTokenMetrics
+	tracer            tracing.Tracer
 
 	// processed classifies each delivery (encapsulating the NATS/apiserver
 	// backend) and counts the start of each reconcile by what enqueued it.
@@ -80,10 +84,12 @@ func NewConnectionController(
 	resyncInterval time.Duration,
 	drainTimeout time.Duration,
 	registry prometheus.Registerer,
+	tracer tracing.Tracer,
 	natsBacked bool,
 ) *ConnectionController {
 	cc := &ConnectionController{
 		conns:     conns,
+		tracer:    tracer,
 		processed: usinformer.NewProcessedMetrics(registry, "connections", natsBacked),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
@@ -240,7 +246,7 @@ func (cc *ConnectionController) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
-func (cc *ConnectionController) process(ctx context.Context, item *connectionQueueItem) error {
+func (cc *ConnectionController) process(ctx context.Context, item *connectionQueueItem) (err error) {
 	logger := cc.logger.With("key", item.key)
 	ctx = logging.Context(ctx, logger)
 
@@ -249,6 +255,21 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 		logger.Error("retrieving namespace and name from key", "error", err)
 		return err
 	}
+
+	// The worker loop carries no active span, so this opens a fresh trace per
+	// reconcile whose children show where the reconcile spends its time.
+	ctx, span := cc.tracer.Start(ctx, "provisioning.controller.reconcile_connection",
+		trace.WithAttributes(
+			attribute.String("connection.namespace", namespace),
+			attribute.String("connection.name", name),
+		),
+	)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.Error(span, err)
+		}
+	}()
 
 	// Reconcile the object the read seam returns; how it is sourced and kept
 	// fresh is the informer.ConnectionGetter's concern, not the controller's.
@@ -313,17 +334,23 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	}
 
 	// Determine the main triggering condition
+	var reason string
 	switch {
 	case hasSpecChanged:
+		reason = "spec_changed"
 		logger.Info("spec changed, reconciling", "generation", conn.Generation, "observedGeneration", conn.Status.ObservedGeneration)
 	case shouldCheckHealth:
+		reason = "health_stale"
 		logger.Info("health is stale, refreshing", "lastChecked", conn.Status.Health.Checked, "healthy", conn.Status.Health.Healthy)
 	case shouldRefreshToken:
+		reason = "token_refresh"
 		logger.Info("token must be refreshed or generated")
 	default:
+		span.SetAttributes(attribute.String("reconcile.reason", "skipped"))
 		logger.Debug("skipping as conditions are not met", "generation", conn.Generation, "observedGeneration", conn.Status.ObservedGeneration)
 		return nil
 	}
+	span.SetAttributes(attribute.String("reconcile.reason", reason))
 
 	var patchOperations []map[string]interface{}
 
@@ -360,7 +387,9 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 	}
 
 	// Handle health checks using the health checker
-	healthResult, err := cc.healthChecker.RefreshHealthWithPatchOps(ctx, conn)
+	healthCtx, healthSpan := cc.tracer.Start(ctx, "provisioning.controller.health_check")
+	healthResult, err := cc.healthChecker.RefreshHealthWithPatchOps(healthCtx, conn)
+	healthSpan.End()
 	if err != nil {
 		logger.Error("failed to get updated health status", "error", err)
 		return fmt.Errorf("update health status: %w", err)
@@ -390,7 +419,12 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 
 	if len(patchOperations) > 0 {
 		// Update fieldErrors from test results
-		if err := cc.statusPatcher.Patch(ctx, conn, patchOperations...); err != nil {
+		patchCtx, patchSpan := cc.tracer.Start(ctx, "provisioning.controller.apply_status",
+			trace.WithAttributes(attribute.Int("patch.operations", len(patchOperations))),
+		)
+		err := cc.statusPatcher.Patch(patchCtx, conn, patchOperations...)
+		patchSpan.End()
+		if err != nil {
 			return fmt.Errorf("failed to update connection status: %w", err)
 		}
 	}

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
 	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/informer"
 )
@@ -1222,6 +1223,7 @@ func TestConnectionController_process(t *testing.T) {
 				connectionFactory: mockFactory,
 				logger:            logging.DefaultLogger,
 				resyncInterval:    5 * time.Minute,
+				tracer:            tracing.InitializeTracerForTest(),
 			}
 
 			item := &connectionQueueItem{key: tt.conn.Namespace + "/" + tt.conn.Name}
@@ -1386,6 +1388,7 @@ func TestConnectionController_process_FieldErrors(t *testing.T) {
 				healthChecker:     mockHealthChecker,
 				statusPatcher:     mockPatcher,
 				logger:            logging.DefaultLogger,
+				tracer:            tracing.InitializeTracerForTest(),
 			}
 
 			// Process the connection

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -607,12 +607,10 @@ func shouldUseIncrementalSync(
 }
 
 func (rc *RepositoryController) addSyncJob(ctx context.Context, obj *provisioning.Repository, syncOptions *provisioning.SyncJobOptions) error {
-	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.add_sync_job")
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.add_sync_job", repoSpanAttrs(obj))
 	defer span.End()
 
 	span.SetAttributes(
-		attribute.String("repository", obj.GetName()),
-		attribute.String("namespace", obj.Namespace),
 		attribute.Bool("incremental", syncOptions != nil && syncOptions.Incremental),
 	)
 

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -868,7 +868,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 		obj.Secure.Token.Create = token
 	}
 
-	buildCtx, buildSpan := rc.tracer.Start(ctx, "provisioning.controller.build_repository", repoSpanAttrs(obj))
+	buildCtx, buildSpan := rc.tracer.Start(ctx, "provisioning.controller.build", repoSpanAttrs(obj))
 	repo, err := rc.repoFactory.Build(buildCtx, obj)
 	buildSpan.End()
 	if err != nil {
@@ -1175,7 +1175,7 @@ func (rc *RepositoryController) generateRepositoryToken(
 	obj *provisioning.Repository,
 	c *provisioning.Connection,
 ) (_ common.RawSecureValue, _ []map[string]any, err error) {
-	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.generate_repository_token", repoSpanAttrs(obj))
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.generate_token", repoSpanAttrs(obj))
 	defer span.End()
 	defer func() {
 		if err != nil {

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -366,6 +367,9 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provisioning.Repository) error {
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.handle_delete")
+	defer span.End()
+
 	logger := logging.FromContext(ctx)
 	logger.Info("handle repository delete")
 
@@ -672,7 +676,7 @@ func (rc *RepositoryController) determineSyncStatusOps(obj *provisioning.Reposit
 }
 
 //nolint:gocyclo
-func (rc *RepositoryController) process(key string) error {
+func (rc *RepositoryController) process(key string) (err error) {
 	logger := rc.logger.With("key", key)
 	ctx := logging.Context(context.Background(), logger)
 
@@ -680,6 +684,21 @@ func (rc *RepositoryController) process(key string) error {
 	if err != nil {
 		return err
 	}
+
+	// process runs from a background context, so this opens a fresh trace per
+	// reconcile whose children show where the reconcile spends its time.
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.reconcile",
+		trace.WithAttributes(
+			attribute.String("repository.namespace", namespace),
+			attribute.String("repository.name", name),
+		),
+	)
+	defer span.End()
+	defer func() {
+		if err != nil {
+			tracing.Error(span, err)
+		}
+	}()
 
 	// Reconcile the object the read seam returns; how it is sourced and kept
 	// fresh is the informer.RepositoryGetter's concern, not the controller's.
@@ -698,6 +717,11 @@ func (rc *RepositoryController) process(key string) error {
 		"connection", obj.ConnectionName(),
 	)
 	ctx = logging.Context(ctx, logger)
+
+	span.SetAttributes(
+		attribute.String("repository.type", string(obj.Spec.Type)),
+		attribute.String("repository.connection", obj.ConnectionName()),
+	)
 
 	ctx, _, err = identity.WithProvisioningIdentity(ctx, namespace)
 	if err != nil {
@@ -748,32 +772,45 @@ func (rc *RepositoryController) process(key string) error {
 	shouldRotateWebhookSecret := rc.shouldRotateWebhookSecret(obj)
 
 	// Determine the main triggering condition
+	var reason string
 	switch {
 	// First, we check if the repository is blocked
 	case isCurrentlyBlocked && isOverQuota:
+		reason = "blocked_over_quota"
 		logger.Info("repository blocked and over quota, reconciling but skipping sync")
 	case !isCurrentlyBlocked && isOverQuota:
+		reason = "over_quota"
 		logger.Info("namespace over quota, blocking repository", "max_repositories", newQuota.MaxRepositories)
 	case hasSpecChanged:
+		reason = "spec_changed"
 		logger.Info("spec changed", "Generation", obj.Generation, "ObservedGeneration", obj.Status.ObservedGeneration)
 	case shouldResync:
+		reason = "resync_interval"
 		logger.Info("sync interval triggered", "sync_interval", time.Duration(obj.Spec.Sync.IntervalSeconds)*time.Second, "sync_status", obj.Status.Sync)
 	case shouldCheckHealth:
+		reason = "health_stale"
 		logger.Info("health is stale", "health_status", obj.Status.Health.Healthy)
 	case forceProcessForUnblock:
+		reason = "unblock"
 		logger.Info("repository was blocked but now within quota, processing to unblock")
 	case shouldGenerateToken:
+		reason = "token_generation"
 		logger.Info("repository token needs to be generated", "connection", obj.Spec.Connection.Name)
 	case hasQuotaChanged:
+		reason = "quota_changed"
 		logger.Info("quota changed", "quota", newQuota)
 	case len(obj.Spec.Workflows) > 0 && repository.GetID(obj.Status.Webhook).IsEmpty():
+		reason = "webhook_missing"
 		logger.Info("webhook missing, reconciling")
 	case shouldRotateWebhookSecret:
+		reason = "webhook_secret_rotation"
 		logger.Info("webhook secret rotation due")
 	default:
+		span.SetAttributes(attribute.String("reconcile.reason", "skipped"))
 		logger.Info("skipping as conditions are not met", "status", obj.Status, "generation", obj.Generation, "sync_spec", obj.Spec.Sync)
 		return nil
 	}
+	span.SetAttributes(attribute.String("reconcile.reason", reason))
 
 	// In any case - repo blocked, repo unblocked, or simply spec has changed - we need to
 	// update the observedGeneration to alight with the given metadata.generation.
@@ -929,7 +966,9 @@ func (rc *RepositoryController) process(key string) error {
 	}
 
 	// Handle health checks using the health checker
-	healthResult, err := rc.healthChecker.RefreshHealthWithPatchOps(ctx, repo)
+	healthCtx, healthSpan := rc.tracer.Start(ctx, "provisioning.controller.health_check")
+	healthResult, err := rc.healthChecker.RefreshHealthWithPatchOps(healthCtx, repo)
+	healthSpan.End()
 	if err != nil {
 		return fmt.Errorf("update health status: %w", err)
 	}
@@ -979,7 +1018,11 @@ func (rc *RepositoryController) process(key string) error {
 
 	// Apply all patch operations
 	if len(patchOperations) > 0 {
-		err := rc.statusPatcher.Patch(ctx, obj, patchOperations...)
+		patchCtx, patchSpan := rc.tracer.Start(ctx, "provisioning.controller.apply_status",
+			trace.WithAttributes(attribute.Int("patch.operations", len(patchOperations))),
+		)
+		err := rc.statusPatcher.Patch(patchCtx, obj, patchOperations...)
+		patchSpan.End()
 		if err != nil {
 			return fmt.Errorf("status patch operations failed: %w", err)
 		}
@@ -1000,6 +1043,9 @@ func (rc *RepositoryController) process(key string) error {
 // processHooks handles hook execution with intelligent retry logic
 // Returns hook operations, whether processing should continue, and any error
 func (rc *RepositoryController) processHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) (hookOps []map[string]interface{}, shouldContinue bool, err error) {
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.process_hooks")
+	defer span.End()
+
 	webhookMissing := len(obj.Spec.Workflows) > 0 &&
 		repository.GetID(obj.Status.Webhook).IsEmpty()
 

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -367,7 +367,7 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 }
 
 func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provisioning.Repository) error {
-	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.handle_delete")
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.handle_delete", repoSpanAttrs(obj))
 	defer span.End()
 
 	logger := logging.FromContext(ctx)
@@ -513,6 +513,9 @@ func (rc *RepositoryController) determineSyncStrategy(
 	isBlocked bool,
 	healthStatus provisioning.HealthStatus,
 ) *provisioning.SyncJobOptions {
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.determine_sync_strategy", repoSpanAttrs(obj))
+	defer span.End()
+
 	logger := logging.FromContext(ctx)
 
 	switch {
@@ -675,6 +678,18 @@ func (rc *RepositoryController) determineSyncStatusOps(obj *provisioning.Reposit
 	return patchOperations
 }
 
+// repoSpanAttrs returns the resource-identifying attributes stamped on every
+// reconcile child span, so a span is self-describing in isolation (e.g. a
+// handle_delete or health_check span says which repository, and of what type,
+// it concerns) rather than only via its parent.
+func repoSpanAttrs(obj *provisioning.Repository) trace.SpanStartOption {
+	return trace.WithAttributes(
+		attribute.String("repository.name", obj.GetName()),
+		attribute.String("repository.namespace", obj.GetNamespace()),
+		attribute.String("repository.type", string(obj.Spec.Type)),
+	)
+}
+
 //nolint:gocyclo
 func (rc *RepositoryController) process(key string) (err error) {
 	logger := rc.logger.With("key", key)
@@ -696,7 +711,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	defer span.End()
 	defer func() {
 		if err != nil {
-			tracing.Error(span, err)
+			_ = tracing.Error(span, err)
 		}
 	}()
 
@@ -746,7 +761,9 @@ func (rc *RepositoryController) process(key string) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to get quota status: %w", err)
 	}
-	quotaCondition, err := rc.quotaChecker.RepositoryQuotaConditions(ctx, namespace, newQuota)
+	quotaCtx, quotaSpan := rc.tracer.Start(ctx, "provisioning.controller.check_quota", repoSpanAttrs(obj))
+	quotaCondition, err := rc.quotaChecker.RepositoryQuotaConditions(quotaCtx, namespace, newQuota)
+	quotaSpan.End()
 	if err != nil {
 		return fmt.Errorf("check repository quota: %w", err)
 	}
@@ -853,7 +870,9 @@ func (rc *RepositoryController) process(key string) (err error) {
 		obj.Secure.Token.Create = token
 	}
 
-	repo, err := rc.repoFactory.Build(ctx, obj)
+	buildCtx, buildSpan := rc.tracer.Start(ctx, "provisioning.controller.build_repository", repoSpanAttrs(obj))
+	repo, err := rc.repoFactory.Build(buildCtx, obj)
+	buildSpan.End()
 	if err != nil {
 		// The token references a stored secret that could not be decrypted (e.g. an
 		// orphaned reference whose secret was deleted). When the token is minted from a
@@ -912,7 +931,9 @@ func (rc *RepositoryController) process(key string) (err error) {
 
 	// Rotate webhook secret if due.
 	if webhookRepo, ok := repo.(repository.WebhookRepository); ok && shouldRotateWebhookSecret {
-		rotateOps, err := rotateWebhookSecret(ctx, webhookRepo)
+		rotateCtx, rotateSpan := rc.tracer.Start(ctx, "provisioning.controller.rotate_webhook_secret", repoSpanAttrs(obj))
+		rotateOps, err := rotateWebhookSecret(rotateCtx, webhookRepo)
+		rotateSpan.End()
 		if err != nil {
 			logger.Warn("webhook secret rotation failed", "error", err)
 		}
@@ -926,7 +947,9 @@ func (rc *RepositoryController) process(key string) (err error) {
 		if branchHandler.GetCurrentBranch() == "" {
 			logger.Info("given repository branch is empty, getting default branch")
 
-			defaultBranch, err := branchHandler.GetDefaultBranch(ctx)
+			branchCtx, branchSpan := rc.tracer.Start(ctx, "provisioning.controller.get_default_branch", repoSpanAttrs(obj))
+			defaultBranch, err := branchHandler.GetDefaultBranch(branchCtx)
+			branchSpan.End()
 			if err != nil {
 				return fmt.Errorf("failed to get default branch: %w", err)
 			}
@@ -966,7 +989,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	}
 
 	// Handle health checks using the health checker
-	healthCtx, healthSpan := rc.tracer.Start(ctx, "provisioning.controller.health_check")
+	healthCtx, healthSpan := rc.tracer.Start(ctx, "provisioning.controller.health_check", repoSpanAttrs(obj))
 	healthResult, err := rc.healthChecker.RefreshHealthWithPatchOps(healthCtx, repo)
 	healthSpan.End()
 	if err != nil {
@@ -1019,6 +1042,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	// Apply all patch operations
 	if len(patchOperations) > 0 {
 		patchCtx, patchSpan := rc.tracer.Start(ctx, "provisioning.controller.apply_status",
+			repoSpanAttrs(obj),
 			trace.WithAttributes(attribute.Int("patch.operations", len(patchOperations))),
 		)
 		err := rc.statusPatcher.Patch(patchCtx, obj, patchOperations...)
@@ -1043,7 +1067,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 // processHooks handles hook execution with intelligent retry logic
 // Returns hook operations, whether processing should continue, and any error
 func (rc *RepositoryController) processHooks(ctx context.Context, repo repository.Repository, obj *provisioning.Repository) (hookOps []map[string]interface{}, shouldContinue bool, err error) {
-	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.process_hooks")
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.process_hooks", repoSpanAttrs(obj))
 	defer span.End()
 
 	webhookMissing := len(obj.Spec.Workflows) > 0 &&
@@ -1153,6 +1177,14 @@ func (rc *RepositoryController) generateRepositoryToken(
 	obj *provisioning.Repository,
 	c *provisioning.Connection,
 ) (_ common.RawSecureValue, _ []map[string]any, err error) {
+	ctx, span := rc.tracer.Start(ctx, "provisioning.controller.generate_repository_token", repoSpanAttrs(obj))
+	defer span.End()
+	defer func() {
+		if err != nil {
+			_ = tracing.Error(span, err)
+		}
+	}()
+
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start).Seconds()

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -204,7 +204,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := repository.NewMockFactory(t)
 
 				f.
-					On("Build", context.Background(), mock.Anything).
+					On("Build", mock.Anything, mock.Anything).
 					Once().
 					Return(nil, nil)
 
@@ -214,7 +214,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := NewMockFinalizerProcessor(t)
 
 				f.
-					On("process", context.Background(), nil, []string{
+					On("process", mock.Anything, nil, []string{
 						repository.RemoveOrphanResourcesFinalizer,
 					}).
 					Once().
@@ -251,7 +251,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := repository.NewMockFactory(t)
 
 				f.
-					On("Build", context.Background(), mock.Anything).
+					On("Build", mock.Anything, mock.Anything).
 					Once().
 					Return(nil, assert.AnError)
 
@@ -275,7 +275,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := repository.NewMockFactory(t)
 
 				f.
-					On("Build", context.Background(), mock.Anything).
+					On("Build", mock.Anything, mock.Anything).
 					Once().
 					Return(nil, nil)
 
@@ -285,7 +285,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := NewMockFinalizerProcessor(t)
 
 				f.
-					On("process", context.Background(), nil, []string{
+					On("process", mock.Anything, nil, []string{
 						repository.RemoveOrphanResourcesFinalizer,
 					}).
 					Once().
@@ -297,7 +297,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				s := mocks.NewStatusPatcher(t)
 
 				s.
-					On("Patch", context.Background(), mock.AnythingOfType("*v0alpha1.Repository"), mock.AnythingOfType("map[string]interface {}")).
+					On("Patch", mock.Anything, mock.AnythingOfType("*v0alpha1.Repository"), mock.AnythingOfType("map[string]interface {}")).
 					Once().
 					Return(nil) // Return nil error for the status patch
 
@@ -319,7 +319,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := repository.NewMockFactory(t)
 
 				f.
-					On("Build", context.Background(), mock.Anything).
+					On("Build", mock.Anything, mock.Anything).
 					Once().
 					Return(nil, nil)
 
@@ -329,7 +329,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				f := NewMockFinalizerProcessor(t)
 
 				f.
-					On("process", context.Background(), nil, []string{
+					On("process", mock.Anything, nil, []string{
 						repository.RemoveOrphanResourcesFinalizer,
 					}).
 					Once().
@@ -370,6 +370,7 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 				finalizer:     tc.finalizer,
 				client:        tc.client,
 				statusPatcher: tc.statusPatcher,
+				tracer:        tracing.InitializeTracerForTest(),
 			}
 
 			err := c.handleDelete(context.Background(), tc.repo)
@@ -391,12 +392,12 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 func TestRepositoryController_handleDelete_RetriesOnConflict(t *testing.T) {
 	finalizer := NewMockFinalizerProcessor(t)
 	finalizer.
-		On("process", context.Background(), nil, []string{repository.RemoveOrphanResourcesFinalizer}).
+		On("process", mock.Anything, nil, []string{repository.RemoveOrphanResourcesFinalizer}).
 		Once().
 		Return(nil)
 
 	factory := repository.NewMockFactory(t)
-	factory.On("Build", context.Background(), mock.Anything).Once().Return(nil, nil)
+	factory.On("Build", mock.Anything, mock.Anything).Once().Return(nil, nil)
 
 	var calls int32
 	repoClient := &mockRepoInterface{
@@ -416,6 +417,7 @@ func TestRepositoryController_handleDelete_RetriesOnConflict(t *testing.T) {
 	c := &RepositoryController{
 		repoFactory: factory,
 		finalizer:   finalizer,
+		tracer:      tracing.InitializeTracerForTest(),
 		client: &mockProvisioningV0alpha1Interface{
 			repositoriesFunc: func(string) client.RepositoryInterface { return repoClient },
 		},
@@ -434,12 +436,12 @@ func TestRepositoryController_handleDelete_RetriesOnConflict(t *testing.T) {
 func TestRepositoryController_handleDelete_ReturnsErrorWhenConflictPersists(t *testing.T) {
 	finalizer := NewMockFinalizerProcessor(t)
 	finalizer.
-		On("process", context.Background(), nil, []string{repository.RemoveOrphanResourcesFinalizer}).
+		On("process", mock.Anything, nil, []string{repository.RemoveOrphanResourcesFinalizer}).
 		Once().
 		Return(nil)
 
 	factory := repository.NewMockFactory(t)
-	factory.On("Build", context.Background(), mock.Anything).Once().Return(nil, nil)
+	factory.On("Build", mock.Anything, mock.Anything).Once().Return(nil, nil)
 
 	var calls int32
 	repoClient := &mockRepoInterface{
@@ -456,6 +458,7 @@ func TestRepositoryController_handleDelete_ReturnsErrorWhenConflictPersists(t *t
 	c := &RepositoryController{
 		repoFactory: factory,
 		finalizer:   finalizer,
+		tracer:      tracing.InitializeTracerForTest(),
 		client: &mockProvisioningV0alpha1Interface{
 			repositoriesFunc: func(string) client.RepositoryInterface { return repoClient },
 		},
@@ -1323,6 +1326,7 @@ func TestRepositoryController_process_ConditionsNotOverwritten(t *testing.T) {
 		repoFactory:   mockFactory,
 		statusPatcher: patcher,
 		logger:        logging.DefaultLogger,
+		tracer:        tracing.InitializeTracerForTest(),
 	}
 
 	err := rc.process("default/test-repo")
@@ -1476,6 +1480,7 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 		healthChecker:     healthChecker,
 		resyncInterval:    resyncInterval,
 		logger:            logging.DefaultLogger.With("logger", loggerName),
+		tracer:            tracing.InitializeTracerForTest(),
 	}
 
 	err := rc.process(namespace + "/" + repoName)
@@ -1580,6 +1585,7 @@ func TestRepositoryController_process_RegeneratesTokenWhenSecretNotFound(t *test
 		healthChecker:     healthChecker,
 		resyncInterval:    5 * time.Minute,
 		logger:            logging.DefaultLogger.With("logger", loggerName),
+		tracer:            tracing.InitializeTracerForTest(),
 	}
 
 	err := rc.process(namespace + "/" + repoName)

--- a/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
@@ -86,6 +86,7 @@ func TestConnectionController_WorkerQueueWaitHistogram(t *testing.T) {
 		nil, nil, nil, nil,
 		time.Minute, 30*time.Second,
 		reg,
+		nil,
 		false,
 	)
 
@@ -143,6 +144,7 @@ func TestConnectionController_WorkerQueueSizeGauge(t *testing.T) {
 		nil, nil, nil, nil,
 		time.Minute, 30*time.Second,
 		reg,
+		nil,
 		false,
 	)
 

--- a/pkg/registry/apis/provisioning/jobs/history_writer.go
+++ b/pkg/registry/apis/provisioning/jobs/history_writer.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/otel/attribute"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 // HistoryWriter stores completed jobs
@@ -31,6 +33,13 @@ func NewAPIClientHistoryWriter(provisioningClient client.ProvisioningV0alpha1Int
 
 // WriteJob implements HistoryWriter.
 func (w *apiClientHistoryWriter) WriteJob(ctx context.Context, job *provisioning.Job) error {
+	ctx, span := tracing.Start(ctx, "provisioning.jobs.write_history",
+		attribute.String("job.name", job.GetName()),
+		attribute.String("job.namespace", job.GetNamespace()),
+		attribute.String("history.backend", "apiserver"),
+	)
+	defer span.End()
+
 	if job.UID == "" {
 		return fmt.Errorf("missing UID in job '%s'", job.GetName())
 	}
@@ -63,6 +72,9 @@ func (w *apiClientHistoryWriter) WriteJob(ctx context.Context, job *provisioning
 	}
 
 	_, err := w.client.HistoricJobs(job.Namespace).Create(ctx, historicJob, metav1.CreateOptions{})
+	if err != nil {
+		span.RecordError(err)
+	}
 
 	return err
 }

--- a/pkg/registry/apis/provisioning/jobs/loki_history.go
+++ b/pkg/registry/apis/provisioning/jobs/loki_history.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/apps/provisioning/pkg/loki"
+	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 )
 
 const (
@@ -51,6 +53,13 @@ func NewLokiJobHistory(cfg loki.Config) *LokiJobHistory {
 
 // WriteJob implements History.WriteJob by storing the job in Loki
 func (h *LokiJobHistory) WriteJob(ctx context.Context, job *provisioning.Job) error {
+	ctx, span := tracing.Start(ctx, LokiJobSpanName,
+		attribute.String("job.name", job.GetName()),
+		attribute.String("job.namespace", job.GetNamespace()),
+		attribute.String("history.backend", "loki"),
+	)
+	defer span.End()
+
 	logger := logging.FromContext(ctx)
 
 	// Clean up the job copy (remove claim label, similar to in-memory implementation)
@@ -70,6 +79,7 @@ func (h *LokiJobHistory) WriteJob(ctx context.Context, job *provisioning.Job) er
 	logger.Debug("Saving job history to Loki")
 
 	if err := h.client.Push(writeCtx, []loki.Stream{stream}); err != nil {
+		span.RecordError(err)
 		logger.Error("Failed to save job history to Loki", "error", err)
 		return fmt.Errorf("failed to save job history: %w", err)
 	}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1234,6 +1234,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				informerFactoryResyncInterval,
 				30*time.Second,
 				b.registry,
+				b.tracer,
 				nats.Enabled(b.natsSubscriber),
 			)
 			connReg, err := connSource.AddEventHandler(connController.EventHandler())


### PR DESCRIPTION
**What is this feature?**

Instruments the provisioning operator paths that were previously invisible in traces. No behavior change — spans only.

**Repository controller reconcile** — root span `provisioning.controller.reconcile`, plus a child span for every sub-operation that does real work:

| Span | Wraps | Work |
|---|---|---|
| `handle_delete` | finalizer processing | git/API |
| `check_quota` | `RepositoryQuotaConditions` | `repos.List` (network in NATS mode) |
| `build` | `repoFactory.Build` | secret-store gRPC decrypt + git/GitHub client build |
| `generate_token` | `generateRepositoryToken` | token minting (network/crypto) |
| `process_hooks` | webhook create/update/delete | provider network calls |
| `rotate_webhook_secret` | webhook get + edit | provider network calls |
| `get_default_branch` | `GetDefaultBranch` | git |
| `health_check` | `RefreshHealthWithPatchOps` | connectivity probe |
| `determine_sync_strategy` | `LatestRef` + `CompareFiles` | git ref/diff |
| `apply_status` | `statusPatcher.Patch` | apiserver PATCH |
| `add_sync_job` | job insert | apiserver create |

The reconcile runs from a background context, so before this the only span (`add_sync_job`) was an orphaned root with no parent.

**Connection controller reconcile** — root span `provisioning.controller.reconcile` with child spans `build`, `generate_token`, `health_check`, `apply_status`. This controller previously had no tracer at all.

**Job history** — spans on `WriteJob` for both backends: `provisioning.jobs.write_history` (apiserver) and `provisioning.job.historian.client` (Loki).

The root spans carry a `reconcile.reason` attribute (which trigger fired: `spec_changed`, `resync_interval`, `token_refresh`, `skipped`, …) and record the terminal error.

**Why do we need this feature?**

The jobqueue sync worker (`provisioning.sync.*`) and the job store (`provisioning.jobs.*`) are already richly instrumented, but the two operator reconcile loops and the history write were dark — so reconcile latency and failures had no trace. A reconcile does secret-store decrypts, token minting, git ref/diff, webhook calls, and status patches; none of it was attributable. This brings a reconcile trace up to the usefulness of a sync-job trace.

The job **queue/store/driver** machinery was audited and is already fully traced (`claim`, `update`, `complete`, `insert`, `claim_and_process_one_job`, `process_job`, `update_progress`, lease renewal) — no changes needed there.

**Who is this feature for?**

Grafana engineers and operators debugging Git Sync / provisioning with distributed tracing enabled. No user-facing surface.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Two conventions, applied uniformly:

- **Resource identity as attributes.** Every reconcile child span is stamped (via a shared `repoSpanAttrs`/`connSpanAttrs` helper) with `repository.name`/`namespace`/`type` or `connection.name`/`namespace`, so a span is self-describing in isolation — a `handle_delete` or `health_check` span tells you which object (and which repo type) it concerns without walking up to its parent.
- **Operation-only span names.** Names describe the operation, not the resource (`reconcile`, `build`, `health_check`, `apply_status`, `generate_token`, …), so both controllers share the same names and the resource is distinguished purely by the attributes above. (Earlier revisions had `reconcile_connection`/`build_repository`/`build_connection`; those were made uniform.)

Implementation:

- Both controllers' `process` run from a worker/background context with no active span, so they use the injected `tracing.Tracer` to open a real root span. The package-level `tracing.Start` helper only emits when a span is already in context — which is why the history writers can use it (they run inside the driver's active `claim_and_process_one_job` span) but the controllers cannot.
- The connection controller gains a `tracer` field + constructor param, threaded through both the single-binary wiring (`register.go`) and the standalone operator (`connection_operator.go`).
- Known scope inconsistency left as-is: controller/sync-worker spans use OTel instrumentation scope `component-main` (injected tracer) while store/driver/history spans use `github.com/grafana/grafana/pkg/infra/tracing` (package helper) — same trace tree, different scope labels. Normalizing that is a broader change.
- Out of scope (follow-ups): the per-action job worker bodies (export / migrate-clean / delete / move / fixfoldermetadata) are each one flat span over resource loops, and the git stage/push wrapper (`apps/provisioning/.../staged.go`) has no spans — the single biggest git-latency blind spot, but it lives in a separate package with a different deploy cadence.

Testing:

- `go test ./pkg/registry/apis/provisioning/controller/ ./pkg/registry/apis/provisioning/jobs/` — pass
- `go build ./pkg/registry/apis/provisioning/... ./pkg/operators/provisioning/...` — clean
- `go vet` + `gofmt` — clean; errcheck on the deferred `tracing.Error` calls (flagged by CI) fixed.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — n/a, instrumentation only.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. — n/a, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)