### PR TITLE
Explore: Close the signal explorer's metric detail panel when a type-only datasource ref changes

### DIFF
--- a/public/app/features/explore/SignalExplorer/MetricsList.test.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricsList.test.tsx
@@ -298,9 +298,20 @@ describe('<MetricsList />', () => {
 
       expect(onSelectMetric).toHaveBeenCalledWith({
         refId: 'A',
-        dsUid: 'prom-uid',
+        dsKey: 'u:prom-uid',
         metric: { name: 'up', type: 'gauge', help: 'Whether the target is reachable.' },
       });
+    });
+
+    it('identifies a type-only datasource ref by its type', async () => {
+      setCatalog([{ name: 'up', type: 'gauge' }]);
+      renderList({ dsUid: undefined, dsType: 'grafana-amazonprometheus-datasource' });
+
+      await selectMetric('up');
+
+      expect(onSelectMetric).toHaveBeenCalledWith(
+        expect.objectContaining({ dsKey: 't:grafana-amazonprometheus-datasource' })
+      );
     });
 
     // The entry is read through a ref to keep the callback stable; the ref has to keep up.

--- a/public/app/features/explore/SignalExplorer/MetricsList.tsx
+++ b/public/app/features/explore/SignalExplorer/MetricsList.tsx
@@ -92,10 +92,10 @@ export const MetricsList = memo(function MetricsList({
     (name: string) => {
       const metric = metricsRef.current.find((candidate) => candidate.name === name);
       if (metric) {
-        onSelectMetric({ refId, dsUid, metric });
+        onSelectMetric({ refId, dsKey: dsKey(dsRef), metric });
       }
     },
-    [onSelectMetric, refId, dsUid]
+    [onSelectMetric, refId, dsRef]
   );
 
   // Paging resets on anything that swaps the catalog out for a different one — the search, but also

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.test.tsx
@@ -423,6 +423,23 @@ describe('<SignalExplorer />', () => {
       expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
     });
 
+    // Neither ref carries a uid, so only the type tells the two catalogs apart.
+    it('closes when a query with a type-only datasource ref moves to another Prometheus flavor', async () => {
+      useMetricCatalogMock.mockReturnValue({ metrics: catalog, loading: false });
+      const typeOnlyQuery = (type: string) => ({ refId: 'A', datasource: { type } }) as DataQuery;
+
+      const { user, rerender } = await setup([typeOnlyQuery('prometheus')]);
+      await user.click(screen.getByRole('button', { name: 'Expand datasource explorer for query A' }));
+      await selectUpIn(user, 'A');
+      expect(screen.getByTestId('metric-detail-panel')).toBeInTheDocument();
+
+      rerender(explorer([typeOnlyQuery('grafana-amazonprometheus-datasource')]));
+
+      // Still expanded, so the panel closed on the catalog behind it rather than on the card.
+      expect(screen.getByPlaceholderText('Search metrics')).toBeInTheDocument();
+      expect(screen.queryByTestId('metric-detail-panel')).not.toBeInTheDocument();
+    });
+
     // A new range fetches a new catalog, which need not still hold the metric.
     it('closes when the time range changes', async () => {
       const { user, rerender } = await openCard('A');

--- a/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
+++ b/public/app/features/explore/SignalExplorer/SignalExplorer.tsx
@@ -16,7 +16,7 @@ import { isPrometheusType } from '../utils/prometheus';
 import { MetricDetailPanel } from './MetricDetailPanel';
 import { MetricsList } from './MetricsList';
 import { SignalCard } from './SignalCard';
-import { rangeKey } from './data/metricResourceClient';
+import { dsKey, rangeKey } from './data/metricResourceClient';
 import { type MetricSelection } from './types';
 
 interface CardDescriptor {
@@ -114,7 +114,12 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
   // The selected metric goes with them, and also when its card keeps its refId but changes
   // datasource, because the list underneath is then a different catalog.
   useEffect(() => {
-    const expandable = new Map(cards.filter((card) => card.isExpandable).map((card) => [card.refId, card.dsUid]));
+    // Keyed by `dsKey`, not uid, so a card compares on the identity its catalog is fetched under.
+    const expandable = new Map(
+      cards
+        .filter((card) => card.isExpandable)
+        .map((card) => [card.refId, dsKey({ uid: card.dsUid, type: card.dsType })])
+    );
 
     setExpandedRefIds((prev) => {
       if (prev.size === 0) {
@@ -131,9 +136,8 @@ export function SignalExplorer({ queries, paneDatasource, timeRange, scroller, t
       if (!prev) {
         return prev;
       }
-      // `has` as well as `get`: a card with no resolved uid stores `undefined`, which `get` alone
-      // cannot tell from a refId that has left the pane.
-      return expandable.has(prev.refId) && expandable.get(prev.refId) === prev.dsUid ? prev : null;
+      // A refId that has left the pane reads `undefined`, which no key can equal.
+      return expandable.get(prev.refId) === prev.dsKey ? prev : null;
     });
   }, [cards]);
 

--- a/public/app/features/explore/SignalExplorer/types.ts
+++ b/public/app/features/explore/SignalExplorer/types.ts
@@ -16,6 +16,6 @@ export interface MetricInfo {
  */
 export interface MetricSelection {
   refId: string;
-  dsUid?: string;
+  dsKey: string;
   metric: MetricInfo;
 }


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Follow-up to #131042. A query whose datasource ref carries only a type (`{ type: 'prometheus' }`, meaning the default datasource of that type) has no uid, so the check that closes the metric detail panel on a datasource change compared `undefined` to `undefined` and kept the panel open. Switching such a query to another Prometheus flavor refetched the metrics list but left the panel describing a metric from the previous catalog.

## Changes
<!--- Describe your changes in detail -->
* `MetricSelection` carries `dsKey` instead of `dsUid`, so the panel is tagged with the same catalog identity the metric cache and the refetch hooks already key on.
* The explorer's cleanup effect compares `dsKey` rather than the bare uid, which also drops the `has` guard the uid comparison needed — `dsKey` never returns `undefined`, so a refId that has left the pane can no longer match a live selection.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->
The comparison now closes the panel in strictly more cases than before, so the risk is a panel closing when it should have stayed open. That needs two refs `dsKey` tells apart but a uid comparison did not, which is only the type-only case this fixes.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
N/A

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Open Explore with a query whose datasource ref names only a type, with defaults configured for two Prometheus flavors (for example Prometheus and Amazon Managed Prometheus).
* Expand the query's card in the signal explorer and click a metric name to open the detail panel.
* Point the query at the other flavor, still by type alone, and confirm the panel closes while the card stays expanded on the new catalog.
* Confirm a query carrying a uid still behaves as before: the panel closes on a datasource switch and survives a refresh of the same relative range.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable

Close DPRO-363