### PR TITLE
Packaging: place backend plugin unix sockets in /run/grafana to survive systemd-tmpfiles age cleanup

### DIFF
--- a/packaging/deb/systemd/grafana-server.service
+++ b/packaging/deb/systemd/grafana-server.service
@@ -14,6 +14,7 @@ Restart=on-failure
 WorkingDirectory=/usr/share/grafana
 RuntimeDirectory=grafana
 RuntimeDirectoryMode=0750
+Environment=PLUGIN_UNIX_SOCKET_DIR=/run/grafana
 ExecStart=/usr/share/grafana/bin/grafana server                                     \
                             --config=${CONF_FILE}                                   \
                             --pidfile=${PID_FILE_DIR}/grafana-server.pid            \

--- a/packaging/rpm/systemd/grafana-server.service
+++ b/packaging/rpm/systemd/grafana-server.service
@@ -14,6 +14,7 @@ Restart=on-failure
 WorkingDirectory=/usr/share/grafana
 RuntimeDirectory=grafana
 RuntimeDirectoryMode=0750
+Environment=PLUGIN_UNIX_SOCKET_DIR=/run/grafana
 ExecStart=/usr/share/grafana/bin/grafana server                                     \
                             --config=${CONF_FILE}                                   \
                             --pidfile=${PID_FILE_DIR}/grafana-server.pid            \


### PR DESCRIPTION
Fixes #131592

**What is this feature?**

Adds `Environment=PLUGIN_UNIX_SOCKET_DIR=/run/grafana` to the rpm and deb `grafana-server.service` unit files, so backend plugin unix sockets are created in the service's runtime directory instead of its private `/tmp`.

**Why do we need this feature?**

On systemd distributions, `systemd-tmpfiles-clean.timer` ages the *contents* of `PrivateTmp` directories with the same policy as the real `/tmp` (10 days on RHEL/Rocky/Fedora, 30 days on Ubuntu 24.04+). The shipped `X /tmp/systemd-private-%b-*/tmp` rule is not a recursive exclusion - it is an active cleanup entry that inherits the age from the `q /tmp ... 10d` rule. systemd's live-socket protection (`/proc/net/unix` lookup) cannot save the sockets either, because the kernel records the bind path from inside the mount namespace (`/tmp/pluginNNN`) while tmpfiles visits the host path (`/tmp/systemd-private-.../tmp/pluginNNN`).

As a result, on any rpm/deb install with more than 10 days of `grafana-server` uptime, all backend plugin sockets are deleted. Grafana keeps working on established gRPC connections, then breaks permanently on the first reconnect with:

```
rpc error: code = Unavailable desc = connection error: desc = "transport: error while
dialing: dial unix /tmp/pluginNNNNNNNNNN: connect: no such file or directory"
```

and does not recover until restart (the plugin process never exits, so it is never respawned). Full root-cause analysis, deterministic reproduction and production evidence in the linked issue.

**Why this approach**

- Both unit files already declare `RuntimeDirectory=grafana`, so `/run/grafana` exists on every packaged install with correct ownership (`RuntimeDirectoryMode=0750`).
- `/run` is exempt from age-based cleanup and is the FHS-correct location for runtime sockets (consistent with the guidance previously given in #25564 for the api socket).
- systemd removes the runtime directory on service stop, so stale sockets from crashed plugins do not accumulate.
- `PLUGIN_UNIX_SOCKET_DIR` is read by go-plugin in the plugin process and is on `permittedHostEnvVarNames` (#120275), so it is forwarded to plugins on `main` and 12.4.2+.
- `PrivateTmp=true` and the rest of the hardening block are intentionally left untouched.
- Alternative considered and rejected: shipping a `tmpfiles.d` exclusion for the private-tmp socket paths - fragile (depends on systemd's undocumented `systemd-private-*` naming), leaves stale sockets until reboot, and keeps sockets in the wrong location per FHS.
- Alternative considered and rejected: setting the variable in the packaged `EnvironmentFile` (`/etc/sysconfig/grafana-server` / `/etc/default/grafana-server`) instead of the unit. Those files are `%config(noreplace)`/dpkg conffiles, so existing installs - the entire affected population - would not receive the fix on upgrade. The unit file is replaced on upgrade, and since systemd reads `EnvironmentFile=` after `Environment=`, admins retain a clean override path for the packaged default.

**Scope / compatibility**

- Packaging-only change; no Go code, no config schema changes.
- No effect on Docker, Windows, macOS or tarball installs (the variable is simply absent there).
- Plugins built with go-plugin versions predating `PLUGIN_UNIX_SOCKET_DIR` support ignore the variable and keep using `/tmp` - no regression versus current behavior.
- Admins can still override via a drop-in or the sysconfig/default `EnvironmentFile`.
- Backport candidates: supported release branches ≥ 12.4.2 (12.4.0/12.4.1 do not forward the variable; 12.3.x and earlier forward the full host environment, so the change is effective there as well if backported).

**Who is this feature for?**

Anyone running Grafana from the official rpm/deb packages on RHEL, Rocky, Alma, Fedora, CentOS Stream, or Ubuntu 24.04+, with any backend datasource plugin, and more than 10 days of uptime between restarts.

**Testing**

On Rocky Linux 9 (systemd 252), Grafana with a backend datasource plugin:

1. Applied the unit change, `systemctl daemon-reload && systemctl restart grafana-server`.
2. Verified sockets are now created in `/run/grafana` (`ss -xlp | grep plugin`) and that the private `/tmp` contains no `plugin*` files.
3. Verified datasource queries, resource calls and health checks work normally.
4. Backdated the socket files (`touch -d '20 days ago' /run/grafana/plugin*`) and ran `systemd-tmpfiles --clean`: sockets in `/run/grafana` are untouched, confirming they are outside the age-cleanup scope.
5. Control test on an unpatched node: the same backdate + clean against `/tmp/systemd-private-*-grafana-server.service-*/tmp/plugin*` deletes the sockets, and the next transport reconnect produces the `dial unix ... no such file or directory` failure until restart.