### PR TITLE
Unified storage: native histograms for remaining metrics

### DIFF
--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -425,6 +425,10 @@ func newClientMetrics(reg prometheus.Registerer) *clientMetrics {
 			Name:    "resource_server_client_request_duration_seconds",
 			Help:    "Time spent executing requests to the resource server.",
 			Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"operation", "status_code"}),
 		requestRetries: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "resource_server_client_request_retries_total",

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -19,13 +19,6 @@ import (
 
 type groupResource map[string]map[string]interface{}
 
-const (
-	metricsNamespace = "grafana"
-	metricsSubSystem = "grpc_authz_limited_client"
-)
-
-var metOnce sync.Once
-
 type accessMetrics struct {
 	checkDuration      *prometheus.HistogramVec
 	compileDuration    *prometheus.HistogramVec
@@ -34,47 +27,40 @@ type accessMetrics struct {
 }
 
 func newMetrics(reg prometheus.Registerer) *accessMetrics {
-	m := &accessMetrics{
-		checkDuration: prometheus.NewHistogramVec(
+	return &accessMetrics{
+		checkDuration: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Name:      "check_duration_seconds",
-				Help:      "duration of the access check calls going through the authz service",
+				Name: "grafana_grpc_authz_limited_client_check_duration_seconds",
+				Help: "duration of the access check calls going through the authz service",
+
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  160,
+				NativeHistogramMinResetDuration: time.Hour,
 			}, []string{"group", "resource", "verb", "allowed"}),
-		compileDuration: prometheus.NewHistogramVec(
+		compileDuration: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Name:      "compile_duration_seconds",
-				Help:      "duration of the access compile calls going through the authz service",
+				Name: "grafana_grpc_authz_limited_client_compile_duration_seconds",
+				Help: "duration of the access compile calls going through the authz service",
+
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  160,
+				NativeHistogramMinResetDuration: time.Hour,
 			}, []string{"group", "resource", "verb"}),
-		batchCheckDuration: prometheus.NewHistogramVec(
+		batchCheckDuration: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Name:      "batch_check_duration_seconds",
-				Help:      "duration of the batch access check calls going through the authz service",
+				Name: "grafana_grpc_authz_limited_client_batch_check_duration_seconds",
+				Help: "duration of the batch access check calls going through the authz service",
+
+				NativeHistogramBucketFactor:     1.1,
+				NativeHistogramMaxBucketNumber:  160,
+				NativeHistogramMinResetDuration: time.Hour,
 			}, []string{"check_count"}),
-		errorsTotal: prometheus.NewCounterVec(
+		errorsTotal: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
-				Namespace: metricsNamespace,
-				Subsystem: metricsSubSystem,
-				Name:      "errors_total",
-				Help:      "Number of errors",
+				Name: "grafana_grpc_authz_limited_client_errors_total",
+				Help: "Number of errors",
 			}, []string{"group", "resource", "verb"}),
 	}
-
-	if reg != nil {
-		metOnce.Do(func() {
-			reg.MustRegister(m.checkDuration)
-			reg.MustRegister(m.compileDuration)
-			reg.MustRegister(m.batchCheckDuration)
-			reg.MustRegister(m.errorsTotal)
-		})
-	}
-
-	return m
 }
 
 // rbacAllowlist is a map of group to resources that are compatible with RBAC.
@@ -99,6 +85,8 @@ type authzLimitedClient struct {
 }
 
 type AuthzOptions struct {
+	// Registry is where the client's metrics are registered. A nil Registry
+	// leaves them unregistered, which is what tests want.
 	Registry         prometheus.Registerer
 	ExemptionEnabled bool
 	ExemptResources  []string
@@ -107,9 +95,6 @@ type AuthzOptions struct {
 // NewAuthzLimitedClient creates a new authzLimitedClient.
 func NewAuthzLimitedClient(client claims.AccessClient, opts AuthzOptions) claims.AccessClient {
 	logger := log.New("limited-authz-client")
-	if opts.Registry == nil {
-		opts.Registry = prometheus.DefaultRegisterer
-	}
 	exemptions, err := parseAuthzExemptions(opts.ExemptResources)
 	if err != nil {
 		// Callers validate with ValidateAuthzOptions first. Drop the whole list

--- a/pkg/storage/unified/resource/cdk_bucket.go
+++ b/pkg/storage/unified/resource/cdk_bucket.go
@@ -46,7 +46,12 @@ func NewInstrumentedBucket(bucket CDKBucket, reg prometheus.Registerer) *Instrum
 		bucket: bucket,
 		latency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "cdk_blobstorage_latency_seconds",
+			Help:    "Time spent on blob storage operations, by operation and status.",
 			Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{cdkBucketOperationLabel, cdkBucketStatusLabel}),
 	}
 	return b

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -24,9 +24,7 @@ var (
 	// searchResultsMatchHistogram tracks the percentage match between legacy and unified search results
 	searchResultsMatchHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace:                      "grafana",
-			Subsystem:                      "unified_storage",
-			Name:                           "search_results_match_percentage",
+			Name:                           "grafana_unified_storage_search_results_match_percentage",
 			Help:                           "Native histogram of percentage match between legacy and unified search results",
 			NativeHistogramBucketFactor:    1.1,
 			NativeHistogramMaxBucketNumber: 100,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -143,14 +143,12 @@ type kvBackendMetrics struct {
 func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
 	return &kvBackendMetrics{
 		ConflictErrors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "storage_server",
-			Name:      "optimistic_lock_conflicts_total",
-			Help:      "Total number of optimistic lock conflict errors in the KV storage backend",
+			Name: "storage_server_optimistic_lock_conflicts_total",
+			Help: "Total number of optimistic lock conflict errors in the KV storage backend",
 		}, []string{"resource", "action"}),
 		EventEmitFailures: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Namespace: "storage_server",
-			Name:      "event_emit_after_commit_failures_total",
-			Help:      "Total number of writes whose data was committed but whose event failed to be emitted",
+			Name: "storage_server_event_emit_after_commit_failures_total",
+			Help: "Total number of writes whose data was committed but whose event failed to be emitted",
 		}, []string{"resource", "action"}),
 		NatsNotifierDropped: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "storage_server_nats_notifier_dropped_events_total",
@@ -165,10 +163,13 @@ func newKVBackendMetrics(reg prometheus.Registerer) *kvBackendMetrics {
 			Help: "Watch notifications that failed to marshal or publish to NATS, by group, resource, and action. Each one is an event live consumers never receive; they recover it on their next re-list.",
 		}, []string{"group", "resource", "action"}),
 		GCGroupResourceDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "storage_server",
-			Name:      "gc_group_resource_duration_seconds",
-			Help:      "Duration of a garbage-collection pass over one group/resource.",
-			Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 30, 60, 300, 1800, 7200},
+			Name:    "storage_server_gc_group_resource_duration_seconds",
+			Help:    "Duration of a garbage-collection pass over one group/resource.",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 30, 60, 300, 1800, 7200},
+
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"group", "resource"}),
 	}
 }

--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -27,36 +27,31 @@ var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql/rvm
 
 var (
 	rvmWriteDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "rvmanager_write_duration_seconds",
+		Name:                        "grafana_rvmanager_write_duration_seconds",
 		Help:                        "Duration of ResourceVersionManager write operations",
-		Namespace:                   "grafana",
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"group", "resource", "status"})
 
 	rvmExecBatchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "rvmanager_exec_batch_duration_seconds",
+		Name:                        "grafana_rvmanager_exec_batch_duration_seconds",
 		Help:                        "Duration of ResourceVersionManager batch operations",
-		Namespace:                   "grafana",
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"group", "resource", "status"})
 
 	rvmExecBatchPhaseDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "rvmanager_exec_batch_phase_duration_seconds",
+		Name:                        "grafana_rvmanager_exec_batch_phase_duration_seconds",
 		Help:                        "Duration of batch operation phases",
-		Namespace:                   "grafana",
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"group", "resource", "phase"})
 
 	rvmInflightWrites = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name:      "rvmanager_inflight_writes",
-		Help:      "Number of concurrent write operations",
-		Namespace: "grafana",
+		Name: "grafana_rvmanager_inflight_writes",
+		Help: "Number of concurrent write operations",
 	}, []string{"group", "resource"})
 
 	rvmBatchSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "rvmanager_batch_size",
+		Name:                        "grafana_rvmanager_batch_size",
 		Help:                        "Number of write operations per batch",
-		Namespace:                   "grafana",
 		NativeHistogramBucketFactor: 1.1,
 	}, []string{"group", "resource"})
 )


### PR DESCRIPTION
Every histogram under `pkg/storage/unified` now exposes a native histogram next to its existing buckets. Four were missing it: the authz check durations, the resource server client request duration, the blob storage latency and the GC pass duration. `lease_manager_acquire_retries` is left alone, since it counts retries.

Classic buckets are kept, so existing dashboards and alerts keep working.

Metric names are now written out in full instead of being assembled from `Namespace` and `Subsystem`, so searching the code base for a metric name finds it. **The exported names do not change** — verified by dumping the registered descriptors before and after.

The authz metrics also stopped going through a package-level `sync.Once`, which registered only the first client's collectors and silently dropped any later client's measurements. They now use `promauto`, with a nil registry meaning "not registered", matching the other constructors in the package. No test changes needed.

**Note:** the three authz histograms have no explicit buckets, so their classic view still stops at 10 seconds (`prometheus.DefBuckets`). The native view covers the slower calls. Happy to add explicit buckets instead.

**Why the `no-check-unified-storage-compatibility` label:** `check-separation` fires because `client.go` is client side while the rest is server side. Nothing here crosses that boundary in a way that matters for a rolling deploy: every change is metrics registration only. No proto or `resourcepb` change, no responsibility moved between client and server, and no new expectation of one side about the other. Any mix of old and new client and server behaves exactly as before, so splitting this into two PRs would add churn without reducing risk.
