### PR TITLE
Teams: Quote columns for queries with external for MySQL compat

### DIFF
--- a/pkg/registry/apis/iam/legacy/create_team_member_query.sql
+++ b/pkg/registry/apis/iam/legacy/create_team_member_query.sql
@@ -1,5 +1,5 @@
 INSERT INTO {{ .Ident .TeamMemberTable }}
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ({{ .Ident "uid" }}, {{ .Ident "team_id" }}, {{ .Ident "user_id" }}, {{ .Ident "org_id" }}, {{ .Ident "created" }}, {{ .Ident "updated" }}, {{ .Ident "external" }}, {{ .Ident "permission" }})
 VALUES
   ({{ .Arg .Command.UID }}, {{ .Arg .Command.TeamID }}, {{ .Arg .Command.UserID }}, {{ .Arg .Command.OrgID }}, {{ .Arg .Command.Created }},
   {{ .Arg .Command.Updated }}, {{ .Arg .Command.External }}, {{ .Arg .Command.Permission }})

--- a/pkg/registry/apis/iam/legacy/create_team_members_bulk.sql
+++ b/pkg/registry/apis/iam/legacy/create_team_members_bulk.sql
@@ -1,5 +1,5 @@
 INSERT INTO {{ .Ident .TeamMemberTable }}
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ({{ .Ident "uid" }}, {{ .Ident "team_id" }}, {{ .Ident "user_id" }}, {{ .Ident "org_id" }}, {{ .Ident "created" }}, {{ .Ident "updated" }}, {{ .Ident "external" }}, {{ .Ident "permission" }})
 VALUES
 {{- range $i, $m := .Command.Members }}
   {{- if $i }},{{ end }}

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_member_query-create_team_member.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_member_query-create_team_member.sql
@@ -1,5 +1,5 @@
 INSERT INTO `grafana`.`team_member`
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  (`uid`, `team_id`, `user_id`, `org_id`, `created`, `updated`, `external`, `permission`)
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Member')

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_member_query-create_team_member_admin.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_member_query-create_team_member_admin.sql
@@ -1,5 +1,5 @@
 INSERT INTO `grafana`.`team_member`
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  (`uid`, `team_id`, `user_id`, `org_id`, `created`, `updated`, `external`, `permission`)
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_members_bulk-create_team_members_bulk_many.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_members_bulk-create_team_members_bulk_many.sql
@@ -1,5 +1,5 @@
 INSERT INTO `grafana`.`team_member`
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  (`uid`, `team_id`, `user_id`, `org_id`, `created`, `updated`, `external`, `permission`)
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member'),
   ('team-member-2', 1, 11, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', TRUE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_members_bulk-create_team_members_bulk_single.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/mysql--create_team_members_bulk-create_team_members_bulk_single.sql
@@ -1,4 +1,4 @@
 INSERT INTO `grafana`.`team_member`
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  (`uid`, `team_id`, `user_id`, `org_id`, `created`, `updated`, `external`, `permission`)
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member')

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_member_query-create_team_member.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_member_query-create_team_member.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Member')

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_member_query-create_team_member_admin.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_member_query-create_team_member_admin.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_members_bulk-create_team_members_bulk_many.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_members_bulk-create_team_members_bulk_many.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member'),
   ('team-member-2', 1, 11, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', TRUE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_members_bulk-create_team_members_bulk_single.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/postgres--create_team_members_bulk-create_team_members_bulk_single.sql
@@ -1,4 +1,4 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member')

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_member_query-create_team_member.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_member_query-create_team_member.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Member')

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_member_query-create_team_member_admin.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_member_query-create_team_member_admin.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('', 1, 1, 0, '2023-01-01 12:00:00',
   '2023-01-01 12:00:00', FALSE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_members_bulk-create_team_members_bulk_many.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_members_bulk-create_team_members_bulk_many.sql
@@ -1,5 +1,5 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member'),
   ('team-member-2', 1, 11, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', TRUE, 'Admin')

--- a/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_members_bulk-create_team_members_bulk_single.sql
+++ b/pkg/registry/apis/iam/legacy/testdata/sqlite--create_team_members_bulk-create_team_members_bulk_single.sql
@@ -1,4 +1,4 @@
 INSERT INTO "grafana"."team_member"
-  (uid, team_id, user_id, org_id, created, updated, external, permission)
+  ("uid", "team_id", "user_id", "org_id", "created", "updated", "external", "permission")
 VALUES
   ('team-member-1', 1, 10, 1, '2023-01-01 12:00:00', '2023-01-01 12:00:00', FALSE, 'Member')


### PR DESCRIPTION
In MySQL 9.7.2 (see release notes: https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-7-2.html), the `EXTERNAL` keyword became reserved, and such this code started to fail:
```
        --- FAIL: TestIntegrationTeams/Team_CRUD_operations_with_dual_writer_mode_0/should_create_team_with_members_and_hydrate_on_Get (0.01s)
            team_integration_test.go:642: 
                	Error Trace:	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/pkg/tests/apis/iam/team/team_integration_test.go:642
                	Error:      	Received unexpected error:
                	            	failed to create team members: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'external, permission)
```


The solution is to quote the columns with `.Ident` !