### PR TITLE
devenv: add Testdata warehouse dashboards for local demos

### DIFF
--- a/conf/demo.ini
+++ b/conf/demo.ini
@@ -1,0 +1,2 @@
+[dashboards]
+default_home_dashboard_path = devenv/demo-dashboards/Warehouse/warehouse-overview.json

--- a/conf/provisioning/dashboards/demo.yaml
+++ b/conf/provisioning/dashboards/demo.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: demo-dashboards
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: devenv/demo-dashboards
+      foldersFromFilesStructure: true

--- a/conf/provisioning/datasources/demo.yaml
+++ b/conf/provisioning/datasources/demo.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Analytics warehouse
+    type: testdata
+    uid: demo-testdata
+    access: proxy
+    orgId: 1
+    isDefault: true

--- a/devenv/demo-dashboards/Pipelines/elt-freshness.json
+++ b/devenv/demo-dashboards/Pipelines/elt-freshness.json
@@ -1,0 +1,288 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 6 },
+              { "color": "red", "value": 12 }
+            ]
+          },
+          "unit": "h",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "orders",
+          "startValue": 1.2,
+          "min": 0.2,
+          "max": 4,
+          "spread": 0.15,
+          "noise": 0.08
+        }
+      ],
+      "title": "orders freshness",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 6 },
+              { "color": "red", "value": 12 }
+            ]
+          },
+          "unit": "h",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "customers",
+          "startValue": 2.4,
+          "min": 0.5,
+          "max": 8,
+          "spread": 0.2,
+          "noise": 0.1
+        }
+      ],
+      "title": "customers freshness",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 2 },
+              { "color": "red", "value": 4 }
+            ]
+          },
+          "unit": "h",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "events",
+          "startValue": 0.6,
+          "min": 0.1,
+          "max": 3,
+          "spread": 0.1,
+          "noise": 0.05
+        }
+      ],
+      "title": "events freshness",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 12 },
+              { "color": "red", "value": 24 }
+            ]
+          },
+          "unit": "h",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "finance",
+          "startValue": 9.5,
+          "min": 4,
+          "max": 28,
+          "spread": 0.8,
+          "noise": 0.4
+        }
+      ],
+      "title": "finance freshness",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "s",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 5 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "dbt-daily",
+          "startValue": 2400,
+          "min": 900,
+          "max": 5400,
+          "spread": 120,
+          "noise": 60
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "dbt-hourly",
+          "startValue": 420,
+          "min": 180,
+          "max": 1200,
+          "spread": 40,
+          "noise": 20
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "alias": "fivetran-sync",
+          "startValue": 780,
+          "min": 240,
+          "max": 2100,
+          "spread": 70,
+          "noise": 35
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "D",
+          "scenarioId": "random_walk",
+          "alias": "reverse-etl",
+          "startValue": 310,
+          "min": 90,
+          "max": 900,
+          "spread": 30,
+          "noise": 15
+        }
+      ],
+      "title": "Job duration",
+      "type": "timeseries"
+    }
+  ],
+  "preload": true,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["pipelines", "elt", "dbt", "demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "ELT freshness",
+  "uid": "demo-pipe-freshness",
+  "version": 1
+}

--- a/devenv/demo-dashboards/Pipelines/failed-jobs.json
+++ b/devenv/demo-dashboards/Pipelines/failed-jobs.json
@@ -1,0 +1,110 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 80 }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "status" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-text" }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  { "type": "value", "options": { "failed": { "color": "red", "index": 0, "text": "failed" } } },
+                  { "type": "value", "options": { "timed_out": { "color": "orange", "index": 1, "text": "timed out" } } }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "csv_content",
+          "alias": "failed jobs",
+          "csvContent": "time,model,warehouse,status,error\n2026-08-26T06:12:01Z,fct_orders,transform-wh,failed,Compilation error: missing relation raw.orders_v2\n2026-08-26T05:48:22Z,stg_events,analytics-wh,timed_out,Statement exceeded 30m warehouse timeout\n2026-08-26T04:03:11Z,dim_customers,transform-wh,failed,Unique test failed on customer_id (14 rows)\n2026-08-26T02:17:44Z,finance_daily,adhoc-wh,failed,Access denied to schema finance_raw\n2026-08-25T22:09:18Z,fivetran_stripe,transform-wh,failed,Sync aborted: source API 429\n2026-08-25T18:41:05Z,reverse_etl_salesforce,analytics-wh,timed_out,Queue wait exceeded SLA (18m)\n2026-08-25T14:22:50Z,int_sessions,transform-wh,failed,Incremental merge conflict on session_sk"
+        }
+      ],
+      "title": "Failed warehouse and ELT jobs",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "logs",
+          "alias": "job runner",
+          "lines": 40,
+          "levelColumn": true
+        }
+      ],
+      "title": "Job runner logs",
+      "type": "logs"
+    }
+  ],
+  "preload": true,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["pipelines", "elt", "errors", "demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Failed jobs",
+  "uid": "demo-pipe-failed-jobs",
+  "version": 1
+}

--- a/devenv/demo-dashboards/README.md
+++ b/devenv/demo-dashboards/README.md
@@ -1,0 +1,23 @@
+# Demo dashboards (data platform)
+
+Local-only pack so `make run` looks like a warehouse / analytics org.
+
+- **Datasource:** Testdata, provisioned as `Analytics warehouse` (`demo-testdata`)
+- **Folders:** Warehouse (overview, query performance), Pipelines (ELT freshness, failed jobs)
+- **Not** a Snowflake / BigQuery / Redshift connector. Query inspector will show Testdata scenarios.
+
+Home dashboard is set via `conf/demo.ini`. Copy it to `conf/custom.ini` (gitignored) if this machine does not already have one:
+
+```bash
+cp conf/demo.ini conf/custom.ini
+```
+
+Then restart the backend.
+
+To remove the pack:
+
+```bash
+rm conf/provisioning/datasources/demo.yaml conf/provisioning/dashboards/demo.yaml
+```
+
+Do not send these provisioning files upstream.

--- a/devenv/demo-dashboards/Warehouse/query-performance.json
+++ b/devenv/demo-dashboards/Warehouse/query-performance.json
@@ -1,0 +1,258 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "s",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "p95"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "p50",
+          "startValue": 1.8,
+          "min": 0.4,
+          "max": 6,
+          "spread": 0.2,
+          "noise": 0.1
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "p95",
+          "startValue": 8.4,
+          "min": 2,
+          "max": 28,
+          "spread": 0.8,
+          "noise": 0.4
+        }
+      ],
+      "title": "Query duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "s",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "queue wait",
+          "startValue": 2.4,
+          "min": 0,
+          "max": 18,
+          "spread": 0.6,
+          "noise": 0.3
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "execution",
+          "startValue": 5.1,
+          "min": 0.5,
+          "max": 22,
+          "spread": 0.7,
+          "noise": 0.35
+        }
+      ],
+      "title": "Queue wait vs execution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "ops",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "analytics-wh",
+          "startValue": 42,
+          "min": 8,
+          "max": 90,
+          "spread": 3,
+          "noise": 1.5
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "transform-wh",
+          "startValue": 68,
+          "min": 16,
+          "max": 140,
+          "spread": 5,
+          "noise": 2
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "alias": "adhoc-wh",
+          "startValue": 11,
+          "min": 1,
+          "max": 36,
+          "spread": 1.5,
+          "noise": 0.8
+        }
+      ],
+      "title": "Queries started",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "slot utilization",
+          "startValue": 62,
+          "min": 20,
+          "max": 98,
+          "spread": 4,
+          "noise": 2
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "spill to storage",
+          "startValue": 8,
+          "min": 0,
+          "max": 35,
+          "spread": 1.5,
+          "noise": 0.8
+        }
+      ],
+      "title": "Slot utilization and spill",
+      "type": "timeseries"
+    }
+  ],
+  "preload": true,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["warehouse", "queries", "demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Query performance",
+  "uid": "demo-wh-query-perf",
+  "version": 1
+}

--- a/devenv/demo-dashboards/Warehouse/warehouse-overview.json
+++ b/devenv/demo-dashboards/Warehouse/warehouse-overview.json
@@ -1,0 +1,401 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 4 }]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "active warehouses",
+          "startValue": 3,
+          "min": 2,
+          "max": 3,
+          "spread": 0.05,
+          "noise": 0.02
+        }
+      ],
+      "title": "Active warehouses",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 8 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "queued queries",
+          "startValue": 6,
+          "min": 0,
+          "max": 28,
+          "spread": 1.5,
+          "noise": 0.8
+        }
+      ],
+      "title": "Queued queries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 40 },
+              { "color": "red", "value": 70 }
+            ]
+          },
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "credits / hour",
+          "startValue": 32,
+          "min": 12,
+          "max": 80,
+          "spread": 2,
+          "noise": 1
+        }
+      ],
+      "title": "Credits this hour",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 3 },
+              { "color": "red", "value": 8 }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "failed queries",
+          "startValue": 2,
+          "min": 0,
+          "max": 12,
+          "spread": 0.6,
+          "noise": 0.4
+        }
+      ],
+      "title": "Failed queries",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "analytics-wh",
+          "startValue": 14,
+          "min": 4,
+          "max": 36,
+          "spread": 1.2,
+          "noise": 0.5
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "transform-wh",
+          "startValue": 22,
+          "min": 8,
+          "max": 48,
+          "spread": 1.8,
+          "noise": 0.7
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "alias": "adhoc-wh",
+          "startValue": 5,
+          "min": 0,
+          "max": 18,
+          "spread": 0.8,
+          "noise": 0.4
+        }
+      ],
+      "title": "Credits by warehouse",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "analytics-wh",
+          "startValue": 18,
+          "min": 2,
+          "max": 64,
+          "spread": 2,
+          "noise": 1
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "transform-wh",
+          "startValue": 36,
+          "min": 8,
+          "max": 80,
+          "spread": 3,
+          "noise": 1.2
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "alias": "adhoc-wh",
+          "startValue": 7,
+          "min": 0,
+          "max": 24,
+          "spread": 1,
+          "noise": 0.5
+        }
+      ],
+      "title": "Query concurrency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "testdata", "uid": "demo-testdata" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "mappings": [],
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "A",
+          "scenarioId": "random_walk",
+          "alias": "analytics-wh",
+          "startValue": 180000000000,
+          "min": 20000000000,
+          "max": 420000000000,
+          "spread": 15000000000,
+          "noise": 8000000000
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "B",
+          "scenarioId": "random_walk",
+          "alias": "transform-wh",
+          "startValue": 310000000000,
+          "min": 40000000000,
+          "max": 780000000000,
+          "spread": 22000000000,
+          "noise": 10000000000
+        },
+        {
+          "datasource": { "type": "testdata", "uid": "demo-testdata" },
+          "refId": "C",
+          "scenarioId": "random_walk",
+          "alias": "adhoc-wh",
+          "startValue": 45000000000,
+          "min": 1000000000,
+          "max": 140000000000,
+          "spread": 8000000000,
+          "noise": 4000000000
+        }
+      ],
+      "title": "Bytes scanned",
+      "type": "timeseries"
+    }
+  ],
+  "preload": true,
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": ["warehouse", "analytics", "demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Warehouse overview",
+  "uid": "demo-wh-overview",
+  "version": 1
+}

--- a/public/app/features/canvas/elements/droneFront.tsx
+++ b/public/app/features/canvas/elements/droneFront.tsx
@@ -9,6 +9,8 @@ import { ScalarDimensionEditor } from 'app/features/dimensions/editors/ScalarDim
 
 import { type CanvasElementItem, type CanvasElementOptions, type CanvasElementProps, defaultBgColor } from '../element';
 
+import { droneAttitudeTransition } from './droneMotionStyles';
+
 interface DroneFrontData {
   rollAngle?: number;
 }
@@ -122,9 +124,5 @@ export const droneFrontItem: CanvasElementItem = {
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  droneFront: css({
-    // TODO: figure out what styles to apply when prefers-reduced-motion is set
-    // eslint-disable-next-line @grafana/no-unreduced-motion
-    transition: 'transform 0.4s',
-  }),
+  droneFront: css(droneAttitudeTransition(theme)),
 });

--- a/public/app/features/canvas/elements/droneMotionStyles.test.ts
+++ b/public/app/features/canvas/elements/droneMotionStyles.test.ts
@@ -1,0 +1,47 @@
+import { createTheme } from '@grafana/data';
+
+import { droneAttitudeTransition, dronePropellerSpin } from './droneMotionStyles';
+
+const theme = createTheme();
+const noPreference = '@media (prefers-reduced-motion: no-preference)';
+
+describe('droneAttitudeTransition', () => {
+  it('tweens transform only when the user has no reduced-motion preference', () => {
+    expect(droneAttitudeTransition(theme)).toEqual({
+      [noPreference]: {
+        transition: 'transform 0.4s',
+      },
+    });
+  });
+});
+
+describe('dronePropellerSpin', () => {
+  it('applies a reverse infinite spin only when the user has no reduced-motion preference', () => {
+    expect(dronePropellerSpin(theme, 'reverse', 60)).toEqual({
+      [noPreference]: {
+        animationName: 'spin',
+        animationDuration: '1s',
+        animationTimingFunction: 'linear',
+        animationIterationCount: 'infinite',
+        animationDirection: 'reverse',
+      },
+    });
+  });
+
+  it.each([
+    { rpm: 120, duration: '0.5s' },
+    { rpm: -30, duration: '2s' },
+    { rpm: 0, duration: '0s' },
+    { rpm: undefined, duration: '0s' },
+  ])('sets animationDuration to $duration when rpm is $rpm', ({ rpm, duration }) => {
+    expect(dronePropellerSpin(theme, 'normal', rpm)).toEqual({
+      [noPreference]: {
+        animationName: 'spin',
+        animationDuration: duration,
+        animationTimingFunction: 'linear',
+        animationIterationCount: 'infinite',
+        animationDirection: 'normal',
+      },
+    });
+  });
+});

--- a/public/app/features/canvas/elements/droneMotionStyles.ts
+++ b/public/app/features/canvas/elements/droneMotionStyles.ts
@@ -1,0 +1,21 @@
+import { type GrafanaTheme2 } from '@grafana/data';
+
+export function droneAttitudeTransition(theme: GrafanaTheme2) {
+  return {
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: 'transform 0.4s',
+    },
+  };
+}
+
+export function dronePropellerSpin(theme: GrafanaTheme2, direction: 'normal' | 'reverse', rpm?: number) {
+  return {
+    [theme.transitions.handleMotion('no-preference')]: {
+      animationName: 'spin',
+      animationDuration: `${rpm ? 60 / Math.abs(rpm) : 0}s`,
+      animationTimingFunction: 'linear',
+      animationIterationCount: 'infinite',
+      animationDirection: direction,
+    },
+  };
+}

--- a/public/app/features/canvas/elements/droneSide.tsx
+++ b/public/app/features/canvas/elements/droneSide.tsx
@@ -9,6 +9,8 @@ import { ScalarDimensionEditor } from 'app/features/dimensions/editors/ScalarDim
 
 import { type CanvasElementItem, type CanvasElementOptions, type CanvasElementProps, defaultBgColor } from '../element';
 
+import { droneAttitudeTransition } from './droneMotionStyles';
+
 interface DroneSideData {
   pitchAngle?: number;
 }
@@ -121,9 +123,5 @@ export const droneSideItem: CanvasElementItem = {
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  droneSide: css({
-    // TODO: figure out what styles to apply when prefers-reduced-motion is set
-    // eslint-disable-next-line @grafana/no-unreduced-motion
-    transition: 'transform 0.4s',
-  }),
+  droneSide: css(droneAttitudeTransition(theme)),
 });

--- a/public/app/features/canvas/elements/droneTop.tsx
+++ b/public/app/features/canvas/elements/droneTop.tsx
@@ -1,13 +1,14 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
-import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type ScalarDimensionConfig } from '@grafana/schema';
-import { useStyles2 } from '@grafana/ui';
+import { useStyles2, useTheme2 } from '@grafana/ui';
 import { type DimensionContext } from 'app/features/dimensions/context';
 import { ScalarDimensionEditor } from 'app/features/dimensions/editors/ScalarDimensionEditor';
 
 import { type CanvasElementItem, type CanvasElementOptions, type CanvasElementProps, defaultBgColor } from '../element';
+
+import { dronePropellerSpin } from './droneMotionStyles';
 
 interface DroneTopData {
   bRightRotorRPM?: number;
@@ -26,15 +27,8 @@ interface DroneTopConfig {
 }
 
 const DroneTopDisplay = ({ data }: CanvasElementProps<DroneTopConfig, DroneTopData>) => {
+  const theme = useTheme2();
   const styles = useStyles2(getStyles);
-
-  const fRightRotorAnimation = `spin ${data?.fRightRotorRPM ? 60 / Math.abs(data.fRightRotorRPM) : 0}s linear infinite`;
-
-  const fLeftRotorAnimation = `spin ${data?.fLeftRotorRPM ? 60 / Math.abs(data.fLeftRotorRPM) : 0}s linear infinite`;
-
-  const bRightRotorAnimation = `spin ${data?.bRightRotorRPM ? 60 / Math.abs(data.bRightRotorRPM) : 0}s linear infinite`;
-
-  const bLeftRotorAnimation = `spin ${data?.bLeftRotorRPM ? 60 / Math.abs(data.bLeftRotorRPM) : 0}s linear infinite`;
 
   const droneTopTransformStyle = `rotate(${data?.yawAngle ? data.yawAngle : 0}deg)`;
 
@@ -56,23 +50,19 @@ const DroneTopDisplay = ({ data }: CanvasElementProps<DroneTopConfig, DroneTopDa
       />
       <g className="propeller-group">
         <path
-          className={`${styles.propeller} ${styles.propellerCW}`}
-          style={{ animation: bRightRotorAnimation }}
+          className={cx(styles.propeller, css(dronePropellerSpin(theme, 'normal', data?.bRightRotorRPM)))}
           d=" M 461.563 418.77 L 463.992 416.34 Q 465.495 407.116 466.461 400.395 C 467.426 393.675 469.363 388.087 474.731 383.284 Q 533.862 341.514 538.196 338.859 C 542.529 336.203 548.345 334.299 551.492 338.29 C 554.639 342.282 553.481 346.02 549.419 350.082 L 471.147 428.354 L 461.563 418.77 Z  M 427.729 471.772 L 425.299 474.202 Q 423.797 483.426 422.831 490.146 C 421.866 496.867 419.929 502.454 414.561 507.257 Q 355.43 549.028 351.096 551.683 C 346.763 554.338 340.947 556.243 337.8 552.251 C 334.653 548.26 335.811 544.522 339.873 540.46 L 418.145 462.187 L 427.729 471.772 Z "
         />
         <path
-          className={`${styles.propeller} ${styles.propellerCCW}`}
-          style={{ animation: fRightRotorAnimation }}
+          className={cx(styles.propeller, css(dronePropellerSpin(theme, 'reverse', data?.fRightRotorRPM)))}
           d=" M 461.563 135.773 L 463.992 138.203 Q 465.495 147.426 466.461 154.147 C 467.426 160.868 469.363 166.455 474.731 171.258 Q 533.862 213.028 538.196 215.684 C 542.529 218.339 548.345 220.244 551.492 216.252 C 554.639 212.26 553.481 208.523 549.419 204.46 L 471.147 126.188 L 461.563 135.773 Z  M 427.729 82.77 L 425.299 80.34 Q 423.797 71.117 422.831 64.396 C 421.866 57.675 419.929 52.088 414.561 47.285 Q 355.43 5.515 351.096 2.859 C 346.763 0.204 340.947 -1.701 337.8 2.291 C 334.653 6.282 335.811 10.02 339.873 14.082 L 418.145 92.355 L 427.729 82.77 Z "
         />
         <path
-          className={`${styles.propeller} ${styles.propellerCCW}`}
-          style={{ animation: bLeftRotorAnimation }}
+          className={cx(styles.propeller, css(dronePropellerSpin(theme, 'reverse', data?.bLeftRotorRPM)))}
           d=" M 125.563 471.772 L 127.993 474.202 Q 129.496 483.426 130.461 490.146 C 131.427 496.867 133.363 502.454 138.731 507.257 Q 197.863 549.028 202.196 551.683 C 206.53 554.338 212.345 556.243 215.492 552.251 C 218.639 548.26 217.482 544.522 213.419 540.46 L 135.148 462.187 L 125.563 471.772 Z  M 91.73 418.77 L 89.3 416.34 Q 87.797 407.116 86.832 400.395 C 85.866 393.675 83.93 388.087 78.562 383.284 Q 19.431 341.514 15.097 338.859 C 10.763 336.203 4.948 334.299 1.801 338.29 C -1.346 342.282 -0.189 346.02 3.874 350.082 L 82.146 428.354 L 91.73 418.77 Z "
         />
         <path
-          className={`${styles.propeller} ${styles.propellerCW}`}
-          style={{ animation: fLeftRotorAnimation }}
+          className={cx(styles.propeller, css(dronePropellerSpin(theme, 'normal', data?.fLeftRotorRPM)))}
           d=" M 125.563 82.77 L 127.993 80.34 Q 129.496 71.117 130.461 64.396 C 131.427 57.675 133.363 52.088 138.731 47.285 Q 197.863 5.515 202.196 2.859 C 206.53 0.204 212.345 -1.701 215.492 2.291 C 218.639 6.282 217.482 10.02 213.419 14.083 L 135.147 92.355 L 125.563 82.77 Z  M 91.73 135.773 L 89.3 138.203 Q 87.797 147.426 86.832 154.147 C 85.866 160.868 83.93 166.455 78.562 171.258 Q 19.431 213.028 15.097 215.684 C 10.763 218.339 4.948 220.243 1.801 216.252 C -1.346 212.26 -0.189 208.523 3.874 204.46 L 82.146 126.188 L 91.73 135.773 Z "
         />
       </g>
@@ -166,7 +156,7 @@ export const droneTopItem: CanvasElementItem = {
   },
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = () => ({
   propeller: css({
     transformOrigin: '50% 50%',
     transformBox: 'fill-box',
@@ -179,15 +169,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
         transform: 'rotate(360deg)',
       },
     },
-  }),
-  propellerCW: css({
-    // TODO: figure out what styles to apply when prefers-reduced-motion is set
-    // eslint-disable-next-line @grafana/no-unreduced-motion
-    animationDirection: 'normal',
-  }),
-  propellerCCW: css({
-    // TODO: figure out what styles to apply when prefers-reduced-motion is set
-    // eslint-disable-next-line @grafana/no-unreduced-motion
-    animationDirection: 'reverse',
   }),
 });


### PR DESCRIPTION
# demo-one changes

Two commits on `demo-one` vs `main`.

## 1. Local demo data (warehouse / analytics)

`make run` no longer opens an empty org. Grafana auto-provisions Testdata-backed dashboards that look like a data platform.

**Datasource:** Analytics warehouse (`testdata`, uid `demo-testdata`, default)

**Folders / dashboards:**
- **Warehouse** — Warehouse overview (home), Query performance
- **Pipelines** — ELT freshness, Failed jobs

Home is set via `conf/demo.ini` (`default_home_dashboard_path` → Warehouse overview). Copy to `conf/custom.ini` on a fresh clone (that file is gitignored).

This is Testdata, not a live Snowflake/BigQuery connector. Query inspector will show `random_walk` / `csv_content` / `logs`.

Provisioning YAML under `conf/provisioning/` is gitignored except `sample.yaml`; the demo YAML files were force-added so they ship on this branch.

## 2. Canvas drone reduced motion

Drone canvas elements no longer ignore `prefers-reduced-motion`. Attitude transitions and propeller spin go through `theme.transitions.handleMotion('no-preference')` in `droneMotionStyles.ts`, with unit tests.

## Files

| Area | Path |
| --- | --- |
| Config | `conf/demo.ini` |
| Provisioning | `conf/provisioning/datasources/demo.yaml`, `conf/provisioning/dashboards/demo.yaml` |
| Dashboards | `devenv/demo-dashboards/Warehouse/*`, `devenv/demo-dashboards/Pipelines/*` |
| Notes | `devenv/demo-dashboards/README.md` |
| Canvas | `public/app/features/canvas/elements/drone{Front,Side,Top}.tsx`, `droneMotionStyles.ts`, `droneMotionStyles.test.ts` |

## How to run

```bash
yarn start      # already watching
make run        # localhost:3000, admin / admin
```

If home is still the empty Grafana welcome: `cp conf/demo.ini conf/custom.ini` and restart the backend.