### PR TITLE
Folders: fix descendant counts for resources still in the legacy tables

### DIFF
--- a/pkg/server/wire_helpers_test.go
+++ b/pkg/server/wire_helpers_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	legacystars "github.com/grafana/grafana/pkg/registry/apis/collections/legacy"
+	dashboardmigrator "github.com/grafana/grafana/pkg/registry/apis/dashboard/migrator"
+	snapshotmigrator "github.com/grafana/grafana/pkg/registry/apis/dashboard/snapshot/migrator"
+	dsmigrator "github.com/grafana/grafana/pkg/registry/apis/datasource/migrator"
+	legacypreferences "github.com/grafana/grafana/pkg/registry/apis/preferences/legacy"
+	playlistmigrator "github.com/grafana/grafana/pkg/registry/apps/playlist/migrator"
+	querycachingmigrator "github.com/grafana/grafana/pkg/registry/apps/querycaching/migrator"
+	shorturlmigrator "github.com/grafana/grafana/pkg/registry/apps/shorturl/migrator"
+	"github.com/grafana/grafana/pkg/storage/unified/federated"
+)
+
+// stubMigrator satisfies every migrator interface the registry needs. Registering a
+// migration only reads the definitions, so the embedded interfaces stay nil.
+type stubMigrator struct {
+	dashboardmigrator.FoldersDashboardsMigrator
+	playlistmigrator.PlaylistMigrator
+	shorturlmigrator.ShortURLMigrator
+	snapshotmigrator.SnapshotMigrator
+	dsmigrator.DataSourceMigrator
+	legacystars.StarsMigrator
+	legacypreferences.PreferencesMigrator
+	querycachingmigrator.QueryCacheConfigMigrator
+}
+
+// Folder counts fall back to the legacy SQL tables for a few resources, and
+// federated.legacyTableIsStale decides from config alone whether those tables are still
+// written. That shortcut only holds while the resource has no migration registered,
+// because the migration log, not config, is what marks a resource as migrated.
+func TestLegacyCountedResourcesHaveNoMigration(t *testing.T) {
+	s := stubMigrator{}
+	registry := ProvideMigrationRegistry(s, s, s, s, s, s, s, s)
+
+	migrated := map[string]bool{}
+	for _, def := range registry.All() {
+		for _, res := range def.Resources {
+			migrated[res.GroupResource.String()] = true
+		}
+	}
+
+	for _, resource := range federated.LegacyCountedResources {
+		require.False(t, migrated[resource],
+			"%s now has a migration registered, so federated.legacyTableIsStale must read the migration status instead of the configured mode",
+			resource)
+	}
+}

--- a/pkg/server/wire_helpers_test.go
+++ b/pkg/server/wire_helpers_test.go
@@ -40,7 +40,7 @@ func TestLegacyCountedResourcesHaveNoMigration(t *testing.T) {
 	migrated := map[string]bool{}
 	for _, def := range registry.All() {
 		for _, res := range def.Resources {
-			migrated[res.GroupResource.String()] = true
+			migrated[res.String()] = true
 		}
 	}
 

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -664,15 +664,13 @@ func toFolderLegacyCounts(u *unstructured.Unstructured) (*folder.DescendantCount
 		return nil, err
 	}
 
+	// A resource can be reported twice, by unified storage and by the "sql-fallback"
+	// group. Resources not yet in unified storage still get an entry there with a count
+	// of 0, so treat 0 as no data, otherwise a folder holding only alert rules looks empty.
 	var out = make(folder.DescendantCounts)
 	for _, v := range ds.Counts {
-		// if stats come from unified storage, we will use them
-		if v.Group != "sql-fallback" {
-			out[v.Resource] = v.Count
-			continue
-		}
-		// if stats are from single tenant DB and they are not in unified storage, we will use them
-		if _, ok := out[v.Resource]; !ok {
+		current, seen := out[v.Resource]
+		if !seen || current == 0 || (v.Group != "sql-fallback" && v.Count != 0) {
 			out[v.Resource] = v.Count
 		}
 	}

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -101,6 +101,67 @@ func TestComputeFullPath(t *testing.T) {
 	}
 }
 
+func TestToFolderLegacyCounts(t *testing.T) {
+	counts := func(stats ...map[string]interface{}) *unstructured.Unstructured {
+		items := make([]interface{}, 0, len(stats))
+		for _, s := range stats {
+			items = append(items, s)
+		}
+		return &unstructured.Unstructured{Object: map[string]interface{}{"counts": items}}
+	}
+	stat := func(group, res string, count int64) map[string]interface{} {
+		return map[string]interface{}{"group": group, "resource": res, "count": count}
+	}
+
+	testCases := []struct {
+		name  string
+		input *unstructured.Unstructured
+		want  folder.DescendantCounts
+	}{
+		{
+			name: "resources still living in the single-tenant tables are counted",
+			input: counts(
+				stat("rules.alerting.grafana.app", "alertrules", 0),
+				stat("sql-fallback", "alertrules", 3),
+			),
+			want: folder.DescendantCounts{"alertrules": 3},
+		},
+		{
+			name: "unified storage counts win over the single-tenant tables",
+			input: counts(
+				stat("rules.alerting.grafana.app", "alertrules", 5),
+				stat("sql-fallback", "alertrules", 3),
+			),
+			want: folder.DescendantCounts{"alertrules": 5},
+		},
+		{
+			name: "order of the entries does not matter",
+			input: counts(
+				stat("sql-fallback", "alertrules", 3),
+				stat("rules.alerting.grafana.app", "alertrules", 0),
+			),
+			want: folder.DescendantCounts{"alertrules": 3},
+		},
+		{
+			name: "empty folder stays empty",
+			input: counts(
+				stat("dashboard.grafana.app", "dashboards", 0),
+				stat("rules.alerting.grafana.app", "alertrules", 0),
+				stat("sql-fallback", "alertrules", 0),
+			),
+			want: folder.DescendantCounts{"dashboards": 0, "alertrules": 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := toFolderLegacyCounts(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, *got)
+		})
+	}
+}
+
 func TestGetParents(t *testing.T) {
 	mockCli := new(client.MockK8sHandler)
 	tracer := noop.NewTracerProvider().Tracer("TestGetParents")

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -8,6 +8,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -19,10 +20,28 @@ import (
 // headroom for the orgID placeholder and stays well under MySQL/Postgres limits.
 const folderBatchSize = 500
 
+// Config section keys for the resources that own the legacy tables counted below.
+const (
+	alertRuleResource     = "alertrules.rules.alerting.grafana.app"
+	recordingRuleResource = "recordingrules.rules.alerting.grafana.app"
+	libraryPanelResource  = "librarypanels.dashboard.grafana.app"
+)
+
 // Read stats from legacy SQL
 type LegacyStatsGetter struct {
 	SQL legacysql.LegacyDatabaseProvider
 	Cfg *setting.Cfg
+}
+
+// From mode 4 on nothing writes the legacy table, so its rows are leftovers and
+// counting them would warn about resources that no longer exist. Config is enough
+// because these two resources have no migration registered; if that changes, read
+// the migration status like dualwrite.Service.ReadFromUnified does.
+func (s *LegacyStatsGetter) legacyTableIsStale(resource string) bool {
+	if s.Cfg == nil {
+		return false
+	}
+	return s.Cfg.UnifiedStorage[resource].DualWriterMode >= grafanarest.Mode4
 }
 
 func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
@@ -102,20 +121,26 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		// NULL has to count as "not a recording rule". Comparing NULL with = or != yields
 		// NULL rather than true, which would drop those rows from both counts and let a
 		// folder that still holds alert rules look empty.
-		err = fn("alert_rule", "namespace_uid", group, "alertrules", false, "(record IS NULL OR record = '')")
-		if err != nil {
-			return err
+		if !s.legacyTableIsStale(alertRuleResource) {
+			err = fn("alert_rule", "namespace_uid", group, "alertrules", false, "(record IS NULL OR record = '')")
+			if err != nil {
+				return err
+			}
 		}
 
-		err = fn("alert_rule", "namespace_uid", group, "recordingrules", false, "(record IS NOT NULL AND record != '')")
-		if err != nil {
-			return err
+		if !s.legacyTableIsStale(recordingRuleResource) {
+			err = fn("alert_rule", "namespace_uid", group, "recordingrules", false, "(record IS NOT NULL AND record != '')")
+			if err != nil {
+				return err
+			}
 		}
 
 		// Legacy library_elements table
-		err = fn("library_element", "folder_uid", group, "library_elements", false, "")
-		if err != nil {
-			return err
+		if !s.legacyTableIsStale(libraryPanelResource) {
+			err = fn("library_element", "folder_uid", group, "library_elements", false, "")
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -27,6 +27,10 @@ const (
 	libraryPanelResource  = "librarypanels.dashboard.grafana.app"
 )
 
+// LegacyCountedResources is guarded by a test: once one of these gets a migration
+// registered, legacyTableIsStale has to read the migration status instead of config.
+var LegacyCountedResources = []string{alertRuleResource, recordingRuleResource, libraryPanelResource}
+
 // Read stats from legacy SQL
 type LegacyStatsGetter struct {
 	SQL legacysql.LegacyDatabaseProvider

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/folder"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -250,6 +252,38 @@ func TestIntegrationDirectSQLStatsSplitsRecordingRules(t *testing.T) {
 			got := counts(t, folderUID)
 			require.Equal(t, total, got["alertrules"]+got["recordingrules"],
 				"alertrules+recordingrules must equal the number of rules in %s", folderUID)
+		}
+	})
+}
+
+func TestLegacyTableIsStale(t *testing.T) {
+	cfgWithMode := func(resource string, mode grafanarest.DualWriterMode) *setting.Cfg {
+		return &setting.Cfg{UnifiedStorage: map[string]setting.UnifiedStorageConfig{
+			resource: {DualWriterMode: mode},
+		}}
+	}
+
+	t.Run("no config means the legacy table is still the source of truth", func(t *testing.T) {
+		s := &LegacyStatsGetter{}
+		require.False(t, s.legacyTableIsStale(alertRuleResource))
+	})
+
+	t.Run("unconfigured resource is still the source of truth", func(t *testing.T) {
+		s := &LegacyStatsGetter{Cfg: cfgWithMode(libraryPanelResource, grafanarest.Mode5)}
+		require.False(t, s.legacyTableIsStale(alertRuleResource))
+	})
+
+	t.Run("dual write modes keep the legacy table", func(t *testing.T) {
+		for _, mode := range []grafanarest.DualWriterMode{grafanarest.Mode0, grafanarest.Mode1, grafanarest.Mode2, grafanarest.Mode3} {
+			s := &LegacyStatsGetter{Cfg: cfgWithMode(alertRuleResource, mode)}
+			require.False(t, s.legacyTableIsStale(alertRuleResource), "mode %d", mode)
+		}
+	})
+
+	t.Run("unified storage modes drop the legacy table", func(t *testing.T) {
+		for _, mode := range []grafanarest.DualWriterMode{grafanarest.Mode4, grafanarest.Mode5} {
+			s := &LegacyStatsGetter{Cfg: cfgWithMode(alertRuleResource, mode)}
+			require.True(t, s.legacyTableIsStale(alertRuleResource), "mode %d", mode)
 		}
 	})
 }


### PR DESCRIPTION
The fix is limited to `/api/folders/:uid/counts`. The second change is a guard for the shared federated stats path so the first one cannot go wrong once a resource finishes migrating; it is inert today.

Folder counts come from unified storage plus a legacy SQL count for the resources still in the single-tenant tables (alert rules, recording rules, library panels), added by `federated.NewFederatedClient`. A resource can therefore be reported twice, once with a real count and once with a zero.

Two changes:

1. `toFolderLegacyCounts` always preferred the unified storage entry, so the zero replaced the real count. Treat zero as missing data instead. This affects `/api/folders/:uid/counts` only, which the delete dialog uses when `foldersAppPlatformAPI` is off — the default, so OSS and on-prem today. The frontend already applies this rule on the app platform path.
2. Stop counting a legacy table once its resource reaches dual-writer mode 4, where nothing writes that table any more. Without this, the first change would let stale rows win. This affects every counts consumer in a single-process Grafana. Dashboards and folders got the same treatment in https://github.com/grafana/grafana/pull/111672.

Both changes only apply where the federated client exists, which is the single-process Grafana. This does **not** close https://github.com/grafana/grafana/issues/131381: that report comes from the multi-tenant folder app, which has no legacy database, so no `sql-fallback` rows are produced there in the first place.
