### PR TITLE
Storage: log when unified storage garbage collection will first run

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -687,6 +687,13 @@ func (b *kvStorageBackend) initGarbageCollection(ctx context.Context) error {
 
 		// delay the first run by a random amount between 0 and the interval to avoid thundering herd
 		jitter := time.Duration(rand.Int64N(b.garbageCollection.Interval.Nanoseconds()))
+
+		// The ticker only starts after the jitter wait, so the first run is jitter plus one full interval.
+		b.log.Info("garbage collection first run scheduled",
+			"jitter", jitter,
+			"interval", b.garbageCollection.Interval,
+			"firstRunAt", time.Now().Add(jitter+b.garbageCollection.Interval))
+
 		select {
 		case <-time.After(jitter):
 		case <-ctx.Done():


### PR DESCRIPTION
Garbage collection logs "starting garbage collection loop" and then stays silent until the first pass. It waits for the startup gate, then a random delay of up to one interval so pods do not hit the database at once, and only then starts the ticker — so the first pass lands between one and two intervals after start. With `garbage_collection_interval: 1h` that is 60 to 120 minutes of silence, indistinguishable from broken.

Adds one log line after the delay is picked, with the delay, the interval, and the absolute time of the first run (delay plus one interval, since the ticker starts after the delay). Logging only, no behaviour or config changes.