### PR TITLE
Dashboards: Fan-out view panel by time window

### DIFF
--- a/public/app/core/utils/timePicker.ts
+++ b/public/app/core/utils/timePicker.ts
@@ -11,13 +11,17 @@ import {
 
 type CopiedTimeRangeResult = { range: RawTimeRange; isError: false } | { range: string; isError: true };
 
-export const getShiftedTimeRange = (direction: number, origRange: TimeRange): AbsoluteTimeRange => {
+export const getShiftedTimeRange = (
+  direction: number,
+  origRange: TimeRange,
+  shiftAmountMs?: number
+): AbsoluteTimeRange => {
   const range = {
     from: toUtc(origRange.from),
     to: toUtc(origRange.to),
   };
 
-  const timespan = (range.to.valueOf() - range.from.valueOf()) / 2;
+  const timespan = shiftAmountMs ?? (range.to.valueOf() - range.from.valueOf()) / 2;
   let to: number, from: number;
 
   if (direction === -1) {

--- a/public/app/features/dashboard-scene/solo/FanoutByData.test.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByData.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@grafana/data';
 import { LoadingState } from '@grafana/schema';
 
-import { groupDataFramesByLabel } from './FanoutPanel';
+import { groupDataFramesByLabel } from './FanoutByData';
 
 describe('SoloPanelWrapper', () => {});
 

--- a/public/app/features/dashboard-scene/solo/FanoutByData.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByData.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties } from 'react';
+import { useMemo } from 'react';
 
 import {
   type PanelData,
@@ -10,86 +10,37 @@ import {
 } from '@grafana/data';
 import { SceneDataNode, type VizConfig, type VizPanel } from '@grafana/scenes';
 import { VizPanel as VizPanelReact } from '@grafana/scenes-react';
-import { useTheme2, Spinner, type ElementSelectionContextState, ElementSelectionContext } from '@grafana/ui';
 
+import { type DataSplitGroup } from './FanoutPanel';
 import { bySeriesMode, getLabelFromMode } from './ViewPanelSidePane';
 
-export function FanoutByData({
-  panel,
+export function FanoutDataGroup({
+  group,
+  viz,
   panelDataIn,
-  fanoutMode,
 }: {
-  panel: VizPanel;
+  group: DataSplitGroup;
+  viz: VizConfig;
   panelDataIn: PanelData;
-  fanoutMode?: string;
 }) {
-  const theme = useTheme2();
-  const viz: VizConfig = {
-    pluginId: panel.state.pluginId,
-    pluginVersion: panel.state.pluginVersion ?? '0.0.0',
-    options: {
-      ...panel.state.options,
-    },
-    fieldConfig: panel.state.fieldConfig,
-  };
-
-  const selectionContext: ElementSelectionContextState = useMemo(() => {
-    return {
-      enabled: false,
-      selected: [],
-      onSelect: () => {},
-      onClear: () => {},
-    };
-  }, []);
-
-  if (!panelDataIn) {
-    return <Spinner />;
-  }
-
-  const groups = groupDataByMode(panel, panelDataIn, fanoutMode, theme);
-
-  const style: CSSProperties = {
-    display: 'grid',
-    flexGrow: 1,
-    gridTemplateColumns: `repeat(auto-fit, minmax(100%, 1fr))`,
-    gridAutoRows: `minmax(250px, auto)`,
-    columnGap: theme.spacing(1),
-    rowGap: theme.spacing(1),
-    height: '100%',
-  };
-
-  return (
-    <ElementSelectionContext.Provider value={selectionContext}>
-      <div style={style}>
-        {groups.map((group, index) => {
-          const dataNode = new SceneDataNode({
-            data: {
-              ...panelDataIn,
-              series: group.frames,
-            },
-          });
-          return <VizPanelReact key={index} title={group.name} viz={viz} dataProvider={dataNode} />;
-        })}
-      </div>
-    </ElementSelectionContext.Provider>
+  const dataNode = useMemo(
+    () => new SceneDataNode({ data: { ...panelDataIn, series: group.frames } }),
+    [panelDataIn, group.frames]
   );
+
+  return <VizPanelReact title={group.name} viz={viz} dataProvider={dataNode} />;
 }
 
-interface SplitGroup {
-  name: string;
-  frames: DataFrame[];
-}
-
-function groupDataByMode(
+export function createDataGroups(
   panel: VizPanel,
   data: PanelData,
   mode: string | undefined,
   theme: GrafanaTheme2
-): SplitGroup[] {
+): DataSplitGroup[] {
   const fieldConfig = panel.state.fieldConfig.defaults;
 
   if (!mode) {
-    return [{ name: panel.state.title, frames: data.series }];
+    return [{ type: 'data', name: panel.state.title, frames: data.series }];
   }
 
   if (mode === bySeriesMode) {
@@ -114,6 +65,7 @@ function groupDataByMode(
       }
 
       return {
+        type: 'data' as const,
         name: getFrameDisplayName(frame, 0),
         frames: [frame],
       };
@@ -124,7 +76,7 @@ function groupDataByMode(
   return groupDataFramesByLabel(data, label);
 }
 
-export function groupDataFramesByLabel(data: PanelData, label: string): SplitGroup[] {
+export function groupDataFramesByLabel(data: PanelData, label: string): DataSplitGroup[] {
   const groups: Record<string, DataFrame[]> = {};
 
   for (const frame of data.series) {
@@ -147,6 +99,7 @@ export function groupDataFramesByLabel(data: PanelData, label: string): SplitGro
   }
 
   return Object.entries(groups).map(([name, frames]) => ({
+    type: 'data',
     name,
     frames,
   }));

--- a/public/app/features/dashboard-scene/solo/FanoutByData.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByData.tsx
@@ -14,14 +14,14 @@ import { useTheme2, Spinner, type ElementSelectionContextState, ElementSelection
 
 import { bySeriesMode, getLabelFromMode } from './ViewPanelSidePane';
 
-export function FanoutPanel({
+export function FanoutByData({
   panel,
   panelDataIn,
   fanoutMode,
 }: {
   panel: VizPanel;
   panelDataIn: PanelData;
-  fanoutMode: string;
+  fanoutMode?: string;
 }) {
   const theme = useTheme2();
   const viz: VizConfig = {
@@ -80,8 +80,17 @@ interface SplitGroup {
   frames: DataFrame[];
 }
 
-function groupDataByMode(panel: VizPanel, data: PanelData, mode: string, theme: GrafanaTheme2): SplitGroup[] {
+function groupDataByMode(
+  panel: VizPanel,
+  data: PanelData,
+  mode: string | undefined,
+  theme: GrafanaTheme2
+): SplitGroup[] {
   const fieldConfig = panel.state.fieldConfig.defaults;
+
+  if (!mode) {
+    return [{ name: panel.state.title, frames: data.series }];
+  }
 
   if (mode === bySeriesMode) {
     return data.series.map((frame, index) => {

--- a/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.test.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.test.tsx
@@ -1,0 +1,117 @@
+import {
+  type DataFrame,
+  FieldType,
+  LoadingState,
+  type PanelData,
+  TIME_SERIES_TIME_FIELD_NAME,
+  getDefaultTimeRange,
+  toDataFrame,
+} from '@grafana/data';
+import { SceneQueryRunner, SceneTimeRange, VizPanel } from '@grafana/scenes';
+
+import { createTimeWindowGroups } from './FanoutByTimeWindow';
+import { type TimeWindowSplitGroup } from './FanoutPanel';
+
+describe('createTimeWindowGroups', () => {
+  it('returns the panel data unmodified as the most recent window', () => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, 'd', 2);
+
+    expect(groups[0]).toEqual({ type: 'data', name: 'Panel A', frames: data.series });
+  });
+
+  it('returns one time shifted group per window in addition to the most recent window', () => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, 'd', 3);
+
+    expect(groups).toHaveLength(4);
+    expect(groups.map((group) => group.type)).toEqual(['data', 'timeWindow', 'timeWindow', 'timeWindow']);
+  });
+
+  it('shifts each window one more time window back than the previous', () => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, 'd', 2);
+
+    expect(getTimeRanges(groups)).toEqual([
+      { from: '2024-03-10T00:00:00.000Z', to: '2024-03-11T00:00:00.000Z' },
+      { from: '2024-03-09T00:00:00.000Z', to: '2024-03-10T00:00:00.000Z' },
+    ]);
+  });
+
+  it.each([
+    { timeWindow: 'h', expected: { from: '2024-03-10T23:00:00.000Z', to: '2024-03-11T23:00:00.000Z' } },
+    { timeWindow: 'w', expected: { from: '2024-03-04T00:00:00.000Z', to: '2024-03-05T00:00:00.000Z' } },
+    { timeWindow: '12h', expected: { from: '2024-03-10T12:00:00.000Z', to: '2024-03-11T12:00:00.000Z' } },
+  ])('shifts the first window by $timeWindow', ({ timeWindow, expected }) => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, timeWindow, 1);
+
+    expect(getTimeRanges(groups)).toEqual([expected]);
+  });
+
+  it('labels each time shifted window with how far back it is shifted', () => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, 'd', 2);
+
+    expect(groups.map((group) => (group.type === 'timeWindow' ? group.timeShift : null))).toEqual([
+      null,
+      'Time shifted -1d',
+      'Time shifted -2d',
+    ]);
+  });
+
+  it('keeps the panel title and queries for the time shifted windows', () => {
+    const { panel, data } = setup();
+
+    const groups = createTimeWindowGroups(panel, data, 'd', 1);
+    const shiftedPanel = getTimeWindowGroups(groups)[0].panel;
+
+    expect(shiftedPanel).not.toBe(panel);
+    expect(shiftedPanel.state.title).toBe('Panel A');
+    expect(shiftedPanel.state.$data).toBeInstanceOf(SceneQueryRunner);
+    expect((shiftedPanel.state.$data as SceneQueryRunner).state.queries).toEqual([{ refId: 'A' }]);
+  });
+});
+
+function setup() {
+  const panel = new VizPanel({
+    title: 'Panel A',
+    pluginId: 'timeseries',
+    $timeRange: new SceneTimeRange({ from: '2024-03-11T00:00:00.000Z', to: '2024-03-12T00:00:00.000Z' }),
+    $data: new SceneQueryRunner({ queries: [{ refId: 'A' }] }),
+  });
+
+  const data: PanelData = {
+    series: [getTestFrame('A-series')],
+    state: LoadingState.Done,
+    timeRange: getDefaultTimeRange(),
+  };
+
+  return { panel, data };
+}
+
+function getTimeWindowGroups(groups: ReturnType<typeof createTimeWindowGroups>): TimeWindowSplitGroup[] {
+  return groups.filter((group): group is TimeWindowSplitGroup => group.type === 'timeWindow');
+}
+
+function getTimeRanges(groups: ReturnType<typeof createTimeWindowGroups>) {
+  return getTimeWindowGroups(groups).map((group) => {
+    const timeRange = group.panel.getTimeRange();
+
+    return { from: timeRange.from.toISOString(), to: timeRange.to.toISOString() };
+  });
+}
+
+function getTestFrame(name: string): DataFrame {
+  return toDataFrame({
+    fields: [
+      { name: TIME_SERIES_TIME_FIELD_NAME, values: [1, 2, 3], type: FieldType.time },
+      { name, values: [1, 2, 3], type: FieldType.number },
+    ],
+  });
+}

--- a/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.tsx
@@ -1,98 +1,45 @@
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useEffect, useState } from 'react';
 
 import { type AbsoluteTimeRange, type PanelData, type TimeRange, rangeUtil, toUtc } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { SceneTimeRange, type VizConfig, type VizPanel } from '@grafana/scenes';
 import { SceneContext, SceneContextObject, useQueryRunner, VizPanel as VizPanelReact } from '@grafana/scenes-react';
-import { useTheme2, type ElementSelectionContextState, ElementSelectionContext, Badge } from '@grafana/ui';
+import { Badge } from '@grafana/ui';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 
 import { getQueryRunnerFor } from '../utils/utils';
 
-import { FanoutByData } from './FanoutByData';
+import { type SplitGroup, type TimeWindowSplitGroup } from './FanoutPanel';
 
-export function FanoutPanelByTimeWindow({
-  panel,
-  panelDataIn,
-  fanoutByData,
-  fanoutByTime,
-}: {
-  panel: VizPanel;
-  panelDataIn: PanelData;
-  fanoutByTime?: string;
-  fanoutByData?: string;
-}) {
-  const theme = useTheme2();
+export function createTimeWindowGroups(
+  panel: VizPanel,
+  data: PanelData,
+  timeWindow: string,
+  windowCount: number
+): SplitGroup[] {
+  // Time window is normally just a unit (h, d, w, M) which needs a count to be a valid interval string
+  const shiftAmountMs = rangeUtil.intervalToMs(/^\d/.test(timeWindow) ? timeWindow : `1${timeWindow}`);
 
-  const selectionContext: ElementSelectionContextState = useMemo(() => {
-    return {
-      enabled: false,
-      selected: [],
-      onSelect: () => {},
-      onClear: () => {},
-    };
-  }, []);
-
-  if (!fanoutByTime) {
-    return <FanoutByData panel={panel} panelDataIn={panelDataIn} fanoutMode={fanoutByData} />;
-  }
-
-  const groups = createTimeWindowGroups(panel, fanoutByTime);
-
-  const style: CSSProperties = {
-    display: 'grid',
-    flexGrow: 1,
-    gridTemplateColumns: `repeat(auto-fit, minmax(100%, 1fr))`,
-    gridAutoRows: `minmax(250px, auto)`,
-    columnGap: theme.spacing(1),
-    rowGap: theme.spacing(1),
-    height: '100%',
-  };
-
-  return (
-    <ElementSelectionContext.Provider value={selectionContext}>
-      <div style={style}>
-        {groups.map((group, index) => {
-          if (index === 0) {
-            return <FanoutByData key={index} panel={panel} panelDataIn={panelDataIn} fanoutMode={fanoutByData} />;
-          }
-
-          return <VizPanelTimeWindow key={index} group={group} />;
-        })}
-      </div>
-    </ElementSelectionContext.Provider>
-  );
-}
-
-interface SplitGroup {
-  timeRange: TimeRange;
-  timeShift: string;
-  panel: VizPanel;
-}
-
-function createTimeWindowGroups(panel: VizPanel, timeWindow: string): SplitGroup[] {
-  const windowCount = 5;
-  const shiftAmountMs = rangeUtil.intervalToMs(timeWindow);
-  const groups: SplitGroup[] = [];
+  /**
+   * The most recent window is the panel time range unmodified, so we can render the data the panel already has
+   */
+  const groups: SplitGroup[] = [{ type: 'data', name: panel.state.title, frames: data.series }];
 
   let timeRange = panel.getTimeRange();
 
-  for (let index = 0; index < windowCount; index++) {
-    if (index > 0) {
-      timeRange = toTimeRange(getShiftedTimeRange(-1, timeRange, shiftAmountMs));
-    }
+  for (let index = 1; index <= windowCount; index++) {
+    timeRange = toTimeRange(getShiftedTimeRange(-1, timeRange, shiftAmountMs));
 
-    const newSceneTimeRange = new SceneTimeRange({});
-    newSceneTimeRange.onTimeRangeChange(timeRange);
+    const shiftedTimeRange = new SceneTimeRange({});
+    shiftedTimeRange.onTimeRangeChange(timeRange);
 
     groups.push({
-      timeShift: index === 0 ? '' : `Time shifted -${index}${timeWindow}`,
-      timeRange,
-      panel:
-        index === 0
-          ? panel
-          : panel.clone({
-              $timeRange: newSceneTimeRange,
-            }),
+      type: 'timeWindow',
+      name: panel.state.title,
+      timeShift: t('dashboard.fanout-by-time.time-shift-badge', 'Time shifted -{{shift}}', {
+        shift: `${index}${timeWindow}`,
+      }),
+      panel: panel.clone({ $timeRange: shiftedTimeRange }),
     });
   }
 
@@ -106,7 +53,7 @@ function toTimeRange({ from, to }: AbsoluteTimeRange): TimeRange {
   return { from: fromUtc, to: toUtcValue, raw: { from: fromUtc, to: toUtcValue } };
 }
 
-function VizPanelTimeWindow({ group }: { group: SplitGroup }) {
+export function FanoutTimeWindowGroup({ group, viz }: { group: TimeWindowSplitGroup; viz: VizConfig }) {
   const context = useTimeWindowContext(group.panel);
 
   if (!context) {
@@ -115,21 +62,12 @@ function VizPanelTimeWindow({ group }: { group: SplitGroup }) {
 
   return (
     <SceneContext.Provider value={context}>
-      <VizPanelReactWrapper group={group} />
+      <TimeWindowQuery group={group} viz={viz} />
     </SceneContext.Provider>
   );
 }
 
-function VizPanelReactWrapper({ group }: { group: SplitGroup }) {
-  const viz: VizConfig = {
-    pluginId: group.panel.state.pluginId,
-    pluginVersion: group.panel.state.pluginVersion ?? '0.0.0',
-    options: {
-      ...group.panel.state.options,
-    },
-    fieldConfig: group.panel.state.fieldConfig,
-  };
-
+function TimeWindowQuery({ group, viz }: { group: TimeWindowSplitGroup; viz: VizConfig }) {
   const queryRunner = getQueryRunnerFor(group.panel);
 
   const data = useQueryRunner({
@@ -140,7 +78,7 @@ function VizPanelReactWrapper({ group }: { group: SplitGroup }) {
 
   return (
     <VizPanelReact
-      title={group.panel.state.title}
+      title={group.name}
       viz={viz}
       dataProvider={data}
       headerActions={<Badge color="blue" text={group.timeShift} />}

--- a/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutByTimeWindow.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+
+import { type AbsoluteTimeRange, type PanelData, type TimeRange, rangeUtil, toUtc } from '@grafana/data';
+import { SceneTimeRange, type VizConfig, type VizPanel } from '@grafana/scenes';
+import { SceneContext, SceneContextObject, useQueryRunner, VizPanel as VizPanelReact } from '@grafana/scenes-react';
+import { useTheme2, type ElementSelectionContextState, ElementSelectionContext, Badge } from '@grafana/ui';
+import { getShiftedTimeRange } from 'app/core/utils/timePicker';
+
+import { getQueryRunnerFor } from '../utils/utils';
+
+import { FanoutByData } from './FanoutByData';
+
+export function FanoutPanelByTimeWindow({
+  panel,
+  panelDataIn,
+  fanoutByData,
+  fanoutByTime,
+}: {
+  panel: VizPanel;
+  panelDataIn: PanelData;
+  fanoutByTime?: string;
+  fanoutByData?: string;
+}) {
+  const theme = useTheme2();
+
+  const selectionContext: ElementSelectionContextState = useMemo(() => {
+    return {
+      enabled: false,
+      selected: [],
+      onSelect: () => {},
+      onClear: () => {},
+    };
+  }, []);
+
+  if (!fanoutByTime) {
+    return <FanoutByData panel={panel} panelDataIn={panelDataIn} fanoutMode={fanoutByData} />;
+  }
+
+  const groups = createTimeWindowGroups(panel, fanoutByTime);
+
+  const style: CSSProperties = {
+    display: 'grid',
+    flexGrow: 1,
+    gridTemplateColumns: `repeat(auto-fit, minmax(100%, 1fr))`,
+    gridAutoRows: `minmax(250px, auto)`,
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(1),
+    height: '100%',
+  };
+
+  return (
+    <ElementSelectionContext.Provider value={selectionContext}>
+      <div style={style}>
+        {groups.map((group, index) => {
+          if (index === 0) {
+            return <FanoutByData key={index} panel={panel} panelDataIn={panelDataIn} fanoutMode={fanoutByData} />;
+          }
+
+          return <VizPanelTimeWindow key={index} group={group} />;
+        })}
+      </div>
+    </ElementSelectionContext.Provider>
+  );
+}
+
+interface SplitGroup {
+  timeRange: TimeRange;
+  timeShift: string;
+  panel: VizPanel;
+}
+
+function createTimeWindowGroups(panel: VizPanel, timeWindow: string): SplitGroup[] {
+  const windowCount = 5;
+  const shiftAmountMs = rangeUtil.intervalToMs(timeWindow);
+  const groups: SplitGroup[] = [];
+
+  let timeRange = panel.getTimeRange();
+
+  for (let index = 0; index < windowCount; index++) {
+    if (index > 0) {
+      timeRange = toTimeRange(getShiftedTimeRange(-1, timeRange, shiftAmountMs));
+    }
+
+    const newSceneTimeRange = new SceneTimeRange({});
+    newSceneTimeRange.onTimeRangeChange(timeRange);
+
+    groups.push({
+      timeShift: index === 0 ? '' : `Time shifted -${index}${timeWindow}`,
+      timeRange,
+      panel:
+        index === 0
+          ? panel
+          : panel.clone({
+              $timeRange: newSceneTimeRange,
+            }),
+    });
+  }
+
+  return groups;
+}
+
+function toTimeRange({ from, to }: AbsoluteTimeRange): TimeRange {
+  const fromUtc = toUtc(from);
+  const toUtcValue = toUtc(to);
+
+  return { from: fromUtc, to: toUtcValue, raw: { from: fromUtc, to: toUtcValue } };
+}
+
+function VizPanelTimeWindow({ group }: { group: SplitGroup }) {
+  const context = useTimeWindowContext(group.panel);
+
+  if (!context) {
+    return null;
+  }
+
+  return (
+    <SceneContext.Provider value={context}>
+      <VizPanelReactWrapper group={group} />
+    </SceneContext.Provider>
+  );
+}
+
+function VizPanelReactWrapper({ group }: { group: SplitGroup }) {
+  const viz: VizConfig = {
+    pluginId: group.panel.state.pluginId,
+    pluginVersion: group.panel.state.pluginVersion ?? '0.0.0',
+    options: {
+      ...group.panel.state.options,
+    },
+    fieldConfig: group.panel.state.fieldConfig,
+  };
+
+  const queryRunner = getQueryRunnerFor(group.panel);
+
+  const data = useQueryRunner({
+    queries: queryRunner?.state.queries ?? [],
+    datasource: queryRunner?.state.datasource,
+    minInterval: queryRunner?.state.minInterval,
+  });
+
+  return (
+    <VizPanelReact
+      title={group.panel.state.title}
+      viz={viz}
+      dataProvider={data}
+      headerActions={<Badge color="blue" text={group.timeShift} />}
+    />
+  );
+}
+
+function useTimeWindowContext(panel: VizPanel): SceneContextObject | null {
+  const [context, setContext] = useState<SceneContextObject | null>(null);
+
+  /**
+   * Attach SceneContextObject to the panel on mount for any dynamically rendered scenes-react panels
+   */
+  useEffect(() => {
+    const newContext = new SceneContextObject();
+    // @ts-expect-error
+    panel.setState({ context: newContext });
+    setContext(newContext);
+
+    return () => {
+      // @ts-expect-error
+      panel.setState({ context: null });
+      setContext(null);
+    };
+  }, [panel]);
+
+  return context;
+}

--- a/public/app/features/dashboard-scene/solo/FanoutPanel.tsx
+++ b/public/app/features/dashboard-scene/solo/FanoutPanel.tsx
@@ -1,0 +1,110 @@
+import { useMemo, type CSSProperties } from 'react';
+
+import { type DataFrame, type GrafanaTheme2, type PanelData } from '@grafana/data';
+import { type VizConfig, type VizPanel } from '@grafana/scenes';
+import { useTheme2, type ElementSelectionContextState, ElementSelectionContext } from '@grafana/ui';
+
+import { createDataGroups, FanoutDataGroup } from './FanoutByData';
+import { createTimeWindowGroups, FanoutTimeWindowGroup } from './FanoutByTimeWindow';
+import { defaultWindowCount, getTimeWindowFromMode } from './ViewPanelSidePane';
+
+export type SplitGroup = DataSplitGroup | TimeWindowSplitGroup;
+
+/**
+ * Renders a slice of the data the panel has already fetched
+ */
+export interface DataSplitGroup {
+  type: 'data';
+  name: string;
+  frames: DataFrame[];
+}
+
+/**
+ * Re-runs the panel queries against a time range shifted back by one or more time windows
+ */
+export interface TimeWindowSplitGroup {
+  type: 'timeWindow';
+  name: string;
+  timeShift: string;
+  panel: VizPanel;
+}
+
+export function FanoutPanel({
+  panel,
+  panelDataIn,
+  fanoutMode,
+  windowCount,
+}: {
+  panel: VizPanel;
+  panelDataIn: PanelData;
+  fanoutMode?: string;
+  windowCount?: number;
+}) {
+  const theme = useTheme2();
+
+  const selectionContext: ElementSelectionContextState = useMemo(() => {
+    return {
+      enabled: false,
+      selected: [],
+      onSelect: () => {},
+      onClear: () => {},
+    };
+  }, []);
+
+  /**
+   * Memoized as the time window groups clone the panel, which we do not want to do on every render
+   */
+  const groups = useMemo(
+    () => createFanoutGroups(panel, panelDataIn, fanoutMode, windowCount, theme),
+    [panel, panelDataIn, fanoutMode, windowCount, theme]
+  );
+
+  const viz: VizConfig = {
+    pluginId: panel.state.pluginId,
+    pluginVersion: panel.state.pluginVersion ?? '0.0.0',
+    options: {
+      ...panel.state.options,
+    },
+    fieldConfig: panel.state.fieldConfig,
+  };
+
+  const style: CSSProperties = {
+    display: 'grid',
+    flexGrow: 1,
+    gridTemplateColumns: `repeat(auto-fit, minmax(100%, 1fr))`,
+    gridAutoRows: `minmax(250px, auto)`,
+    columnGap: theme.spacing(1),
+    rowGap: theme.spacing(1),
+    height: '100%',
+  };
+
+  return (
+    <ElementSelectionContext.Provider value={selectionContext}>
+      <div style={style}>
+        {groups.map((group, index) =>
+          group.type === 'timeWindow' ? (
+            <FanoutTimeWindowGroup key={index} group={group} viz={viz} />
+          ) : (
+            <FanoutDataGroup key={index} group={group} viz={viz} panelDataIn={panelDataIn} />
+          )
+        )}
+      </div>
+    </ElementSelectionContext.Provider>
+  );
+}
+
+function createFanoutGroups(
+  panel: VizPanel,
+  data: PanelData,
+  mode: string | undefined,
+  windowCount: number | undefined,
+  theme: GrafanaTheme2
+): SplitGroup[] {
+  const timeWindow = mode ? getTimeWindowFromMode(mode) : undefined;
+
+  if (timeWindow) {
+    return createTimeWindowGroups(panel, data, timeWindow, windowCount ?? defaultWindowCount);
+  }
+
+  return createDataGroups(panel, data, mode, theme);
+}

--- a/public/app/features/dashboard-scene/solo/ViewPanelQuickToggles.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelQuickToggles.tsx
@@ -51,7 +51,7 @@ export function ViewPanelQuickToggles({ panel, plugin }: Props) {
     <OptionsPaneCategory
       id="quick-toggles"
       title={t('dashboard.sidebar.view-panel.quick-toggles', 'Quick toggles')}
-      forceOpen={true}
+      isOpenDefault={true}
     >
       {optionHits.map((hit) => hit.renderElement('asd'))}
     </OptionsPaneCategory>

--- a/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
@@ -13,7 +13,7 @@ import {
   type SceneObjectUrlValues,
   type VizPanel,
 } from '@grafana/scenes';
-import { Box, ScrollContainer, Sidebar, Text, RadioButtonDot, Button, Spinner } from '@grafana/ui';
+import { Box, ScrollContainer, Sidebar, Text, RadioButtonDot, Button, Spinner, Field, Slider } from '@grafana/ui';
 import { OptionsPaneCategory } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategory';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
@@ -25,13 +25,13 @@ import { ViewPanelQuickToggles } from './ViewPanelQuickToggles';
 export interface ViewPanelSidePaneState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
   fanoutMode?: string;
-  fanoutByTime?: string;
+  fanoutWindowCount?: number;
 }
 
 export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
   public static Component = ViewPanelSidePaneRenderer;
 
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['fanout', 'fanoutTime'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['fanout', 'fanoutWindows'] });
 
   public getId() {
     return 'view-panel-pane';
@@ -42,13 +42,13 @@ export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
     DashboardInteractions.viewPanelAction({ action: 'set_fanout_mode', value: value ?? '' });
   }
 
-  public onSetByTimeMode(value: string | undefined) {
-    this.setState({ fanoutByTime: value });
-    DashboardInteractions.viewPanelAction({ action: 'set_fanout_by_time', value: value ?? '' });
+  public onSetWindowCount(value: number) {
+    this.setState({ fanoutWindowCount: value });
+    DashboardInteractions.viewPanelAction({ action: 'set_fanout_window_count', value: value.toString() });
   }
 
   public getUrlState() {
-    return { fanout: this.state.fanoutMode, fanoutTime: this.state.fanoutByTime };
+    return { fanout: this.state.fanoutMode, fanoutWindows: this.state.fanoutWindowCount?.toString() };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
@@ -58,10 +58,11 @@ export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
       this.setState({ fanoutMode: undefined });
     }
 
-    if (typeof values.fanoutTime === 'string') {
-      this.setState({ fanoutByTime: values.fanoutTime });
-    } else if (Object.hasOwn(values, 'fanoutTime')) {
-      this.setState({ fanoutByTime: undefined });
+    if (typeof values.fanoutWindows === 'string') {
+      const count = parseInt(values.fanoutWindows, 10);
+      this.setState({ fanoutWindowCount: isNaN(count) ? undefined : clampWindowCount(count) });
+    } else if (Object.hasOwn(values, 'fanoutWindows')) {
+      this.setState({ fanoutWindowCount: undefined });
     }
   }
 }
@@ -110,12 +111,7 @@ function ViewPanelSidePaneRenderer({ model }: SceneComponentProps<ViewPanelSideP
             </Button>
           </Box>
           {viewPanelOptions?.quickToggles && <ViewPanelQuickToggles panel={panel} plugin={plugin.value} />}
-          {viewPanelOptions?.fanout?.enabled && (
-            <>
-              <ViewPanelFanoutOptions panel={panel} pane={model} />
-              <ViewPanelFanoutByTimeOptions pane={model} />
-            </>
-          )}
+          {viewPanelOptions?.fanout?.enabled && <ViewPanelFanoutOptions panel={panel} pane={model} />}
         </Box>
       </ScrollContainer>
     </Box>
@@ -146,9 +142,16 @@ function ViewPanelFanoutOptions({ panel, pane }: ViewPaneFanoutOptionsProps) {
     return () => dataSub.unsubscribe();
   }, [panel]);
 
+  const byTimeWindowOptions = [
+    { value: 'h', label: t('dashboard.sidebar.view-panel.fanout-by-time-1h', 'Hour') },
+    { value: 'd', label: t('dashboard.sidebar.view-panel.fanout-by-time-1d', 'Day') },
+    { value: 'w', label: t('dashboard.sidebar.view-panel.fanout-by-time-1w', 'Week') },
+    { value: 'M', label: t('dashboard.sidebar.view-panel.fanout-by-time-1M', 'Month') },
+  ];
+
   return (
     <OptionsPaneCategory
-      title={t('dashboard.sidebar.view-panel.fanout-category', 'Fan-out by series or label')}
+      title={t('dashboard.sidebar.view-panel.fanout-category', 'Fan-out')}
       id="fanout"
       isOpenDefault={true}
     >
@@ -169,15 +172,19 @@ function ViewPanelFanoutOptions({ panel, pane }: ViewPaneFanoutOptionsProps) {
         />
       </Box>
       <Box padding={1}>
-        <Text variant="bodySmall" weight="medium">
-          {t('dashboard.sidebar.view-panel.fanout-labels', 'Labels')}
-        </Text>
+        <Text weight="medium">{t('dashboard.sidebar.view-panel.fanout-labels', 'By label')}</Text>
       </Box>
-      <Box direction="column" gap={1} display="flex" paddingLeft={1}>
+      <Box direction="column" gap={1} display="flex" paddingLeft={2}>
         {labels && labels.length === 0 && (
-          <Text italic variant="bodySmall">
-            {t('dashboard.sidebar.view-panel.fanout-no-labels', 'Data has no labels')}
-          </Text>
+          <RadioButtonDot
+            key={'no labels'}
+            id={'no labels'}
+            name="fanout"
+            label={t('dashboard.sidebar.view-panel.fanout-no-labels', 'No labels found')}
+            checked={false}
+            onClick={() => {}}
+            disabled
+          />
         )}
         {labels?.map((label) => (
           <RadioButtonDot
@@ -190,48 +197,44 @@ function ViewPanelFanoutOptions({ panel, pane }: ViewPaneFanoutOptionsProps) {
           />
         ))}
       </Box>
+      <Box padding={1}>
+        <Text weight="medium">{t('dashboard.sidebar.view-panel.fanout-time-window', 'By time window')}</Text>
+      </Box>
+      <Box direction="column" gap={1} display="flex" paddingLeft={1}>
+        {byTimeWindowOptions.map((option) => (
+          <RadioButtonDot
+            key={option.value}
+            name="fanout"
+            id={getModeForTimeWindow(option.value)}
+            label={option.label}
+            checked={modeValue === getModeForTimeWindow(option.value)}
+            onClick={() => pane.onSetMode(getModeForTimeWindow(option.value))}
+          />
+        ))}
+      </Box>
+      {fanoutMode && getTimeWindowFromMode(fanoutMode) && <ViewPanelFanoutWindowCount pane={pane} />}
     </OptionsPaneCategory>
   );
 }
 
-function ViewPanelFanoutByTimeOptions({ pane }: { pane: ViewPanelSidePane }) {
-  const { fanoutByTime } = pane.useState();
-
-  const modeValue = fanoutByTime ?? '$__none__$';
-
-  const byTimeOptions = [
-    { value: '1h', label: t('dashboard.sidebar.view-panel.fanout-by-time-1h', '1 hour') },
-    { value: '1d', label: t('dashboard.sidebar.view-panel.fanout-by-time-1d', '1 day') },
-    { value: '1w', label: t('dashboard.sidebar.view-panel.fanout-by-time-1w', '1 week') },
-    { value: '1M', label: t('dashboard.sidebar.view-panel.fanout-by-time-1M', '1 month') },
-  ];
+function ViewPanelFanoutWindowCount({ pane }: { pane: ViewPanelSidePane }) {
+  const { fanoutWindowCount } = pane.useState();
 
   return (
-    <OptionsPaneCategory
-      title={t('dashboard.sidebar.view-panel.fanout-by-time-category', 'Fan-out by time window')}
-      id="fanout-by-time"
-      isOpenDefault={true}
-    >
-      <Box direction="column" gap={1} display="flex" paddingLeft={1}>
-        <RadioButtonDot
-          name="fanout-by-time"
-          id="fanout-by-time-$__none__$"
-          label={t('dashboard.sidebar.view-panel.disabled', 'Disabled')}
-          checked={modeValue === '$__none__$'}
-          onClick={() => pane.onSetByTimeMode(undefined)}
+    <Box paddingTop={2} paddingX={1}>
+      <Field label={t('dashboard.sidebar.view-panel.fanout-window-count', 'Window count')} noMargin>
+        <Slider
+          min={minWindowCount}
+          max={maxWindowCount}
+          step={1}
+          value={fanoutWindowCount ?? defaultWindowCount}
+          /**
+           * Only commit when the handle is released so that dragging does not re-query for every step
+           */
+          onAfterChange={(value) => pane.onSetWindowCount(clampWindowCount(value ?? defaultWindowCount))}
         />
-        {byTimeOptions.map((option) => (
-          <RadioButtonDot
-            key={option.value}
-            name="fanout-by-time"
-            id={option.value}
-            label={option.label}
-            checked={modeValue === option.value}
-            onClick={() => pane.onSetByTimeMode(option.value)}
-          />
-        ))}
-      </Box>
-    </OptionsPaneCategory>
+      </Field>
+    </Box>
   );
 }
 
@@ -253,15 +256,42 @@ function extractLabelsFromData(panelData: PanelData | undefined): string[] {
 }
 
 function getModeForLabel(label: string) {
-  return `$__by_label__${label}`;
+  return `${byLabelModePrefix}${label}`;
 }
 
 export function getLabelFromMode(mode: string) {
-  if (mode.startsWith('$__by_label__')) {
-    return mode.replace('$__by_label__', '');
+  if (mode.startsWith(byLabelModePrefix)) {
+    return mode.replace(byLabelModePrefix, '');
   }
 
   return 'unknown';
 }
 
+function getModeForTimeWindow(timeWindow: string) {
+  return `${byTimeModePrefix}${timeWindow}`;
+}
+
+/**
+ * Returns the time window (interval string like 1h or 1d) for by time window fan-out modes, undefined for other modes
+ */
+export function getTimeWindowFromMode(mode: string): string | undefined {
+  if (mode.startsWith(byTimeModePrefix)) {
+    return mode.replace(byTimeModePrefix, '');
+  }
+
+  return undefined;
+}
+
+function clampWindowCount(count: number) {
+  return Math.min(Math.max(count, minWindowCount), maxWindowCount);
+}
+
 export const bySeriesMode = '$__by_series__$';
+
+export const defaultWindowCount = 3;
+
+const minWindowCount = 1;
+const maxWindowCount = 12;
+
+const byLabelModePrefix = '$__by_label__';
+const byTimeModePrefix = '$__by_time_';

--- a/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelSidePane.tsx
@@ -25,12 +25,13 @@ import { ViewPanelQuickToggles } from './ViewPanelQuickToggles';
 export interface ViewPanelSidePaneState extends SceneObjectState {
   panelRef: SceneObjectRef<VizPanel>;
   fanoutMode?: string;
+  fanoutByTime?: string;
 }
 
 export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
   public static Component = ViewPanelSidePaneRenderer;
 
-  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['fanout'] });
+  protected _urlSync = new SceneObjectUrlSyncConfig(this, { keys: ['fanout', 'fanoutTime'] });
 
   public getId() {
     return 'view-panel-pane';
@@ -41,8 +42,13 @@ export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
     DashboardInteractions.viewPanelAction({ action: 'set_fanout_mode', value: value ?? '' });
   }
 
+  public onSetByTimeMode(value: string | undefined) {
+    this.setState({ fanoutByTime: value });
+    DashboardInteractions.viewPanelAction({ action: 'set_fanout_by_time', value: value ?? '' });
+  }
+
   public getUrlState() {
-    return { fanout: this.state.fanoutMode };
+    return { fanout: this.state.fanoutMode, fanoutTime: this.state.fanoutByTime };
   }
 
   public updateFromUrl(values: SceneObjectUrlValues) {
@@ -50,6 +56,12 @@ export class ViewPanelSidePane extends SceneObjectBase<ViewPanelSidePaneState> {
       this.setState({ fanoutMode: values.fanout });
     } else if (Object.hasOwn(values, 'fanout')) {
       this.setState({ fanoutMode: undefined });
+    }
+
+    if (typeof values.fanoutTime === 'string') {
+      this.setState({ fanoutByTime: values.fanoutTime });
+    } else if (Object.hasOwn(values, 'fanoutTime')) {
+      this.setState({ fanoutByTime: undefined });
     }
   }
 }
@@ -98,7 +110,12 @@ function ViewPanelSidePaneRenderer({ model }: SceneComponentProps<ViewPanelSideP
             </Button>
           </Box>
           {viewPanelOptions?.quickToggles && <ViewPanelQuickToggles panel={panel} plugin={plugin.value} />}
-          {viewPanelOptions?.fanout?.enabled && <ViewPanelFanoutOptions panel={panel} pane={model} />}
+          {viewPanelOptions?.fanout?.enabled && (
+            <>
+              <ViewPanelFanoutOptions panel={panel} pane={model} />
+              <ViewPanelFanoutByTimeOptions pane={model} />
+            </>
+          )}
         </Box>
       </ScrollContainer>
     </Box>
@@ -170,6 +187,47 @@ function ViewPanelFanoutOptions({ panel, pane }: ViewPaneFanoutOptionsProps) {
             label={label}
             checked={modeValue === getModeForLabel(label)}
             onClick={() => pane.onSetMode(getModeForLabel(label))}
+          />
+        ))}
+      </Box>
+    </OptionsPaneCategory>
+  );
+}
+
+function ViewPanelFanoutByTimeOptions({ pane }: { pane: ViewPanelSidePane }) {
+  const { fanoutByTime } = pane.useState();
+
+  const modeValue = fanoutByTime ?? '$__none__$';
+
+  const byTimeOptions = [
+    { value: '1h', label: t('dashboard.sidebar.view-panel.fanout-by-time-1h', '1 hour') },
+    { value: '1d', label: t('dashboard.sidebar.view-panel.fanout-by-time-1d', '1 day') },
+    { value: '1w', label: t('dashboard.sidebar.view-panel.fanout-by-time-1w', '1 week') },
+    { value: '1M', label: t('dashboard.sidebar.view-panel.fanout-by-time-1M', '1 month') },
+  ];
+
+  return (
+    <OptionsPaneCategory
+      title={t('dashboard.sidebar.view-panel.fanout-by-time-category', 'Fan-out by time window')}
+      id="fanout-by-time"
+      isOpenDefault={true}
+    >
+      <Box direction="column" gap={1} display="flex" paddingLeft={1}>
+        <RadioButtonDot
+          name="fanout-by-time"
+          id="fanout-by-time-$__none__$"
+          label={t('dashboard.sidebar.view-panel.disabled', 'Disabled')}
+          checked={modeValue === '$__none__$'}
+          onClick={() => pane.onSetByTimeMode(undefined)}
+        />
+        {byTimeOptions.map((option) => (
+          <RadioButtonDot
+            key={option.value}
+            name="fanout-by-time"
+            id={option.value}
+            label={option.label}
+            checked={modeValue === option.value}
+            onClick={() => pane.onSetByTimeMode(option.value)}
           />
         ))}
       </Box>

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -8,7 +8,7 @@ import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { getDashboardSceneLike } from '../scene/types/dashboard';
 import { ToggleViewPanePaneEvent } from '../sidebar/events';
 
-import { FanoutPanelByTimeWindow } from './FanoutByTimeWindow';
+import { FanoutPanel } from './FanoutPanel';
 import { ViewPanelSidePane } from './ViewPanelSidePane';
 
 export function ViewPanelWrapper({ panel, showControlsPane }: { panel: VizPanel; showControlsPane?: boolean }) {
@@ -29,7 +29,7 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
   const context = usePanelSceneContextObject(panel);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
   const viewPanelPane = useMemo(() => new ViewPanelSidePane({ panelRef: panel.getRef() }), [panel]);
-  const { fanoutMode, fanoutByTime } = useSceneObjectState(viewPanelPane, { shouldActivateOrKeepAlive: true });
+  const { fanoutMode, fanoutWindowCount } = useSceneObjectState(viewPanelPane, { shouldActivateOrKeepAlive: true });
 
   // Open pane on mount
   useEffect(() => {
@@ -58,12 +58,7 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
 
   return (
     <SceneContext.Provider value={context}>
-      <FanoutPanelByTimeWindow
-        panel={panel}
-        panelDataIn={data!}
-        fanoutByTime={fanoutByTime}
-        fanoutByData={fanoutMode}
-      />
+      <FanoutPanel panel={panel} panelDataIn={data} fanoutMode={fanoutMode} windowCount={fanoutWindowCount} />
     </SceneContext.Provider>
   );
 }

--- a/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
+++ b/public/app/features/dashboard-scene/solo/ViewPanelWrapper.tsx
@@ -8,7 +8,7 @@ import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { getDashboardSceneLike } from '../scene/types/dashboard';
 import { ToggleViewPanePaneEvent } from '../sidebar/events';
 
-import { FanoutPanel } from './FanoutPanel';
+import { FanoutPanelByTimeWindow } from './FanoutByTimeWindow';
 import { ViewPanelSidePane } from './ViewPanelSidePane';
 
 export function ViewPanelWrapper({ panel, showControlsPane }: { panel: VizPanel; showControlsPane?: boolean }) {
@@ -29,7 +29,7 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
   const context = usePanelSceneContextObject(panel);
   const isSmallScreen = !useMediaQueryMinWidth('sm');
   const viewPanelPane = useMemo(() => new ViewPanelSidePane({ panelRef: panel.getRef() }), [panel]);
-  const { fanoutMode } = useSceneObjectState(viewPanelPane, { shouldActivateOrKeepAlive: true });
+  const { fanoutMode, fanoutByTime } = useSceneObjectState(viewPanelPane, { shouldActivateOrKeepAlive: true });
 
   // Open pane on mount
   useEffect(() => {
@@ -52,13 +52,18 @@ function ViewPanelWithPane({ panel, dataProvider }: { panel: VizPanel; dataProvi
     return () => sub.unsubscribe();
   }, [viewPanelPane, sidebar]);
 
-  if (!context || !data || !fanoutMode) {
+  if (!context || !data) {
     return <panel.Component model={panel} />;
   }
 
   return (
     <SceneContext.Provider value={context}>
-      <FanoutPanel panel={panel} panelDataIn={data!} fanoutMode={fanoutMode} />
+      <FanoutPanelByTimeWindow
+        panel={panel}
+        panelDataIn={data!}
+        fanoutByTime={fanoutByTime}
+        fanoutByData={fanoutMode}
+      />
     </SceneContext.Provider>
   );
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6495,6 +6495,11 @@
       "view-panel": {
         "disabled": "Disabled",
         "fanout-by-series": "By series",
+        "fanout-by-time-12h": "12 hours",
+        "fanout-by-time-1d": "1 day",
+        "fanout-by-time-1h": "1 hour",
+        "fanout-by-time-1w": "1 week",
+        "fanout-by-time-category": "Fan-out by time window",
         "fanout-category": "Fan-out by series or label",
         "fanout-labels": "Labels",
         "fanout-no-labels": "Data has no labels",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5786,6 +5786,9 @@
         "label": "Export dashboard menu"
       }
     },
+    "fanout-by-time": {
+      "time-shift-badge": "Time shifted -{{shift}}"
+    },
     "filters-overview": {
       "apply": "Apply",
       "apply-close": "Apply and close",
@@ -6495,14 +6498,15 @@
       "view-panel": {
         "disabled": "Disabled",
         "fanout-by-series": "By series",
-        "fanout-by-time-12h": "12 hours",
-        "fanout-by-time-1d": "1 day",
-        "fanout-by-time-1h": "1 hour",
-        "fanout-by-time-1w": "1 week",
-        "fanout-by-time-category": "Fan-out by time window",
-        "fanout-category": "Fan-out by series or label",
-        "fanout-labels": "Labels",
-        "fanout-no-labels": "Data has no labels",
+        "fanout-by-time-1d": "Day",
+        "fanout-by-time-1h": "Hour",
+        "fanout-by-time-1M": "Month",
+        "fanout-by-time-1w": "Week",
+        "fanout-category": "Fan-out",
+        "fanout-labels": "By label",
+        "fanout-no-labels": "No labels found",
+        "fanout-time-window": "By time window",
+        "fanout-window-count": "Window count",
         "pane-header": "View panel",
         "quick-toggles": "Quick toggles",
         "title": "View panel controls"


### PR DESCRIPTION
**What is this feature?**

Adds fan-out by time window to the view panel side pane, and unifies all fan-out options behind a single option value.

- The side pane's fan-out category now has three sections in one radio group: series, labels, and **Time window** (hour / day / week / month). The mode is stored in one `fanoutMode` state property (`$__by_series__$`, `$__by_label__<label>`, `$__by_time_<unit>`) and URL synced as `fanout`.
- When a time window mode is picked, a **Window count** slider (1–12, default 5) appears, URL synced as `fanoutWindows`.
- Fan-out by time window renders the panel once per window: the most recent window reuses the data the panel already fetched, and each older window is a panel clone with its own `$timeRange`, shifted one window further back, and its own query runner. Shifted panels get a `Time shifted -2d` badge in the header.

Refactor that came with it:

- New `FanoutPanel` root component owns the grid, the element selection context and the group creation, so by-data and by-time-window fan-outs share one layout and one entry point.
- Group creation is unified behind a discriminated `SplitGroup` union — `DataSplitGroup` (a slice of the data the panel already has) and `TimeWindowSplitGroup` (a panel clone that re-queries a shifted range) — with `createDataGroups` in `FanoutByData.tsx` and `createTimeWindowGroups` in `FanoutByTimeWindow.tsx`.
- `getShiftedTimeRange` takes an optional shift amount in ms, so the range can be shifted by a time window instead of half its own span.

**Why do we need this feature?**

Comparing the same panel across periods (this day vs the previous days, this week vs previous weeks) currently means duplicating panels or changing the dashboard time range back and forth. Fanning the panel out by time window makes that a one-click comparison from the view panel pane.

The unification is also a correctness/simplicity win: fan-out by data and fan-out by time window were two independent options that could be combined into states nobody wanted, and each had its own root component and grid.

**Who is this feature for?**

Dashboard users viewing a single panel who want to split it into multiple panels — by series, by label, or now by time window.

**Special notes for your reviewer:**

- All of this sits behind the existing view panel pane feature flag (`useFlagGrafanaViewPanelPane`), so it is off by default.
- `createTimeWindowGroups` is covered by unit tests in `FanoutByTimeWindow.test.tsx` (window count, cumulative shifting asserted against fixed ISO ranges, bare-unit and count-prefixed intervals, badge text, clone keeps title and queries). `FanoutPanel.test.tsx` moved to `FanoutByData.test.tsx` along with the code it tests.
- `windowCount` means windows *back*, so the grid renders `count + 1` panels (the current window plus the shifted ones).
- Time window values are bare units (`h`, `d`, `w`, `M`) which are not valid interval strings on their own, so `createTimeWindowGroups` prefixes a count before parsing; interval strings with a count (`12h`) still work.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
