### PR TITLE
AuthZ: Populate user permissions from the AuthZ API during frontend-service boot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -948,7 +948,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/services/ResponseQueue* @grafana/grafana-frontend-platform
 /public/app/core/services/StateManagerBase.ts @grafana/grafana-frontend-platform
 /public/app/core/services/theme* @grafana/grafana-frontend-platform
-/public/app/core/services/userPermissions* @grafana/grafana-frontend-navigation
+/public/app/core/services/userPermissions* @grafana/grafana-frontend-navigation @grafana/identity-access-team
 /public/app/core/specs/backend_srv.test.ts @grafana/grafana-frontend-platform
 /public/app/core/specs/factors.test.ts @grafana/dashboards-squad
 /public/app/core/specs/flatten.test.ts @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -948,6 +948,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/services/ResponseQueue* @grafana/grafana-frontend-platform
 /public/app/core/services/StateManagerBase.ts @grafana/grafana-frontend-platform
 /public/app/core/services/theme* @grafana/grafana-frontend-platform
+/public/app/core/services/userPermissions* @grafana/grafana-frontend-navigation
 /public/app/core/specs/backend_srv.test.ts @grafana/grafana-frontend-platform
 /public/app/core/specs/factors.test.ts @grafana/dashboards-squad
 /public/app/core/specs/flatten.test.ts @grafana/grafana-frontend-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -932,6 +932,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/selectors/ @grafana/grafana-frontend-platform
 /public/app/core/services/__mocks__/backend_srv.ts @grafana/grafana-frontend-platform
 /public/app/core/services/backend_srv.ts @grafana/grafana-frontend-platform
+/public/app/core/services/context_srv.test.ts @grafana/grafana-frontend-platform
 /public/app/core/services/context_srv.ts @grafana/grafana-frontend-platform
 /public/app/core/services/CorrelationsService.ts @grafana/datapro
 /public/app/core/services/echo/ @grafana/grafana-frontend-platform

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -36,6 +36,7 @@ declare module "@openfeature/core" {
     | "grafana.customDashboardTemplates"
     | "dashboardTemplatesAssistantButton"
     | "suggestedDashboardsAssistantButton"
+    | "authz.userPermissions"
     | "alerting.manualAssistantInvestigation"
     | "alerting.ruleQuality"
     | "datasources.azureMonitorBatchAPI"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -36,7 +36,6 @@ declare module "@openfeature/core" {
     | "grafana.customDashboardTemplates"
     | "dashboardTemplatesAssistantButton"
     | "suggestedDashboardsAssistantButton"
-    | "authz.userPermissions"
     | "alerting.manualAssistantInvestigation"
     | "alerting.ruleQuality"
     | "datasources.azureMonitorBatchAPI"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -98,7 +98,8 @@ declare module "@openfeature/core" {
     | "datasources.queryGateway"
     | "grafana.panelPluginTransformations"
     | "grafana.dashboardsAutoHeightPanels"
-    | "grafana.dashboardAutoGridDefault";
+    | "grafana.dashboardAutoGridDefault"
+    | "grafana.userPermissionsApi";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -99,7 +99,7 @@ declare module "@openfeature/core" {
     | "grafana.panelPluginTransformations"
     | "grafana.dashboardsAutoHeightPanels"
     | "grafana.dashboardAutoGridDefault"
-    | "grafana.userPermissionsApi";
+    | "grafana.multiTenantUserPermissions";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -27,6 +27,8 @@ export const FlagKeys = {
   AssistantFrontendToolsDashboardTemplates: "assistant.frontend.tools.dashboardTemplates",
   /** Enables the global fullscreen Workspace (Grafana Assistant workspace shell) in the top bar */
   AssistantFullscreenWorkspace: "assistant.fullscreenWorkspace",
+  /** Route user permission snapshots through the AuthZ service. */
+  AuthzUserPermissions: "authz.userPermissions",
   /** Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID. */
   AwsAssumeRolePerDatasourceExternalId: "awsAssumeRolePerDatasourceExternalId",
   /** Enable notebooks, a resource in the dashboard API group for mixing text cells, code cells, and visualization panels */
@@ -268,6 +270,17 @@ export const useFlagAssistantFrontendToolsDashboardTemplates = (options?: ReactF
  */
 export const useFlagAssistantFullscreenWorkspace = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("assistant.fullscreenWorkspace", false, options).value;
+};
+
+/**
+ * Route user permission snapshots through the AuthZ service.
+ *
+ * **Details:**
+ * - flag key: `authz.userPermissions`
+ * - default value: `false`
+ */
+export const useFlagAuthzUserPermissions = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("authz.userPermissions", false, options).value;
 };
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -27,8 +27,6 @@ export const FlagKeys = {
   AssistantFrontendToolsDashboardTemplates: "assistant.frontend.tools.dashboardTemplates",
   /** Enables the global fullscreen Workspace (Grafana Assistant workspace shell) in the top bar */
   AssistantFullscreenWorkspace: "assistant.fullscreenWorkspace",
-  /** Route user permission snapshots through the AuthZ service. */
-  AuthzUserPermissions: "authz.userPermissions",
   /** Generate a per-datasource external ID for Grafana Assume Role (jsonData.grafanaExternalId). When disabled, new datasources keep using the stack-level external ID. */
   AwsAssumeRolePerDatasourceExternalId: "awsAssumeRolePerDatasourceExternalId",
   /** Enable notebooks, a resource in the dashboard API group for mixing text cells, code cells, and visualization panels */
@@ -270,17 +268,6 @@ export const useFlagAssistantFrontendToolsDashboardTemplates = (options?: ReactF
  */
 export const useFlagAssistantFullscreenWorkspace = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("assistant.fullscreenWorkspace", false, options).value;
-};
-
-/**
- * Route user permission snapshots through the AuthZ service.
- *
- * **Details:**
- * - flag key: `authz.userPermissions`
- * - default value: `false`
- */
-export const useFlagAuthzUserPermissions = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("authz.userPermissions", false, options).value;
 };
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -117,6 +117,8 @@ export const FlagKeys = {
   GrafanaUnifiedDataSourcePicker: "grafana.unifiedDataSourcePicker",
   /** Use the find default scope endpoint to seed the initial scope selection when none is set. */
   GrafanaUseDefaultScopesEndpoint: "grafana.useDefaultScopesEndpoint",
+  /** Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions */
+  GrafanaUserPermissionsApi: "grafana.userPermissionsApi",
   /** Enables semantic (vector) dashboard search in the command palette */
   GrafanaVectorSearchCmdk: "grafana.vectorSearchCmdk",
   /** Enables the sidebar pane with new toggles and options in panel view mode */
@@ -763,6 +765,17 @@ export const useFlagGrafanaUnifiedDataSourcePicker = (options?: ReactFlagEvaluat
  */
 export const useFlagGrafanaUseDefaultScopesEndpoint = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.useDefaultScopesEndpoint", false, options).value;
+};
+
+/**
+ * Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions
+ *
+ * **Details:**
+ * - flag key: `grafana.userPermissionsApi`
+ * - default value: `false`
+ */
+export const useFlagGrafanaUserPermissionsApi = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.userPermissionsApi", false, options).value;
 };
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -91,6 +91,8 @@ export const FlagKeys = {
   GrafanaLogLevelInference: "grafana.logLevelInference",
   /** Builds the navigation tree client-side instead of reading it from /bootdata */
   GrafanaMultiTenantNavTree: "grafana.multiTenantNavTree",
+  /** Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions */
+  GrafanaMultiTenantUserPermissions: "grafana.multiTenantUserPermissions",
   /** Enables a new UI for query errors and notices */
   GrafanaNewPanelQueryErrorsUI: "grafana.newPanelQueryErrorsUI",
   /** Enables the new text panel */
@@ -117,8 +119,6 @@ export const FlagKeys = {
   GrafanaUnifiedDataSourcePicker: "grafana.unifiedDataSourcePicker",
   /** Use the find default scope endpoint to seed the initial scope selection when none is set. */
   GrafanaUseDefaultScopesEndpoint: "grafana.useDefaultScopesEndpoint",
-  /** Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions */
-  GrafanaUserPermissionsApi: "grafana.userPermissionsApi",
   /** Enables semantic (vector) dashboard search in the command palette */
   GrafanaVectorSearchCmdk: "grafana.vectorSearchCmdk",
   /** Enables the sidebar pane with new toggles and options in panel view mode */
@@ -625,6 +625,17 @@ export const useFlagGrafanaMultiTenantNavTree = (options?: ReactFlagEvaluationOp
 };
 
 /**
+ * Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions
+ *
+ * **Details:**
+ * - flag key: `grafana.multiTenantUserPermissions`
+ * - default value: `false`
+ */
+export const useFlagGrafanaMultiTenantUserPermissions = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.multiTenantUserPermissions", false, options).value;
+};
+
+/**
  * Enables a new UI for query errors and notices
  *
  * **Details:**
@@ -765,17 +776,6 @@ export const useFlagGrafanaUnifiedDataSourcePicker = (options?: ReactFlagEvaluat
  */
 export const useFlagGrafanaUseDefaultScopesEndpoint = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.useDefaultScopesEndpoint", false, options).value;
-};
-
-/**
- * Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions
- *
- * **Details:**
- * - flag key: `grafana.userPermissionsApi`
- * - default value: `false`
- */
-export const useFlagGrafanaUserPermissionsApi = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("grafana.userPermissionsApi", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1132,7 +1132,7 @@ var (
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 			Expression:   "false",
-			Generate:     Generate{Go: true, React: true},
+			Generate:     Generate{Go: true},
 		},
 		{
 			Name:         "zanzana",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1132,7 +1132,7 @@ var (
 			Owner:        identityAccessTeam,
 			HideFromDocs: true,
 			Expression:   "false",
-			Generate:     Generate{Go: true},
+			Generate:     Generate{Go: true, React: true},
 		},
 		{
 			Name:         "zanzana",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3312,6 +3312,15 @@ var (
 			Owner:       grafanaDashboardsSquad,
 			Expression:  "true",
 		},
+		{
+			Name:         "grafana.userPermissionsApi",
+			Description:  "Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3313,7 +3313,7 @@ var (
 			Expression:  "true",
 		},
 		{
-			Name:         "grafana.userPermissionsApi",
+			Name:         "grafana.multiTenantUserPermissions",
 			Description:  "Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions",
 			Stage:        FeatureStageExperimental,
 			Owner:        identityAccessTeam,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -385,4 +385,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-08-17,grafana.panelPluginTransformations,experimental,@grafana/dataviz-squad,false,false,true
 2026-08-18,grafana.dashboardsAutoHeightPanels,experimental,@grafana/dashboards-squad,false,false,true
 2026-08-13,grafana.dashboardAutoGridDefault,GA,@grafana/dashboards-squad,false,false,true
-2026-09-03,grafana.userPermissionsApi,experimental,@grafana/identity-access-team,false,false,true
+2026-09-03,grafana.multiTenantUserPermissions,experimental,@grafana/identity-access-team,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -385,3 +385,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-08-17,grafana.panelPluginTransformations,experimental,@grafana/dataviz-squad,false,false,true
 2026-08-18,grafana.dashboardsAutoHeightPanels,experimental,@grafana/dashboards-squad,false,false,true
 2026-08-13,grafana.dashboardAutoGridDefault,GA,@grafana/dashboards-squad,false,false,true
+2026-09-03,grafana.userPermissionsApi,experimental,@grafana/identity-access-team,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3486,6 +3486,21 @@
     },
     {
       "metadata": {
+        "name": "grafana.userPermissionsApi",
+        "resourceVersion": "1788437516189",
+        "creationTimestamp": "2026-09-03T12:11:56Z"
+      },
+      "spec": {
+        "description": "Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.vectorSearchCmdk",
         "resourceVersion": "1782378994121",
         "creationTimestamp": "2026-06-25T09:16:34Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3181,6 +3181,21 @@
     },
     {
       "metadata": {
+        "name": "grafana.multiTenantUserPermissions",
+        "resourceVersion": "1788454129908",
+        "creationTimestamp": "2026-09-03T16:48:49Z"
+      },
+      "spec": {
+        "description": "Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.newPanelQueryErrorsUI",
         "resourceVersion": "1781775898347",
         "creationTimestamp": "2026-06-18T09:44:58Z"
@@ -3479,21 +3494,6 @@
         "description": "Use the find default scope endpoint to seed the initial scope selection when none is set.",
         "stage": "experimental",
         "codeowner": "@grafana/grafana-operator-experience-squad",
-        "frontend": true,
-        "hideFromDocs": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
-        "name": "grafana.userPermissionsApi",
-        "resourceVersion": "1788437516189",
-        "creationTimestamp": "2026-09-03T12:11:56Z"
-      },
-      "spec": {
-        "description": "Read the current user's permissions from the IAM app platform API instead of /api/access-control/user/actions",
-        "stage": "experimental",
-        "codeowner": "@grafana/identity-access-team",
         "frontend": true,
         "hideFromDocs": true,
         "expression": "false"

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -47,6 +47,8 @@ import {
 } from '@grafana/runtime';
 import {
   getPanelPluginMetas,
+  getFeatureFlagClient,
+  FlagKeys,
   initDataSourceInstanceSettings,
   initOpenFeature,
   setExpressionDataSourceInstance,
@@ -96,6 +98,8 @@ import { JourneyRegistryImpl } from './core/services/journey/JourneyRegistryImpl
 import { JourneyTrackerImpl } from './core/services/journey/JourneyTrackerImpl';
 import { JOURNEY_REGISTRY } from './core/services/journey/journeyRegistry';
 import { KeybindingSrv } from './core/services/keybindingSrv';
+import { loadUserPermissions } from './core/services/userPermissions';
+import { isFrontendService } from './core/utils/isFrontendService';
 import { startMeasure, stopMeasure } from './core/utils/metrics';
 import { initAlerting } from './features/alerting/unified/initAlerting';
 import { getTimeSrv } from './features/dashboard/services/TimeSrv';
@@ -243,6 +247,14 @@ export class GrafanaApp {
       // Important that extension reducers are initialized before store
       addExtensionReducers();
       configureStore(undefined, { mergedPreferences: options?.mergedPreferences });
+
+      // The multi-tenant frontend service ships a reduced boot with no user
+      // permissions, so fetch them from the AuthZ user-permissions API and
+      // populate contextSrv before the nav and route guards read them.
+      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.AuthzUserPermissions, false)) {
+        contextSrv.user.permissions = await loadUserPermissions();
+      }
+
       initExtensions();
 
       initAlerting();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -89,6 +89,8 @@ import { postInitTasks, preInitTasks } from './core/lifecycle-hooks';
 import { setMonacoEnv } from './core/monacoEnv';
 import { handleRedirectTo } from './core/navigation/handleRedirectTo';
 import { interceptLinkClicks } from './core/navigation/patch/interceptLinkClicks';
+import { navTreeInitialized } from './core/reducers/navBarTree';
+import { navIndexInitialized } from './core/reducers/navModel';
 import { CorrelationsService } from './core/services/CorrelationsService';
 import { NewFrontendAssetsChecker } from './core/services/NewFrontendAssetsChecker';
 import { backendSrv } from './core/services/backend_srv';
@@ -143,6 +145,7 @@ import { createSwitchVariableAdapter } from './features/variables/switch/adapter
 import { createSystemVariableAdapter } from './features/variables/system/adapter';
 import { createTextBoxVariableAdapter } from './features/variables/textbox/adapter';
 import { configureStore } from './store/configureStore';
+import { dispatch } from './store/store';
 
 // import symlinked extensions
 const extensionsIndex = require.context('.', true, /extensions\/index.ts/);
@@ -249,10 +252,13 @@ export class GrafanaApp {
       configureStore(undefined, { mergedPreferences: options?.mergedPreferences });
 
       // The multi-tenant frontend service ships a reduced boot with no user
-      // permissions, so fetch them from the AuthZ user-permissions API and
-      // populate contextSrv before the nav and route guards read them.
+      // permissions. Fetch them from the AuthZ user-permissions API (via RTK
+      // Query, so the result is cached) and rebuild the nav tree — configureStore
+      // built it with an empty permission set, and its sections are permission-gated.
       if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.AuthzUserPermissions, false)) {
         contextSrv.user.permissions = await loadUserPermissions();
+        dispatch(navTreeInitialized());
+        dispatch(navIndexInitialized());
       }
 
       initExtensions();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -252,16 +252,9 @@ export class GrafanaApp {
       configureStore(undefined, { mergedPreferences: options?.mergedPreferences });
 
       // The multi-tenant frontend service ships a reduced boot with no user
-      // permissions. Fetch them from the AuthZ user-permissions API (via RTK
-      // Query, so the result is cached) and rebuild the nav tree — configureStore
-      // built it with an empty permission set, and its sections are permission-gated.
-      //
-      // Gated on the nav flag too: the client-built tree is what needs these
-      // permissions, and without it the rebuild below would only re-derive the
-      // bootdata tree. Both flag reads share the parked OpenFeature gap
-      // documented on isClientNavTreeEnabled (buildStaticNavTree.ts) — a failed
-      // or slow OFREP fetch resolves to the false default and skips this, which
-      // leaves boot's own permissions in place.
+      // permissions. Fetch them from the AuthZ user-permissions API and rebuild
+      // the nav tree — configureStore built it with an empty permission set, and
+      // its sections are permission-gated.
       if (
         isFrontendService() &&
         getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantNavTree, false) &&

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -255,10 +255,27 @@ export class GrafanaApp {
       // permissions. Fetch them from the AuthZ user-permissions API (via RTK
       // Query, so the result is cached) and rebuild the nav tree — configureStore
       // built it with an empty permission set, and its sections are permission-gated.
-      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.AuthzUserPermissions, false)) {
-        contextSrv.user.permissions = await loadUserPermissions();
-        dispatch(navTreeInitialized());
-        dispatch(navIndexInitialized());
+      //
+      // Gated on the nav flag too: the client-built tree is what needs these
+      // permissions, and without it the rebuild below would only re-derive the
+      // bootdata tree. Both flag reads share the parked OpenFeature gap
+      // documented on isClientNavTreeEnabled (buildStaticNavTree.ts) — a failed
+      // or slow OFREP fetch resolves to the false default and skips this, which
+      // leaves boot's own permissions in place.
+      if (
+        isFrontendService() &&
+        getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantNavTree, false) &&
+        getFeatureFlagClient().getBooleanValue(FlagKeys.AuthzUserPermissions, false)
+      ) {
+        // Only replace boot's permissions on a successful response: the legacy
+        // boot path populates a real map from /bootdata, and a failed request
+        // must not downgrade the session to "no permissions".
+        const permissions = await loadUserPermissions();
+        if (permissions) {
+          contextSrv.user.permissions = permissions;
+          dispatch(navTreeInitialized());
+          dispatch(navIndexInitialized());
+        }
       }
 
       initExtensions();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -255,11 +255,7 @@ export class GrafanaApp {
       // permissions. Fetch them from the AuthZ user-permissions API and rebuild
       // the nav tree — configureStore built it with an empty permission set, and
       // its sections are permission-gated.
-      if (
-        isFrontendService() &&
-        getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantNavTree, false) &&
-        getFeatureFlagClient().getBooleanValue(FlagKeys.AuthzUserPermissions, false)
-      ) {
+      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantNavTree, false)) {
         // Only replace boot's permissions on a successful response: the legacy
         // boot path populates a real map from /bootdata, and a failed request
         // must not downgrade the session to "no permissions".

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -100,7 +100,6 @@ import { JourneyRegistryImpl } from './core/services/journey/JourneyRegistryImpl
 import { JourneyTrackerImpl } from './core/services/journey/JourneyTrackerImpl';
 import { JOURNEY_REGISTRY } from './core/services/journey/journeyRegistry';
 import { KeybindingSrv } from './core/services/keybindingSrv';
-import { loadUserPermissions } from './core/services/userPermissions';
 import { isFrontendService } from './core/utils/isFrontendService';
 import { startMeasure, stopMeasure } from './core/utils/metrics';
 import { initAlerting } from './features/alerting/unified/initAlerting';
@@ -252,19 +251,13 @@ export class GrafanaApp {
       configureStore(undefined, { mergedPreferences: options?.mergedPreferences });
 
       // The multi-tenant frontend service ships a reduced boot with no user
-      // permissions. Fetch them from the AuthZ user-permissions API and rebuild
-      // the nav tree — configureStore built it with an empty permission set, and
-      // its sections are permission-gated.
-      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantNavTree, false)) {
-        // Only replace boot's permissions on a successful response: the legacy
-        // boot path populates a real map from /bootdata, and a failed request
-        // must not downgrade the session to "no permissions".
-        const permissions = await loadUserPermissions();
-        if (permissions) {
-          contextSrv.user.permissions = permissions;
-          dispatch(navTreeInitialized());
-          dispatch(navIndexInitialized());
-        }
+      // permissions, so fetch them before anything permission-gated renders. The
+      // nav tree needs rebuilding either way: configureStore built it with an
+      // empty permission set, and its sections are permission-gated.
+      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUserPermissionsApi, false)) {
+        await contextSrv.fetchUserPermissions();
+        dispatch(navTreeInitialized());
+        dispatch(navIndexInitialized());
       }
 
       initExtensions();

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -254,7 +254,10 @@ export class GrafanaApp {
       // permissions, so fetch them before anything permission-gated renders. The
       // nav tree needs rebuilding either way: configureStore built it with an
       // empty permission set, and its sections are permission-gated.
-      if (isFrontendService() && getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUserPermissionsApi, false)) {
+      if (
+        isFrontendService() &&
+        getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantUserPermissions, false)
+      ) {
         await contextSrv.fetchUserPermissions();
         dispatch(navTreeInitialized());
         dispatch(navIndexInitialized());

--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -40,6 +40,10 @@ const navTreeSlice = createSlice({
   name: 'navBarTree',
   initialState: () => translateNav(getInitialNavTree()),
   reducers: {
+    // Rebuilds the tree from the current permissions. The frontend service loads
+    // permissions asynchronously after the store is configured, so the tree built
+    // at store-init sees an empty permission set and must be rebuilt once they land.
+    navTreeInitialized: () => translateNav(getInitialNavTree()),
     setStarred: (state, action: PayloadAction<StarredNavItem & { isStarred: boolean }>) => {
       const starredItems = state.find((navItem) => navItem.id === 'starred');
       const { id, title, url, icon, sortWeight, isStarred } = action.payload;
@@ -141,6 +145,12 @@ const navTreeSlice = createSlice({
   },
 });
 
-export const { setStarred, setStarredItems, removePluginFromNavTree, updateDashboardName, setBookmark } =
-  navTreeSlice.actions;
+export const {
+  navTreeInitialized,
+  setStarred,
+  setStarredItems,
+  removePluginFromNavTree,
+  updateDashboardName,
+  setBookmark,
+} = navTreeSlice.actions;
 export const navTreeReducer = navTreeSlice.reducer;

--- a/public/app/core/reducers/navModel.ts
+++ b/public/app/core/reducers/navModel.ts
@@ -69,6 +69,10 @@ function buildWarningNav(text: string, subTitle?: string): NavModel {
 const initialState: NavIndex = {};
 
 export const updateNavIndex = createAction<NavModelItem>('navIndex/updateNavIndex');
+// Rebuilds the index from the current permissions. The frontend service loads
+// permissions asynchronously after the store is configured, so the index built
+// at store-init sees an empty permission set and must be rebuilt once they land.
+export const navIndexInitialized = createAction('navIndex/navIndexInitialized');
 // Since the configuration subtitle includes the organization name, we include this action to update the org name if it changes.
 export const updateConfigurationSubtitle = createAction<string>('navIndex/updateConfigurationSubtitle');
 
@@ -89,7 +93,9 @@ const getItemWithNewSubTitle = (item: NavModelItem, subTitle: string): NavModelI
 // the frozen state.
 // https://github.com/reduxjs/redux-toolkit/issues/242
 export const navIndexReducer = (state: NavIndex = initialState, action: AnyAction): NavIndex => {
-  if (updateNavIndex.match(action)) {
+  if (navIndexInitialized.match(action)) {
+    return buildInitialState();
+  } else if (updateNavIndex.match(action)) {
     const newPages: NavIndex = {};
     const payload = action.payload;
 

--- a/public/app/core/services/context_srv.test.ts
+++ b/public/app/core/services/context_srv.test.ts
@@ -35,7 +35,7 @@ describe('fetchUserPermissions', () => {
   });
 
   it('reads from the IAM app platform API when the flag is on', async () => {
-    setTestFlags({ 'grafana.userPermissionsApi': true });
+    setTestFlags({ 'grafana.multiTenantUserPermissions': true });
     mockLoadUserPermissions.mockResolvedValue({ 'datasources:read': true });
 
     await contextSrv.fetchUserPermissions();
@@ -47,7 +47,7 @@ describe('fetchUserPermissions', () => {
   // A failed refresh must not downgrade the session to "no permissions" — the
   // user keeps whatever they were granted at boot.
   it('keeps the existing permissions when the IAM request fails', async () => {
-    setTestFlags({ 'grafana.userPermissionsApi': true });
+    setTestFlags({ 'grafana.multiTenantUserPermissions': true });
     mockLoadUserPermissions.mockResolvedValue(null);
 
     await contextSrv.fetchUserPermissions();

--- a/public/app/core/services/context_srv.test.ts
+++ b/public/app/core/services/context_srv.test.ts
@@ -1,0 +1,57 @@
+import { getBackendSrv } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
+
+import { contextSrv } from './context_srv';
+import { loadUserPermissions } from './userPermissions';
+
+jest.mock('./userPermissions', () => ({ loadUserPermissions: jest.fn() }));
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+const mockLoadUserPermissions = jest.mocked(loadUserPermissions);
+const mockGet = jest.fn();
+
+describe('fetchUserPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getBackendSrv).mockReturnValue({ get: mockGet } as unknown as ReturnType<typeof getBackendSrv>);
+    contextSrv.user.permissions = { 'dashboards:read': true };
+  });
+
+  afterEach(() => {
+    setTestFlags();
+  });
+
+  it('reads from the legacy access-control endpoint by default', async () => {
+    mockGet.mockResolvedValue({ 'datasources:read': true });
+
+    await contextSrv.fetchUserPermissions();
+
+    expect(mockGet).toHaveBeenCalledWith('/api/access-control/user/actions', { reloadcache: true });
+    expect(mockLoadUserPermissions).not.toHaveBeenCalled();
+    expect(contextSrv.user.permissions).toEqual({ 'datasources:read': true });
+  });
+
+  it('reads from the IAM app platform API when the flag is on', async () => {
+    setTestFlags({ 'grafana.userPermissionsApi': true });
+    mockLoadUserPermissions.mockResolvedValue({ 'datasources:read': true });
+
+    await contextSrv.fetchUserPermissions();
+
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(contextSrv.user.permissions).toEqual({ 'datasources:read': true });
+  });
+
+  // A failed refresh must not downgrade the session to "no permissions" — the
+  // user keeps whatever they were granted at boot.
+  it('keeps the existing permissions when the IAM request fails', async () => {
+    setTestFlags({ 'grafana.userPermissionsApi': true });
+    mockLoadUserPermissions.mockResolvedValue(null);
+
+    await contextSrv.fetchUserPermissions();
+
+    expect(contextSrv.user.permissions).toEqual({ 'dashboards:read': true });
+  });
+});

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -10,11 +10,14 @@ import {
   userHasAnyPermission,
 } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { canRotateSessionToken, getSessionExpiry } from 'app/core/utils/auth';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
 
 import config from '../../core/config';
+
+import { loadUserPermissions } from './userPermissions';
 
 // When set to auto, the interval will be based on the query range
 // NOTE: this is defined here rather than TimeSrv so we avoid circular dependencies
@@ -103,6 +106,16 @@ export class ContextSrv {
   }
 
   async fetchUserPermissions() {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUserPermissionsApi, false)) {
+      // Null means the request failed; keep the permissions we already have rather
+      // than downgrading the session to "no permissions"
+      const permissions = await loadUserPermissions();
+      if (permissions) {
+        this.user.permissions = permissions;
+      }
+      return;
+    }
+
     try {
       this.user.permissions = await getBackendSrv().get('/api/access-control/user/actions', {
         reloadcache: true,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -106,7 +106,7 @@ export class ContextSrv {
   }
 
   async fetchUserPermissions() {
-    if (getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaUserPermissionsApi, false)) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaMultiTenantUserPermissions, false)) {
       // Null means the request failed; keep the permissions we already have rather
       // than downgrading the session to "no permissions"
       const permissions = await loadUserPermissions();

--- a/public/app/core/services/userPermissions.test.ts
+++ b/public/app/core/services/userPermissions.test.ts
@@ -1,0 +1,51 @@
+import { logError } from '@grafana/runtime';
+import { dispatch } from 'app/store/store';
+
+import { loadUserPermissions } from './userPermissions';
+
+jest.mock('app/store/store', () => ({ dispatch: jest.fn() }));
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  logError: jest.fn(),
+}));
+
+const mockDispatch = jest.mocked(dispatch);
+
+function mockResponse(result: Promise<unknown>) {
+  mockDispatch.mockReturnValue({ unwrap: () => result } as unknown as ReturnType<typeof dispatch>);
+}
+
+describe('loadUserPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reduces the flat action/scope list into an action-keyed map, deduping repeated actions', async () => {
+    mockResponse(
+      Promise.resolve({
+        permissions: [
+          { action: 'dashboards:read', scope: 'dashboards:uid:a' },
+          { action: 'dashboards:read', scope: 'dashboards:uid:b' },
+          { action: 'playlists:write', scope: '' },
+        ],
+      })
+    );
+
+    expect(await loadUserPermissions()).toEqual({
+      'dashboards:read': true,
+      'playlists:write': true,
+    });
+  });
+
+  it('returns an empty map for an empty response', async () => {
+    mockResponse(Promise.resolve({ permissions: [] }));
+    expect(await loadUserPermissions()).toEqual({});
+  });
+
+  it('returns an empty map and logs the error when the request fails', async () => {
+    mockResponse(Promise.reject(new Error('boom')));
+
+    expect(await loadUserPermissions()).toEqual({});
+    expect(logError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/core/services/userPermissions.test.ts
+++ b/public/app/core/services/userPermissions.test.ts
@@ -37,15 +37,17 @@ describe('loadUserPermissions', () => {
     });
   });
 
+  // A successful response with no permissions is the real answer, so it stays an
+  // empty map — only a failed request resolves to null.
   it('returns an empty map for an empty response', async () => {
     mockResponse(Promise.resolve({ permissions: [] }));
     expect(await loadUserPermissions()).toEqual({});
   });
 
-  it('returns an empty map and logs the error when the request fails', async () => {
+  it('returns null and logs the error when the request fails', async () => {
     mockResponse(Promise.reject(new Error('boom')));
 
-    expect(await loadUserPermissions()).toEqual({});
+    expect(await loadUserPermissions()).toBeNull();
     expect(logError).toHaveBeenCalledTimes(1);
   });
 });

--- a/public/app/core/services/userPermissions.test.ts
+++ b/public/app/core/services/userPermissions.test.ts
@@ -44,10 +44,19 @@ describe('loadUserPermissions', () => {
     expect(await loadUserPermissions()).toEqual({});
   });
 
-  it('returns null and logs the error when the request fails', async () => {
-    mockResponse(Promise.reject(new Error('boom')));
+  // unwrap() rejects with a serialised RTK Query error, not an Error instance,
+  // so the message has to be extracted from that shape rather than passed through.
+  it('returns null and logs the error message when the request fails', async () => {
+    mockResponse(Promise.reject({ status: 500, data: { message: 'authz exploded' } }));
 
     expect(await loadUserPermissions()).toBeNull();
-    expect(logError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(expect.objectContaining({ message: 'authz exploded' }));
+  });
+
+  it('falls back to a generic message when the error carries none', async () => {
+    mockResponse(Promise.reject({ status: 'FETCH_ERROR' }));
+
+    expect(await loadUserPermissions()).toBeNull();
+    expect(logError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Failed to load user permissions' }));
   });
 });

--- a/public/app/core/services/userPermissions.test.ts
+++ b/public/app/core/services/userPermissions.test.ts
@@ -1,23 +1,23 @@
-import { logError } from '@grafana/runtime';
-import { dispatch } from 'app/store/store';
+import { getBackendSrv, logError } from '@grafana/runtime';
 
 import { loadUserPermissions } from './userPermissions';
 
-jest.mock('app/store/store', () => ({ dispatch: jest.fn() }));
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
   logError: jest.fn(),
 }));
 
-const mockDispatch = jest.mocked(dispatch);
+const mockGet = jest.fn();
 
 function mockResponse(result: Promise<unknown>) {
-  mockDispatch.mockReturnValue({ unwrap: () => result } as unknown as ReturnType<typeof dispatch>);
+  mockGet.mockReturnValue(result);
 }
 
 describe('loadUserPermissions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getBackendSrv).mockReturnValue({ get: mockGet } as unknown as ReturnType<typeof getBackendSrv>);
   });
 
   it('reduces the flat action/scope list into an action-keyed map, deduping repeated actions', async () => {
@@ -35,6 +35,12 @@ describe('loadUserPermissions', () => {
       'dashboards:read': true,
       'playlists:write': true,
     });
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringMatching(/^\/apis\/iam\.grafana\.app\/v0alpha1\/namespaces\/.*\/users\/~\/permissions$/),
+      { skipCache: true },
+      undefined,
+      { showErrorAlert: false }
+    );
   });
 
   // A successful response with no permissions is the real answer, so it stays an
@@ -44,8 +50,8 @@ describe('loadUserPermissions', () => {
     expect(await loadUserPermissions()).toEqual({});
   });
 
-  // unwrap() rejects with a serialised RTK Query error, not an Error instance,
-  // so the message has to be extracted from that shape rather than passed through.
+  // backendSrv rejects with a FetchError carrying the message under data rather
+  // than an Error instance, so it has to be extracted from that shape.
   it('returns null and logs the error message when the request fails', async () => {
     mockResponse(Promise.reject({ status: 500, data: { message: 'authz exploded' } }));
 
@@ -54,7 +60,7 @@ describe('loadUserPermissions', () => {
   });
 
   it('falls back to a generic message when the error carries none', async () => {
-    mockResponse(Promise.reject({ status: 'FETCH_ERROR' }));
+    mockResponse(Promise.reject({ status: 500 }));
 
     expect(await loadUserPermissions()).toBeNull();
     expect(logError).toHaveBeenCalledWith(expect.objectContaining({ message: 'Failed to load user permissions' }));

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -1,5 +1,6 @@
 import { logError } from '@grafana/runtime';
 import { iamAPIv0alpha1, type UserPermissions } from 'app/api/clients/iam/v0alpha1';
+import { extractErrorMessage } from 'app/api/utils';
 import { dispatch } from 'app/store/store';
 import { type UserPermission } from 'app/types/accessControl';
 
@@ -27,7 +28,9 @@ export async function loadUserPermissions(): Promise<UserPermission | null> {
       return acc;
     }, {});
   } catch (error) {
-    logError(error instanceof Error ? error : new Error('Failed to load user permissions'));
+    // unwrap() rejects with a serialised RTK Query error rather than an Error,
+    // so pull the message out instead of testing for an Error instance.
+    logError(new Error(extractErrorMessage(error, 'Failed to load user permissions')));
     return null;
   }
 }

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -7,6 +7,9 @@ import { type UserPermission } from 'app/types/accessControl';
  * Loads the current user's effective permissions from the multi-tenant AuthZ
  * user-permissions API as an action-keyed lookup map. Isolated here so the
  * underlying API can be swapped without touching callers.
+ *
+ * Goes through the RTK Query client so the result is cached and shared with any
+ * later useGetCurrentUserPermissionsQuery consumers.
  */
 export async function loadUserPermissions(): Promise<UserPermission> {
   try {

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -8,14 +8,6 @@ import { type UserPermission } from 'app/types/accessControl';
  * Loads the current user's effective permissions from the multi-tenant AuthZ
  * user-permissions API as an action-keyed lookup map. Isolated here so the
  * underlying API can be swapped without touching callers.
- *
- * Goes through the RTK Query client so the result is cached and shared with any
- * later useGetCurrentUserPermissionsQuery consumers.
- *
- * Resolves to null when the request fails, rather than to an empty map: callers
- * must be able to keep whatever permissions boot already gave them instead of
- * replacing them with "no permissions". A successful response carrying no
- * permissions still resolves to an empty map, because that is the real answer.
  */
 export async function loadUserPermissions(): Promise<UserPermission | null> {
   try {
@@ -28,9 +20,10 @@ export async function loadUserPermissions(): Promise<UserPermission | null> {
       return acc;
     }, {});
   } catch (error) {
-    // unwrap() rejects with a serialised RTK Query error rather than an Error,
-    // so pull the message out instead of testing for an Error instance.
     logError(new Error(extractErrorMessage(error, 'Failed to load user permissions')));
+    // Null rather than an empty map, so callers keep whatever permissions boot
+    // already gave them instead of downgrading to "no permissions". A
+    // successful response carrying none still returns an empty map.
     return null;
   }
 }

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -1,0 +1,25 @@
+import { logError } from '@grafana/runtime';
+import { iamAPIv0alpha1, type UserPermissions } from 'app/api/clients/iam/v0alpha1';
+import { dispatch } from 'app/store/store';
+import { type UserPermission } from 'app/types/accessControl';
+
+/**
+ * Loads the current user's effective permissions from the multi-tenant AuthZ
+ * user-permissions API as an action-keyed lookup map. Isolated here so the
+ * underlying API can be swapped without touching callers.
+ */
+export async function loadUserPermissions(): Promise<UserPermission> {
+  try {
+    const { permissions }: UserPermissions = await dispatch(
+      iamAPIv0alpha1.endpoints.getCurrentUserPermissions.initiate(undefined, { subscribe: false })
+    ).unwrap();
+
+    return permissions.reduce<UserPermission>((acc, { action }) => {
+      acc[action] = true;
+      return acc;
+    }, {});
+  } catch (error) {
+    logError(error instanceof Error ? error : new Error('Failed to load user permissions'));
+    return {};
+  }
+}

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -10,8 +10,13 @@ import { type UserPermission } from 'app/types/accessControl';
  *
  * Goes through the RTK Query client so the result is cached and shared with any
  * later useGetCurrentUserPermissionsQuery consumers.
+ *
+ * Resolves to null when the request fails, rather than to an empty map: callers
+ * must be able to keep whatever permissions boot already gave them instead of
+ * replacing them with "no permissions". A successful response carrying no
+ * permissions still resolves to an empty map, because that is the real answer.
  */
-export async function loadUserPermissions(): Promise<UserPermission> {
+export async function loadUserPermissions(): Promise<UserPermission | null> {
   try {
     const { permissions }: UserPermissions = await dispatch(
       iamAPIv0alpha1.endpoints.getCurrentUserPermissions.initiate(undefined, { subscribe: false })
@@ -23,6 +28,6 @@ export async function loadUserPermissions(): Promise<UserPermission> {
     }, {});
   } catch (error) {
     logError(error instanceof Error ? error : new Error('Failed to load user permissions'));
-    return {};
+    return null;
   }
 }

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -12,7 +12,12 @@ import { type UserPermission } from 'app/types/accessControl';
 export async function loadUserPermissions(): Promise<UserPermission | null> {
   try {
     const { permissions }: UserPermissions = await dispatch(
-      iamAPIv0alpha1.endpoints.getCurrentUserPermissions.initiate(undefined, { subscribe: false })
+      // forceRefetch because callers use this to observe permissions they were
+      // just granted; subscribe: false alone would serve a cached map back
+      iamAPIv0alpha1.endpoints.getCurrentUserPermissions.initiate(undefined, {
+        subscribe: false,
+        forceRefetch: true,
+      })
     ).unwrap();
 
     return permissions.reduce<UserPermission>((acc, { action }) => {

--- a/public/app/core/services/userPermissions.ts
+++ b/public/app/core/services/userPermissions.ts
@@ -1,7 +1,6 @@
-import { logError } from '@grafana/runtime';
-import { iamAPIv0alpha1, type UserPermissions } from 'app/api/clients/iam/v0alpha1';
-import { extractErrorMessage } from 'app/api/utils';
-import { dispatch } from 'app/store/store';
+import { getBackendSrv, logError } from '@grafana/runtime';
+import { API_GROUP, API_VERSION, type UserPermissions } from 'app/api/clients/iam/v0alpha1';
+import { extractErrorMessage, getAPIBaseURL } from 'app/api/utils';
 import { type UserPermission } from 'app/types/accessControl';
 
 /**
@@ -11,14 +10,18 @@ import { type UserPermission } from 'app/types/accessControl';
  */
 export async function loadUserPermissions(): Promise<UserPermission | null> {
   try {
-    const { permissions }: UserPermissions = await dispatch(
-      // forceRefetch because callers use this to observe permissions they were
-      // just granted; subscribe: false alone would serve a cached map back
-      iamAPIv0alpha1.endpoints.getCurrentUserPermissions.initiate(undefined, {
-        subscribe: false,
-        forceRefetch: true,
-      })
-    ).unwrap();
+    const { permissions } = await getBackendSrv().get<UserPermissions>(
+      `${getAPIBaseURL(API_GROUP, API_VERSION)}/users/~/permissions`,
+      // Recompute rather than serving the cached AuthZ snapshot: callers use this
+      // to observe permissions they were just granted. Older servers without the
+      // parameter ignore it and answer from the cache as before
+      { skipCache: true },
+      undefined,
+      // Callers fall back to the permissions they already have, so a failure is
+      // not worth a toast on top of that — boot in particular has no context to
+      // show one against
+      { showErrorAlert: false }
+    );
 
     return permissions.reduce<UserPermission>((acc, { action }) => {
       acc[action] = true;


### PR DESCRIPTION
## What

- Adds `grafana.multiTenantUserPermissions`, a React-generated OpenFeature flag that switches
  the source of user permissions from `/api/access-control/user/actions` to the IAM app
  platform API (`iam.grafana.app/v0alpha1 .../users/~/permissions`).
- Branches on it inside `contextSrv.fetchUserPermissions()`, so the existing refresh path
  keeps working with no caller changes, and has frontend-service boot go through that same
  method rather than assigning permissions itself.
- Rebuilds the nav tree after the load, since the reduced boot builds it with an empty
  permission set and its sections are permission-gated.

## Why

The multi-tenant frontend service ships a reduced boot with an empty user, so
`contextSrv.hasPermission(...)` always returns `false`. Populating the map from the new API
makes every existing **synchronous** permission check work unchanged in that deployment — no
consumer signature changes, and plugins get it for free, since `@grafana/runtime`'s
`hasPermission()` reads the same object by reference via `setCurrentUser(contextSrv.user)`.

The branch lives in `fetchUserPermissions` rather than at the boot site because that method is
the app's only permission-refresh path, and its four mid-session callers (datasource, service
account and team creation, dashboard saves) all hit an endpoint the reduced boot does not
serve. Doing it there fixes them too.

The flag is separate from the backend's `authz.userPermissions`: the IAM
`users/~/permissions` subresource is registered unconditionally, so the frontend can adopt the
app platform API independently of the backend routing its own snapshots through AuthZ.

## Who is this feature for?

Anyone running Grafana as the multi-tenant frontend service — nothing changes with the flag off.

## Notes

- The fetch is isolated in `public/app/core/services/userPermissions.ts` so the underlying API
  can be swapped without touching callers. It goes through `backendSrv`, not RTK Query:
  everything RTKQ offers was being switched off (`subscribe: false`, since there is no
  component lifecycle to release the subscription; `forceRefetch: true`, since a cached entry
  defeats the point of a refresh), leaving an HTTP GET whose result is copied into `contextSrv`.
- It sends `skipCache`, the parameter added in #131960. A server without it ignores the extra
  query param and answers from the cache as before, so the two merge in any order.
- A failed request returns `null` and keeps whatever permissions the session already had,
  rather than downgrading it to "no permissions".