### PR TITLE
TimeRange: Evaluate relative endpoints from one timestamp

### DIFF
--- a/packages/grafana-data/src/datetime/parser.test.ts
+++ b/packages/grafana-data/src/datetime/parser.test.ts
@@ -2,6 +2,33 @@ import { systemDateFormats, type SystemDateFormatsState } from './formats';
 import { dateTimeParse } from './parser';
 
 describe('dateTimeParse', () => {
+  it('should evaluate relative dates from the supplied current time', () => {
+    const now = Date.parse('2024-07-05T12:00:00.000Z');
+    const date = dateTimeParse('now-6h', { timeZone: 'utc', now });
+
+    expect(date.toISOString()).toBe('2024-07-05T06:00:00.000Z');
+  });
+
+  it('should accept the Unix epoch as the current time', () => {
+    const date = dateTimeParse('now', { timeZone: 'utc', now: 0 });
+
+    expect(date.toISOString()).toBe('1970-01-01T00:00:00.000Z');
+  });
+
+  it('should round the supplied current time in the requested timezone', () => {
+    const now = Date.parse('2024-07-05T02:00:00.000Z');
+    const date = dateTimeParse('now/d', { timeZone: 'America/New_York', roundUp: true, now });
+
+    expect(date.toISOString()).toBe('2024-07-05T03:59:59.999Z');
+  });
+
+  it('should round the supplied current time to the requested fiscal quarter', () => {
+    const now = Date.parse('2024-07-05T12:00:00.000Z');
+    const date = dateTimeParse('now/fQ', { timeZone: 'utc', fiscalYearStartMonth: 7, roundUp: true, now });
+
+    expect(date.toISOString()).toBe('2024-07-31T23:59:59.999Z');
+  });
+
   it('should parse using the systems configured timezone', () => {
     const date = dateTimeParse('2020-03-02 15:00:22');
     expect(date.format()).toEqual('2020-03-02T15:00:22-05:00');

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -2,7 +2,7 @@
 import { lowerCase } from 'lodash';
 
 import { type DateTimeOptions, getTimeZone } from './common';
-import { parse, isValid } from './datemath';
+import { toDateTime, isValid } from './datemath';
 import { systemDateFormats } from './formats';
 import moment from './moment_implementation';
 import { type DateTimeInput, type DateTime, isDateTime, dateTime, toUtc, dateTimeForTimeZone } from './moment_wrapper';
@@ -21,6 +21,10 @@ export interface DateTimeOptionsWhenParsing extends DateTimeOptions {
    */
   roundUp?: boolean;
   fiscalYearStartMonth?: number;
+  /**
+   * Time to use for now in relative date expressions.
+   */
+  now?: DateTimeInput;
 }
 
 type DateTimeParser<T extends DateTimeOptions = DateTimeOptions> = (value: DateTimeInput, options?: T) => DateTime;
@@ -58,7 +62,12 @@ const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateT
       return dateTime();
     }
 
-    const parsed = parse(value, options?.roundUp, options?.timeZone, options?.fiscalYearStartMonth);
+    const parsed = toDateTime(value, {
+      roundUp: options?.roundUp,
+      timezone: options?.timeZone,
+      fiscalYearStartMonth: options?.fiscalYearStartMonth,
+      now: options?.now,
+    });
     return parsed || dateTime();
   }
 

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -43,6 +43,35 @@ describe('Range Utils', () => {
       expect(deserializedTimeRange.from.format()).toBe('1996-07-30T16:00:00Z');
     });
 
+    it.each([
+      { from: 'now-6h', to: 'now', duration: 21_600_000 },
+      { from: 'now-6h', to: 'now-1h', duration: 18_000_000 },
+      { from: 'now', to: 'now', duration: 0 },
+    ])('should preserve the duration from $from to $to while the clock advances', ({ from, to, duration }) => {
+      let now = Date.parse('2024-07-05T12:00:00.000Z');
+      const clock = jest.spyOn(Date, 'now').mockImplementation(() => now++);
+
+      try {
+        const timeRange = convertRawToRange({ from, to }, 'utc');
+        expect(timeRange.to.valueOf() - timeRange.from.valueOf()).toBe(duration);
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
+    it('should round both endpoints to the same day when the clock crosses midnight', () => {
+      let now = Date.parse('2024-07-05T23:59:59.998Z');
+      const clock = jest.spyOn(Date, 'now').mockImplementation(() => now++);
+
+      try {
+        const timeRange = convertRawToRange({ from: 'now/d', to: 'now/d' }, 'utc');
+        expect(timeRange.from.toISOString()).toBe('2024-07-05T00:00:00.000Z');
+        expect(timeRange.to.toISOString()).toBe('2024-07-05T23:59:59.999Z');
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
     it('should leave the raw part intact if it has calculations', () => {
       const timeRange = {
         from: 'now-6h',

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -498,8 +498,9 @@ export const convertRawToRange = (
   fiscalYearStartMonth?: number,
   format?: string
 ): TimeRange => {
-  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format });
-  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format });
+  const now = Date.now();
+  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format, now });
+  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format, now });
 
   return {
     from,


### PR DESCRIPTION
**What is this feature?**

`convertRawToRange` captures one timestamp for both endpoints. `dateTimeParse`
accepts that timestamp as `now` and passes it to `dateMath.toDateTime`.

**Why do we need this feature?**

Parsing each endpoint against the clock can make a range from `now-6h` to `now`
longer than six hours. If parsing crosses midnight, `now/d` endpoints can refer
to different calendar days.

**Who is this feature for?**

Users of relative time ranges in Grafana and callers of `@grafana/data`.

**Which issue(s) does this PR fix?**

Fixes #131634

**Special notes for your reviewer:**

The change preserves endpoint rounding, timezones, fiscal settings,
absolute date formats, and raw range values.

Eight regression cases cover an advancing clock, midnight, an explicit
reference timestamp, the Unix epoch, timezone rounding, and fiscal quarters.
