### PR TITLE
AuthZ: Populate resource permission subject kinds

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -432,12 +432,12 @@ func (a *api) setResourcePermissionsToK8s(c *contextmodel.ReqContext, namespace 
 	}
 	changes := make([]permissionChange, 0, len(permissions))
 	for _, perm := range permissions {
-		name, err := a.getPermissionName(ctx, perm)
+		kind, name, err := a.getPermissionSubject(ctx, c.GetOrgID(), perm)
 		if err != nil {
-			return fmt.Errorf("failed to get permission name: %w", err)
+			return fmt.Errorf("failed to get permission subject: %w", err)
 		}
 		changes = append(changes, permissionChange{
-			kind:       iamv0.ResourcePermissionSpecPermissionKind(a.getPermissionKind(perm)),
+			kind:       kind,
 			name:       name,
 			permission: perm.Permission,
 		})
@@ -471,29 +471,31 @@ func (a *api) setResourcePermissionsToK8s(c *contextmodel.ReqContext, namespace 
 		k8sPermissions := slices.Clone(existingResourcePerm.Spec.Permissions)
 		changed := false
 		for _, change := range changes {
-			idx := slices.IndexFunc(k8sPermissions, func(existing iamv0.ResourcePermissionspecPermission) bool {
-				return existing.Kind == change.kind && existing.Name == change.name
-			})
-			if change.permission == "" {
-				if idx >= 0 {
-					k8sPermissions = slices.Delete(k8sPermissions, idx, idx+1)
-					changed = true
+			nextPermissions := make([]iamv0.ResourcePermissionspecPermission, 0, len(k8sPermissions)+1)
+			inserted := false
+			for _, existing := range k8sPermissions {
+				if !permissionSubjectMatches(existing, change.kind, change.name) {
+					nextPermissions = append(nextPermissions, existing)
+					continue
 				}
-				continue
-			}
-
-			updatedPermission := iamv0.ResourcePermissionspecPermission{
-				Kind: change.kind,
-				Name: change.name,
-				Verb: cases.Lower(language.Und).String(change.permission),
-			}
-			if idx >= 0 {
-				if k8sPermissions[idx] != updatedPermission {
-					k8sPermissions[idx] = updatedPermission
-					changed = true
+				if change.permission != "" && !inserted {
+					nextPermissions = append(nextPermissions, iamv0.ResourcePermissionspecPermission{
+						Kind: change.kind,
+						Name: change.name,
+						Verb: cases.Lower(language.Und).String(change.permission),
+					})
+					inserted = true
 				}
-			} else {
-				k8sPermissions = append(k8sPermissions, updatedPermission)
+			}
+			if change.permission != "" && !inserted {
+				nextPermissions = append(nextPermissions, iamv0.ResourcePermissionspecPermission{
+					Kind: change.kind,
+					Name: change.name,
+					Verb: cases.Lower(language.Und).String(change.permission),
+				})
+			}
+			if !slices.Equal(k8sPermissions, nextPermissions) {
+				k8sPermissions = nextPermissions
 				changed = true
 			}
 		}
@@ -544,12 +546,12 @@ func (a *api) setResourcePermissionsToK8s(c *contextmodel.ReqContext, namespace 
 
 func (a *api) setUserPermissionToK8s(c *contextmodel.ReqContext, namespace string, resourceID string, userID int64, permission string) error {
 	ctx := c.Req.Context()
-	userDetails, err := a.service.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: userID})
+	kind, name, err := a.getPermissionSubject(ctx, c.GetOrgID(), accesscontrol.SetResourcePermissionCommand{UserID: userID})
 	if err != nil {
-		return fmt.Errorf("failed to get user details: %w", err)
+		return fmt.Errorf("failed to get user permission subject: %w", err)
 	}
 
-	return a.setSinglePermissionToK8s(c, namespace, resourceID, string(iamv0.ResourcePermissionSpecPermissionKindUser), userDetails.UID, permission)
+	return a.setSinglePermissionToK8s(c, namespace, resourceID, string(kind), name, permission)
 }
 
 func (a *api) setTeamPermissionToK8s(c *contextmodel.ReqContext, namespace string, resourceID string, teamID int64, permission string) error {
@@ -586,7 +588,7 @@ func (a *api) setSinglePermissionToK8s(c *contextmodel.ReqContext, namespace str
 
 	newPermissions := make([]iamv0.ResourcePermissionspecPermission, 0)
 	for _, perm := range existingResourcePerm.Spec.Permissions {
-		if string(perm.Kind) == kind && perm.Name == name {
+		if permissionSubjectMatches(perm, iamv0.ResourcePermissionSpecPermissionKind(kind), name) {
 			continue
 		}
 		newPermissions = append(newPermissions, perm)
@@ -690,27 +692,42 @@ func (a *api) createOrUpdateResourcePermission(ctx context.Context, resourcePerm
 	return nil
 }
 
-func (a *api) getPermissionName(ctx context.Context, perm accesscontrol.SetResourcePermissionCommand) (string, error) {
+func (a *api) getPermissionSubject(ctx context.Context, orgID int64, perm accesscontrol.SetResourcePermissionCommand) (iamv0.ResourcePermissionSpecPermissionKind, string, error) {
+	kind := iamv0.ResourcePermissionSpecPermissionKind(a.getPermissionKind(perm))
 	if perm.UserID != 0 {
-		userDetails, err := a.service.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: perm.UserID})
+		userDetails, err := a.service.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
+			OrgID:  orgID,
+			UserID: perm.UserID,
+		})
 		if err != nil {
-			return "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, err)
+			return "", "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, err)
 		}
-		return userDetails.UID, nil
+		if userDetails.IsServiceAccount {
+			kind = iamv0.ResourcePermissionSpecPermissionKindServiceAccount
+		}
+		return kind, userDetails.UserUID, nil
 	}
 	if perm.TeamID != 0 {
 		teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{
-			ID: perm.TeamID,
+			OrgID: orgID,
+			ID:    perm.TeamID,
 		})
 		if err != nil {
-			return "", fmt.Errorf("failed to get team details for team ID %d: %w", perm.TeamID, err)
+			return "", "", fmt.Errorf("failed to get team details for team ID %d: %w", perm.TeamID, err)
 		}
-		return teamDetails.UID, nil
+		return kind, teamDetails.UID, nil
 	}
 	if perm.BuiltinRole != "" {
-		return perm.BuiltinRole, nil
+		return kind, perm.BuiltinRole, nil
 	}
-	return "", fmt.Errorf("no valid permission subject found")
+	return "", "", fmt.Errorf("no valid permission subject found")
+}
+
+func permissionSubjectMatches(existing iamv0.ResourcePermissionspecPermission, kind iamv0.ResourcePermissionSpecPermissionKind, name string) bool {
+	if existing.Name != name {
+		return false
+	}
+	return existing.Kind == kind || (kind == iamv0.ResourcePermissionSpecPermissionKindServiceAccount && existing.Kind == iamv0.ResourcePermissionSpecPermissionKindUser)
 }
 
 // Teams-specific redirect functions reading and writing Team.Spec.Members.

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -554,7 +554,7 @@ func (a *api) setUserPermissionToK8s(c *contextmodel.ReqContext, namespace strin
 
 func (a *api) setTeamPermissionToK8s(c *contextmodel.ReqContext, namespace string, resourceID string, teamID int64, permission string) error {
 	ctx := c.Req.Context()
-	teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{ID: teamID})
+	teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{OrgID: c.GetOrgID(), ID: teamID})
 	if err != nil {
 		return fmt.Errorf("failed to get team details: %w", err)
 	}
@@ -693,17 +693,18 @@ func (a *api) createOrUpdateResourcePermission(ctx context.Context, resourcePerm
 func (a *api) getPermissionSubject(ctx context.Context, orgID int64, perm accesscontrol.SetResourcePermissionCommand) (iamv0.ResourcePermissionSpecPermissionKind, string, error) {
 	kind := iamv0.ResourcePermissionSpecPermissionKind(a.getPermissionKind(perm))
 	if perm.UserID != 0 {
-		userDetails, err := a.service.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
-			OrgID:  orgID,
-			UserID: perm.UserID,
-		})
+		users, err := a.service.userService.ListByIdOrUID(ctx, nil, []int64{perm.UserID})
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, err)
 		}
+		if len(users) != 1 {
+			return "", "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, user.ErrUserNotFound)
+		}
+		userDetails := users[0]
 		if userDetails.IsServiceAccount {
 			kind = iamv0.ResourcePermissionSpecPermissionKindServiceAccount
 		}
-		return kind, userDetails.UserUID, nil
+		return kind, userDetails.UID, nil
 	}
 	if perm.TeamID != 0 {
 		teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -693,18 +693,18 @@ func (a *api) createOrUpdateResourcePermission(ctx context.Context, resourcePerm
 func (a *api) getPermissionSubject(ctx context.Context, orgID int64, perm accesscontrol.SetResourcePermissionCommand) (iamv0.ResourcePermissionSpecPermissionKind, string, error) {
 	kind := iamv0.ResourcePermissionSpecPermissionKind(a.getPermissionKind(perm))
 	if perm.UserID != 0 {
-		users, err := a.service.userService.ListByIdOrUID(ctx, nil, []int64{perm.UserID})
+		userDetails, err := a.service.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
+			OrgID:          orgID,
+			UserID:         perm.UserID,
+			SkipTeamLookup: true,
+		})
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, err)
 		}
-		if len(users) != 1 {
-			return "", "", fmt.Errorf("failed to get user details for user ID %d: %w", perm.UserID, user.ErrUserNotFound)
-		}
-		userDetails := users[0]
 		if userDetails.IsServiceAccount {
 			kind = iamv0.ResourcePermissionSpecPermissionKindServiceAccount
 		}
-		return kind, userDetails.UID, nil
+		return kind, userDetails.UserUID, nil
 	}
 	if perm.TeamID != 0 {
 		teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -471,31 +471,29 @@ func (a *api) setResourcePermissionsToK8s(c *contextmodel.ReqContext, namespace 
 		k8sPermissions := slices.Clone(existingResourcePerm.Spec.Permissions)
 		changed := false
 		for _, change := range changes {
-			nextPermissions := make([]iamv0.ResourcePermissionspecPermission, 0, len(k8sPermissions)+1)
-			inserted := false
-			for _, existing := range k8sPermissions {
-				if !permissionSubjectMatches(existing, change.kind, change.name) {
-					nextPermissions = append(nextPermissions, existing)
-					continue
+			idx := slices.IndexFunc(k8sPermissions, func(existing iamv0.ResourcePermissionspecPermission) bool {
+				return existing.Kind == change.kind && existing.Name == change.name
+			})
+			if change.permission == "" {
+				if idx >= 0 {
+					k8sPermissions = slices.Delete(k8sPermissions, idx, idx+1)
+					changed = true
 				}
-				if change.permission != "" && !inserted {
-					nextPermissions = append(nextPermissions, iamv0.ResourcePermissionspecPermission{
-						Kind: change.kind,
-						Name: change.name,
-						Verb: cases.Lower(language.Und).String(change.permission),
-					})
-					inserted = true
+				continue
+			}
+
+			updatedPermission := iamv0.ResourcePermissionspecPermission{
+				Kind: change.kind,
+				Name: change.name,
+				Verb: cases.Lower(language.Und).String(change.permission),
+			}
+			if idx >= 0 {
+				if k8sPermissions[idx] != updatedPermission {
+					k8sPermissions[idx] = updatedPermission
+					changed = true
 				}
-			}
-			if change.permission != "" && !inserted {
-				nextPermissions = append(nextPermissions, iamv0.ResourcePermissionspecPermission{
-					Kind: change.kind,
-					Name: change.name,
-					Verb: cases.Lower(language.Und).String(change.permission),
-				})
-			}
-			if !slices.Equal(k8sPermissions, nextPermissions) {
-				k8sPermissions = nextPermissions
+			} else {
+				k8sPermissions = append(k8sPermissions, updatedPermission)
 				changed = true
 			}
 		}
@@ -588,7 +586,7 @@ func (a *api) setSinglePermissionToK8s(c *contextmodel.ReqContext, namespace str
 
 	newPermissions := make([]iamv0.ResourcePermissionspecPermission, 0)
 	for _, perm := range existingResourcePerm.Spec.Permissions {
-		if permissionSubjectMatches(perm, iamv0.ResourcePermissionSpecPermissionKind(kind), name) {
+		if string(perm.Kind) == kind && perm.Name == name {
 			continue
 		}
 		newPermissions = append(newPermissions, perm)
@@ -721,13 +719,6 @@ func (a *api) getPermissionSubject(ctx context.Context, orgID int64, perm access
 		return kind, perm.BuiltinRole, nil
 	}
 	return "", "", fmt.Errorf("no valid permission subject found")
-}
-
-func permissionSubjectMatches(existing iamv0.ResourcePermissionspecPermission, kind iamv0.ResourcePermissionSpecPermissionKind, name string) bool {
-	if existing.Name != name {
-		return false
-	}
-	return existing.Kind == kind || (kind == iamv0.ResourcePermissionSpecPermissionKindServiceAccount && existing.Kind == iamv0.ResourcePermissionSpecPermissionKindUser)
 }
 
 // Teams-specific redirect functions reading and writing Team.Spec.Members.

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -179,6 +179,7 @@ func TestSetResourcePermissionsToK8sLegacyIncrementalSemantics(t *testing.T) {
 		commands       []accesscontrol.SetResourcePermissionCommand
 		expected       []iamv0.ResourcePermissionspecPermission
 		expectedMethod string
+		userSvc        user.Service
 	}{
 		{
 			name:     "preserves unmentioned permissions on upsert",
@@ -231,6 +232,30 @@ func TestSetResourcePermissionsToK8sLegacyIncrementalSemantics(t *testing.T) {
 			commands:       []accesscontrol.SetResourcePermissionCommand{{BuiltinRole: "Viewer", Permission: "View"}},
 			expected:       []iamv0.ResourcePermissionspecPermission{viewer},
 			expectedMethod: http.MethodPost,
+		},
+		{
+			name:           "migrates legacy user-kind service account on upsert",
+			exists:         true,
+			initial:        []iamv0.ResourcePermissionspecPermission{{Kind: iamv0.ResourcePermissionSpecPermissionKindUser, Name: "sa-uid", Verb: "view"}},
+			commands:       []accesscontrol.SetResourcePermissionCommand{{UserID: 42, Permission: "Edit"}},
+			expected:       []iamv0.ResourcePermissionspecPermission{{Kind: iamv0.ResourcePermissionSpecPermissionKindServiceAccount, Name: "sa-uid", Verb: "edit"}},
+			expectedMethod: http.MethodPut,
+			userSvc: &usertest.FakeUserService{
+				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
+			},
+		},
+		{
+			name:   "deletes every service account kind representation",
+			exists: true,
+			initial: []iamv0.ResourcePermissionspecPermission{
+				{Kind: iamv0.ResourcePermissionSpecPermissionKindUser, Name: "sa-uid", Verb: "view"},
+				{Kind: iamv0.ResourcePermissionSpecPermissionKindServiceAccount, Name: "sa-uid", Verb: "edit"},
+			},
+			commands:       []accesscontrol.SetResourcePermissionCommand{{UserID: 42, Permission: ""}},
+			expectedMethod: http.MethodDelete,
+			userSvc: &usertest.FakeUserService{
+				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
+			},
 		},
 	}
 
@@ -294,10 +319,13 @@ func TestSetResourcePermissionsToK8sLegacyIncrementalSemantics(t *testing.T) {
 
 			a := &api{
 				restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
-				service: &Service{options: Options{
-					Resource: "dashboards",
-					APIGroup: dashboardv1.APIGroup,
-				}},
+				service: &Service{
+					userService: tt.userSvc,
+					options: Options{
+						Resource: "dashboards",
+						APIGroup: dashboardv1.APIGroup,
+					},
+				},
 			}
 
 			err := a.setResourcePermissionsToK8s(makeReqCtx(), "org-1", "1", tt.commands)
@@ -314,6 +342,91 @@ func TestSetResourcePermissionsToK8sLegacyIncrementalSemantics(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
+	var created iamv0.ResourcePermission
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			w.WriteHeader(http.StatusNotFound)
+			require.NoError(t, json.NewEncoder(w).Encode(&metav1.Status{
+				Status: metav1.StatusFailure,
+				Code:   http.StatusNotFound,
+				Reason: metav1.StatusReasonNotFound,
+			}))
+		case http.MethodPost:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&created))
+			require.NoError(t, json.NewEncoder(w).Encode(&created))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	a := &api{
+		restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
+		service: &Service{
+			userService: &usertest.FakeUserService{
+				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
+			},
+			options: Options{Resource: "dashboards", APIGroup: dashboardv1.APIGroup},
+		},
+	}
+
+	err := a.setUserPermissionToK8s(makeReqCtx(), "org-1", "1", 42, "Edit")
+	require.NoError(t, err)
+	require.Len(t, created.Spec.Permissions, 1)
+	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, created.Spec.Permissions[0].Kind)
+}
+
+func TestSetUserPermissionToK8sMigratesLegacyUserKind(t *testing.T) {
+	existing := iamv0.ResourcePermission{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: iamv0.ResourcePermissionInfo.GroupVersion().String(),
+			Kind:       iamv0.ResourcePermissionInfo.TypeMeta().Kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "dashboard.grafana.app-dashboards-1", Namespace: "org-1", ResourceVersion: "1"},
+		Spec: iamv0.ResourcePermissionSpec{
+			Resource: iamv0.ResourcePermissionspecResource{ApiGroup: dashboardv1.APIGroup, Resource: "dashboards", Name: "1"},
+			Permissions: []iamv0.ResourcePermissionspecPermission{{
+				Kind: iamv0.ResourcePermissionSpecPermissionKindUser,
+				Name: "sa-uid",
+				Verb: "view",
+			}},
+		},
+	}
+	var updated iamv0.ResourcePermission
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			require.NoError(t, json.NewEncoder(w).Encode(&existing))
+		case http.MethodPut:
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&updated))
+			require.NoError(t, json.NewEncoder(w).Encode(&updated))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	a := &api{
+		restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
+		service: &Service{
+			userService: &usertest.FakeUserService{
+				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
+			},
+			options: Options{Resource: "dashboards", APIGroup: dashboardv1.APIGroup},
+		},
+	}
+
+	err := a.setUserPermissionToK8s(makeReqCtx(), "org-1", "1", 42, "Edit")
+	require.NoError(t, err)
+	require.Len(t, updated.Spec.Permissions, 1)
+	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, updated.Spec.Permissions[0].Kind)
+	assert.Equal(t, "edit", updated.Spec.Permissions[0].Verb)
 }
 
 func TestSetResourcePermissionsToK8sRetriesConflicts(t *testing.T) {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -233,30 +233,6 @@ func TestSetResourcePermissionsToK8sLegacyIncrementalSemantics(t *testing.T) {
 			expected:       []iamv0.ResourcePermissionspecPermission{viewer},
 			expectedMethod: http.MethodPost,
 		},
-		{
-			name:           "migrates legacy user-kind service account on upsert",
-			exists:         true,
-			initial:        []iamv0.ResourcePermissionspecPermission{{Kind: iamv0.ResourcePermissionSpecPermissionKindUser, Name: "sa-uid", Verb: "view"}},
-			commands:       []accesscontrol.SetResourcePermissionCommand{{UserID: 42, Permission: "Edit"}},
-			expected:       []iamv0.ResourcePermissionspecPermission{{Kind: iamv0.ResourcePermissionSpecPermissionKindServiceAccount, Name: "sa-uid", Verb: "edit"}},
-			expectedMethod: http.MethodPut,
-			userSvc: &usertest.FakeUserService{
-				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
-			},
-		},
-		{
-			name:   "deletes every service account kind representation",
-			exists: true,
-			initial: []iamv0.ResourcePermissionspecPermission{
-				{Kind: iamv0.ResourcePermissionSpecPermissionKindUser, Name: "sa-uid", Verb: "view"},
-				{Kind: iamv0.ResourcePermissionSpecPermissionKindServiceAccount, Name: "sa-uid", Verb: "edit"},
-			},
-			commands:       []accesscontrol.SetResourcePermissionCommand{{UserID: 42, Permission: ""}},
-			expectedMethod: http.MethodDelete,
-			userSvc: &usertest.FakeUserService{
-				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -379,54 +355,6 @@ func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, created.Spec.Permissions, 1)
 	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, created.Spec.Permissions[0].Kind)
-}
-
-func TestSetUserPermissionToK8sMigratesLegacyUserKind(t *testing.T) {
-	existing := iamv0.ResourcePermission{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: iamv0.ResourcePermissionInfo.GroupVersion().String(),
-			Kind:       iamv0.ResourcePermissionInfo.TypeMeta().Kind,
-		},
-		ObjectMeta: metav1.ObjectMeta{Name: "dashboard.grafana.app-dashboards-1", Namespace: "org-1", ResourceVersion: "1"},
-		Spec: iamv0.ResourcePermissionSpec{
-			Resource: iamv0.ResourcePermissionspecResource{ApiGroup: dashboardv1.APIGroup, Resource: "dashboards", Name: "1"},
-			Permissions: []iamv0.ResourcePermissionspecPermission{{
-				Kind: iamv0.ResourcePermissionSpecPermissionKindUser,
-				Name: "sa-uid",
-				Verb: "view",
-			}},
-		},
-	}
-	var updated iamv0.ResourcePermission
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch r.Method {
-		case http.MethodGet:
-			require.NoError(t, json.NewEncoder(w).Encode(&existing))
-		case http.MethodPut:
-			require.NoError(t, json.NewDecoder(r.Body).Decode(&updated))
-			require.NoError(t, json.NewEncoder(w).Encode(&updated))
-		default:
-			t.Fatalf("unexpected method %s", r.Method)
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	a := &api{
-		restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
-		service: &Service{
-			userService: &usertest.FakeUserService{
-				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
-			},
-			options: Options{Resource: "dashboards", APIGroup: dashboardv1.APIGroup},
-		},
-	}
-
-	err := a.setUserPermissionToK8s(makeReqCtx(), "org-1", "1", 42, "Edit")
-	require.NoError(t, err)
-	require.Len(t, updated.Spec.Permissions, 1)
-	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, updated.Spec.Permissions[0].Kind)
-	assert.Equal(t, "edit", updated.Spec.Permissions[0].Verb)
 }
 
 func TestSetResourcePermissionsToK8sRetriesConflicts(t *testing.T) {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -345,7 +345,7 @@ func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
 		restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
 		service: &Service{
 			userService: &usertest.FakeUserService{
-				ExpectedSignedInUser: &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true},
+				ExpectedListUsersByIdOrUid: []*user.User{{ID: 42, UID: "sa-uid", IsServiceAccount: true}},
 			},
 			options: Options{Resource: "dashboards", APIGroup: dashboardv1.APIGroup},
 		},
@@ -353,6 +353,7 @@ func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
 
 	err := a.setUserPermissionToK8s(makeReqCtx(), "org-1", "1", 42, "Edit")
 	require.NoError(t, err)
+	require.Equal(t, []usertest.ListUsersByIdOrUidCall{{Ids: []int64{42}}}, a.service.userService.(*usertest.FakeUserService).ListUsersByIdOrUidCalls)
 	require.Len(t, created.Spec.Permissions, 1)
 	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, created.Spec.Permissions[0].Kind)
 }

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -345,7 +345,10 @@ func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
 		restConfigProvider: &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: ts.URL}},
 		service: &Service{
 			userService: &usertest.FakeUserService{
-				ExpectedListUsersByIdOrUid: []*user.User{{ID: 42, UID: "sa-uid", IsServiceAccount: true}},
+				GetSignedInUserFn: func(_ context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
+					require.Equal(t, &user.GetSignedInUserQuery{OrgID: 1, UserID: 42, SkipTeamLookup: true}, query)
+					return &user.SignedInUser{UserID: 42, UserUID: "sa-uid", IsServiceAccount: true}, nil
+				},
 			},
 			options: Options{Resource: "dashboards", APIGroup: dashboardv1.APIGroup},
 		},
@@ -353,7 +356,6 @@ func TestSetUserPermissionToK8sUsesServiceAccountKind(t *testing.T) {
 
 	err := a.setUserPermissionToK8s(makeReqCtx(), "org-1", "1", 42, "Edit")
 	require.NoError(t, err)
-	require.Equal(t, []usertest.ListUsersByIdOrUidCall{{Ids: []int64{42}}}, a.service.userService.(*usertest.FakeUserService).ListUsersByIdOrUidCalls)
 	require.Len(t, created.Spec.Permissions, 1)
 	assert.Equal(t, iamv0.ResourcePermissionSpecPermissionKindServiceAccount, created.Spec.Permissions[0].Kind)
 }

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/team"
 	"github.com/grafana/grafana/pkg/services/team/teamimpl"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -796,6 +797,36 @@ func TestIntegrationApi_bulkPermissionsLegacyAndK8sRedirectMatch(t *testing.T) {
 				{UserID: parityFirstUserID, Permission: "Edit"},
 			},
 		},
+		{
+			name: "basic role subjects match",
+			initial: []accesscontrol.SetResourcePermissionCommand{
+				{BuiltinRole: "Viewer", Permission: "View"},
+				{UserID: parityFirstUserID, Permission: "View"},
+			},
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{BuiltinRole: "Viewer", Permission: "Edit"},
+			},
+		},
+		{
+			name: "team subjects match",
+			initial: []accesscontrol.SetResourcePermissionCommand{
+				{TeamID: parityTeamID, Permission: "View"},
+				{UserID: parityFirstUserID, Permission: "View"},
+			},
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{TeamID: parityTeamID, Permission: "Edit"},
+			},
+		},
+		{
+			name: "service account subjects match",
+			initial: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: parityServiceAccountID, Permission: "View"},
+				{UserID: parityFirstUserID, Permission: "View"},
+			},
+			commands: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: parityServiceAccountID, Permission: "Edit"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1079,16 +1110,21 @@ func setPermission(t *testing.T, server *web.Mux, resource, resourceID, permissi
 }
 
 type observedResourcePermission struct {
-	UserID      int64
-	Permission  string
-	IsManaged   bool
-	IsInherited bool
+	UserID           int64
+	TeamID           int64
+	BuiltInRole      string
+	Permission       string
+	IsManaged        bool
+	IsInherited      bool
+	IsServiceAccount bool
 }
 
 const (
-	parityFirstUserID  int64 = -1
-	paritySecondUserID int64 = -2
-	parityThirdUserID  int64 = -3
+	parityFirstUserID      int64 = -1
+	paritySecondUserID     int64 = -2
+	parityThirdUserID      int64 = -3
+	parityServiceAccountID int64 = -4
+	parityTeamID           int64 = -1
 )
 
 func runBulkPermissionHTTPScenario(t *testing.T, redirect bool, initial, commands []accesscontrol.SetResourcePermissionCommand) []observedResourcePermission {
@@ -1104,7 +1140,7 @@ func runBulkPermissionHTTPScenario(t *testing.T, redirect bool, initial, command
 		options.RestConfigProvider = &mockDirectRestConfigProvider{restConfig: &clientrest.Config{Host: k8sServer.URL}}
 	}
 
-	service, userSvc, _, cfg := setupTestEnvironmentWithCfg(t, options, featuremgmt.WithFeatures())
+	service, userSvc, teamSvc, cfg := setupTestEnvironmentWithCfg(t, options, featuremgmt.WithFeatures())
 	if redirect {
 		cfg.UnifiedStorage = map[string]setting.UnifiedStorageConfig{
 			iamv0.ResourcePermissionInfo.GroupResource().String(): {DualWriterMode: grafanarest.Mode5},
@@ -1116,13 +1152,19 @@ func runBulkPermissionHTTPScenario(t *testing.T, redirect bool, initial, command
 		require.NoError(t, err)
 		userIDs[i] = createdUser.ID
 	}
-	initial = materializeParityUsers(initial, userIDs)
-	commands = materializeParityUsers(commands, userIDs)
+	createdServiceAccount, err := userSvc.CreateServiceAccount(context.Background(), &user.CreateUserCommand{Login: "parity-service-account", OrgID: 1})
+	require.NoError(t, err)
+	createdTeam, err := teamSvc.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "parity-team", Email: "parity-team@example.com", OrgID: 1})
+	require.NoError(t, err)
+	initial = materializeParitySubjects(initial, userIDs, createdServiceAccount.ID, createdTeam.ID)
+	commands = materializeParitySubjects(commands, userIDs, createdServiceAccount.ID, createdTeam.ID)
 
 	authorized := []accesscontrol.Permission{
 		{Action: "dashboards.permissions:read", Scope: "dashboards:id:1"},
 		{Action: "dashboards.permissions:write", Scope: "dashboards:id:1"},
 		{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+		{Action: accesscontrol.ActionTeamsRead, Scope: accesscontrol.ScopeTeamsAll},
+		{Action: serviceaccounts.ActionRead, Scope: fmt.Sprintf("serviceaccounts:id:%d", createdServiceAccount.ID)},
 	}
 	server := setupTestServer(t, &user.SignedInUser{
 		OrgID:       1,
@@ -1138,16 +1180,19 @@ func runBulkPermissionHTTPScenario(t *testing.T, redirect bool, initial, command
 	observed := make([]observedResourcePermission, 0, len(permissions))
 	for _, permission := range permissions {
 		observed = append(observed, observedResourcePermission{
-			UserID:      permission.UserID,
-			Permission:  permission.Permission,
-			IsManaged:   permission.IsManaged,
-			IsInherited: permission.IsInherited,
+			UserID:           permission.UserID,
+			TeamID:           permission.TeamID,
+			BuiltInRole:      permission.BuiltInRole,
+			Permission:       permission.Permission,
+			IsManaged:        permission.IsManaged,
+			IsInherited:      permission.IsInherited,
+			IsServiceAccount: permission.IsServiceAccount,
 		})
 	}
 	return observed
 }
 
-func materializeParityUsers(commands []accesscontrol.SetResourcePermissionCommand, userIDs []int64) []accesscontrol.SetResourcePermissionCommand {
+func materializeParitySubjects(commands []accesscontrol.SetResourcePermissionCommand, userIDs []int64, serviceAccountID, teamID int64) []accesscontrol.SetResourcePermissionCommand {
 	materialized := make([]accesscontrol.SetResourcePermissionCommand, len(commands))
 	copy(materialized, commands)
 	for i := range materialized {
@@ -1158,6 +1203,11 @@ func materializeParityUsers(commands []accesscontrol.SetResourcePermissionComman
 			materialized[i].UserID = userIDs[1]
 		case parityThirdUserID:
 			materialized[i].UserID = userIDs[2]
+		case parityServiceAccountID:
+			materialized[i].UserID = serviceAccountID
+		}
+		if materialized[i].TeamID == parityTeamID {
+			materialized[i].TeamID = teamID
 		}
 	}
 	return materialized

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -201,6 +201,8 @@ type GetSignedInUserQuery struct {
 	Login  string
 	Email  string
 	OrgID  int64 `xorm:"org_id"`
+	// SkipTeamLookup returns identity fields without populating TeamIDs or TeamUIDs.
+	SkipTeamLookup bool
 }
 
 type AnalyticsSettings struct {

--- a/pkg/services/user/userimpl/legacy_user.go
+++ b/pkg/services/user/userimpl/legacy_user.go
@@ -381,7 +381,7 @@ func (s *LegacyService) GetSignedInUser(ctx context.Context, query *user.GetSign
 		return nil, err
 	}
 
-	if s.cacheService != nil {
+	if s.cacheService != nil && !query.SkipTeamLookup {
 		cacheKey := newSignedInUserCacheKey(result.OrgID, result.UserID)
 		s.cacheService.Set(cacheKey, *result, time.Second*5)
 	}
@@ -405,13 +405,15 @@ func (s *LegacyService) getSignedInUser(ctx context.Context, query *user.GetSign
 		return nil, err
 	}
 
-	// nolint:staticcheck
-	usr.TeamIDs, usr.TeamUIDs, err = s.teamService.GetTeamIDsByUser(ctx, &team.GetTeamIDsByUserQuery{
-		OrgID:  usr.OrgID,
-		UserID: usr.UserID,
-	})
-	if err != nil {
-		return nil, err
+	if !query.SkipTeamLookup {
+		// nolint:staticcheck
+		usr.TeamIDs, usr.TeamUIDs, err = s.teamService.GetTeamIDsByUser(ctx, &team.GetTeamIDsByUserQuery{
+			OrgID:  usr.OrgID,
+			UserID: usr.UserID,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return usr, err

--- a/pkg/services/user/userimpl/user_test.go
+++ b/pkg/services/user/userimpl/user_test.go
@@ -415,6 +415,24 @@ func TestService_GetSignedInUser_FallbackOnlyOnNotFound(t *testing.T) {
 		require.Equal(t, "from-legacy", got.Login)
 	})
 
+	t.Run("k8s not-found preserves skip-team lookup when falling back for a service account", func(t *testing.T) {
+		legacy := &usertest.FakeUserService{
+			GetSignedInUserFn: func(_ context.Context, query *user.GetSignedInUserQuery) (*user.SignedInUser, error) {
+				require.True(t, query.SkipTeamLookup)
+				return &user.SignedInUser{UserID: 5, UserUID: "sa-uid", IsServiceAccount: true}, nil
+			},
+		}
+		s := newWrapperServiceForTest(
+			&usertest.FakeUserService{ExpectedError: user.ErrUserNotFound},
+			legacy,
+		)
+
+		got, err := s.GetSignedInUser(context.Background(), &user.GetSignedInUserQuery{OrgID: 1, UserID: 5, SkipTeamLookup: true})
+		require.NoError(t, err)
+		require.Equal(t, "sa-uid", got.UserUID)
+		require.True(t, got.IsServiceAccount)
+	})
+
 	t.Run("k8s forbidden is surfaced, no fallback to legacy", func(t *testing.T) {
 		forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "iam.grafana.app", Resource: "users"}, "u", errors.New("nope"))
 		s := newWrapperServiceForTest(
@@ -459,6 +477,25 @@ func TestService_GetSignedInUser_FallbackOnlyOnNotFound(t *testing.T) {
 		require.ErrorIs(t, err, user.ErrUserNotFound)
 		require.Nil(t, got)
 	})
+}
+
+func TestLegacyService_GetSignedInUserSkipsTeamLookup(t *testing.T) {
+	teamSvc := teamtest.NewFakeService()
+	teamSvc.ExpectedError = errors.New("team lookup should not be called")
+	s := LegacyService{
+		store:       &FakeUserStore{ExpectedSignedInUser: &user.SignedInUser{UserID: 5, UserUID: "sa-uid", OrgID: 1, IsServiceAccount: true}},
+		teamService: teamSvc,
+		tracer:      tracing.InitializeTracerForTest(),
+	}
+
+	got, err := s.GetSignedInUser(context.Background(), &user.GetSignedInUserQuery{
+		OrgID:          1,
+		UserID:         5,
+		SkipTeamLookup: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "sa-uid", got.UserUID)
+	require.True(t, got.IsServiceAccount)
 }
 
 // ctxCapturingUserService records the context passed to GetProfile so tests can


### PR DESCRIPTION
**What is this feature?**

Populates the canonical K8s subject kind when legacy resource-permission requests are redirected to the `ResourcePermission` API.

This PR is stacked on #131508, which preserves the legacy incremental contract independently of subject-kind resolution.

The adapter now:

- Resolves a legacy user ID as either `User` or `ServiceAccount` for both bulk and single-item writes.
- Emits the canonical `ServiceAccount` kind for service-account subjects.
- Resolves teams within the request organization.
- Uses a lightweight user lookup that does not hydrate team memberships.
- Keeps K8s subject identity matching exact on `(kind, name)`.

**Why do we need this feature?**

The redirect represented every legacy `userId` as K8s kind `User`, including service accounts. That is not the canonical K8s identity for a service account and would become observable once unified storage is the source of truth.

Pre-fix redirect writes were persisted in legacy SQL rather than unified storage, so there is no deployed corpus of malformed `(User, service-account-uid)` ResourcePermission entries to migrate. This PR therefore fixes newly written identities without adding compatibility matching that weakens the K8s `(kind, name)` contract. If a rollout path later imports malformed K8s objects, that should be handled as an explicit data migration.

**Who is this feature for?**

Users managing resource permissions for users, teams, and service accounts through legacy Grafana APIs while the K8s redirect is enabled.
