### PR TITLE
Alerting: Fix notification policy drop and query drift in rule saves

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.test.ts
@@ -1,0 +1,151 @@
+import { mockDataQuery, mockReduceExpression, mockThresholdExpression } from '../../../mocks';
+import { getDefaultFormValues } from '../../../rule-editor/formDefaults';
+import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
+
+import { getNotificationSettings, toExpression } from './formValuesToAppPlatform';
+
+describe('getNotificationSettings', () => {
+  const baseValues: RuleFormValues = {
+    ...getDefaultFormValues(),
+    type: RuleFormType.grafana,
+  };
+
+  it('returns a NamedRoutingTree when a named policy is selected and manual routing is off', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: false,
+      selectedPolicy: 'TestPolicy',
+    });
+
+    expect(result).toEqual({ type: 'NamedRoutingTree', routingTree: 'TestPolicy' });
+  });
+
+  it('returns undefined for the empty-string selectedPolicy (Default policy)', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: false,
+      selectedPolicy: '',
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when neither selectedPolicy nor manual routing is set', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: false,
+      selectedPolicy: undefined,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('prefers manual routing over a stale selectedPolicy value', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: true,
+      selectedPolicy: 'TestPolicy',
+      contactPoints: {
+        grafana: {
+          selectedContactPoint: 'my-receiver',
+          muteTimeIntervals: [],
+          activeTimeIntervals: [],
+          overrideGrouping: false,
+          overrideTimings: false,
+          groupBy: [],
+          groupWaitValue: '',
+          groupIntervalValue: '',
+          repeatIntervalValue: '',
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ type: 'SimplifiedRouting', receiver: 'my-receiver' });
+  });
+
+  it('returns a SimplifiedRouting when manual routing is on with a selected contact point', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: true,
+      contactPoints: {
+        grafana: {
+          selectedContactPoint: 'team-receiver',
+          muteTimeIntervals: ['mute1'],
+          activeTimeIntervals: ['active1'],
+          overrideGrouping: true,
+          groupBy: ['alertname', 'cluster'],
+          overrideTimings: true,
+          groupWaitValue: '10s',
+          groupIntervalValue: '5m',
+          repeatIntervalValue: '4h',
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: 'SimplifiedRouting',
+      receiver: 'team-receiver',
+      muteTimeIntervals: ['mute1'],
+      activeTimeIntervals: ['active1'],
+      groupBy: ['alertname', 'cluster'],
+      groupWait: '10s',
+      groupInterval: '5m',
+      repeatInterval: '4h',
+    });
+  });
+
+  it('returns undefined when manual routing is on but no contact point is selected', () => {
+    const result = getNotificationSettings({
+      ...baseValues,
+      manualRouting: true,
+      contactPoints: {},
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('toExpression', () => {
+  it('does not include relativeTimeRange for a reduce expression, even if form state has one', () => {
+    const query = { ...mockReduceExpression(), relativeTimeRange: { from: 0, to: 0 } };
+
+    const result = toExpression(query, 'B');
+
+    expect(result.relativeTimeRange).toBeUndefined();
+  });
+
+  it('does not include relativeTimeRange for a threshold expression, even if form state has one', () => {
+    const query = { ...mockThresholdExpression(), relativeTimeRange: { from: 0, to: 0 } };
+
+    const result = toExpression(query, 'C');
+
+    expect(result.relativeTimeRange).toBeUndefined();
+  });
+
+  it('leaves expressions without a relativeTimeRange in form state unaffected', () => {
+    const result = toExpression(mockReduceExpression(), 'B');
+
+    expect(result.relativeTimeRange).toBeUndefined();
+  });
+
+  it('omits relativeTimeRange for a data-source query when form state has none', () => {
+    const result = toExpression(mockDataQuery(), 'A');
+
+    expect(result.relativeTimeRange).toBeUndefined();
+  });
+
+  it('still includes relativeTimeRange for a data-source query', () => {
+    const query = { ...mockDataQuery(), relativeTimeRange: { from: 600, to: 0 } };
+
+    const result = toExpression(query, 'A');
+
+    expect(result.relativeTimeRange).toEqual({ from: '600s', to: '0s' });
+    expect(result.datasourceUID).toBe('abc123');
+  });
+
+  it('marks the refId matching the condition as the source, expression or not', () => {
+    const result = toExpression(mockThresholdExpression(), 'C');
+
+    expect(result.source).toBe(true);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.test.ts
@@ -1,8 +1,11 @@
-import { mockDataQuery, mockReduceExpression, mockThresholdExpression } from '../../../mocks';
+import { config } from '@grafana/runtime';
+
+import { mockDataQuery, mockReduceExpression, mockResampleExpression, mockThresholdExpression } from '../../../mocks';
 import { getDefaultFormValues } from '../../../rule-editor/formDefaults';
 import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
+import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificationPolicyRoute';
 
-import { getNotificationSettings, toExpression } from './formValuesToAppPlatform';
+import { buildAlertRuleResource, getNotificationSettings, toExpression } from './formValuesToAppPlatform';
 
 describe('getNotificationSettings', () => {
   const baseValues: RuleFormValues = {
@@ -128,6 +131,14 @@ describe('toExpression', () => {
     expect(result.relativeTimeRange).toBeUndefined();
   });
 
+  it('keeps relativeTimeRange for a resample expression, since it needs its own window', () => {
+    const query = { ...mockResampleExpression(), relativeTimeRange: { from: 600, to: 0 } };
+
+    const result = toExpression(query, 'B');
+
+    expect(result.relativeTimeRange).toEqual({ from: '600s', to: '0s' });
+  });
+
   it('omits relativeTimeRange for a data-source query when form state has none', () => {
     const result = toExpression(mockDataQuery(), 'A');
 
@@ -147,5 +158,61 @@ describe('toExpression', () => {
     const result = toExpression(mockThresholdExpression(), 'C');
 
     expect(result.source).toBe(true);
+  });
+});
+
+describe('buildAlertRuleResource label stripping', () => {
+  const baseValues = (): RuleFormValues => ({
+    ...getDefaultFormValues(),
+    condition: 'A',
+    type: RuleFormType.grafana,
+    folder: { title: 'Test folder', uid: 'test-folder-uid' },
+    queries: [mockDataQuery()],
+    labels: [
+      { key: NAMED_ROOT_LABEL_NAME, value: 'TestPolicy' },
+      { key: 'env', value: 'prod' },
+    ],
+  });
+
+  it('strips __grafana_managed_route__ from the resource labels when FF is ON', () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      ...config.featureToggles,
+      alertingPolicyRoutingSettings: true,
+    });
+
+    const result = buildAlertRuleResource(baseValues());
+
+    expect(result.spec.labels).not.toHaveProperty(NAMED_ROOT_LABEL_NAME);
+    expect(result.spec.labels).toHaveProperty('env', 'prod');
+    jest.restoreAllMocks();
+  });
+
+  it('strips the legacy label when a NamedRoutingTree is selected, even if FF is OFF', () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      ...config.featureToggles,
+      alertingPolicyRoutingSettings: false,
+    });
+
+    const result = buildAlertRuleResource({
+      ...baseValues(),
+      manualRouting: false,
+      selectedPolicy: 'OtherPolicy',
+    });
+
+    expect(result.spec.notificationSettings).toEqual({ type: 'NamedRoutingTree', routingTree: 'OtherPolicy' });
+    expect(result.spec.labels).not.toHaveProperty(NAMED_ROOT_LABEL_NAME);
+    jest.restoreAllMocks();
+  });
+
+  it('preserves __grafana_managed_route__ when FF is OFF and no policy is selected', () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      ...config.featureToggles,
+      alertingPolicyRoutingSettings: false,
+    });
+
+    const result = buildAlertRuleResource(baseValues());
+
+    expect(result.spec.labels).toHaveProperty(NAMED_ROOT_LABEL_NAME, 'TestPolicy');
+    jest.restoreAllMocks();
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
@@ -8,11 +8,14 @@ import {
   type RecordingRuleExpression,
   type RecordingRuleSpec,
 } from '@grafana/api-clients/rtkq/rules.alerting/v0alpha1';
+import { config } from '@grafana/runtime';
 import { isExpressionQuery } from 'app/features/expressions/guards';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 
 import { type RuleFormValues } from '../../../types/rule-form';
 import { cleanAnnotations, cleanLabels, fixBothInstantAndRangeQuery } from '../../../utils/rule-form';
+import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificationPolicyRoute';
 
 const ALERT_RULE_API_VERSION = 'rules.alerting.grafana.app/v0alpha1';
 const FOLDER_ANNOTATION = 'grafana.app/folder';
@@ -68,6 +71,13 @@ export function buildAlertRuleResource(values: RuleFormValues, existingK8sName?:
 
   const labels = toRecord(cleanLabels(values.labels));
   const annotations = toRecord(cleanAnnotations(values.annotations));
+  const notificationSettings = getNotificationSettings(values);
+  // The legacy label and the routingTree field must not coexist, since the backend derives
+  // the same routing label from routingTree — a stale one left in `labels` would win once
+  // routingTree is unset (e.g. back to the Default policy).
+  if (config.featureToggles.alertingPolicyRoutingSettings || notificationSettings?.type === 'NamedRoutingTree') {
+    delete labels[NAMED_ROOT_LABEL_NAME];
+  }
 
   const spec = {
     title: values.name,
@@ -83,7 +93,7 @@ export function buildAlertRuleResource(values: RuleFormValues, existingK8sName?:
     missingSeriesEvalsToResolve: values.missingSeriesEvalsToResolve
       ? Number(values.missingSeriesEvalsToResolve)
       : undefined,
-    notificationSettings: getNotificationSettings(values),
+    notificationSettings,
   } satisfies AlertRuleSpec;
 
   return {
@@ -150,13 +160,17 @@ export function toExpression(
   const isSource = normalizedQuery.refId === condition;
   const hasRelativeTimeRange = normalizedQuery.relativeTimeRange !== undefined;
   const isExpression = isExpressionQuery(normalizedQuery.model);
+  // Resample is the one expression type that needs its own time window (copied from the
+  // source query by the query editor); every other expression type never has one.
+  const isResample =
+    isExpressionQuery(normalizedQuery.model) && normalizedQuery.model.type === ExpressionQueryType.resample;
 
   return {
     model: normalizedQuery.model,
     queryType: normalizedQuery.queryType || undefined,
     datasourceUID: isExpression ? undefined : normalizedQuery.datasourceUid,
     relativeTimeRange:
-      !isExpression && hasRelativeTimeRange && normalizedQuery.relativeTimeRange
+      (!isExpression || isResample) && hasRelativeTimeRange && normalizedQuery.relativeTimeRange
         ? {
             from: `${normalizedQuery.relativeTimeRange.from}s`,
             to: `${normalizedQuery.relativeTimeRange.to}s`,

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
@@ -142,7 +142,7 @@ function toRecordingExpressionMap(values: RuleFormValues): Record<string, Record
   }, {});
 }
 
-function toExpression(
+export function toExpression(
   query: RuleFormValues['queries'][number],
   condition: RuleFormValues['condition']
 ): AlertRuleExpression {
@@ -156,7 +156,7 @@ function toExpression(
     queryType: normalizedQuery.queryType || undefined,
     datasourceUID: isExpression ? undefined : normalizedQuery.datasourceUid,
     relativeTimeRange:
-      hasRelativeTimeRange && normalizedQuery.relativeTimeRange
+      !isExpression && hasRelativeTimeRange && normalizedQuery.relativeTimeRange
         ? {
             from: `${normalizedQuery.relativeTimeRange.from}s`,
             to: `${normalizedQuery.relativeTimeRange.to}s`,
@@ -187,7 +187,14 @@ function toRecord(items: Array<{ key: string; value: string }>): Record<string, 
   }, {});
 }
 
-function getNotificationSettings(values: RuleFormValues): AlertRuleSpec['notificationSettings'] {
+export function getNotificationSettings(values: RuleFormValues): AlertRuleSpec['notificationSettings'] {
+  if (values.selectedPolicy && !values.manualRouting) {
+    return {
+      type: 'NamedRoutingTree',
+      routingTree: values.selectedPolicy,
+    };
+  }
+
   const settings = values.contactPoints?.grafana;
   if (!values.manualRouting || !settings?.selectedContactPoint) {
     return undefined;

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -782,6 +782,20 @@ export const mockThresholdExpression = (partial: Partial<ExpressionQuery> = {}):
   },
 });
 
+export const mockResampleExpression = (partial: Partial<ExpressionQuery> = {}): AlertQuery<ExpressionQuery> => ({
+  refId: 'B',
+  queryType: 'expression',
+  datasourceUid: '__expr__',
+  model: {
+    type: ExpressionQueryType.resample,
+    refId: 'B',
+    window: '10s',
+    downsampler: 'mean',
+    upsampler: 'fillna',
+    ...partial,
+  },
+});
+
 class LocalStorageMock implements Storage {
   [key: string]: any;
 


### PR DESCRIPTION
**Changes**

Fixes two bugs in the app-platform alert rule resource builder used when the `alerting.rulesAPIV2` and `alertingPolicyRoutingSettings` toggles are on:
- Selecting a named notification policy tree in the rule editor is now sent to the backend correctly. 
- Saving an existing rule with no changes no longer adds a relativeTimeRange to its expression-type queries.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1963

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
<!-- Not applicable: bug fix in an experimental, docs-hidden toggle combination, no doc changes needed. -->