### PR TITLE
Connections: Add the connections nav section to the client-built tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -926,6 +926,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/navtree/ @grafana/grafana-frontend-navigation
 /public/app/core/navtree/sections/dashboards.navEntry.ts @grafana/grafana-frontend-navigation @grafana/dashboards-squad
 /public/app/core/navtree/sections/profile.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-frontend-platform
+/public/app/core/navtree/sections/connections.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-catalog
 /public/app/core/navtree/sections/admin.navEntry.ts @grafana/grafana-frontend-navigation @grafana/identity-access-team
 /public/app/core/journeys/ @grafana/dashboards-squad
 /scripts/cuj-new.ts @grafana/dashboards-squad

--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -15,10 +15,10 @@ describe('buildStaticNavTree', () => {
   describe('sections', () => {
     it('builds the minimal tree for a user with no permissions', () => {
       setup();
-      // cfg is an attachment-parent shell here; pruneEmptyNavSections removes it
+      // Connections and cfg are attachment-parent shells here; pruneEmptyNavSections removes them
       const tree = buildStaticNavTree();
 
-      expect(ids(tree)).toEqual([NavID.home, NavID.bookmarks, NavID.cfg, NavID.profile, NavID.help]);
+      expect(ids(tree)).toEqual([NavID.home, NavID.bookmarks, NavID.connections, NavID.cfg, NavID.profile, NavID.help]);
     });
 
     it('orders sections by sort weight', () => {
@@ -30,6 +30,7 @@ describe('buildStaticNavTree', () => {
         NavID.starred,
         NavID.dashboards,
         NavID.alerting,
+        NavID.connections,
         NavID.cfg,
         NavID.profile,
         NavID.help,
@@ -239,6 +240,28 @@ describe('buildStaticNavTree', () => {
     });
   });
 
+  describe('connections section', () => {
+    it('is always present as a plugin attachment parent', () => {
+      setup();
+      expect(findById(buildStaticNavTree(), NavID.connections)?.children).toEqual([]);
+    });
+
+    it('adds datasource children with configuration page access', () => {
+      setup({ permissions: [AccessControlAction.DataSourcesRead, AccessControlAction.DataSourcesWrite] });
+
+      expect(ids(findById(buildStaticNavTree(), NavID.connections)?.children ?? [])).toEqual([
+        'connections-add-new-connection',
+        'connections-datasources',
+      ]);
+    });
+
+    it('withholds datasource children on read-only access', () => {
+      setup({ permissions: [AccessControlAction.DataSourcesRead] });
+
+      expect(findById(buildStaticNavTree(), NavID.connections)?.children).toEqual([]);
+    });
+  });
+
   describe('administration section', () => {
     it('always contains the subsection shells so plugin pages and enterprise items can inject into them', () => {
       setup();
@@ -346,7 +369,7 @@ describe('buildStaticNavTree', () => {
 });
 
 describe('pruneEmptyNavSections', () => {
-  it('removes empty cfg/access and cfg shells like the server does', () => {
+  it('removes empty connections, cfg/access and cfg shells like the server does', () => {
     setup();
     const tree = pruneEmptyNavSections(buildStaticNavTree());
 
@@ -354,9 +377,17 @@ describe('pruneEmptyNavSections', () => {
   });
 
   it('keeps sections that gained children', () => {
-    setup({ orgRole: 'Admin', permissions: [AccessControlAction.OrgUsersRead] });
+    setup({
+      orgRole: 'Admin',
+      permissions: [
+        AccessControlAction.DataSourcesRead,
+        AccessControlAction.DataSourcesWrite,
+        AccessControlAction.OrgUsersRead,
+      ],
+    });
     const tree = pruneEmptyNavSections(buildStaticNavTree());
 
+    expect(ids(tree)).toContain(NavID.connections);
     expect(ids(tree)).toContain(NavID.cfg);
     const cfg = findById(tree, NavID.cfg);
     expect(ids(cfg?.children ?? [])).toContain(NavID.cfgAccess);

--- a/public/app/core/navtree/buildStaticNavTree.ts
+++ b/public/app/core/navtree/buildStaticNavTree.ts
@@ -6,6 +6,7 @@ import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { alertingNavEntry } from 'app/features/alerting/unified/navigation/alerting.navEntry';
 
 import { adminNavEntry } from './sections/admin.navEntry';
+import { connectionsNavEntry } from './sections/connections.navEntry';
 import { dashboardsNavEntry } from './sections/dashboards.navEntry';
 import { helpNavEntry } from './sections/help.navEntry';
 import { getHomeNode } from './sections/home.navEntry';
@@ -69,6 +70,7 @@ const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [
   dashboardsNavEntry,
   profileNavEntry,
   alertingNavEntry,
+  connectionsNavEntry,
   adminNavEntry,
   helpNavEntry,
   bookmarksNavEntry,

--- a/public/app/core/navtree/sections/connections.navEntry.ts
+++ b/public/app/core/navtree/sections/connections.navEntry.ts
@@ -1,0 +1,49 @@
+import { type NavModelItem } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { NavID, NavWeight } from '../constants';
+import { buildEntries, type NavEntryBuilder } from '../utils';
+
+const connectionsConfigPageAccess = () =>
+  contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) ||
+  (contextSrv.hasPermission(AccessControlAction.DataSourcesRead) &&
+    (contextSrv.hasPermission(AccessControlAction.DataSourcesDelete) ||
+      contextSrv.hasPermission(AccessControlAction.DataSourcesWrite)));
+
+const CONNECTIONS_CHILDREN: NavEntryBuilder[] = [
+  {
+    when: connectionsConfigPageAccess,
+    build: () => ({
+      id: 'connections-add-new-connection',
+      text: 'Add new connection',
+      subTitle: 'Browse and create new connections',
+      url: '/connections/add-new-connection',
+      children: [],
+      keywords: ['csv', 'graphite', 'json', 'loki', 'prometheus', 'sql', 'tempo'],
+    }),
+  },
+  {
+    when: connectionsConfigPageAccess,
+    build: () => ({
+      id: 'connections-datasources',
+      text: 'Data sources',
+      subTitle: 'View and manage your connected data source connections',
+      url: '/connections/datasources',
+      children: [],
+    }),
+  },
+];
+
+export const connectionsNavEntry: NavEntryBuilder = {
+  // Always present so plugin pages can attach to it; pruned by
+  // pruneEmptyNavSections if it still has no children after the merge.
+  build: (): NavModelItem => ({
+    text: 'Connections',
+    icon: 'adjust-circle',
+    id: NavID.connections,
+    url: '/connections',
+    children: buildEntries(CONNECTIONS_CHILDREN),
+    sortWeight: NavWeight.dataConnections,
+  }),
+};


### PR DESCRIPTION
## What

Adds the **connections** section to the client-built static nav tree. The section is always present as a plugin attachment shell (pruned later when it has no children), with its add-new-connection and data sources children gated on data source configuration access.

## Why

Part of the client-built nav tree behind `grafana.multiTenantNavTree`

## Who is this for

Anyone running the multi-tenant frontend service. No behaviour change with the flag off.
