### PR TITLE
Explore: Add the explore and drilldown nav sections to the client-built tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -926,6 +926,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/navtree/ @grafana/grafana-frontend-navigation
 /public/app/core/navtree/sections/dashboards.navEntry.ts @grafana/grafana-frontend-navigation @grafana/dashboards-squad
 /public/app/core/navtree/sections/profile.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-frontend-platform
+/public/app/core/navtree/sections/explore.navEntry.ts @grafana/grafana-frontend-navigation @grafana/datapro
 /public/app/core/navtree/sections/connections.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-catalog
 /public/app/core/navtree/sections/admin.navEntry.ts @grafana/grafana-frontend-navigation @grafana/identity-access-team
 /public/app/core/journeys/ @grafana/dashboards-squad

--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -380,6 +380,19 @@ describe('pruneEmptyNavSections', () => {
     expect(ids(tree)).toEqual([NavID.home, NavID.bookmarks, NavID.profile, NavID.help]);
   });
 
+  // Drilldown's children are the drilldown apps, so with none attached the
+  // server drops the section (RemoveEmptyDrilldownSection) rather than leaving
+  // a top-level item that opens an empty landing page.
+  it('removes the drilldown shell when no drilldown apps attached', () => {
+    setup({ permissions: [AccessControlAction.DataSourcesExplore] });
+    const tree = pruneEmptyNavSections(buildStaticNavTree());
+
+    expect(findById(buildStaticNavTree(), NavID.drilldown)).toBeDefined();
+    expect(findById(tree, NavID.drilldown)).toBeUndefined();
+    // Explore is a leaf, not an attachment shell, so it survives
+    expect(findById(tree, NavID.explore)).toBeDefined();
+  });
+
   it('keeps sections that gained children', () => {
     setup({
       orgRole: 'Admin',

--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -22,13 +22,17 @@ describe('buildStaticNavTree', () => {
     });
 
     it('orders sections by sort weight', () => {
-      setup({ permissions: [...DASHBOARD_READER, ...ALERT_RULES_READER] });
+      setup({
+        permissions: [...DASHBOARD_READER, ...ALERT_RULES_READER, AccessControlAction.DataSourcesExplore],
+      });
 
       expect(ids(buildStaticNavTree())).toEqual([
         NavID.home,
         NavID.bookmarks,
         NavID.starred,
         NavID.dashboards,
+        NavID.explore,
+        NavID.drilldown,
         NavID.alerting,
         NavID.connections,
         NavID.cfg,

--- a/public/app/core/navtree/buildStaticNavTree.ts
+++ b/public/app/core/navtree/buildStaticNavTree.ts
@@ -8,6 +8,7 @@ import { alertingNavEntry } from 'app/features/alerting/unified/navigation/alert
 import { adminNavEntry } from './sections/admin.navEntry';
 import { connectionsNavEntry } from './sections/connections.navEntry';
 import { dashboardsNavEntry } from './sections/dashboards.navEntry';
+import { drilldownNavEntry, exploreNavEntry } from './sections/explore.navEntry';
 import { helpNavEntry } from './sections/help.navEntry';
 import { getHomeNode } from './sections/home.navEntry';
 import { profileNavEntry } from './sections/profile.navEntry';
@@ -68,6 +69,8 @@ export function getInitialNavTree(): NavModelItem[] {
 const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [
   starredNavEntry,
   dashboardsNavEntry,
+  exploreNavEntry,
+  drilldownNavEntry,
   profileNavEntry,
   alertingNavEntry,
   connectionsNavEntry,

--- a/public/app/core/navtree/pageAccess.ts
+++ b/public/app/core/navtree/pageAccess.ts
@@ -13,6 +13,8 @@ export const dashboardVariablesAccess = () =>
 export const snapshotsAccess = () => contextSrv.hasPermission(AccessControlAction.SnapshotsRead);
 export const playlistsAccess = () => contextSrv.hasPermission(AccessControlAction.PlaylistsRead);
 
+export const dataSourcesExploreAccess = () => contextSrv.hasPermission(AccessControlAction.DataSourcesExplore);
+
 export const serviceAccountsAccess = () =>
   hasAny(AccessControlAction.ServiceAccountsRead, AccessControlAction.ServiceAccountsCreate);
 export const migrateToCloudAccess = () => contextSrv.hasPermission(AccessControlAction.MigrationAssistantMigrate);

--- a/public/app/core/navtree/sections/explore.navEntry.ts
+++ b/public/app/core/navtree/sections/explore.navEntry.ts
@@ -1,0 +1,29 @@
+import { config } from '@grafana/runtime';
+
+import { NavID, NavWeight } from '../constants';
+import { dataSourcesExploreAccess } from '../pageAccess';
+import { type NavEntryBuilder } from '../utils';
+
+export const exploreNavEntry: NavEntryBuilder = {
+  when: () => config.exploreEnabled && dataSourcesExploreAccess(),
+  build: () => ({
+    text: 'Explore',
+    id: NavID.explore,
+    subTitle: 'Explore your data',
+    icon: 'compass',
+    sortWeight: NavWeight.explore,
+    url: '/explore',
+  }),
+};
+
+export const drilldownNavEntry: NavEntryBuilder = {
+  when: dataSourcesExploreAccess,
+  build: () => ({
+    text: 'Drilldown',
+    id: NavID.drilldown,
+    subTitle: "Drill down into your data using Grafana's powerful queryless apps",
+    icon: 'drilldown',
+    sortWeight: NavWeight.drilldown,
+    url: '/drilldown',
+  }),
+};

--- a/public/app/core/navtree/utils.ts
+++ b/public/app/core/navtree/utils.ts
@@ -26,6 +26,11 @@ export const buildEntries = (entries: NavEntryBuilder[]): NavModelItem[] =>
 // registered enterprise items, pruned when nothing attached
 const PRUNABLE_ADMIN_SECTIONS: NavId[] = [NavID.cfgGeneral, NavID.cfgPlugins, NavID.cfgAccess];
 
+// Top-level sections built unconditionally as attachment targets, pruned when
+// nothing attached. Mirrors the server's RemoveEmptyConnectionsSection and
+// RemoveEmptyDrilldownSection, plus Administration once its subsections go.
+const PRUNABLE_SECTIONS: NavId[] = [NavID.cfg, NavID.connections, NavID.drilldown];
+
 /** Depth-first search of a nav tree by item id */
 export function findNavById(nodes: NavModelItem[], id: string): NavModelItem | undefined {
   for (const node of nodes) {
@@ -77,13 +82,17 @@ export function sortNavTree(nodes: NavModelItem[]): NavModelItem[] {
 }
 
 /**
- * Removes attachment-target shells that ended up empty: the admin subsections
- * (PRUNABLE_ADMIN_SECTIONS) and the top-level Connections and Administration
- * sections, all built unconditionally so plugin pages and registered items
- * can attach, then dropped when nothing did. Returns a new tree.
+ * Removes attachment-target shells that ended up empty, in the server's order:
+ * the admin subsections first (PRUNABLE_ADMIN_SECTIONS), then the top-level
+ * sections (PRUNABLE_SECTIONS) — so Administration goes once its last
+ * subsection does. Mirrors RemoveEmptyAdminSections,
+ * RemoveEmptyConnectionsSection and RemoveEmptyDrilldownSection. Returns a new
+ * tree.
  */
 export function pruneEmptyNavSections(tree: NavModelItem[]): NavModelItem[] {
   const isEmpty = (node: NavModelItem) => (node.children ?? []).length === 0;
+  const isPrunable = (ids: NavId[], node: NavModelItem) =>
+    Boolean(node.id) && ids.some((id) => id === node.id) && isEmpty(node);
 
   return tree
     .map((node) => {
@@ -92,10 +101,8 @@ export function pruneEmptyNavSections(tree: NavModelItem[]): NavModelItem[] {
       }
       return {
         ...node,
-        children: node.children.filter(
-          (child) => !(child.id && PRUNABLE_ADMIN_SECTIONS.some((id) => id === child.id) && isEmpty(child))
-        ),
+        children: node.children.filter((child) => !isPrunable(PRUNABLE_ADMIN_SECTIONS, child)),
       };
     })
-    .filter((node) => !((node.id === NavID.cfg || node.id === NavID.connections) && isEmpty(node)));
+    .filter((node) => !isPrunable(PRUNABLE_SECTIONS, node));
 }


### PR DESCRIPTION
## What

Adds the **explore** and **drilldown** sections to the client-built static nav tree, both gated on the data sources explore permission (and explore additionally on the `exploreEnabled` config), plus the `dataSourcesExploreAccess` page-access predicate they share.

## Why

Part of the client-built nav tree behind `grafana.multiTenantNavTree`

## Who is this for

Anyone running the multi-tenant frontend service. No behaviour change with the flag off.
