### PR TITLE
Notebooks: Add the notebooks nav section to the client-built tree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -931,6 +931,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/navtree/sections/explore.navEntry.ts @grafana/grafana-frontend-navigation @grafana/datapro
 /public/app/core/navtree/sections/connections.navEntry.ts @grafana/grafana-frontend-navigation @grafana/grafana-catalog
 /public/app/core/navtree/sections/admin.navEntry.ts @grafana/grafana-frontend-navigation @grafana/identity-access-team
+/public/app/core/navtree/sections/notebooks.navEntry.ts @grafana/grafana-frontend-navigation @grafana/sharing-squad
 /public/app/core/journeys/ @grafana/dashboards-squad
 /scripts/cuj-new.ts @grafana/dashboards-squad
 /scripts/cuj-smoke.ts @grafana/dashboards-squad

--- a/public/app/core/navtree/buildStaticNavTree.test.ts
+++ b/public/app/core/navtree/buildStaticNavTree.test.ts
@@ -41,6 +41,21 @@ describe('buildStaticNavTree', () => {
       ]);
     });
 
+    it('places notebooks after drilldown when the flag is on and the user can read dashboards', () => {
+      const dashboardReader = [AccessControlAction.DashboardsRead, AccessControlAction.DataSourcesExplore];
+      setup({ permissions: dashboardReader, openFeatureFlags: { 'dashboard.notebooks': true } });
+
+      const treeIds = ids(buildStaticNavTree());
+      expect(treeIds.indexOf(NavID.notebooks)).toBe(treeIds.indexOf(NavID.drilldown) + 1);
+
+      setup({ permissions: dashboardReader });
+      expect(findById(buildStaticNavTree(), NavID.notebooks)).toBeUndefined();
+
+      // Notebooks reuse dashboard RBAC; without dashboards:read there is no entry
+      setup({ permissions: [], openFeatureFlags: { 'dashboard.notebooks': true } });
+      expect(findById(buildStaticNavTree(), NavID.notebooks)).toBeUndefined();
+    });
+
     it('omits signed-in-only sections for anonymous users', () => {
       setup({ isSignedIn: false, config: { anonymousEnabled: true } });
       const tree = buildStaticNavTree();

--- a/public/app/core/navtree/buildStaticNavTree.ts
+++ b/public/app/core/navtree/buildStaticNavTree.ts
@@ -11,6 +11,7 @@ import { dashboardsNavEntry } from './sections/dashboards.navEntry';
 import { drilldownNavEntry, exploreNavEntry } from './sections/explore.navEntry';
 import { helpNavEntry } from './sections/help.navEntry';
 import { getHomeNode } from './sections/home.navEntry';
+import { notebooksNavEntry } from './sections/notebooks.navEntry';
 import { profileNavEntry } from './sections/profile.navEntry';
 import { bookmarksNavEntry, starredNavEntry } from './sections/savedItems.navEntry';
 import { applyAppSubUrl, buildEntries, type NavEntryBuilder, pruneEmptyNavSections, sortNavTree } from './utils';
@@ -71,6 +72,7 @@ const STATIC_NAV_ENTRIES: NavEntryBuilder[] = [
   dashboardsNavEntry,
   exploreNavEntry,
   drilldownNavEntry,
+  notebooksNavEntry,
   profileNavEntry,
   alertingNavEntry,
   connectionsNavEntry,

--- a/public/app/core/navtree/sections/notebooks.navEntry.ts
+++ b/public/app/core/navtree/sections/notebooks.navEntry.ts
@@ -1,0 +1,23 @@
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { NavID, NavWeight } from '../constants';
+import { isSignedIn, type NavEntryBuilder } from '../utils';
+
+// Notebooks reuse dashboard RBAC: an unscoped dashboards:read grants the list
+// page, and the apiserver filters the list down to what the user may see.
+export const notebooksNavEntry: NavEntryBuilder = {
+  when: () =>
+    isSignedIn() &&
+    contextSrv.hasPermission(AccessControlAction.DashboardsRead) &&
+    getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardNotebooks, false),
+  build: () => ({
+    text: 'Notebooks',
+    id: NavID.notebooks,
+    subTitle: 'Investigation notebooks created from workspaces, dashboards, alerts, and incidents.',
+    icon: 'book',
+    sortWeight: NavWeight.notebooks,
+    url: '/notebooks',
+  }),
+};


### PR DESCRIPTION
## What

Adds the **notebooks** section to the client-built static nav tree, gated on the `dashboard.notebooks` feature flag and dashboards read access (notebooks reuse dashboard RBAC actions).

## Why

Part of the client-built nav tree behind `grafana.multiTenantNavTree`.

With this PR merged the stack is byte-identical to the original single commit on #130966.

## Who is this for

Anyone running the multi-tenant frontend service. No behaviour change with the flag off.
