### PR TITLE
E2E: fix datasource variable test flakiness with regex filter

### DIFF
--- a/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
@@ -20,7 +20,7 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('can add a new datasource variable', async ({ page, gotoDashboardPage, selectors }) => {
+    test.skip('can add a new datasource variable', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({
         uid: PAGE_UNDER_TEST,
         queryParams: new URLSearchParams({ orgId: '1', editview: 'variables' }),

--- a/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
@@ -46,8 +46,9 @@ test.describe(
       const datasourceSelect = dashboardPage.getByGrafanaSelector(
         selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
       );
-      await datasourceSelect.locator('input').fill('Prometheus');
-      await datasourceSelect.locator('input').press('Enter');
+      await datasourceSelect.click();
+      await page.keyboard.type('Prometheus');
+      await page.getByRole('option', { name: 'Prometheus' }).click();
 
       const previewOptions = dashboardPage.getByGrafanaSelector(
         selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption

--- a/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
@@ -20,7 +20,7 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test.skip('can add a new datasource variable', async ({ page, gotoDashboardPage, selectors }) => {
+    test('can add a new datasource variable', async ({ page, gotoDashboardPage, selectors }) => {
       const dashboardPage = await gotoDashboardPage({
         uid: PAGE_UNDER_TEST,
         queryParams: new URLSearchParams({ orgId: '1', editview: 'variables' }),
@@ -43,8 +43,6 @@ test.describe(
       );
       await labelInput.fill('Variable under test');
 
-      // If this is failing, make sure there are Prometheus datasources named "gdev-prometheus" and "gdev-slow-prometheus"
-      // Or update to match available gdev datasources for testing
       const datasourceSelect = dashboardPage.getByGrafanaSelector(
         selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect
       );
@@ -54,8 +52,18 @@ test.describe(
       const previewOptions = dashboardPage.getByGrafanaSelector(
         selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption
       );
-      await expect(previewOptions.first()).toContainText('gdev-prometheus');
-      await expect(previewOptions.last()).toContainText('gdev-slow-prometheus');
+      
+      // Wait for preview options to populate after selecting datasource type
+      await expect(previewOptions.first()).toBeVisible({ timeout: 15000 });
+      
+      // Verify the expected provisioned datasources are present
+      // Note: Other tests may create temporary datasources (e.g., e2e-diagnostics-prometheus-*)
+      // so we explicitly check for our expected ones rather than relying on position
+      const gdevPrometheus = previewOptions.filter({ hasText: 'gdev-prometheus' });
+      const gdevSlowPrometheus = previewOptions.filter({ hasText: 'gdev-slow-prometheus' });
+      
+      await expect(gdevPrometheus.first()).toBeVisible();
+      await expect(gdevSlowPrometheus.first()).toBeVisible();
 
       // Navigate back to the homepage and change the selected variable value
       await dashboardPage

--- a/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
+++ b/e2e-playwright/dashboards-suite/new-datasource-variable.spec.ts
@@ -52,16 +52,16 @@ test.describe(
       const previewOptions = dashboardPage.getByGrafanaSelector(
         selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption
       );
-      
+
       // Wait for preview options to populate after selecting datasource type
       await expect(previewOptions.first()).toBeVisible({ timeout: 15000 });
-      
+
       // Verify the expected provisioned datasources are present
       // Note: Other tests may create temporary datasources (e.g., e2e-diagnostics-prometheus-*)
       // so we explicitly check for our expected ones rather than relying on position
       const gdevPrometheus = previewOptions.filter({ hasText: 'gdev-prometheus' });
       const gdevSlowPrometheus = previewOptions.filter({ hasText: 'gdev-slow-prometheus' });
-      
+
       await expect(gdevPrometheus.first()).toBeVisible();
       await expect(gdevSlowPrometheus.first()).toBeVisible();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR fixes the flaky e2e test "Variables - Datasource › can add a new datasource variable" by making the assertions more robust against parallel test interference.

## Root Cause

The test was failing intermittently due to race conditions with parallel test execution:

1. **Parallel execution**: Tests run with `fullyParallel: true` in the Playwright config
2. **Temporary datasources**: The diagnostics suite creates temporary datasources like `e2e-diagnostics-prometheus-failure-<uuid>` during test execution
3. **Type-based filtering**: The test filters datasources by "Prometheus" type, which matches both:
   - Provisioned `gdev-prometheus` and `gdev-slow-prometheus` datasources
   - Temporary `e2e-diagnostics-prometheus-*` datasources created by parallel tests
4. **Positional selectors**: Using `.first()` and `.last()` caused non-deterministic failures when the ordering changed due to temporary datasources being present

## Solution

Made the test assertions more resilient:
- Added explicit wait for preview options to load (15s timeout) to prevent timing issues
- Use `.filter({ hasText: 'gdev-prometheus' })` to explicitly find the expected datasources
- This makes the test work correctly even when other datasources are present in the list

## Why not use regex filter in variable config?

The initial approach was to add a `/^gdev-/` regex filter to the datasource variable configuration using the `nameFilter` selector. However, this selector only exists in the **new** dashboard settings UI (`dashboardSettingsRedesign: true`). This test uses the **old** UI (`dashboardSettingsRedesign: false`), where that field doesn't exist, causing the test to timeout waiting for the selector.

The current solution works with both old and new UI by making the test assertions themselves more robust.

## Testing

The fix addresses both failure modes observed in CI:
1. ✅ Page load timeouts (added explicit wait with longer timeout)
2. ✅ Unexpected datasource names (explicit filtering instead of positional selectors)

## Related
- Closes #131655
- Related to skip PR: #131654
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C081AF3S814/p1787765185204889?thread_ts=1787765185.204889&cid=C081AF3S814)

<div><a href="https://cursor.com/agents/bc-b800f0e4-2343-5b4a-80e3-5d5c68e80fc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b800f0e4-2343-5b4a-80e3-5d5c68e80fc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

