### PR TITLE
A11y: label dash pattern and scalar dimension comboboxes

### DIFF
--- a/public/app/features/dimensions/editors/ScalarDimensionEditor.test.tsx
+++ b/public/app/features/dimensions/editors/ScalarDimensionEditor.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from 'test/test-utils';
 import { FieldType, toDataFrame } from '@grafana/data';
 import { type ScalarDimensionConfig } from '@grafana/schema';
 import { mockComboboxRect } from '@grafana/test-utils';
-import { Field } from '@grafana/ui';
 
 import { type ScalarDimensionOptions } from '../types';
 
@@ -21,21 +20,20 @@ const makeProps = makePropsFactory<ScalarDimensionConfig, ScalarDimensionOptions
 beforeEach(() => mockComboboxRect());
 
 describe('ScalarDimensionEditor', () => {
-  it('uses the parent field label as the combobox accessible name', () => {
+  it('labels the field combobox with an inline Field row', () => {
     const { props } = makeProps({ min: 0, max: 360, fixed: 15 });
-    render(
-      <Field label="Rotation angle">
-        <ScalarDimensionEditor {...props} />
-      </Field>
-    );
+    render(<ScalarDimensionEditor {...props} />);
 
-    expect(screen.getByRole('combobox', { name: 'Rotation angle' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Field' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Mod' })).toBeChecked();
+    expect(screen.getByLabelText('Value')).toHaveValue(15);
   });
 
-  it('falls back to a Scalar name when no id is provided', () => {
-    const { props } = makeProps({ min: 0, max: 360, fixed: 15 });
-    render(<ScalarDimensionEditor {...props} id={undefined} />);
+  it('hides the fixed value input when a field is selected', () => {
+    const { props } = makeProps({ min: 0, max: 360, field: 'temp', fixed: 15 });
+    render(<ScalarDimensionEditor {...props} />);
 
-    expect(screen.getByRole('combobox', { name: 'Scalar' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Field' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Value')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/dimensions/editors/ScalarDimensionEditor.test.tsx
+++ b/public/app/features/dimensions/editors/ScalarDimensionEditor.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from 'test/test-utils';
+
+import { FieldType, toDataFrame } from '@grafana/data';
+import { type ScalarDimensionConfig } from '@grafana/schema';
+import { mockComboboxRect } from '@grafana/test-utils';
+import { Field } from '@grafana/ui';
+
+import { type ScalarDimensionOptions } from '../types';
+
+import { ScalarDimensionEditor } from './ScalarDimensionEditor';
+import { makePropsFactory } from './test-utils';
+
+const makeProps = makePropsFactory<ScalarDimensionConfig, ScalarDimensionOptions>(
+  'rotation',
+  { min: 0, max: 360 },
+  {
+    data: [toDataFrame({ fields: [{ name: 'temp', type: FieldType.number, values: [1, 2, 3] }] })],
+  }
+);
+
+beforeEach(() => mockComboboxRect());
+
+describe('ScalarDimensionEditor', () => {
+  it('uses the parent field label as the combobox accessible name', () => {
+    const { props } = makeProps({ min: 0, max: 360, fixed: 15 });
+    render(
+      <Field label="Rotation angle">
+        <ScalarDimensionEditor {...props} />
+      </Field>
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Rotation angle' })).toBeInTheDocument();
+  });
+
+  it('falls back to a Scalar name when no id is provided', () => {
+    const { props } = makeProps({ min: 0, max: 360, fixed: 15 });
+    render(<ScalarDimensionEditor {...props} id={undefined} />);
+
+    expect(screen.getByRole('combobox', { name: 'Scalar' })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/dimensions/editors/ScalarDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ScalarDimensionEditor.tsx
@@ -12,7 +12,7 @@ import { type ScalarDimensionOptions } from '../types';
 
 type Props = StandardEditorProps<ScalarDimensionConfig, ScalarDimensionOptions>;
 
-export const ScalarDimensionEditor = ({ value, context, onChange, item }: Props) => {
+export const ScalarDimensionEditor = ({ value, context, onChange, item, id }: Props) => {
   const { settings } = item;
 
   const fixedValueOption = useMemo(
@@ -109,7 +109,8 @@ export const ScalarDimensionEditor = ({ value, context, onChange, item }: Props)
           </InlineField>
         </InlineFieldRow>
         <Combobox
-          aria-label={t('dimensions.scalar-dimension-editor.label', 'Scalar')}
+          id={id}
+          aria-label={id ? undefined : t('dimensions.scalar-dimension-editor.label', 'Scalar')}
           value={selectedOption}
           options={selectOptions}
           onChange={onSelectChange}

--- a/public/app/features/dimensions/editors/ScalarDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ScalarDimensionEditor.tsx
@@ -1,10 +1,9 @@
-import { css } from '@emotion/css';
 import { useCallback, useId, useMemo } from 'react';
 
-import { FieldType, type GrafanaTheme2, type SelectableValue, type StandardEditorProps } from '@grafana/data';
+import { FieldType, type SelectableValue, type StandardEditorProps } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ScalarDimensionMode, type ScalarDimensionConfig } from '@grafana/schema';
-import { InlineField, InlineFieldRow, RadioButtonGroup, Combobox, useStyles2 } from '@grafana/ui';
+import { InlineField, InlineFieldRow, RadioButtonGroup, Combobox } from '@grafana/ui';
 import { useFieldDisplayNames, useMatcherSelectOptions } from '@grafana/ui/internal';
 import { NumberInput } from 'app/core/components/OptionsUI/NumberInput';
 
@@ -12,7 +11,7 @@ import { type ScalarDimensionOptions } from '../types';
 
 type Props = StandardEditorProps<ScalarDimensionConfig, ScalarDimensionOptions>;
 
-export const ScalarDimensionEditor = ({ value, context, onChange, item, id }: Props) => {
+export const ScalarDimensionEditor = ({ value, context, onChange, item }: Props) => {
   const { settings } = item;
 
   const fixedValueOption = useMemo(
@@ -51,8 +50,6 @@ export const ScalarDimensionEditor = ({ value, context, onChange, item, id }: Pr
     firstItem: fixedValueOption,
     fieldType: FieldType.number,
   });
-
-  const styles = useStyles2(getStyles);
 
   const onSelectChange = useCallback(
     (selection: SelectableValue<string>) => {
@@ -102,46 +99,37 @@ export const ScalarDimensionEditor = ({ value, context, onChange, item, id }: Pr
   const selectedOption = isFixed ? fixedValueOption : selectOptions.find((v) => v.value === fieldName);
   return (
     <>
-      <div>
+      <InlineFieldRow>
+        <InlineField label={t('dimensions.scalar-dimension-editor.label-limit', 'Limit')} labelWidth={8} grow={true}>
+          <RadioButtonGroup value={mode} options={scalarOptions} onChange={onModeChange} fullWidth />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label={t('dimensions.scalar-dimension-editor.label-field', 'Field')} labelWidth={8} grow={true}>
+          <Combobox
+            value={selectedOption}
+            options={selectOptions}
+            onChange={onSelectChange}
+            noOptionsMessage={t(
+              'dimensions.scalar-dimension-editor.noOptionsMessage-no-fields-found',
+              'No fields found'
+            )}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      {isFixed && (
         <InlineFieldRow>
-          <InlineField label={t('dimensions.scalar-dimension-editor.label-limit', 'Limit')} labelWidth={8} grow={true}>
-            <RadioButtonGroup value={mode} options={scalarOptions} onChange={onModeChange} fullWidth />
+          <InlineField label={t('dimensions.scalar-dimension-editor.label-value', 'Value')} labelWidth={8} grow={true}>
+            <NumberInput
+              id={valueInputId}
+              value={val?.fixed ?? DEFAULT_VALUE}
+              onChange={onValueChange}
+              max={settings?.max}
+              min={settings?.min}
+            />
           </InlineField>
         </InlineFieldRow>
-        <Combobox
-          id={id}
-          aria-label={id ? undefined : t('dimensions.scalar-dimension-editor.label', 'Scalar')}
-          value={selectedOption}
-          options={selectOptions}
-          onChange={onSelectChange}
-          noOptionsMessage={t('dimensions.scalar-dimension-editor.noOptionsMessage-no-fields-found', 'No fields found')}
-        />
-      </div>
-      <div className={styles.range}>
-        {isFixed && (
-          <InlineFieldRow>
-            <InlineField
-              label={t('dimensions.scalar-dimension-editor.label-value', 'Value')}
-              labelWidth={8}
-              grow={true}
-            >
-              <NumberInput
-                id={valueInputId}
-                value={val?.fixed ?? DEFAULT_VALUE}
-                onChange={onValueChange}
-                max={settings?.max}
-                min={settings?.min}
-              />
-            </InlineField>
-          </InlineFieldRow>
-        )}
-      </div>
+      )}
     </>
   );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  range: css({
-    paddingTop: theme.spacing(1),
-  }),
-});

--- a/public/app/plugins/panel/timeseries/LineStyleEditor.test.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.test.tsx
@@ -117,7 +117,28 @@ describe('LineStyleEditor', () => {
         />
       );
 
-      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(
+        screen.getByRole('combobox', {
+          name: 'Dash pattern Comma or space separated lengths. Example: 10, 20',
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('labels the dash pattern combobox and explains the input format', () => {
+      render(
+        <LineStyleEditor
+          value={{ fill: 'dash', dash: [10, 10] }}
+          onChange={jest.fn()}
+          context={mockContext}
+          item={mockItem}
+        />
+      );
+
+      expect(
+        screen.getByRole('combobox', {
+          name: 'Dash pattern Comma or space separated lengths. Example: 10, 20',
+        })
+      ).toBeInTheDocument();
     });
 
     it('should show default segments when dash array is empty', () => {

--- a/public/app/plugins/panel/timeseries/LineStyleEditor.test.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.test.tsx
@@ -124,7 +124,7 @@ describe('LineStyleEditor', () => {
       ).toBeInTheDocument();
     });
 
-    it('labels the dash pattern combobox and explains the input format', () => {
+    it('labels the dash pattern combobox and keeps help inside the field', () => {
       render(
         <LineStyleEditor
           value={{ fill: 'dash', dash: [10, 10] }}
@@ -139,6 +139,7 @@ describe('LineStyleEditor', () => {
           name: 'Dash pattern Comma or space separated lengths. Example: 10, 20',
         })
       ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Help' })).toBeInTheDocument();
     });
 
     it('should show default segments when dash array is empty', () => {

--- a/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 
 import { type StandardEditorProps, type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type LineStyle } from '@grafana/schema';
-import { IconButton, RadioButtonGroup, Select, Stack } from '@grafana/ui';
+import { Field, IconButton, RadioButtonGroup, Select, Stack } from '@grafana/ui';
 
 type LineFill = 'solid' | 'dash' | 'dot' | 'accessible';
 
@@ -42,6 +42,7 @@ const dotOptions: Array<SelectableValue<string>> = [
 type Props = StandardEditorProps<LineStyle, unknown>;
 
 export const LineStyleEditor = ({ value, onChange }: Props) => {
+  const dashPatternId = useId();
   const lineFillOptions: Array<SelectableValue<LineFill>> = [
     {
       label: t('timeseries.line-style-editor.line-fill-options.label-solid', 'Solid'),
@@ -83,7 +84,7 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
   const hasDashPattern = value?.fill && value?.fill !== 'solid' && value?.fill !== 'accessible';
 
   return (
-    <Stack wrap={true} alignItems="flex-end">
+    <Stack direction="column" gap={1}>
       <RadioButtonGroup
         value={value?.fill || 'solid'}
         options={lineFillOptions}
@@ -101,35 +102,43 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
         }}
       />
       {hasDashPattern && (
-        <>
-          <Select
-            allowCustomValue={true}
-            options={options}
-            value={current}
-            width={20}
-            onChange={(v) => {
-              onChange({
-                ...value,
-                dash: parseText(v.value ?? ''),
-              });
-            }}
-            formatCreateLabel={(t) => `Segments: ${parseText(t).join(', ')}`}
-          />
-          <div>
-            &nbsp;
-            <a
-              title={t(
-                'timeseries.line-style-editor.title-the-input-expects-a-segment-list',
-                'The input expects a segment list'
-              )}
-              href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Parameters"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <IconButton name="question-circle" tooltip={t('timeseries.line-style-editor.tooltip-help', 'Help')} />
-            </a>
-          </div>
-        </>
+        <Stack wrap={true} alignItems="flex-start">
+          <Field
+            noMargin
+            htmlFor={dashPatternId}
+            label={t('timeseries.line-style-editor.label-dash-pattern', 'Dash pattern')}
+            description={t(
+              'timeseries.line-style-editor.description-dash-pattern',
+              'Comma or space separated lengths. Example: 10, 20'
+            )}
+          >
+            <Select
+              inputId={dashPatternId}
+              allowCustomValue={true}
+              options={options}
+              value={current}
+              width={20}
+              onChange={(v) => {
+                onChange({
+                  ...value,
+                  dash: parseText(v.value ?? ''),
+                });
+              }}
+              formatCreateLabel={(text) => `Segments: ${parseText(text).join(', ')}`}
+            />
+          </Field>
+          <a
+            title={t(
+              'timeseries.line-style-editor.title-the-input-expects-a-segment-list',
+              'The input expects a segment list'
+            )}
+            href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Parameters"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <IconButton name="question-circle" tooltip={t('timeseries.line-style-editor.tooltip-help', 'Help')} />
+          </a>
+        </Stack>
       )}
     </Stack>
   );

--- a/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
@@ -84,7 +84,7 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
   const hasDashPattern = value?.fill && value?.fill !== 'solid' && value?.fill !== 'accessible';
 
   return (
-    <Stack direction="column" gap={1}>
+    <Stack direction="column" gap={2} alignItems="flex-start">
       <RadioButtonGroup
         value={value?.fill || 'solid'}
         options={lineFillOptions}
@@ -102,16 +102,16 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
         }}
       />
       {hasDashPattern && (
-        <Stack wrap={true} alignItems="flex-start">
-          <Field
-            noMargin
-            htmlFor={dashPatternId}
-            label={t('timeseries.line-style-editor.label-dash-pattern', 'Dash pattern')}
-            description={t(
-              'timeseries.line-style-editor.description-dash-pattern',
-              'Comma or space separated lengths. Example: 10, 20'
-            )}
-          >
+        <Field
+          noMargin
+          htmlFor={dashPatternId}
+          label={t('timeseries.line-style-editor.label-dash-pattern', 'Dash pattern')}
+          description={t(
+            'timeseries.line-style-editor.description-dash-pattern',
+            'Comma or space separated lengths. Example: 10, 20'
+          )}
+        >
+          <Stack wrap={true} alignItems="center">
             <Select
               inputId={dashPatternId}
               allowCustomValue={true}
@@ -126,19 +126,19 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
               }}
               formatCreateLabel={(text) => `Segments: ${parseText(text).join(', ')}`}
             />
-          </Field>
-          <a
-            title={t(
-              'timeseries.line-style-editor.title-the-input-expects-a-segment-list',
-              'The input expects a segment list'
-            )}
-            href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Parameters"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <IconButton name="question-circle" tooltip={t('timeseries.line-style-editor.tooltip-help', 'Help')} />
-          </a>
-        </Stack>
+            <a
+              title={t(
+                'timeseries.line-style-editor.title-the-input-expects-a-segment-list',
+                'The input expects a segment list'
+              )}
+              href="https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Parameters"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <IconButton name="question-circle" tooltip={t('timeseries.line-style-editor.tooltip-help', 'Help')} />
+            </a>
+          </Stack>
+        </Field>
       )}
     </Stack>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8388,7 +8388,6 @@
       "fixed-value-options": {
         "label-fixed-values": "Fixed value"
       },
-      "label": "Scalar",
       "label-field": "Field",
       "label-limit": "Limit",
       "label-value": "Value",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -16555,6 +16555,8 @@
       "name-faceted-filter": "Series visibility"
     },
     "line-style-editor": {
+      "description-dash-pattern": "Comma or space separated lengths. Example: 10, 20",
+      "label-dash-pattern": "Dash pattern",
       "line-fill-options": {
         "label-accessible": "Accessible",
         "label-dash": "Dash",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8389,6 +8389,7 @@
         "label-fixed-values": "Fixed value"
       },
       "label": "Scalar",
+      "label-field": "Field",
       "label-limit": "Limit",
       "label-value": "Value",
       "noOptionsMessage-no-fields-found": "No fields found",


### PR DESCRIPTION
**What is this feature?**

Gives the timeseries line style dash/dot Select a visible name and format help, and wires `ScalarDimensionEditor` to the parent Field `id` so geomap/canvas labels actually name the combobox.

**Why do we need this feature?**

Keyboard and screen reader users hit an unlabeled spacing combobox under Line style, and the MDN help link does not explain the `10, 20` input format. Geomap Rotation angle (and canvas RPM) wrap `ScalarDimensionEditor` in a Field and pass an `id`, but the combobox ignored it.

**Who is this feature for?**

Anyone editing panel styles without a mouse, and anyone who needs the dash pattern format spelled out next to the control.

**Which issue(s) does this PR fix?**:

Fixes #109757

**Special notes for your reviewer:**

- Line style: `Field` + `inputId` so the combobox name is "Dash pattern" plus the format description (that is how `Field`/`Label` concatenate).
- Scalar editor: pass `id` through like `ScaleDimensionEditor` / `ColorDimensionEditor`. Keep the generic "Scalar" `aria-label` only when no `id` is provided.
- Unit tests cover the labeled dash pattern combobox and the parent-Field name on the scalar combobox.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.