### PR TITLE
Text: Add data refresh tests coverage

### DIFF
--- a/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
@@ -578,6 +578,7 @@ describe('TextNGPanel', () => {
       settle();
 
       expect(html()).toContain('web-2');
+      expect(html()).not.toContain('web-1');
     });
 
     it('re-renders the content when a referenced variable changes', () => {
@@ -595,6 +596,7 @@ describe('TextNGPanel', () => {
       settle();
 
       expect(html()).toContain('second');
+      expect(html()).not.toContain('first');
     });
   });
 

--- a/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, type InterpolateFunction, toDataFrame } from '@grafana/data';
@@ -539,6 +539,62 @@ describe('TextNGPanel', () => {
         ancestor = ancestor.parentElement;
       }
       expect(ancestor).not.toBeNull();
+    });
+  });
+
+  describe('refresh lifecycle', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const viewing = (props: Props) => (
+      <PanelContextProvider value={{ app: CoreApp.Dashboard } as PanelContext}>
+        <TextNGPanel {...props} />
+      </PanelContextProvider>
+    );
+
+    const settle = () => act(() => jest.advanceTimersByTime(200));
+
+    const html = () => screen.getByTestId('TextNGPanel-converted-content').innerHTML;
+
+    it('re-renders the content when new query data arrives', () => {
+      const props = createProps((target) => target, {
+        data: createData([toDataFrame({ fields: [{ name: 'host', values: ['web-1'] }] })]),
+        options: { content: '{{#each data}}{{host}}{{/each}}', mode: TextMode.Markdown },
+      });
+
+      const { rerender } = render(viewing(props));
+      settle();
+      expect(html()).toContain('web-1');
+
+      const refreshed = Object.assign({}, props, {
+        data: createData([toDataFrame({ fields: [{ name: 'host', values: ['web-2'] }] })]),
+      });
+      rerender(viewing(refreshed));
+      settle();
+
+      expect(html()).toContain('web-2');
+    });
+
+    it('re-renders the content when a referenced variable changes', () => {
+      let value = 'first';
+      const props = createProps((target) => target.replace('${host}', value), {
+        options: { content: '${host}', mode: TextMode.Markdown },
+      });
+
+      const { rerender } = render(viewing(props));
+      settle();
+      expect(html()).toContain('first');
+
+      value = 'second';
+      rerender(viewing(Object.assign({}, props, { renderCounter: props.renderCounter + 1 })));
+      settle();
+
+      expect(html()).toContain('second');
     });
   });
 


### PR DESCRIPTION
Functionality was covered by the rendering/interpolation work, this PR adds tests.

Fixes https://github.com/grafana/grafana/issues/128902

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
