### PR TITLE
Alerting: Save options tooltip values when clicking outside

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx
@@ -1,0 +1,74 @@
+import { act, render, screen, userEvent, waitFor } from 'test/test-utils';
+
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { QueryOptions } from './QueryOptions';
+
+const query: AlertQuery = {
+  refId: 'A',
+  queryType: '',
+  datasourceUid: 'prometheus',
+  model: { refId: 'A' },
+};
+
+function renderQueryOptions(queryOptions = { maxDataPoints: 100, minInterval: '1m' }) {
+  const onChangeQueryOptions = jest.fn();
+
+  render(
+    <QueryOptions query={query} queryOptions={queryOptions} onChangeQueryOptions={onChangeQueryOptions} index={0} />
+  );
+
+  return { onChangeQueryOptions };
+}
+
+async function flushFloatingUi() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function openOptions() {
+  await userEvent.click(screen.getByRole('button', { name: /options/i }));
+  expect(await screen.findByTestId('toggletip-content')).toBeInTheDocument();
+  await flushFloatingUi();
+}
+
+async function dismissWithoutBlur() {
+  // Escape and click-outside both close the toggletip via onClose without a blur on the
+  // focused input, which is the path that used to drop the in-progress value.
+  await userEvent.keyboard('{Escape}');
+  await flushFloatingUi();
+}
+
+describe('QueryOptions', () => {
+  it('saves the interval when the tooltip is dismissed without blur', async () => {
+    const { onChangeQueryOptions } = renderQueryOptions();
+
+    await openOptions();
+
+    const intervalInput = screen.getByRole('textbox', { name: /interval/i });
+    await userEvent.clear(intervalInput);
+    await userEvent.type(intervalInput, '5m');
+
+    expect(onChangeQueryOptions).not.toHaveBeenCalled();
+
+    dismissWithoutBlur();
+
+    await waitFor(() => {
+      expect(onChangeQueryOptions).toHaveBeenCalledTimes(1);
+    });
+    expect(onChangeQueryOptions).toHaveBeenCalledWith({ maxDataPoints: 100, minInterval: '5m' }, 0);
+  });
+
+  it('does not persist query options when the tooltip is dismissed with no edits', async () => {
+    const { onChangeQueryOptions } = renderQueryOptions();
+
+    await openOptions();
+    dismissWithoutBlur();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('toggletip-content')).not.toBeInTheDocument();
+    });
+    expect(onChangeQueryOptions).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { type GrafanaTheme2, type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -18,6 +18,10 @@ export interface QueryOptionsProps {
   index: number;
 }
 
+function haveQueryOptionsChanged(a: AlertQueryOptions, b: AlertQueryOptions) {
+  return a.maxDataPoints !== b.maxDataPoints || a.minInterval !== b.minInterval;
+}
+
 export const QueryOptions = ({
   query,
   queryOptions,
@@ -28,6 +32,35 @@ export const QueryOptions = ({
   const styles = useStyles2(getStyles);
 
   const [showOptions, setShowOptions] = useState(false);
+  const draftOptionsRef = useRef<AlertQueryOptions>(queryOptions);
+
+  const handleOpen = () => {
+    draftOptionsRef.current = queryOptions;
+    setShowOptions(true);
+  };
+
+  const handleClose = () => {
+    // Dismissing the toggletip can unmount these inputs without a blur, so persist the draft here.
+    const draft = draftOptionsRef.current;
+    if (haveQueryOptionsChanged(draft, queryOptions)) {
+      onChangeQueryOptions(draft, index);
+    }
+    setShowOptions(false);
+  };
+
+  const handleMaxDataPointsChange = (options: AlertQueryOptions) => {
+    draftOptionsRef.current = {
+      ...draftOptionsRef.current,
+      maxDataPoints: options.maxDataPoints,
+    };
+  };
+
+  const handleMinIntervalChange = (options: AlertQueryOptions) => {
+    draftOptionsRef.current = {
+      ...draftOptionsRef.current,
+      minInterval: options.minInterval,
+    };
+  };
 
   const separator = <span>, </span>;
 
@@ -44,12 +77,14 @@ export const QueryOptions = ({
                 />
               </InlineField>
             )}
-            <MaxDataPointsOption options={queryOptions} onChange={(options) => onChangeQueryOptions(options, index)} />
-            <MinIntervalOption options={queryOptions} onChange={(options) => onChangeQueryOptions(options, index)} />
+            <MaxDataPointsOption options={queryOptions} onChange={handleMaxDataPointsChange} />
+            <MinIntervalOption options={queryOptions} onChange={handleMinIntervalChange} />
           </div>
         }
         closeButton={true}
         placement="bottom-start"
+        onOpen={handleOpen}
+        onClose={handleClose}
       >
         <button type="button" className={styles.actionLink} onClick={() => setShowOptions(!showOptions)}>
           <Trans i18nKey="alerting.query-options.button-options">Options</Trans>{' '}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, userEvent } from 'test/test-utils';
+
+import { MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
+
+describe('MaxDataPointsOption', () => {
+  it('reports the parsed value on change without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MaxDataPointsOption options={{ minInterval: '1m' }} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('spinbutton', { name: /max data points/i }), '250');
+
+    expect(onChange).toHaveBeenLastCalledWith({ minInterval: '1m', maxDataPoints: 250 });
+  });
+});
+
+describe('MinIntervalOption', () => {
+  it('reports the typed interval on change without requiring blur', async () => {
+    const onChange = jest.fn();
+    render(<MinIntervalOption options={{ maxDataPoints: 100 }} onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('textbox', { name: /interval/i }), '5m');
+
+    expect(onChange).toHaveBeenLastCalledWith({ maxDataPoints: 100, minInterval: '5m' });
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -230,17 +230,15 @@ export function MaxDataPointsOption({
 }) {
   const value = options.maxDataPoints ?? '';
 
-  const onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
+  const commitMaxDataPoints = (event: ChangeEvent<HTMLInputElement>) => {
     const maxDataPointsNumber = parseInt(event.target.value, 10);
 
     const maxDataPoints = isNaN(maxDataPointsNumber) || maxDataPointsNumber === 0 ? undefined : maxDataPointsNumber;
 
-    if (maxDataPoints !== options.maxDataPoints) {
-      onChange({
-        ...options,
-        maxDataPoints,
-      });
-    }
+    onChange({
+      ...options,
+      maxDataPoints,
+    });
   };
 
   return (
@@ -257,7 +255,8 @@ export function MaxDataPointsOption({
         width={10}
         placeholder={DEFAULT_MAX_DATA_POINTS.toString()}
         spellCheck={false}
-        onBlur={onMaxDataPointsBlur}
+        onChange={commitMaxDataPoints}
+        onBlur={commitMaxDataPoints}
         defaultValue={value}
       />
     </InlineField>
@@ -273,14 +272,11 @@ export function MinIntervalOption({
 }) {
   const value = options.minInterval ?? '';
 
-  const onMinIntervalBlur = (event: ChangeEvent<HTMLInputElement>) => {
-    const minInterval = event.target.value;
-    if (minInterval !== value) {
-      onChange({
-        ...options,
-        minInterval,
-      });
-    }
+  const commitMinInterval = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange({
+      ...options,
+      minInterval: event.target.value,
+    });
   };
 
   return (
@@ -299,7 +295,8 @@ export function MinIntervalOption({
         width={10}
         placeholder={DEFAULT_MIN_INTERVAL}
         spellCheck={false}
-        onBlur={onMinIntervalBlur}
+        onChange={commitMinInterval}
+        onBlur={commitMinInterval}
         defaultValue={value}
       />
     </InlineField>


### PR DESCRIPTION
## Summary

On the alert rule create/edit page, changing Interval or Max data points in the Options toggletip next to the data source selector did not persist if the user clicked outside (or otherwise dismissed) the tooltip. Those fields only committed on `blur`, and closing the toggletip unmounts the inputs without firing that event.

This change keeps a draft of the in-progress values and writes them when the toggletip closes, so click-outside, Escape, and the close button all save.

## Related Issue (Fixes #111664)

Fixes #111664

## Changes Made

- Track pending Interval and Max data points in a draft while the Options toggletip is open.
- Commit those fields as the user types, not only on blur, so the draft is current if the tooltip unmounts.
- Persist the draft from `Toggletip` `onClose` when it differs from the last saved options.

## Testing

- `yarn jest --watchAll=false public/app/features/alerting/unified/components/rule-editor/QueryOptions.test.tsx public/app/features/alerting/unified/components/rule-editor/QueryWrapper.test.tsx`
- Regression coverage: Interval is saved when the tooltip is dismissed without blur; Max data points and Interval report on change without requiring blur; dismissing with no edits does not call `onChangeQueryOptions`.
- Those tests fail on unfixed `main` and pass with this change.

## Notes

- No feature toggle. Bug fix for an existing editor control.
- I will sign the Grafana CLA if the bot asks.