### PR TITLE
IAM: Classify unmapped legacy datasource actions

### DIFF
--- a/pkg/registry/apis/iam/datasourcek8s/k8s.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s.go
@@ -72,6 +72,18 @@ func legacyActionToK8s(dsType, action string) (string, bool) {
 	return convertedAction, convertedAction != action
 }
 
+// IsUnmappedLegacyDatasourceAction reports whether action belongs to the legacy
+// datasource action family but has no Kubernetes action mapping.
+func IsUnmappedLegacyDatasourceAction(action string) bool {
+	resource, verb, ok := strings.Cut(action, ":")
+	if !ok || verb == "" || (resource != "datasources" && !strings.HasPrefix(resource, "datasources.")) {
+		return false
+	}
+
+	converted, _ := legacyActionToK8s("*", action)
+	return converted == action
+}
+
 // LegacyDatasourceAction replaces a legacy ds action string with its k8s form
 func LegacyDatasourceAction(dsType string, action *string) {
 	if converted, ok := legacyActionToK8s(dsType, *action); ok {

--- a/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
@@ -74,3 +74,25 @@ func TestLegacyDatasourceAction(t *testing.T) {
 		assert.Equal(t, "datasources.id:read", a)
 	})
 }
+
+func TestIsUnmappedLegacyDatasourceAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		want   bool
+	}{
+		{name: "unmapped nested resource", action: "datasources.caching:read", want: true},
+		{name: "unmapped datasource verb", action: "datasources:custom", want: true},
+		{name: "mapped datasource verb", action: "datasources:read", want: false},
+		{name: "mapped permissions verb", action: "datasources.permissions:read", want: false},
+		{name: "different resource", action: "dashboards:read", want: false},
+		{name: "missing verb", action: "datasources:", want: false},
+		{name: "k8s action", action: "loki.datasource.grafana.app/datasources:get", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUnmappedLegacyDatasourceAction(tt.action))
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adds a shared classifier for legacy datasource actions that do not have a Kubernetes action mapping. This lets IAM admission distinguish permissions that must remain entirely in legacy format from mapped permissions that must use canonical Kubernetes action and scope formats.

**Why do we need this feature?**

PR #131396 correctly preserves both the action and scope for unmapped datasource permissions such as `datasources.caching:read` with `datasources:*`. Enterprise Role and GlobalRole admission need a narrow way to accept those preserved pairs without weakening validation for mapped actions.

**Who is this feature for?**

Grafana Enterprise users whose fixed or custom RBAC roles grant datasource query-caching permissions.

**Which issue(s) does this PR fix?**:

Related to #131396.

**Special notes for your reviewer:**

Paired Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/13336

Tests: `go test ./pkg/registry/apis/iam/datasourcek8s -count=1`