### PR TITLE
storage: return SQL list iteration errors

### DIFF
--- a/pkg/storage/unified/sql/list_iterator.go
+++ b/pkg/storage/unified/sql/list_iterator.go
@@ -69,5 +69,8 @@ func (l *listIter) Next() bool {
 		l.err = l.rows.Scan(&l.guid, &l.rv, &l.namespace, &l.group, &l.resource, &l.name, &l.folder, &l.value)
 		return true
 	}
+	if l.err == nil {
+		l.err = l.rows.Err()
+	}
 	return false
 }

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
@@ -16,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	dbsql "github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
+	dbmocks "github.com/grafana/grafana/pkg/storage/unified/sql/db/mocks"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
@@ -26,6 +29,35 @@ import (
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
+
+func TestListIterReturnsRowsError(t *testing.T) {
+	rowsErr := errors.New("row iteration failed")
+	rows := dbmocks.NewRows(t)
+	rows.EXPECT().Next().Return(false).Once()
+	rows.EXPECT().Err().Return(rowsErr).Once()
+
+	iter := &listIter{rows: rows}
+
+	require.False(t, iter.Next())
+	require.ErrorIs(t, iter.Error(), rowsErr)
+}
+
+func TestListIterPreservesScanError(t *testing.T) {
+	scanErr := errors.New("row scan failed")
+	rows := dbmocks.NewRows(t)
+	rows.EXPECT().Next().Return(true).Once()
+	rows.On("Scan", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(scanErr).Once()
+	rows.EXPECT().Next().Return(false).Once()
+
+	iter := &listIter{rows: rows}
+
+	require.True(t, iter.Next())
+	require.ErrorIs(t, iter.Error(), scanErr)
+	require.False(t, iter.Next())
+	require.ErrorIs(t, iter.Error(), scanErr)
+}
+
 func TestIntegrationListIter(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 


### PR DESCRIPTION
## What

Propagate errors reported by `db.Rows` after `Next()` stops returning rows. This prevents failed unified-storage list queries from being returned as successful empty results.

Fixes #131671

## How to test

- `go test ./pkg/storage/unified/sql -run "^TestListIterReturnsRowsError$" -count=1`

The regression test verifies `listIter.Error()` returns an error reported after iteration ends.