### PR TITLE
fix(unified-storage): surface DB errors from list iterator Next()

### DIFF
--- a/pkg/storage/unified/sql/list_iterator.go
+++ b/pkg/storage/unified/sql/list_iterator.go
@@ -69,5 +69,12 @@ func (l *listIter) Next() bool {
 		l.err = l.rows.Scan(&l.guid, &l.rv, &l.namespace, &l.group, &l.resource, &l.name, &l.folder, &l.value)
 		return true
 	}
+	// Rows.Next() returning false means either "no more rows" or "an error
+	// occurred" — database/sql requires calling Rows.Err() to distinguish the
+	// two. Surface any iteration error so a mid-query DB failure is not
+	// reported as a successful (empty) result.
+	if l.err == nil {
+		l.err = l.rows.Err()
+	}
 	return false
 }

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -1,269 +1,31 @@
 package sql
 
 import (
-	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	dbsql "github.com/grafana/grafana/pkg/storage/unified/sql/db"
-	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
-	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
-	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
-	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
-	"github.com/grafana/grafana/pkg/tests/testsuite"
-	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db/mocks"
 )
 
-func TestMain(m *testing.M) {
-	testsuite.Run(m)
+func TestListIter_NextSurfacesRowsErr(t *testing.T) {
+	rows := mocks.NewRows(t)
+	iterErr := errors.New("mid-iteration database failure")
+	rows.On("Next").Return(false)
+	rows.On("Err").Return(iterErr)
+
+	iter := &listIter{rows: rows}
+	require.False(t, iter.Next())
+	require.ErrorIs(t, iter.Error(), iterErr)
 }
-func TestIntegrationListIter(t *testing.T) {
-	testutil.SkipIntegrationTestInShortMode(t)
 
-	ctx := context.Background()
+func TestListIter_NextEndOfRowsIsNotError(t *testing.T) {
+	rows := mocks.NewRows(t)
+	rows.On("Next").Return(false)
+	rows.On("Err").Return(nil)
 
-	grafanaDB := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
-
-	resourceDBProvider, err := dbimpl.ProvideResourceDB(grafanaDB, setting.NewCfg(), tracing.NewNoopTracerService())
-	require.NoError(t, err)
-
-	resourceDB, err := resourceDBProvider.Init(ctx)
-	require.NoError(t, err)
-
-	dialect := sqltemplate.DialectForDriver(resourceDB.DriverName())
-
-	testData := []struct {
-		guid            string
-		resourceVersion int64
-		namespace       string
-		resource        string
-		group           string
-		name            string
-		folder          string
-		value           []byte
-	}{
-		{
-			guid:            "guid-1",
-			resourceVersion: 100,
-			namespace:       "namespace-1",
-			resource:        "resource-1",
-			group:           "group-1",
-			name:            "name-1",
-			folder:          "folder-1",
-			value:           []byte(`{"test":"value-1"}`),
-		},
-		{
-			guid:            "guid-2",
-			resourceVersion: 200,
-			namespace:       "namespace-2",
-			resource:        "resource-2",
-			group:           "group-2",
-			name:            "name-2",
-			folder:          "folder-2",
-			value:           []byte(`{"test":"value-2"}`),
-		},
-	}
-
-	// Insert the test data directly with SQL to include resource_version
-	err = resourceDB.WithTx(ctx, nil, func(ctx context.Context, tx dbsql.Tx) error {
-		for _, item := range testData {
-			_, err := dbutil.Exec(ctx, tx, sqlResourceInsert, sqlResourceRequest{
-				SQLTemplate:     sqltemplate.New(dialect),
-				GUID:            item.guid,
-				Folder:          item.folder,
-				ResourceVersion: item.resourceVersion,
-				WriteEvent: resource.WriteEvent{
-					Key: &resourcepb.ResourceKey{
-						Namespace: item.namespace,
-						Resource:  item.resource,
-						Group:     item.group,
-						Name:      item.name,
-					},
-					Value: item.value,
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("failed to insert test data: %w", err)
-			}
-
-			if _, err = dbutil.Exec(ctx, tx, rvmanager.SqlResourceUpdateRV, rvmanager.SqlResourceUpdateRVRequest{
-				SQLTemplate: sqltemplate.New(dialect),
-				GUIDToRV: map[string]int64{
-					item.guid: item.resourceVersion,
-				},
-			}); err != nil {
-				return fmt.Errorf("failed to insert test data: %w", err)
-			}
-
-			if _, err = dbutil.Exec(ctx, tx, sqlResourceUpdate, sqlResourceRequest{
-				SQLTemplate:     sqltemplate.New(dialect),
-				GUID:            item.guid,
-				ResourceVersion: item.resourceVersion,
-				Folder:          item.folder,
-				WriteEvent: resource.WriteEvent{
-					Key: &resourcepb.ResourceKey{
-						Namespace: item.namespace,
-						Resource:  item.resource,
-						Group:     item.group,
-						Name:      item.name,
-					},
-					Value:      item.value,
-					PreviousRV: item.resourceVersion,
-					Type:       1,
-				},
-			}); err != nil {
-				return fmt.Errorf("failed to insert resource version: %w", err)
-			}
-		}
-		return err
-	})
-	require.NoError(t, err)
-
-	t.Run("Next() iterates through results", func(t *testing.T) {
-		listReq := sqlResourceListRequest{
-			SQLTemplate: sqltemplate.New(dialect),
-			Request:     new(resourcepb.ListRequest),
-		}
-		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
-		require.NoError(t, err)
-
-		iter := &listIter{
-			rows:    rows,
-			listRV:  300,
-			sortAsc: true,
-		}
-
-		// First row.
-		require.True(t, iter.Next())
-		require.NoError(t, iter.Error())
-		require.Equal(t, "guid-1", iter.guid)
-		require.Equal(t, int64(100), iter.ResourceVersion())
-		require.Equal(t, "namespace-1", iter.Namespace())
-		require.Equal(t, "resource-1", iter.resource)
-		require.Equal(t, "group-1", iter.group)
-		require.Equal(t, "name-1", iter.Name())
-		require.Equal(t, "folder-1", iter.Folder())
-		require.Equal(t, []byte(`{"test":"value-1"}`), iter.Value())
-
-		// Second row.
-		require.True(t, iter.Next())
-		require.NoError(t, iter.Error())
-		require.Equal(t, "guid-2", iter.guid)
-		require.Equal(t, int64(200), iter.ResourceVersion())
-		require.Equal(t, "namespace-2", iter.Namespace())
-		require.Equal(t, "resource-2", iter.resource)
-		require.Equal(t, "group-2", iter.group)
-		require.Equal(t, "name-2", iter.Name())
-		require.Equal(t, "folder-2", iter.Folder())
-		require.Equal(t, []byte(`{"test":"value-2"}`), iter.Value())
-
-		// No more rows.
-		require.False(t, iter.Next())
-		require.NoError(t, iter.Error())
-	})
-
-	t.Run("Next() returns false when no rows", func(t *testing.T) {
-		listReq := sqlResourceListRequest{
-			SQLTemplate: sqltemplate.New(dialect),
-			Request: &resourcepb.ListRequest{
-				Options: &resourcepb.ListOptions{
-					Key: &resourcepb.ResourceKey{
-						// Add a filter for a namespace that doesn't exist.
-						Namespace: "non-existent-namespace",
-					},
-				},
-			},
-		}
-		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
-		require.NoError(t, err)
-
-		iter := &listIter{
-			rows:    rows,
-			listRV:  300,
-			sortAsc: true,
-		}
-
-		require.False(t, iter.Next())
-		require.NoError(t, iter.Error())
-	})
-
-	t.Run("ContinueToken returns encoded token", func(t *testing.T) {
-		listReq := sqlResourceListRequest{
-			SQLTemplate: sqltemplate.New(dialect),
-			Request:     new(resourcepb.ListRequest),
-		}
-
-		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
-		require.NoError(t, err)
-
-		iter := &listIter{
-			rows:    rows,
-			listRV:  300,
-			sortAsc: true,
-		}
-
-		require.True(t, iter.Next())
-
-		token := iter.ContinueToken()
-
-		var actual ContinueToken
-		b, err := base64.StdEncoding.DecodeString(token)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(b, &actual)
-		require.NoError(t, err)
-
-		expected := ContinueToken{
-			ResourceVersion: 300,
-			StartOffset:     1,
-			SortAscending:   true,
-		}
-
-		require.Equal(t, expected, actual)
-	})
-
-	t.Run("ContinueToken uses the current row's RV", func(t *testing.T) {
-		listReq := sqlResourceListRequest{
-			SQLTemplate: sqltemplate.New(dialect),
-			Request:     new(resourcepb.ListRequest),
-		}
-
-		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
-		require.NoError(t, err)
-
-		iter := &listIter{
-			rows:         rows,
-			listRV:       300,
-			sortAsc:      true,
-			useCurrentRV: true, // use the current RV for the continue token instead of the listRV
-		}
-
-		require.True(t, iter.Next())
-
-		token := iter.ContinueToken()
-
-		var actual ContinueToken
-		b, err := base64.StdEncoding.DecodeString(token)
-		require.NoError(t, err)
-
-		err = json.Unmarshal(b, &actual)
-		require.NoError(t, err)
-
-		expected := ContinueToken{
-			ResourceVersion: 100,
-			StartOffset:     1,
-			SortAscending:   true,
-		}
-
-		require.Equal(t, expected, actual)
-	})
+	iter := &listIter{rows: rows}
+	require.False(t, iter.Next())
+	require.NoError(t, iter.Error())
 }

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -1,16 +1,276 @@
 package sql
 
 import (
+	"context"
 	"errors"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/storage/unified/sql/db/mocks"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	dbsql "github.com/grafana/grafana/pkg/storage/unified/sql/db"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
+	dbmocks "github.com/grafana/grafana/pkg/storage/unified/sql/db/mocks"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}
+func TestIntegrationListIter(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+
+	grafanaDB := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	resourceDBProvider, err := dbimpl.ProvideResourceDB(grafanaDB, setting.NewCfg(), tracing.NewNoopTracerService())
+	require.NoError(t, err)
+
+	resourceDB, err := resourceDBProvider.Init(ctx)
+	require.NoError(t, err)
+
+	dialect := sqltemplate.DialectForDriver(resourceDB.DriverName())
+
+	testData := []struct {
+		guid            string
+		resourceVersion int64
+		namespace       string
+		resource        string
+		group           string
+		name            string
+		folder          string
+		value           []byte
+	}{
+		{
+			guid:            "guid-1",
+			resourceVersion: 100,
+			namespace:       "namespace-1",
+			resource:        "resource-1",
+			group:           "group-1",
+			name:            "name-1",
+			folder:          "folder-1",
+			value:           []byte(`{"test":"value-1"}`),
+		},
+		{
+			guid:            "guid-2",
+			resourceVersion: 200,
+			namespace:       "namespace-2",
+			resource:        "resource-2",
+			group:           "group-2",
+			name:            "name-2",
+			folder:          "folder-2",
+			value:           []byte(`{"test":"value-2"}`),
+		},
+	}
+
+	// Insert the test data directly with SQL to include resource_version
+	err = resourceDB.WithTx(ctx, nil, func(ctx context.Context, tx dbsql.Tx) error {
+		for _, item := range testData {
+			_, err := dbutil.Exec(ctx, tx, sqlResourceInsert, sqlResourceRequest{
+				SQLTemplate:     sqltemplate.New(dialect),
+				GUID:            item.guid,
+				Folder:          item.folder,
+				ResourceVersion: item.resourceVersion,
+				WriteEvent: resource.WriteEvent{
+					Key: &resourcepb.ResourceKey{
+						Namespace: item.namespace,
+						Resource:  item.resource,
+						Group:     item.group,
+						Name:      item.name,
+					},
+					Value: item.value,
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to insert test data: %w", err)
+			}
+
+			if _, err = dbutil.Exec(ctx, tx, rvmanager.SqlResourceUpdateRV, rvmanager.SqlResourceUpdateRVRequest{
+				SQLTemplate: sqltemplate.New(dialect),
+				GUIDToRV: map[string]int64{
+					item.guid: item.resourceVersion,
+				},
+			}); err != nil {
+				return fmt.Errorf("failed to insert test data: %w", err)
+			}
+
+			if _, err = dbutil.Exec(ctx, tx, sqlResourceUpdate, sqlResourceRequest{
+				SQLTemplate:     sqltemplate.New(dialect),
+				GUID:            item.guid,
+				ResourceVersion: item.resourceVersion,
+				Folder:          item.folder,
+				WriteEvent: resource.WriteEvent{
+					Key: &resourcepb.ResourceKey{
+						Namespace: item.namespace,
+						Resource:  item.resource,
+						Group:     item.group,
+						Name:      item.name,
+					},
+					Value:      item.value,
+					PreviousRV: item.resourceVersion,
+					Type:       1,
+				},
+			}); err != nil {
+				return fmt.Errorf("failed to insert resource version: %w", err)
+			}
+		}
+		return err
+	})
+	require.NoError(t, err)
+
+	t.Run("Next() iterates through results", func(t *testing.T) {
+		listReq := sqlResourceListRequest{
+			SQLTemplate: sqltemplate.New(dialect),
+			Request:     new(resourcepb.ListRequest),
+		}
+		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
+		require.NoError(t, err)
+
+		iter := &listIter{
+			rows:    rows,
+			listRV:  300,
+			sortAsc: true,
+		}
+
+		// First row.
+		require.True(t, iter.Next())
+		require.NoError(t, iter.Error())
+		require.Equal(t, "guid-1", iter.guid)
+		require.Equal(t, int64(100), iter.ResourceVersion())
+		require.Equal(t, "namespace-1", iter.Namespace())
+		require.Equal(t, "resource-1", iter.resource)
+		require.Equal(t, "group-1", iter.group)
+		require.Equal(t, "name-1", iter.Name())
+		require.Equal(t, "folder-1", iter.Folder())
+		require.Equal(t, []byte(`{"test":"value-1"}`), iter.Value())
+
+		// Second row.
+		require.True(t, iter.Next())
+		require.NoError(t, iter.Error())
+		require.Equal(t, "guid-2", iter.guid)
+		require.Equal(t, int64(200), iter.ResourceVersion())
+		require.Equal(t, "namespace-2", iter.Namespace())
+		require.Equal(t, "resource-2", iter.resource)
+		require.Equal(t, "group-2", iter.group)
+		require.Equal(t, "name-2", iter.Name())
+		require.Equal(t, "folder-2", iter.Folder())
+		require.Equal(t, []byte(`{"test":"value-2"}`), iter.Value())
+
+		// No more rows.
+		require.False(t, iter.Next())
+		require.NoError(t, iter.Error())
+	})
+
+	t.Run("Next() returns false when no rows", func(t *testing.T) {
+		listReq := sqlResourceListRequest{
+			SQLTemplate: sqltemplate.New(dialect),
+			Request: &resourcepb.ListRequest{
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						// Add a filter for a namespace that doesn't exist.
+						Namespace: "non-existent-namespace",
+					},
+				},
+			},
+		}
+		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
+		require.NoError(t, err)
+
+		iter := &listIter{
+			rows:    rows,
+			listRV:  300,
+			sortAsc: true,
+		}
+
+		require.False(t, iter.Next())
+		require.NoError(t, iter.Error())
+	})
+
+	t.Run("ContinueToken returns encoded token", func(t *testing.T) {
+		listReq := sqlResourceListRequest{
+			SQLTemplate: sqltemplate.New(dialect),
+			Request:     new(resourcepb.ListRequest),
+		}
+
+		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
+		require.NoError(t, err)
+
+		iter := &listIter{
+			rows:    rows,
+			listRV:  300,
+			sortAsc: true,
+		}
+
+		require.True(t, iter.Next())
+
+		token := iter.ContinueToken()
+
+		var actual ContinueToken
+		b, err := base64.StdEncoding.DecodeString(token)
+		require.NoError(t, err)
+
+		err = json.Unmarshal(b, &actual)
+		require.NoError(t, err)
+
+		expected := ContinueToken{
+			ResourceVersion: 300,
+			StartOffset:     1,
+			SortAscending:   true,
+		}
+
+		require.Equal(t, expected, actual)
+	})
+
+	t.Run("ContinueToken uses the current row's RV", func(t *testing.T) {
+		listReq := sqlResourceListRequest{
+			SQLTemplate: sqltemplate.New(dialect),
+			Request:     new(resourcepb.ListRequest),
+		}
+
+		rows, err := dbutil.QueryRows(ctx, resourceDB, sqlResourceList, listReq)
+		require.NoError(t, err)
+
+		iter := &listIter{
+			rows:         rows,
+			listRV:       300,
+			sortAsc:      true,
+			useCurrentRV: true, // use the current RV for the continue token instead of the listRV
+		}
+
+		require.True(t, iter.Next())
+
+		token := iter.ContinueToken()
+
+		var actual ContinueToken
+		b, err := base64.StdEncoding.DecodeString(token)
+		require.NoError(t, err)
+
+		err = json.Unmarshal(b, &actual)
+		require.NoError(t, err)
+
+		expected := ContinueToken{
+			ResourceVersion: 100,
+			StartOffset:     1,
+			SortAscending:   true,
+		}
+
+		require.Equal(t, expected, actual)
+	})
+}
 func TestListIter_NextSurfacesRowsErr(t *testing.T) {
-	rows := mocks.NewRows(t)
+	rows := dbmocks.NewRows(t)
 	iterErr := errors.New("mid-iteration database failure")
 	rows.On("Next").Return(false)
 	rows.On("Err").Return(iterErr)
@@ -21,7 +281,7 @@ func TestListIter_NextSurfacesRowsErr(t *testing.T) {
 }
 
 func TestListIter_NextEndOfRowsIsNotError(t *testing.T) {
-	rows := mocks.NewRows(t)
+	rows := dbmocks.NewRows(t)
 	rows.On("Next").Return(false)
 	rows.On("Err").Return(nil)
 


### PR DESCRIPTION
### Problem

`listIter.Next()` never checks `rows.Err()`. When `database/sql` iteration fails mid-query, `Rows.Next()` returns `false`, but `Next()` returns `false` without setting any error — the caller can't distinguish "no more rows" from "DB connection failed."

The `listLatest` handler in `backend.go` passes the iterator straight to the callback, so a mid-iteration DB failure surfaces as a successful HTTP 200 with an empty list — the application error is silently swallowed.

### Fix

In `listIter.Next()`, after `rows.Next()` returns `false`, check `rows.Err()` and propagate any iteration error:

```go
if l.err == nil {
    l.err = l.rows.Err()
}
```

`rows.Err()` returns `nil` when iteration completed normally (clean end-of-rows), so the existing behavior for the happy path is unchanged.

### Tests

Two unit tests using the `db/mocks.Rows` mock:
- `TestListIter_NextSurfacesRowsErr` — verifies that `Error()` returns the `rows.Err()` value when `Next()` returns `false`
- `TestListIter_NextEndOfRowsIsNotError` — verifies that `Error()` returns `nil` when iteration ends normally

Fixes #131671