### PR TITLE
Search: Add example to the generated openapi spec

### DIFF
--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v0alpha1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -285,6 +291,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v1beta1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -285,6 +291,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -285,6 +291,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2alpha1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -285,6 +291,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
+++ b/packages/grafana-openapi/src/apis/dashboard.grafana.app-v2beta1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -285,6 +291,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },
@@ -1056,6 +1067,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/folder.grafana.app-v1beta1.json
@@ -254,6 +254,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -41,6 +41,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -106,6 +112,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1149,6 +1161,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1393,6 +1411,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -2183,6 +2207,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/rules.alerting.grafana.app-v0alpha1.json
@@ -253,6 +253,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1231,6 +1237,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/pkg/registry/apis/search/openapi_schemas.go
+++ b/pkg/registry/apis/search/openapi_schemas.go
@@ -71,13 +71,14 @@ func envelopeSchemas(roots ...string) map[string]spec.Schema {
 }
 
 // jsonContent describes a JSON body carrying the named Go type.
-func jsonContent(goName string) map[string]*spec3.MediaType {
+func jsonContent(goName string, example any) map[string]*spec3.MediaType {
 	return map[string]*spec3.MediaType{
 		"application/json": {
 			MediaTypeProps: spec3.MediaTypeProps{
 				Schema: &spec.Schema{
 					SchemaProps: spec.SchemaProps{Ref: schemaRef(goName)},
 				},
+				Example: example,
 			},
 		},
 	}

--- a/pkg/registry/apis/search/route.go
+++ b/pkg/registry/apis/search/route.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
@@ -99,6 +100,10 @@ func searchRouteSpec(kindName, version string) *spec3.PathProps {
 		requestGo:    searchQueryGoName,
 		responseKind: searchv0.KindSearchResults,
 		responseGo:   searchResultsGoName,
+		example: &searchv0.SearchQuery{
+			TypeMeta: v1.TypeMeta{APIVersion: searchv0.APIVERSION, Kind: searchv0.KindSearchQuery},
+			Limit:    10,
+		},
 	})
 }
 
@@ -110,6 +115,10 @@ func trashRouteSpec(kindName, version string) *spec3.PathProps {
 		requestGo:    trashQueryGoName,
 		responseKind: searchv0.KindTrashResults,
 		responseGo:   trashResultsGoName,
+		example: &searchv0.TrashQuery{
+			TypeMeta: v1.TypeMeta{APIVersion: searchv0.APIVERSION, Kind: searchv0.KindTrashQuery},
+			Limit:    10,
+		},
 	})
 }
 
@@ -123,6 +132,7 @@ type routeSpecArgs struct {
 	requestGo    string
 	responseKind string
 	responseGo   string
+	example      any
 }
 
 // routeSpec builds what both endpoints have in common: a namespaced POST taking a
@@ -150,7 +160,7 @@ func routeSpec(a routeSpecArgs) *spec3.PathProps {
 					RequestBodyProps: spec3.RequestBodyProps{
 						Required:    true,
 						Description: "A " + a.requestKind + " describing what to match, sort and return.",
-						Content:     jsonContent(a.requestGo),
+						Content:     jsonContent(a.requestGo, a.example),
 					},
 				},
 				Responses: &spec3.Responses{
@@ -159,7 +169,7 @@ func routeSpec(a routeSpecArgs) *spec3.PathProps {
 							200: {
 								ResponseProps: spec3.ResponseProps{
 									Description: "A " + a.responseKind + " envelope.",
-									Content:     jsonContent(a.responseGo),
+									Content:     jsonContent(a.responseGo, nil),
 								},
 							},
 						},

--- a/pkg/registry/apis/search/route_test.go
+++ b/pkg/registry/apis/search/route_test.go
@@ -1,6 +1,8 @@
 package search
 
 import (
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -8,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 	"k8s.io/kube-openapi/pkg/validation/spec"
+
+	searchv0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
 )
 
 func TestSearchRoute(t *testing.T) {
@@ -23,6 +27,13 @@ func TestSearchRoute(t *testing.T) {
 	require.NotNil(t, r.Spec.Post, "search is a POST, so no other method should be described")
 	assert.Nil(t, r.Spec.Get)
 	assert.Equal(t, "listDashboardSearchV0alpha1", r.Spec.Post.OperationId)
+
+	// A documented example is only useful if a client can send it back, so it
+	// goes through the handler that serves the route it is documented on.
+	example := requestExample(t, r)
+	assert.JSONEq(t, `{"apiVersion":"`+searchv0.APIVERSION+`","kind":"`+searchv0.KindSearchQuery+`","limit":10}`, example)
+	w := doRequest(t, h, example)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 }
 
 func TestTrashRoute(t *testing.T) {
@@ -36,6 +47,26 @@ func TestTrashRoute(t *testing.T) {
 	require.NotNil(t, r.Spec.Post, "trash is a POST, so no other method should be described")
 	assert.Nil(t, r.Spec.Get)
 	assert.Equal(t, "listDashboardTrashV0alpha1", r.Spec.Post.OperationId)
+
+	example := requestExample(t, r)
+	assert.JSONEq(t, `{"apiVersion":"`+searchv0.APIVERSION+`","kind":"`+searchv0.KindTrashQuery+`","limit":10}`, example)
+	w := doTrashRequest(t, h, example)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+// requestExample is the example body the spec documents for the route, encoded
+// the way a client reading the spec would send it.
+func requestExample(t *testing.T, r Route) string {
+	t.Helper()
+
+	require.NotNil(t, r.Spec.Post.RequestBody)
+	media, ok := r.Spec.Post.RequestBody.Content["application/json"]
+	require.True(t, ok, "the request body describes a JSON payload")
+	require.NotNil(t, media.Example, "the request body carries an example")
+
+	raw, err := json.Marshal(media.Example)
+	require.NoError(t, err)
+	return string(raw)
 }
 
 func TestOperationIDs(t *testing.T) {

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -4,9 +4,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
@@ -33,15 +33,23 @@ func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {
 // for manifests read at runtime, which can be malformed without this build
 // being at fault.
 func ManifestBackedProvider(manifests []app.Manifest) (SearchFieldsProvider, error) {
+	data := make([]*app.ManifestData, len(manifests))
+	for i, m := range manifests {
+		data[i] = m.ManifestData
+	}
+	return NewSearchFieldsProvider(data)
+}
+
+func NewSearchFieldsProvider(manifests []*app.ManifestData) (SearchFieldsProvider, error) {
 	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	preferred := map[schema.GroupResource]string{}
 
 	for _, m := range manifests {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
-		group := m.ManifestData.Group
-		for _, version := range m.ManifestData.Versions {
+		group := m.Group
+		for _, version := range m.Versions {
 			for _, kind := range version.Kinds {
 				if len(kind.SearchFields) == 0 {
 					continue
@@ -54,7 +62,7 @@ func ManifestBackedProvider(manifests []app.Manifest) (SearchFieldsProvider, err
 				fields[gvr] = manifestSearchFieldsToDefinitions(kind.SearchFields)
 
 				gr := gvr.GroupResource()
-				if pv := m.ManifestData.PreferredVersion; pv != "" {
+				if pv := m.PreferredVersion; pv != "" {
 					preferred[gr] = pv
 				} else {
 					// No explicit preference: the last version that declares the

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -327,6 +333,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v1beta1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -327,6 +333,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -327,6 +333,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2alpha1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -327,6 +333,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v2beta1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -327,6 +333,11 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.TrashQuery"
+              },
+              "example": {
+                "kind": "TrashQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "limit": 10
               }
             }
           },
@@ -1157,6 +1168,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/folder.grafana.app-v1beta1.json
@@ -283,6 +283,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -56,6 +56,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -146,6 +152,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1298,6 +1310,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1569,6 +1587,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -2452,6 +2476,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },

--- a/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/rules.alerting.grafana.app-v0alpha1.json
@@ -282,6 +282,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },
@@ -1323,6 +1329,12 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.search.v0alpha1.SearchQuery"
+              },
+              "example": {
+                "kind": "SearchQuery",
+                "apiVersion": "search.grafana.app/v0alpha1",
+                "facetLimit": 0,
+                "limit": 10
               }
             }
           },


### PR DESCRIPTION
This adds an example request for the `/search` and `/trash` endpoints -- this makes it so the swagger UI can easily execute a test query without needing to change anything.

For example: http://localhost:3000/swagger?api=folder.grafana.app-v1#/Search/listFolderSearchV1

<img width="1856" height="1854" alt="CleanShot 2026-08-27 at 13 59 45@2x" src="https://github.com/user-attachments/assets/83b8764b-f2db-452c-9a33-9e839282eb79" />


Added `no-check-unified-storage-compatibility` because this does not change anything with compatibility issues between client+server
