### PR TITLE
Provisioning: Fix flaky webhook hook-failure cooldown test

### DIFF
--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -199,9 +199,43 @@ func TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately(t *testin
 		assert.Nil(collect, repo.Status.Webhook, "webhook status should remain unset when creation fails")
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should record the initial webhook failure")
 
+	// The controller reads the repository from its informer cache, so a reconcile
+	// pass that starts before the HealthFailureHook patch has propagated there
+	// still sees a pre-failure status and legitimately re-attempts the create.
+	// That makes "exactly one attempt" the wrong invariant; what must hold is
+	// that attempts stop once the cooldown is visible. Settle first, then require
+	// silence — a controller that hot-loops never settles and fails in
+	// waitForStableCount instead.
+	settled := waitForStableCount(t, &webhookCreateCalls, 2*time.Second, common.WaitTimeoutDefault)
+
 	require.Never(t, func() bool {
-		return webhookCreateCalls.Load() > 1
-	}, 5*time.Second, 100*time.Millisecond, "webhook creation should not be retried immediately after a hook failure")
+		return webhookCreateCalls.Load() > settled
+	}, 5*time.Second, 100*time.Millisecond, "webhook creation should not be retried while the hook failure cooldown is active")
+}
+
+// waitForStableCount polls counter until it holds the same value for stableFor,
+// and returns that value. It fails the test if the counter is still moving after
+// timeout, which is what a hook-failure hot loop looks like.
+func waitForStableCount(t *testing.T, counter *atomic.Int32, stableFor, timeout time.Duration) int32 {
+	t.Helper()
+
+	const pollInterval = 50 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+	last := counter.Load()
+	stableSince := time.Now()
+
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+		switch current := counter.Load(); {
+		case current != last:
+			last, stableSince = current, time.Now()
+		case time.Since(stableSince) >= stableFor:
+			return current
+		}
+	}
+
+	t.Fatalf("webhook creation attempts never stopped: still climbing after %s (last count %d)", timeout, last)
+	return 0
 }
 
 // TestIntegrationProvisioning_GithubPullRequestWebhookPostsComment verifies the


### PR DESCRIPTION
## What is this feature?

Fixes a flaky assertion in `TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately` (`pkg/tests/apis/provisioning/git/webhook`).

## Why do we need this feature?

The test has been failing across unrelated PRs, always on the same line and always at ~1.1s:

```
--- FAIL: TestIntegrationProvisioning_WebhookFailureDoesNotRetryImmediately (1.09s)
    webhook_test.go:202:
        Error:    Condition satisfied
        Messages: webhook creation should not be retried immediately after a hook failure
```

Seen in [98419434045](https://github.com/grafana/grafana/actions/runs/33041411526/job/98419434045), [98419035384](https://github.com/grafana/grafana/actions/runs/33042479303/job/98419035384) and [98419958837](https://github.com/grafana/grafana/actions/runs/33042765012/job/98419958837), on both MySQL and Postgres Enterprise.

The Gitea container logs in the failing runs show two identical groups of git operations against the repo under test:

```
GET  :46714  info/refs?service=git-upload-pack    ┐
GET  :46722  info/refs?service=git-upload-pack    │ reconcile pass 1
POST :46736  git-upload-pack                      │ (Test() health check)
GET  :46736  info/refs?service=git-receive-pack   ┘
GET  :46744  info/refs?service=git-upload-pack    ┐
GET  :46748  info/refs?service=git-upload-pack    │ reconcile pass 2
POST :46750  git-upload-pack                      │ (Test() ran again)
GET  :46750  info/refs?service=git-receive-pack   ┘
```

That second health check is the tell. `RefreshHealthWithPatchOps` returns early and skips `Test()` whenever the hook-failure cooldown is active, so pass 2 running `Test()` proves it did not observe the cooldown — and therefore also re-ran `processHooks` and re-attempted `CreateWebhook`.

The cause is a read-after-write race rather than a broken cooldown. `inHookFailureCooldown` is derived purely from the persisted `Status.Health`, and the controller reads the repository from the informer's local cache (`NewCachedRepositoryGetter(inf.Lister())` on the non-NATS path). A reconcile pass that starts before the `HealthFailureHook` patch propagates into that cache sees a pre-failure status and legitimately attempts the create once more.

So `Never(calls > 1)` asserts something the current design does not guarantee.

## Which issue(s) does this PR fix?

Test-only change; no issue filed.

## Special notes for your reviewer

The invariant worth testing is that attempts *stop*, not that exactly one is ever made. The test now settles the counter first, then requires silence:

- `waitForStableCount` polls until the counter holds steady for 2s, and fails the test if it is still climbing after the timeout — which is exactly what the hot loop this test guards against looks like, so that regression still fails, just with a clearer message.
- `require.Never` then asserts no growth beyond the settled count for 5s, against a 60s cooldown.

Worth flagging separately, and deliberately **not** changed here: because the racing pass does not see the cooldown, it re-runs the health check and emits a `replace /status/health` with a *healthy* status, which can clobber the `HealthFailureHook` that was just persisted, dropping the cooldown and restarting the cycle. In production that is an extra provider API call per stale pass and potentially a slow retry loop against a failing GitHub. An in-process cooldown record in `RepositoryController`, complementing the persisted status, would close it — but that is a production controller change, and the deterministic unit tests (`TestRepositoryController_process_HookFailureCooldownSuppressesRetry` and friends) encode the current design. Happy to follow up if the team wants it.

Verified `go vet`, `gofmt` and test compilation. The test itself needs a Gitea testcontainer, so it was not run locally — relying on CI here.
