### PR TITLE
test: improve cleanup reliability in diagnostics e2e test

### DIFF
--- a/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
+++ b/e2e-playwright/diagnostics-suite/download-diagnostics.spec.ts
@@ -163,6 +163,40 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
   let dashboardUid: string;
   let apiContext: APIRequestContext;
 
+  // Helper function to clean up resources with error handling
+  async function cleanupResources() {
+    const cleanupErrors: Error[] = [];
+
+    if (dashboardUid) {
+      try {
+        await apiContext.delete(`/api/dashboards/uid/${dashboardUid}`);
+        dashboardUid = '';
+      } catch (error) {
+        cleanupErrors.push(new Error(`Failed to delete dashboard: ${error}`));
+      }
+    }
+    if (successDsUid) {
+      try {
+        await apiContext.delete(`/api/datasources/uid/${successDsUid}`);
+        successDsUid = '';
+      } catch (error) {
+        cleanupErrors.push(new Error(`Failed to delete success datasource: ${error}`));
+      }
+    }
+    if (failureDsUid) {
+      try {
+        await apiContext.delete(`/api/datasources/uid/${failureDsUid}`);
+        failureDsUid = '';
+      } catch (error) {
+        cleanupErrors.push(new Error(`Failed to delete failure datasource: ${error}`));
+      }
+    }
+
+    if (cleanupErrors.length > 0) {
+      console.error('Diagnostics test cleanup encountered errors:', cleanupErrors);
+    }
+  }
+
   // createDataSource and the `request` fixture are both test-scoped, and Playwright only allows
   // worker-scoped fixtures in beforeAll/afterAll -- so setup/teardown go through a manually created
   // APIRequestContext (via the worker-scoped `playwright` fixture) instead.
@@ -177,6 +211,9 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
 
     // Unique per run: repeated/sharded runs (e.g. `yarn e2e:playwright:10x`) can execute this file
     // more than once concurrently, and a fixed name would race across those runs.
+    // Note: These datasources are visible to other parallel tests until afterAll cleanup completes.
+    // Tests filtering by datasource type should use explicit name filters (e.g., regex) to avoid
+    // accidentally selecting these temporary datasources.
     const runId = randomUUID();
 
     const successDsResponse = await apiContext.post('/api/datasources', {
@@ -211,16 +248,16 @@ test.describe('diagnostics: Download diagnostics drawer', { tag: ['@diagnostics'
   });
 
   test.afterAll(async () => {
-    if (dashboardUid) {
-      await apiContext.delete(`/api/dashboards/uid/${dashboardUid}`);
+    // Clean up datasources and dashboard with error handling
+    await cleanupResources();
+
+    // Clean up server resources
+    try {
+      await apiContext.dispose();
+    } catch (error) {
+      console.error('Failed to dispose API context:', error);
     }
-    if (successDsUid) {
-      await apiContext.delete(`/api/datasources/uid/${successDsUid}`);
-    }
-    if (failureDsUid) {
-      await apiContext.delete(`/api/datasources/uid/${failureDsUid}`);
-    }
-    await apiContext.dispose();
+
     successUpstream?.server.close();
     failureUpstream?.server.close();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR improves the cleanup reliability of the diagnostics e2e test suite (added in #129805) to prevent interference with parallel tests and handle errors gracefully.

## Background

The diagnostics test creates temporary Prometheus datasources (`e2e-diagnostics-prometheus-success-<uuid>` and `e2e-diagnostics-prometheus-failure-<uuid>`) in `beforeAll` and cleans them up in `afterAll`. These datasources are visible to other parallel tests during this window, which caused the datasource variable test to fail intermittently (see #131655).

## Changes

### 1. **Robust Error Handling**
- Extracted cleanup into a reusable `cleanupResources()` helper function
- Added try-catch blocks for each deletion to ensure all cleanup attempts run even if one fails
- Errors are logged but don't fail the test suite

### 2. **Prevent Double Cleanup**
- Reset UIDs to empty strings after successful deletion
- Prevents attempting to delete the same resource twice

### 3. **Defensive Server Cleanup**
- Added error handling for API context disposal
- Ensures HTTP server cleanup always happens

### 4. **Documentation**
- Added comment explaining that temporary datasources are visible to parallel tests
- Recommends that other tests use explicit name filters when filtering by datasource type

## Testing

The changes are defensive improvements to error handling and don't change test behavior. The cleanup should be more robust when:
- API calls fail
- Tests are interrupted
- Multiple cleanup attempts occur

## Related Issues

- **Root cause**: #129805 (PR that added this test on Aug 5, 2026)
- **Symptom**: #131655 (datasource variable test flakiness)
- **Primary fix**: #131656 (makes datasource variable test resilient to parallel tests)
- **This PR**: Improves the diagnostics test cleanup to be a better citizen in the parallel test environment

## Note

This is a defensive improvement. The primary fix for the flakiness is in #131656, which makes tests resilient to parallel execution. However, improving cleanup reliability is good practice and reduces the window for potential interference.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C081AF3S814/p1787765185204889?thread_ts=1787765185.204889&cid=C081AF3S814)

<div><a href="https://cursor.com/agents/bc-b800f0e4-2343-5b4a-80e3-5d5c68e80fc9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b800f0e4-2343-5b4a-80e3-5d5c68e80fc9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

