### PR TITLE
CI: Update govulncheck to use large runners not xlarge-io

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -23,7 +23,7 @@ jobs:
   govulncheck:
     # Run on `grafana/grafana` pushes, or on pull requests, to prevent double-running on mirrors
     if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
-    runs-on: ubuntu-x64-xlarge-io
+    runs-on: ubuntu-x64-large
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Syncing the runner class to main, which uses `ubuntu-x64-large` and not the `xlarge-io`!