### PR TITLE
fix: untangle legacy folder count from /apis folder count

### DIFF
--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -299,7 +299,7 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 			sm := resource.NewMockResourceClient(t)
 			if !tt.cascadeDeleteEnabled || !forceDeleteFromDeleteOptions(tt.deleteOptions) {
-				sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: countedKinds, Folder: []string{obj.Name}}).Return(
+				sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: CountedKinds, Folder: []string{obj.Name}}).Return(
 					&resourcepb.ResourceStatsResponse{Stats: tt.statsResponse},
 					nil,
 				).Once()

--- a/pkg/registry/apis/folders/sub_count.go
+++ b/pkg/registry/apis/folders/sub_count.go
@@ -14,13 +14,13 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-// countedKinds is the explicit "group/resource" list passed to GetStats.
+// CountedKinds is the explicit "group/resource" list passed to GetStats.
 // Without it, the search server enumerates every kind in the namespace first
 // (very expensive on KV-backed storage). Each consumer of this stats response
 // (e.g. the browse-dashboards UI, validateOnDelete) keeps its own allow-list
 // of which of these kinds it actually uses, so adding a kind here does not by
 // itself change behavior anywhere else.
-var countedKinds = []string{
+var CountedKinds = []string{
 	"folder.grafana.app/folders",
 	"dashboard.grafana.app/dashboards",
 	"dashboard.grafana.app/librarypanels",
@@ -74,7 +74,7 @@ func (r *subCountREST) Connect(ctx context.Context, name string, opts runtime.Ob
 
 		stats, err := r.searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{
 			Namespace: ns.Value,
-			Kinds:     countedKinds,
+			Kinds:     CountedKinds,
 			Folder:    []string{name},
 		})
 		if err != nil {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -564,7 +564,7 @@ func validateOnDelete(ctx context.Context,
 		return nil
 	}
 
-	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
+	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: CountedKinds, Folder: []string{f.Name}})
 	if err := resource.ErrorFromResponse(resp.GetError(), err); err != nil {
 		return fmt.Errorf("could not verify if folder is empty: %w", err)
 	}

--- a/pkg/services/folder/folderimpl/conversions_test.go
+++ b/pkg/services/folder/folderimpl/conversions_test.go
@@ -64,7 +64,7 @@ func TestFolderConversions(t *testing.T) {
 		},
 	}
 
-	fs := ProvideUnifiedStore(nil, fake, tracer, setting.NewCfg())
+	fs := ProvideUnifiedStore(nil, nil, fake, tracer, setting.NewCfg())
 
 	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{OrgID: 1})
 	converted, err := fs.UnstructuredToLegacyFolder(ctx, input)
@@ -271,7 +271,7 @@ func TestFolderListConversions(t *testing.T) {
 		},
 	}
 
-	fs := ProvideUnifiedStore(nil, fake, tracer, setting.NewCfg())
+	fs := ProvideUnifiedStore(nil, nil, fake, tracer, setting.NewCfg())
 
 	ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{OrgID: 1})
 	converted, err := fs.UnstructuredToLegacyFolderList(ctx, input)

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -89,7 +89,7 @@ func ProvideService(
 		resourceClient,
 	)
 
-	unifiedStore := ProvideUnifiedStore(k8sHandler, userService, tracer, cfg)
+	unifiedStore := ProvideUnifiedStore(k8sHandler, resourceClient, userService, tracer, cfg)
 
 	srv.unifiedStore = unifiedStore
 	srv.k8sclient = k8sHandler

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -271,7 +271,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	tracer := noop.NewTracerProvider().Tracer("TestIntegrationFolderServiceViaUnifiedStorage")
 	searchMock := resource.NewMockResourceClient(t)
 	k8sCli := client.NewK8sHandler(request.GetNamespaceMapper(cfg), folderv1.FolderResourceInfo.GroupVersionResource(), restCfgProvider.GetRestConfig, userService, searchMock)
-	unifiedStore := ProvideUnifiedStore(k8sCli, userService, tracer, cfg)
+	unifiedStore := ProvideUnifiedStore(k8sCli, searchMock, userService, tracer, cfg)
 
 	ctx := context.Background()
 	usr := &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{

--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -32,23 +32,25 @@ import (
 const tracePrefix = "folder.unifiedstore."
 
 type FolderUnifiedStoreImpl struct {
-	log         log.Logger
-	k8sclient   client.K8sHandler
-	userService user.Service
-	tracer      trace.Tracer
-	maxDepth    int
+	log            log.Logger
+	k8sclient      client.K8sHandler
+	resourceClient resource.ResourceClient
+	userService    user.Service
+	tracer         trace.Tracer
+	maxDepth       int
 }
 
 // sqlStore implements the store interface.
 var _ folder.Store = (*FolderUnifiedStoreImpl)(nil)
 
-func ProvideUnifiedStore(k8sHandler client.K8sHandler, userService user.Service, tracer trace.Tracer, cfg *setting.Cfg) *FolderUnifiedStoreImpl {
+func ProvideUnifiedStore(k8sHandler client.K8sHandler, resourceClient resource.ResourceClient, userService user.Service, tracer trace.Tracer, cfg *setting.Cfg) *FolderUnifiedStoreImpl {
 	return &FolderUnifiedStoreImpl{
-		k8sclient:   k8sHandler,
-		log:         log.New("folder-store"),
-		userService: userService,
-		tracer:      tracer,
-		maxDepth:    cfg.MaxNestedFolderDepth,
+		k8sclient:      k8sHandler,
+		resourceClient: resourceClient,
+		log:            log.New("folder-store"),
+		userService:    userService,
+		tracer:         tracer,
+		maxDepth:       cfg.MaxNestedFolderDepth,
 	}
 }
 
@@ -588,8 +590,18 @@ func (ss *FolderUnifiedStoreImpl) CountFolderContent(ctx context.Context, orgID 
 	ctx, span := ss.tracer.Start(ctx, tracePrefix+"CountFolderContent")
 	defer span.End()
 
-	counts, err := ss.k8sclient.Get(ctx, ancestor_uid, orgID, v1.GetOptions{}, "counts")
-	if err != nil {
+	gvr := folderv1.FolderResourceInfo.GroupVersionResource()
+	namespace := ss.k8sclient.GetNamespace(orgID)
+
+	read, err := ss.resourceClient.Read(ctx, &resourcepb.ReadRequest{
+		Key: &resourcepb.ResourceKey{
+			Namespace: namespace,
+			Group:     gvr.Group,
+			Resource:  gvr.Resource,
+			Name:      ancestor_uid,
+		},
+	})
+	if err := resource.ErrorFromResponse(read.GetError(), err); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, dashboards.ErrFolderNotFound
 		}
@@ -597,8 +609,16 @@ func (ss *FolderUnifiedStoreImpl) CountFolderContent(ctx context.Context, orgID 
 		return nil, err
 	}
 
-	res, err := toFolderLegacyCounts(counts)
-	return *res, err
+	stats, err := ss.resourceClient.GetStats(ctx, &resourcepb.ResourceStatsRequest{
+		Namespace: namespace,
+		Kinds:     internalfolders.CountedKinds,
+		Folder:    []string{ancestor_uid},
+	})
+	if err := resource.ErrorFromResponse(stats.GetError(), err); err != nil {
+		return nil, err
+	}
+
+	return mergeDescendantCounts(stats.GetStats()), nil
 }
 
 func (ss *FolderUnifiedStoreImpl) CountInOrg(ctx context.Context, orgID int64) (int64, error) {
@@ -658,23 +678,18 @@ func (ss *FolderUnifiedStoreImpl) list(ctx context.Context, orgID int64, opts v1
 	return result, nil
 }
 
-func toFolderLegacyCounts(u *unstructured.Unstructured) (*folder.DescendantCounts, error) {
-	ds, err := folderv1.UnstructuredToDescendantCounts(u)
-	if err != nil {
-		return nil, err
-	}
-
+func mergeDescendantCounts(stats []*resourcepb.ResourceStatsResponse_Stats) folder.DescendantCounts {
 	// A resource can be reported twice, by unified storage and by the "sql-fallback"
 	// group. Resources not yet in unified storage still get an entry there with a count
 	// of 0, so treat 0 as no data, otherwise a folder holding only alert rules looks empty.
-	var out = make(folder.DescendantCounts)
-	for _, v := range ds.Counts {
+	out := make(folder.DescendantCounts, len(stats))
+	for _, v := range stats {
 		current, seen := out[v.Resource]
 		if !seen || current == 0 || (v.Group != "sql-fallback" && v.Count != 0) {
 			out[v.Resource] = v.Count
 		}
 	}
-	return &out, nil
+	return out
 }
 
 func computeFullPath(parents []*folder.Folder) (string, string) {

--- a/pkg/services/folder/folderimpl/unifiedstore_test.go
+++ b/pkg/services/folder/folderimpl/unifiedstore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
+	internalfolders "github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -101,63 +102,54 @@ func TestComputeFullPath(t *testing.T) {
 	}
 }
 
-func TestToFolderLegacyCounts(t *testing.T) {
-	counts := func(stats ...map[string]interface{}) *unstructured.Unstructured {
-		items := make([]interface{}, 0, len(stats))
-		for _, s := range stats {
-			items = append(items, s)
-		}
-		return &unstructured.Unstructured{Object: map[string]interface{}{"counts": items}}
-	}
-	stat := func(group, res string, count int64) map[string]interface{} {
-		return map[string]interface{}{"group": group, "resource": res, "count": count}
+func TestMergeDescendantCounts(t *testing.T) {
+	stat := func(group, res string, count int64) *resourcepb.ResourceStatsResponse_Stats {
+		return &resourcepb.ResourceStatsResponse_Stats{Group: group, Resource: res, Count: count}
 	}
 
 	testCases := []struct {
 		name  string
-		input *unstructured.Unstructured
+		input []*resourcepb.ResourceStatsResponse_Stats
 		want  folder.DescendantCounts
 	}{
 		{
 			name: "resources still living in the single-tenant tables are counted",
-			input: counts(
+			input: []*resourcepb.ResourceStatsResponse_Stats{
 				stat("rules.alerting.grafana.app", "alertrules", 0),
 				stat("sql-fallback", "alertrules", 3),
-			),
+			},
 			want: folder.DescendantCounts{"alertrules": 3},
 		},
 		{
 			name: "unified storage counts win over the single-tenant tables",
-			input: counts(
+			input: []*resourcepb.ResourceStatsResponse_Stats{
 				stat("rules.alerting.grafana.app", "alertrules", 5),
 				stat("sql-fallback", "alertrules", 3),
-			),
+			},
 			want: folder.DescendantCounts{"alertrules": 5},
 		},
 		{
 			name: "order of the entries does not matter",
-			input: counts(
+			input: []*resourcepb.ResourceStatsResponse_Stats{
 				stat("sql-fallback", "alertrules", 3),
 				stat("rules.alerting.grafana.app", "alertrules", 0),
-			),
+			},
 			want: folder.DescendantCounts{"alertrules": 3},
 		},
 		{
 			name: "empty folder stays empty",
-			input: counts(
+			input: []*resourcepb.ResourceStatsResponse_Stats{
 				stat("dashboard.grafana.app", "dashboards", 0),
 				stat("rules.alerting.grafana.app", "alertrules", 0),
 				stat("sql-fallback", "alertrules", 0),
-			),
+			},
 			want: folder.DescendantCounts{"dashboards": 0, "alertrules": 0},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := toFolderLegacyCounts(tc.input)
-			require.NoError(t, err)
-			require.Equal(t, tc.want, *got)
+			require.Equal(t, tc.want, mergeDescendantCounts(tc.input))
 		})
 	}
 }
@@ -1664,5 +1656,90 @@ func TestGetFoldersMetadata(t *testing.T) {
 		// Ancestors A and B aren't in the result set but are still resolved for the path.
 		require.Equal(t, "A/B/C", got[0].Fullpath)
 		mockCli.AssertExpectations(t)
+	})
+}
+
+func TestCountFolderContent(t *testing.T) {
+	tracer := noop.NewTracerProvider().Tracer("TestCountFolderContent")
+	orgID := int64(1)
+	ctx := context.Background()
+
+	folderKey := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "folder.grafana.app",
+		Resource:  "folders",
+		Name:      "parent",
+	}
+
+	newStore := func(t *testing.T) (*FolderUnifiedStoreImpl, *client.MockK8sHandler, *resource.MockResourceClient) {
+		mockCli := new(client.MockK8sHandler)
+		mockCli.On("GetNamespace", orgID).Return("default")
+		resourceClient := resource.NewMockResourceClient(t)
+		return &FolderUnifiedStoreImpl{
+			k8sclient:      mockCli,
+			resourceClient: resourceClient,
+			userService:    usertest.NewUserServiceFake(),
+			tracer:         tracer,
+		}, mockCli, resourceClient
+	}
+
+	t.Run("merges unified storage and sql-fallback counts", func(t *testing.T) {
+		store, _, resourceClient := newStore(t)
+
+		resourceClient.On("Read", mock.Anything, &resourcepb.ReadRequest{Key: folderKey}).
+			Return(&resourcepb.ReadResponse{ResourceVersion: 1}, nil).Once()
+
+		resourceClient.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{
+			Namespace: "default",
+			Kinds:     internalfolders.CountedKinds,
+			Folder:    []string{"parent"},
+		}).Return(&resourcepb.ResourceStatsResponse{
+			Stats: []*resourcepb.ResourceStatsResponse_Stats{
+				{Group: "folder.grafana.app", Resource: "folders", Count: 2},
+				{Group: "dashboard.grafana.app", Resource: "dashboards", Count: 3},
+				{Group: "rules.alerting.grafana.app", Resource: "alertrules", Count: 0},
+				{Group: "sql-fallback", Resource: "alertrules", Count: 7},
+				{Group: "sql-fallback", Resource: "library_elements", Count: 4},
+			},
+		}, nil).Once()
+
+		counts, err := store.CountFolderContent(ctx, orgID, "parent")
+		require.NoError(t, err)
+		require.Equal(t, folder.DescendantCounts{
+			"folders":          2,
+			"dashboards":       3,
+			"alertrules":       7,
+			"library_elements": 4,
+		}, counts)
+	})
+
+	t.Run("returns ErrFolderNotFound without counting when the folder does not exist", func(t *testing.T) {
+		store, _, resourceClient := newStore(t)
+
+		resourceClient.On("Read", mock.Anything, &resourcepb.ReadRequest{Key: folderKey}).
+			Return(&resourcepb.ReadResponse{Error: resource.NewNotFoundError(folderKey)}, nil).Once()
+
+		counts, err := store.CountFolderContent(ctx, orgID, "parent")
+		require.ErrorIs(t, err, dashboards.ErrFolderNotFound)
+		require.Nil(t, counts)
+		resourceClient.AssertNotCalled(t, "GetStats", mock.Anything, mock.Anything)
+	})
+
+	t.Run("surfaces a stats error", func(t *testing.T) {
+		store, _, resourceClient := newStore(t)
+
+		resourceClient.On("Read", mock.Anything, &resourcepb.ReadRequest{Key: folderKey}).
+			Return(&resourcepb.ReadResponse{ResourceVersion: 1}, nil).Once()
+
+		resourceClient.On("GetStats", mock.Anything, mock.Anything).
+			Return(&resourcepb.ResourceStatsResponse{Error: &resourcepb.ErrorResult{
+				Code:    http.StatusInternalServerError,
+				Message: "boom",
+			}}, nil).Once()
+
+		counts, err := store.CountFolderContent(ctx, orgID, "parent")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "boom")
+		require.Nil(t, counts)
 	})
 }


### PR DESCRIPTION
This fix intends to untangle the legacy REST `/count` api from the new k8s style `/apis/.../folders/:name/counts`. Within the wrapper folder service, we were relying on the k8s api as the source of truth, this PR removes this. The legacy endpoint stops depending on the multi-tenant folder app.

## Before:
```mermaid
flowchart TB
  classDef fe fill:#dbe4f2,stroke:#3f63a8,color:#101a26
  classDef rest fill:#e8edf5,stroke:#5a7bb8,color:#101a26
  classDef step fill:#e9ecef,stroke:#7d8b99,color:#14181c
  classDef gate fill:#f7e2c6,stroke:#a3550c,color:#3a2408,stroke-width:1.6px
  classDef api fill:#d5e8e2,stroke:#1f7364,color:#0e1620
  classDef engine fill:#cfe3f0,stroke:#2b6f97,color:#0e1620,stroke-width:1.6px
  classDef term fill:#dee3e9,stroke:#5b6874,color:#14181c
  classDef grp fill:#e4e9ef,stroke:#aab5c2,color:#3a4550

  subgraph UI["Browser"]
    MODAL["DeleteModal · AffectedFolderContents · useGetAffectedItems"]
    BTN["FolderActionsButton · BrowseActions · useDeleteFolderMutationFacade"]
  end

  MODAL -->|"foldersAppPlatformAPI OFF"| LC
  MODAL -->|"foldersAppPlatformAPI ON"| KC
  BTN -->|"isBackendSupport = false · always legacy"| LD

  subgraph LEG["Legacy REST · /api/folders"]
    LC["GET /:uid/counts · hs.GetFolderDescendantCounts"]
    LD["DELETE /:uid?forceDeleteRules=true · hs.DeleteFolder"]
  end

  LC --> SVCC["Service.GetDescendantCounts · CountFolderContent"]
  SVCC -->|"k8sclient.Get subresource counts"| KC

  LD --> SVCD["folderimpl Service.Delete"]
  SVCD --> DESC["unifiedStore.GetDescendants · postorder, leaves first"]
  DESC --> FORCE{"ForceDeleteRules?"}

  FORCE -->|"true · every UI delete"| REG["registry DeleteInFolders for all 3 kinds · dashboards · library panels · alert rules · no count check, per-folder RBAC instead"]

  FORCE -->|"false · direct API caller"| G1["GATE 1 · alertRuleSrv.CountInFolders · count over 0 gives ErrFolderNotEmpty"]
  G1 --> G2["GATE 2 · libraryPanelSrv.DeleteInFolders · dangling panels deleted, a connected one gives 403 ErrFolderHasConnectedLibraryElements"]
  G2 --> DASH["search dashboards in folders, delete each, then public dashboards"]

  REG --> DEL
  DASH --> DEL
  DEL["unifiedStore.Delete · k8s DELETE per UID · empty DeleteOptions"]
  DEL --> KD

  subgraph K8S["folder.grafana.app apiserver"]
    KD["DELETE /apis/.../folders/:name"]
    G3["GATE 3 · admission validateOnDelete · cascade flag plus gracePeriodSeconds=0 skips it · otherwise GetStats and any allow-listed resource over 0 gives ErrFolderNotEmpty"]
    CAS["cascadeDeleteStorage.Delete · only when flag and grace=0 · DFS mark terminating, per-folder authz, child folders, dashboards, ContentsCleaner"]
    KC["GET /apis/.../folders/:name/counts · subCountREST.Connect"]
  end

  KD --> G3
  G3 --> CAS
  CAS --> STORE["store.Delete · row removed"]

  KC --> STATS["searcher.GetStats · Kinds = countedKinds · Folder = one name"]
  G3 --> STATS

  class MODAL,BTN fe
  class LC,LD rest
  class SVCC,SVCD,DESC,FORCE,REG,DASH,DEL step
  class G1,G2,G3 gate
  class KD,CAS,KC api
  class STATS engine
  class STORE term
  class UI,LEG,K8S grp

```



## After:
```mermaid
flowchart TB
  classDef fe fill:#dbe4f2,stroke:#3f63a8,color:#101a26
  classDef rest fill:#e8edf5,stroke:#5a7bb8,color:#101a26
  classDef step fill:#e9ecef,stroke:#7d8b99,color:#14181c
  classDef gate fill:#f7e2c6,stroke:#a3550c,color:#3a2408,stroke-width:1.6px
  classDef api fill:#d5e8e2,stroke:#1f7364,color:#0e1620
  classDef engine fill:#cfe3f0,stroke:#2b6f97,color:#0e1620,stroke-width:1.6px
  classDef term fill:#dee3e9,stroke:#5b6874,color:#14181c
  classDef grp fill:#e4e9ef,stroke:#aab5c2,color:#3a4550

  subgraph UI["Browser"]
    MODAL["DeleteModal"]
    BTN["Delete button"]
  end

  MODAL -->|"app platform off"| LC
  MODAL -->|"on"| KC
  BTN -->|"always legacy"| LD

  subgraph LEG["Legacy /api/folders"]
    LC["GET /:uid/counts"]
    LD["DELETE /:uid"]
  end

  LC --> SVCC["GetDescendantCounts"]
  SVCC --> READ["Read (404 check)"]
  SVCC --> STATS

  LD --> SVCD["Service.Delete"]
  SVCD --> DESC["GetDescendants"]
  DESC --> FORCE{"forceDeleteRules"}
  FORCE -->|"true"| REG["DeleteInFolders (x3)"]
  FORCE -->|"false"| G1["GATE 1 alert rules"]
  G1 --> G2["GATE 2 linked panels"]
  G2 --> DASH["delete dashboards"]
  REG --> DEL
  DASH --> DEL
  DEL["unifiedStore.Delete"]
  DEL --> KD

  subgraph K8S["folder.grafana.app"]
    KD["DELETE folders/:name"]
    G3["GATE 3 admission"]
    CAS["cascade delete (DFS)"]
    KC["counts subresource"]
  end

  KD --> G3
  G3 --> CAS
  CAS --> STORE["store.Delete"]
  KC --> STATS["searcher.GetStats"]
  G3 --> STATS

  class MODAL,BTN fe
  class LC,LD rest
  class SVCC,SVCD,DESC,FORCE,REG,DASH,DEL step
  class G1,G2,G3 gate
  class KD,CAS,KC api
  class READ,STATS engine
  class STORE term
  class UI,LEG,K8S grp

```
