### PR TITLE
Alerting: Migrate  RecordingRuleEditor to async datasource API

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,15 +11,6 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
-jest.mock('app/features/datasources/hooks', () => ({
-  ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
-  // getDataSourceSrv (configured via the alerting test factories) so the current data source
-  // resolves synchronously and no post-render state update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
-}));
-
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 
@@ -64,11 +55,15 @@ describe('ImportToGMARules', () => {
   grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleCreate]);
   testWithFeatureToggles({ enable: ['alertingImportYAMLUI', 'alertingMigrationUI'] });
 
-  it('should render the import source options', () => {
+  it('should render the import source options', async () => {
     render(<ImportToGMARules />);
 
     expect(ui.importSource.existingDatasource.get()).toBeInTheDocument();
     expect(ui.importSource.yaml.get()).toBeInTheDocument();
+
+    // The data source picker resolves its current data source asynchronously; wait for it to
+    // settle so the state update doesn't escape act().
+    await waitFor(() => expect(ui.dsImport.dsPicker.get()).toBeEnabled());
   });
 
   describe('existing datasource', () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,6 +11,15 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
+  // getDataSourceSrv (configured via the alerting test factories) so the current data source
+  // resolves synchronously and no post-render state update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/css';
 import { type FC, useCallback, useEffect, useState } from 'react';
-import { useAsync } from 'react-use';
 
 import { CoreApp, type GrafanaTheme2, LoadingState, type PanelData } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstance } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
@@ -44,13 +43,7 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     setData(panelData?.[queries[0]?.refId]);
   }, [panelData, queries]);
 
-  const {
-    error,
-    loading,
-    value: dataSource,
-  } = useAsync(() => {
-    return getDataSourceSrv().get(dataSourceName);
-  }, [dataSourceName]);
+  const { error, isLoading: loading, dataSource } = useDataSourceInstance(dataSourceName);
 
   const handleChangedQuery = useCallback(
     (changedQuery: DataQuery) => {
@@ -73,13 +66,9 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
           datasource: changedQuery.datasource,
           refId: changedQuery.refId,
           editorMode: changedQuery.editorMode,
-          // Instant and range are used by Prometheus queries
           instant: changedQuery.instant,
           range: changedQuery.range,
-          // Query type is used by Loki queries
-          // On first render/when creating a recording rule, the query type is not set
-          // unless the user has changed it betwee range/instant. The cleanest way to handle this
-          // is to default to instant, or whatever the changed type is
+          // Loki queries default to instant until the user explicitly picks range/instant
           queryType: isLoki ? changedQuery.queryType || LokiQueryType.Instant : changedQuery.queryType,
           legendFormat: changedQuery.legendFormat,
         },
@@ -93,9 +82,7 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     return null;
   }
 
-  const dsi = getDataSourceSrv().getInstanceSettings(dataSourceName);
-
-  if (error || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
+  if (error || !dataSource || !dataSource?.components?.QueryEditor) {
     const errorMessage = error?.message || 'Data source plugin does not export any Query Editor component';
     return (
       <div>

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
@@ -11,6 +11,13 @@ import { setupDataSources } from '../../testSetup/datasources';
 import { RECEIVER_NAME, listContactPointsScenario } from './ContactPointLink.scenario';
 import { Details } from './Details';
 
+// useDatasource wraps the async settings API. Stub it so the (synchronous) tests below
+// don't trigger a post-mount state update for a datasource none of them assert on.
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  useDatasource: jest.fn(),
+}));
+
 const server = setupMockServer();
 
 beforeAll(() => {

--- a/public/app/features/alerting/unified/testSetup/datasources.ts
+++ b/public/app/features/alerting/unified/testSetup/datasources.ts
@@ -2,11 +2,13 @@ import { keyBy } from 'lodash';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { config, setDataSourceSrv } from '@grafana/runtime';
+import { initDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 /**
  * Sets up the data sources for the tests.
- * Sets up both config object from grafana/runtime and the data source server
+ * Sets up the config object from grafana/runtime, the legacy data source service and the
+ * settings cache backing the async getDataSourceInstanceSettings API
  * @param configs data source instance settings. Use **mockDataSource** to create mock settings
  */
 export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
@@ -14,9 +16,11 @@ export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
   const datasourceSettings = keyBy(configs, (c) => c.name);
 
   const defaultDatasource = configs.find((c) => c.isDefault);
+  const defaultDatasourceName = defaultDatasource?.name || config.defaultDatasource;
   config.datasources = datasourceSettings;
-  dataSourceSrv.init(config.datasources, defaultDatasource?.name || config.defaultDatasource);
+  dataSourceSrv.init(config.datasources, defaultDatasourceName);
   setDataSourceSrv(dataSourceSrv);
+  initDataSourceInstanceSettings(datasourceSettings, defaultDatasourceName);
 
   return dataSourceSrv;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { type DataQuery } from '@grafana/schema';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { dashboardDsSettingsMock, ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
 import { type Transformation } from '../types';
@@ -16,12 +17,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ds1SettingsMock);
 
 describe('QueryEditorSidebar', () => {
   afterAll(() => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -14,6 +14,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorSidebar', () => {
   afterAll(() => {
     jest.clearAllMocks();

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { AdHocVariableForm, type AdHocVariableFormProps } from './AdHocVariableForm';
 
@@ -31,12 +32,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('AdHocVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -29,6 +29,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('AdHocVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -6,6 +6,7 @@ import { VariableSupportType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { GroupByVariableForm, type GroupByVariableFormProps } from './GroupByVariableForm';
@@ -38,12 +39,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -36,6 +36,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -17,6 +17,7 @@ import { setRunRequest } from '@grafana/runtime';
 import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 import { getVariableQueryEditor } from 'app/features/variables/editor/getVariableQueryEditor';
 
@@ -50,12 +51,16 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation((ref) => {
+  const uid = typeof ref === 'string' ? ref : ref?.uid;
+  return uid === promDatasource.uid ? promDatasource : defaultDatasource;
+});
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -48,6 +48,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { AdHocFiltersVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { type AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
@@ -79,6 +80,16 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
+}));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -45,6 +45,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -7,6 +7,7 @@ import { GroupByVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { getGroupByVariableOptions, GroupByVariableEditor } from './GroupByVariableEditor';
@@ -47,12 +48,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -55,6 +55,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { QueryVariableEditor, Editor } from './QueryVariableEditor';
@@ -57,12 +58,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -81,6 +81,9 @@ jest.mock('../../hooks', () => {
     ...actual,
     useRecentlyUsedDataSources: () => [[mockDS2.name], pushRecentlyUsedDataSourceMock],
     useDatasources: () => mockDSList,
+    // useDatasource now wraps the async settings API; resolve it synchronously in tests
+    // via the same mock that stands in for the legacy getInstanceSettings lookup.
+    useDatasource: (ref: unknown) => getInstanceSettingsMock(ref),
   };
 });
 

--- a/public/app/features/datasources/hooks.test.ts
+++ b/public/app/features/datasources/hooks.test.ts
@@ -1,15 +1,23 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { TestDataSettings } from '../query/state/mocks/mockDataSource';
 
-import { useRecentlyUsedDataSources } from './hooks';
+import { useDatasource, useRecentlyUsedDataSources } from './hooks';
 
-// Mock react-use's useLocalStorage
+// Mock react-use's useLocalStorage while keeping the rest (e.g. useAsync) intact
 jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
   useLocalStorage: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
 const mockUseLocalStorage = jest.requireMock('react-use').useLocalStorage;
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 describe('useRecentlyUsedDataSources', () => {
   let mockSetStorage: jest.Mock;
@@ -110,5 +118,38 @@ describe('useRecentlyUsedDataSources', () => {
       // Should remove the first item and add new one at the end
       expect(mockSetStorage).toHaveBeenCalledWith(['uid2', 'uid3', 'uid4', 'uid5', 'test-uid']);
     });
+  });
+});
+
+describe('useDatasource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve to the settings returned by getDataSourceInstanceSettings', async () => {
+    const settings = { ...TestDataSettings, uid: 'test-uid' };
+    mockGetDataSourceInstanceSettings.mockResolvedValue(settings);
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    await waitFor(() => expect(result.current).toBe(settings));
+  });
+
+  it('should forward the ref and scopedVars to getDataSourceInstanceSettings', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+    const scopedVars = { ds: { text: 'prometheus', value: 'prometheus' } };
+
+    renderHook(() => useDatasource('$ds', scopedVars));
+
+    await waitFor(() => expect(mockGetDataSourceInstanceSettings).toHaveBeenCalledWith('$ds', scopedVars));
+  });
+
+  it('should return undefined while the lookup is pending', () => {
+    // Never resolves so the hook stays in its loading state.
+    mockGetDataSourceInstanceSettings.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    expect(result.current).toBeUndefined();
   });
 });

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
-import { useLocalStorage } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 import { type GetDataSourceListFilters, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 const LOCAL_STORAGE_KEY = 'grafana.features.datasources.components.picker.DataSourceDropDown.history';
 
@@ -55,14 +56,18 @@ export function useDatasources(filters: GetDataSourceListFilters, datasources?: 
 export function useDatasource(
   dataSource: string | DataSourceRef | DataSourceInstanceSettings | null | undefined,
   scopedVars?: ScopedVars
-) {
-  const dataSourceSrv = getDataSourceSrv();
+): DataSourceInstanceSettings | undefined {
+  // Compare `dataSource` and `scopedVars` by value so inline objects don't re-trigger the lookup.
+  const refKey = JSON.stringify(dataSource ?? null);
+  const scopedVarsKey = JSON.stringify(scopedVars ?? null);
 
-  if (typeof dataSource === 'string') {
-    return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
-  }
+  const { value } = useAsync(
+    () => getDataSourceInstanceSettings(dataSource, scopedVars),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refKey, scopedVarsKey]
+  );
 
-  return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
+  return value;
 }
 
 export interface KeyboardNavigatableListProps {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -138,11 +138,9 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it so the tests
+  // below don't trigger a post-render state update for a datasource none of them assert on.
+  useDatasource: jest.fn(),
 }));
 
 jest.mock('app/core/services/context_srv', () => ({

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -136,6 +136,15 @@ jest.mock('@grafana/runtime', () => ({
   usePluginLinks: jest.fn(() => ({ links: [] })),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -28,6 +28,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { type Props, QueryEditorRowHeader } from './QueryEditorRowHeader';
 
@@ -30,12 +31,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => mockDS);
 
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {


### PR DESCRIPTION
Related issue:  #127031

### What changed?
Migrates `RecordingRuleEditor` off the  deprecated synchronous `getDataSourceSrv()` calls to the async  `useDataSourceInstance` hook from `@grafana/runtime/unstable`. Also drops a redundant second settings lookup that could briefly show a "no query  editor" error while the datasource was still resolving.