### PR TITLE
Alerting: Fix negative triage filters being cancelled out by alias expansion

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -203,6 +203,14 @@ describe('triage queries combined filter exclusions', () => {
     expect(query).not.toContain(' or ');
   });
 
+  it('treats an empty-value exclusion as "has any of these labels"', () => {
+    const query = summaryChartQuery('cluster!=""').expr;
+
+    // Prometheus reads a missing label as empty, so ANDing the two here would mean
+    // "has both labels" and match almost nothing. Branching keeps it to "has either".
+    expect(query).toBe('count by (alertstate) ((GRAFANA_ALERTS{cluster!=""} or GRAFANA_ALERTS{cluster_name!=""}))');
+  });
+
   it('carries exclusions into the deduplicated unique-instances query', () => {
     const query = uniqueAlertInstancesQuery('cluster!="prod-me-central-1"').expr;
 

--- a/public/app/features/alerting/unified/triage/scene/queries.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.test.ts
@@ -1,3 +1,4 @@
+import { prometheusExpressionBuilder } from './expressionBuilder';
 import { alertRuleInstancesQuery, getWorkbenchQueries, summaryChartQuery, uniqueAlertInstancesQuery } from './queries';
 
 describe('triage queries service combined filter', () => {
@@ -130,5 +131,82 @@ describe('alertRuleInstancesQuery group scoping', () => {
     expect(query).toContain('grafana_rule_uid="rule-1"');
     expect(query).not.toContain('cluster=');
     expect(query).not.toContain('environment=');
+  });
+});
+
+describe('triage queries combined filter exclusions', () => {
+  it('keeps every backing label of an excluded key in the same selector', () => {
+    const query = summaryChartQuery('cluster!="prod-me-central-1"').expr;
+
+    expect(query).toBe(
+      'count by (alertstate) (GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1"})'
+    );
+    expect(query).not.toContain(' or ');
+  });
+
+  it('applies an excluded key to every branch of an included key', () => {
+    const query = summaryChartQuery('namespace="alloy-otlp",cluster!="prod-me-central-1"').expr;
+
+    expect(query).toBe(
+      'count by (alertstate) (' +
+        '(GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",namespace="alloy-otlp"}' +
+        ' or GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",exported_namespace="alloy-otlp"}' +
+        ' or GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",namespace_extracted="alloy-otlp"})' +
+        ')'
+    );
+  });
+
+  it('combines include and exclude matchers on the same key', () => {
+    const query = summaryChartQuery('cluster="prod-a",cluster!="prod-b"').expr;
+
+    expect(query).toBe(
+      'count by (alertstate) (' +
+        '(GRAFANA_ALERTS{cluster!="prod-b",cluster_name!="prod-b",cluster="prod-a"}' +
+        ' or GRAFANA_ALERTS{cluster!="prod-b",cluster_name!="prod-b",cluster_name="prod-a"})' +
+        ')'
+    );
+  });
+
+  it('expands regex exclusions across every backing label', () => {
+    const query = summaryChartQuery('severity!~"info|debug"').expr;
+
+    expect(query).toBe(
+      'count by (alertstate) (GRAFANA_ALERTS{' +
+        'severity!~"info|debug",priority!~"info|debug",level!~"info|debug",loglevel!~"info|debug",' +
+        'logLevel!~"info|debug",lvl!~"info|debug",detected_level!~"info|debug"' +
+        '})'
+    );
+    expect(query).not.toContain(' or ');
+  });
+
+  it('leaves exclusions on non-combined keys alone', () => {
+    const query = summaryChartQuery('environment!="dev"').expr;
+
+    expect(query).toBe('count by (alertstate) (GRAFANA_ALERTS{environment!="dev"})');
+  });
+
+  it('keeps multi-value exclusions (!=|) in the same selector', () => {
+    // The multi-value operator is rewritten to !~ before it reaches the query builder,
+    // so go through the expression builder rather than hand-writing the filter string.
+    const filter = prometheusExpressionBuilder([
+      { key: 'cluster', operator: '!=|', value: 'prod-me-central-1', values: ['prod-me-central-1', 'prod-eu-west-2'] },
+    ]);
+    expect(filter).toBe('cluster!~"prod-me-central-1|prod-eu-west-2"');
+
+    const query = summaryChartQuery(filter).expr;
+
+    expect(query).toBe(
+      'count by (alertstate) (GRAFANA_ALERTS{' +
+        'cluster!~"prod-me-central-1|prod-eu-west-2",cluster_name!~"prod-me-central-1|prod-eu-west-2"' +
+        '})'
+    );
+    expect(query).not.toContain(' or ');
+  });
+
+  it('carries exclusions into the deduplicated unique-instances query', () => {
+    const query = uniqueAlertInstancesQuery('cluster!="prod-me-central-1"').expr;
+
+    expect(query).toContain('alertstate="firing",cluster!="prod-me-central-1",cluster_name!="prod-me-central-1"');
+    expect(query).toContain('alertstate="pending",cluster!="prod-me-central-1",cluster_name!="prod-me-central-1"');
   });
 });

--- a/public/app/features/alerting/unified/triage/scene/queries.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.ts
@@ -41,10 +41,8 @@ function isNegativeOperator(operator: MatcherOperator): boolean {
 }
 
 /**
- * An exclusion with an empty value is not really an exclusion of a value — because
- * Prometheus reads a label the series doesn't have as empty, `cluster!=""` is asking
- * "does this series have a cluster at all?". That's a question about any of the
- * backing labels, so it spreads across branches like an inclusion does.
+ * `cluster!=""` rules out no value, it only asks "does the series have a cluster label
+ * set?". Any one of the label names can answer yes, so we treat it as an include.
  */
 function excludesAValue(matcher: MatcherExpr): boolean {
   return isNegativeOperator(matcher.operator) && matcher.value !== '';
@@ -57,20 +55,16 @@ function renameMatchers(matchers: MatcherExpr[], name: string): MatcherExpr[] {
 /**
  * Builds one or more metric selectors from the current ad-hoc filter string.
  *
- * Combined filters use a single user-facing key (for example `service`) while
- * alert series may have one of several backing label keys (`service`, `service_name`).
+ * A combined filter shows one key (`service`), but the series can carry the value under
+ * any of a few label names (`service`, `service_name`), so every matcher on such a key
+ * gets rewritten for each name:
  *
- * Which way we expand a matcher depends on whether it includes or excludes:
+ * - Include (`=`, `=~`): one selector per label name, joined with `or`.
+ * - Exclude (`!=`, `!~`): all names in a single selector. Separate `or` branches would
+ *   let the excluded series back in, since Prometheus reads a missing label as empty —
+ *   a series with `cluster="foo"` and no `cluster_name` passes `cluster_name!="foo"`.
  *
- * - Include (`=`, `=~`): one selector per backing label, joined with `or`. A series
- *   matches if any of its backing labels has the value.
- * - Exclude (`!=`, `!~`): every backing label goes into the same selector. Splitting
- *   these across `or` branches would undo the exclusion — Prometheus treats a label
- *   that isn't on the series as empty, so a series with `cluster="foo"` and no
- *   `cluster_name` would still match the `cluster_name!="foo"` branch and come back
- *   in the union.
- *
- * See `excludesAValue` for why an exclusion with an empty value goes the first way.
+ * See `excludesAValue` for why `!=""` counts as an include.
  */
 function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = []): string[] {
   const allMatchers = [...parseFilterMatchers(filter), ...extraMatchers];

--- a/public/app/features/alerting/unified/triage/scene/queries.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.ts
@@ -36,36 +36,60 @@ function serializeMatchers(matchers: MatcherExpr[]): string {
   return matchers.map((m) => `${m.name}${m.operator}${quoteWithEscape(m.value)}`).join(',');
 }
 
+function isNegativeOperator(operator: MatcherOperator): boolean {
+  return operator === '!=' || operator === '!~';
+}
+
+function renameMatchers(matchers: MatcherExpr[], name: string): MatcherExpr[] {
+  return matchers.map((matcher) => ({ ...matcher, name }));
+}
+
 /**
  * Builds one or more metric selectors from the current ad-hoc filter string.
  *
  * Combined filters use a single user-facing key (for example `service`) while
  * alert series may have one of several backing label keys (`service`, `service_name`).
- * We expand those matchers into OR selectors so filtering is consistent.
+ *
+ * Which way we expand a matcher depends on whether it includes or excludes:
+ *
+ * - Include (`=`, `=~`): one selector per backing label, joined with `or`. A series
+ *   matches if any of its backing labels has the value.
+ * - Exclude (`!=`, `!~`): every backing label goes into the same selector. Splitting
+ *   these across `or` branches would undo the exclusion — Prometheus treats a label
+ *   that isn't on the series as empty, so a series with `cluster="foo"` and no
+ *   `cluster_name` would still match the `cluster_name!="foo"` branch and come back
+ *   in the union.
  */
 function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = []): string[] {
   const allMatchers = [...parseFilterMatchers(filter), ...extraMatchers];
   const combinedMatchers = Object.entries(COMBINED_FILTER_LABEL_KEYS)
-    .map(([canonicalKey, labelKeys]) => ({
-      canonicalKey,
-      labelKeys,
-      matchers: allMatchers.filter((m) => m.name === canonicalKey),
-    }))
+    .map(([canonicalKey, labelKeys]) => {
+      const matchers = allMatchers.filter((m) => m.name === canonicalKey);
+      return {
+        canonicalKey,
+        labelKeys,
+        matchers,
+        includeMatchers: matchers.filter((m) => !isNegativeOperator(m.operator)),
+        excludeMatchers: matchers.filter((m) => isNegativeOperator(m.operator)),
+      };
+    })
     .filter((entry) => entry.matchers.length > 0);
 
   const combinedCanonicalKeys = new Set(combinedMatchers.map((entry) => entry.canonicalKey));
   const baseMatchers = allMatchers.filter((m) => !combinedCanonicalKeys.has(m.name));
 
-  let branches: MatcherExpr[][] = [baseMatchers];
+  // Exclusions apply to every branch, so they live alongside the non-combined matchers.
+  const expandedExcludeMatchers = combinedMatchers.flatMap((entry) =>
+    entry.labelKeys.flatMap((labelKey) => renameMatchers(entry.excludeMatchers, labelKey))
+  );
+
+  let branches: MatcherExpr[][] = [[...baseMatchers, ...expandedExcludeMatchers]];
   for (const entry of combinedMatchers) {
+    if (entry.includeMatchers.length === 0) {
+      continue;
+    }
     branches = branches.flatMap((branch) =>
-      entry.labelKeys.map((labelKey) => [
-        ...branch,
-        ...entry.matchers.map((matcher) => ({
-          ...matcher,
-          name: labelKey,
-        })),
-      ])
+      entry.labelKeys.map((labelKey) => [...branch, ...renameMatchers(entry.includeMatchers, labelKey)])
     );
   }
 

--- a/public/app/features/alerting/unified/triage/scene/queries.ts
+++ b/public/app/features/alerting/unified/triage/scene/queries.ts
@@ -40,6 +40,16 @@ function isNegativeOperator(operator: MatcherOperator): boolean {
   return operator === '!=' || operator === '!~';
 }
 
+/**
+ * An exclusion with an empty value is not really an exclusion of a value — because
+ * Prometheus reads a label the series doesn't have as empty, `cluster!=""` is asking
+ * "does this series have a cluster at all?". That's a question about any of the
+ * backing labels, so it spreads across branches like an inclusion does.
+ */
+function excludesAValue(matcher: MatcherExpr): boolean {
+  return isNegativeOperator(matcher.operator) && matcher.value !== '';
+}
+
 function renameMatchers(matchers: MatcherExpr[], name: string): MatcherExpr[] {
   return matchers.map((matcher) => ({ ...matcher, name }));
 }
@@ -59,6 +69,8 @@ function renameMatchers(matchers: MatcherExpr[], name: string): MatcherExpr[] {
  *   that isn't on the series as empty, so a series with `cluster="foo"` and no
  *   `cluster_name` would still match the `cluster_name!="foo"` branch and come back
  *   in the union.
+ *
+ * See `excludesAValue` for why an exclusion with an empty value goes the first way.
  */
 function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = []): string[] {
   const allMatchers = [...parseFilterMatchers(filter), ...extraMatchers];
@@ -69,8 +81,8 @@ function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = [])
         canonicalKey,
         labelKeys,
         matchers,
-        includeMatchers: matchers.filter((m) => !isNegativeOperator(m.operator)),
-        excludeMatchers: matchers.filter((m) => isNegativeOperator(m.operator)),
+        branchedMatchers: matchers.filter((m) => !excludesAValue(m)),
+        sharedMatchers: matchers.filter(excludesAValue),
       };
     })
     .filter((entry) => entry.matchers.length > 0);
@@ -79,17 +91,17 @@ function buildMetricSelectors(filter: string, extraMatchers: MatcherExpr[] = [])
   const baseMatchers = allMatchers.filter((m) => !combinedCanonicalKeys.has(m.name));
 
   // Exclusions apply to every branch, so they live alongside the non-combined matchers.
-  const expandedExcludeMatchers = combinedMatchers.flatMap((entry) =>
-    entry.labelKeys.flatMap((labelKey) => renameMatchers(entry.excludeMatchers, labelKey))
+  const expandedSharedMatchers = combinedMatchers.flatMap((entry) =>
+    entry.labelKeys.flatMap((labelKey) => renameMatchers(entry.sharedMatchers, labelKey))
   );
 
-  let branches: MatcherExpr[][] = [[...baseMatchers, ...expandedExcludeMatchers]];
+  let branches: MatcherExpr[][] = [[...baseMatchers, ...expandedSharedMatchers]];
   for (const entry of combinedMatchers) {
-    if (entry.includeMatchers.length === 0) {
+    if (entry.branchedMatchers.length === 0) {
       continue;
     }
     branches = branches.flatMap((branch) =>
-      entry.labelKeys.map((labelKey) => [...branch, ...renameMatchers(entry.includeMatchers, labelKey)])
+      entry.labelKeys.map((labelKey) => [...branch, ...renameMatchers(entry.branchedMatchers, labelKey)])
     );
   }
 


### PR DESCRIPTION
## What is this feature?

Fixes exclusion filters (`!=`, `!~`, and the multi-value `!=|`) on the Alerts activity page silently doing nothing.

The page lets a single filter key stand for several real label names — `cluster` covers `cluster` and `cluster_name`, `namespace` covers `namespace`, `exported_namespace` and `namespace_extracted`, `service` and `severity` likewise. Until now every matcher on such a key was expanded into one selector per backing label, joined with `or`.

That's right for `=` and `=~`, but it undoes `!=` and `!~`. Prometheus treats a label the series doesn't have as empty, so a series with `cluster="prod-me-central-1"` and no `cluster_name` still matches the `cluster_name!="prod-me-central-1"` branch, and the `or` unions it right back in.

Filtering `namespace = alloy-otlp` and `cluster != prod-me-central-1` used to build:

```promql
count by (alertstate) ((
  GRAFANA_ALERTS{cluster!="prod-me-central-1",namespace="alloy-otlp"} or
  GRAFANA_ALERTS{cluster!="prod-me-central-1",exported_namespace="alloy-otlp"} or
  GRAFANA_ALERTS{cluster!="prod-me-central-1",namespace_extracted="alloy-otlp"} or
  GRAFANA_ALERTS{cluster_name!="prod-me-central-1",namespace="alloy-otlp"} or       ← brings them back
  GRAFANA_ALERTS{cluster_name!="prod-me-central-1",exported_namespace="alloy-otlp"} or
  GRAFANA_ALERTS{cluster_name!="prod-me-central-1",namespace_extracted="alloy-otlp"}
))
```

and now builds:

```promql
count by (alertstate) ((
  GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",namespace="alloy-otlp"} or
  GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",exported_namespace="alloy-otlp"} or
  GRAFANA_ALERTS{cluster!="prod-me-central-1",cluster_name!="prod-me-central-1",namespace_extracted="alloy-otlp"}
))
```

Exclusions now go into every selector together instead of being split across `or` branches. Inclusions keep branching exactly as before.

One exception, in the second commit: `cluster!=""` isn't excluding a value — since Prometheus reads an absent label as empty, it's asking whether the series has a cluster at all. That's a question about *any* backing label, so it keeps branching. ANDed it would mean "has both `cluster` and `cluster_name`", which almost nothing does. Not reachable from the value dropdown (`label_values` never returns an empty value), but external integrations can link into the page with a hand-built URL.

## Why do we need this feature?

Reported internally: filtering `cluster != prod-me-central-1` on the Alerts activity page returned prod-me-central-1 alerts anyway. Any exclusion on `cluster`, `namespace`, `service`, or `severity` is affected. Regression from #121410.

## Testing

Eight new cases in `queries.test.ts`, asserting full expressions rather than substrings — substring matching is what let the original bug through. Covers exclusion-only, the reported include+exclude combination, include and exclude on the same key, `!~` across all seven severity aliases, multi-value `!=|` fed through `prometheusExpressionBuilder`, non-combined keys left alone, empty-value exclusions still branching, and exclusions flowing into the deduplicated `last_over_time` query.

Six of them fail against the old builder. The existing alias-expansion tests are untouched and still pass, so inclusion behaviour is unchanged.

## Which issue(s) does this PR fix?

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
