### PR TITLE
Calendar (UI): Fix month and weekday names not being translated

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DatePicker/DatePicker.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { memo } from 'react';
 import Calendar from 'react-calendar';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { getLocale, type GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
 import { ClickOutsideWrapper } from '../../ClickOutsideWrapper/ClickOutsideWrapper';
@@ -61,7 +61,7 @@ const Body = memo<DatePickerProps>(({ value, minDate, maxDate, onChange }) => {
           onChange(ev);
         }
       }}
-      locale="en"
+      locale={getLocale()}
     />
   );
 });

--- a/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/DateTimePicker/DateTimePicker.tsx
@@ -16,6 +16,7 @@ import {
   isDateTime,
   dateTimeForTimeZone,
   getTimeZone,
+  getLocale,
   type TimeZone,
 } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
@@ -351,7 +352,7 @@ const DateTimeCalendar = React.forwardRef<HTMLDivElement, DateTimeCalendarProps>
           prevLabel={<Icon name="angle-left" />}
           prevAriaLabel={t('grafana-ui.date-time-picker.previous-label', 'Previous month')}
           onChange={onChangeDate}
-          locale="en"
+          locale={getLocale()}
           className={calendarStyles.body}
           tileClassName={calendarStyles.title}
           maxDate={maxDate}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback } from 'react';
 import Calendar, { type CalendarType } from 'react-calendar';
 
-import { type GrafanaTheme2, dateTimeParse, type DateTime, type TimeZone } from '@grafana/data';
+import { type GrafanaTheme2, dateTimeParse, type DateTime, getLocale, type TimeZone } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../../themes/ThemeContext';
@@ -37,7 +37,7 @@ export function Body({ onChange, from, to, timeZone, weekStart }: TimePickerCale
       prevLabel={<Icon name="angle-left" />}
       prevAriaLabel={t('time-picker.calendar.previous-month', 'Previous month')}
       onChange={onCalendarChange}
-      locale="en"
+      locale={getLocale()}
       calendarType={weekStartMap[weekStartValue]}
     />
   );

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.test.tsx
@@ -1,6 +1,52 @@
-import { dateTime } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
 
-import { inputToValue } from './CalendarBody';
+import { dateTime, getLocale, setLocale } from '@grafana/data';
+
+import { Body, inputToValue } from './CalendarBody';
+
+describe('Body', () => {
+  const originalLocale = getLocale();
+
+  afterEach(() => {
+    setLocale(originalLocale);
+  });
+
+  const renderBody = () =>
+    render(
+      <Body
+        isOpen={true}
+        isFullscreen={true}
+        from={dateTime('2020-04-16T10:00:00.000Z')}
+        to={dateTime('2020-04-16T11:00:00.000Z')}
+        weekStart="monday"
+        onChange={jest.fn()}
+        onClose={jest.fn()}
+        onApply={jest.fn()}
+      />
+    );
+
+  // react-calendar renders the weekday row as plain divs, so there is no role to query them by
+  const getWeekdayNames = () =>
+    Array.from(document.querySelectorAll('.react-calendar__month-view__weekdays abbr')).map((el) => el.textContent);
+
+  it('renders month and weekday names in the locale set for the app', () => {
+    setLocale('cs-CZ');
+
+    renderBody();
+
+    expect(screen.getByRole('button', { name: 'duben 2020' })).toBeInTheDocument();
+    expect(getWeekdayNames()).toEqual(['po', 'út', 'st', 'čt', 'pá', 'so', 'ne']);
+  });
+
+  it('renders month and weekday names in English when the app locale is English', () => {
+    setLocale('en-US');
+
+    renderBody();
+
+    expect(screen.getByRole('button', { name: 'April 2020' })).toBeInTheDocument();
+    expect(getWeekdayNames()).toEqual(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']);
+  });
+});
 
 describe('inputToValue', () => {
   describe('when called with valid dates', () => {


### PR DESCRIPTION
**What is this feature?**

The calendar popups in the time range picker, `DatePicker` and `DateTimePicker` now render
their month and weekday names in the user's chosen language instead of always in English.

All three components render `react-calendar` with a hardcoded `locale="en"`.
`react-calendar` derives month and weekday names itself via `Intl.DateTimeFormat(locale)`,
so that hardcoded value overrode the translated UI around it. This PR passes `getLocale()`
from `@grafana/data`, which returns the locale set from the user's language preference at
app bootstrap (`public/app/app.ts`).

**Why do we need this feature?**

Picking a time range is one of the most common interactions in Grafana, and until now the
calendar was an untranslated island in an otherwise fully translated UI. The mismatch is
most visible in languages where month names differ from English — in Czech the header read
`August 2026` instead of `srpen 2026`, and the weekday row read `Mon Tue Wed` instead of
`po út st`.

Note this was not a missing-translation problem: `react-calendar` produces these strings
through `Intl`, so no new translation keys are involved and every language Grafana ships
is covered at once.

**Who is this feature for?**

Any user running Grafana in a language other than English.

**Which issue(s) does this PR fix?**:

Fixes #<!-- PLACEHOLDER: issue number -->

**Special notes for your reviewer:**

Verified in a local dev build against a Grafana instance with the user language set to
German, Czech and English, with the *browser* locale deliberately set to `en-GB` to confirm
the calendar follows the app language rather than the browser's:

| Language    | Header (before) | Header (after) | Weekdays (after)              |
| ----------- | --------------- | -------------- | ----------------------------- |
| `de-DE`     | `August 2026`   | `August 2026`  | `Mo Di Mi Do Fr Sa So`        |
| `cs-CZ`     | `August 2026`   | `srpen 2026`   | `po út st čt pá so ne`        |
| `en-US`     | `August 2026`   | `August 2026`  | `Mon Tue Wed Thu Fri Sat Sun` |

Before (German):

<img width="1512" height="772" alt="grafana_de_before" src="https://github.com/user-attachments/assets/bbbd3bea-fbbf-4b0c-b4fc-d1e31bebcceb" />


After (German):

<img width="1512" height="772" alt="grafana_de_after" src="https://github.com/user-attachments/assets/b0f68269-e836-4b42-8937-86ed577db7be" />

Two regression tests were added in
`packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.test.tsx`.
The Czech one fails on `main` and passes with this change; the English one is a control that
passes either way, pinning that English output is unchanged.

`getLocale()` was chosen over `getLanguage()` from `@grafana/i18n` because the `internal`
entry point that exports it is not importable from `packages/**` — see the
`no-restricted-imports` rule in `eslint.config.js`. `getLocale()` is already public
`@grafana/data` API and is set from the same user language preference.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. <!-- n/a — bug fix -->
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. <!-- n/a — no user-facing docs describe the calendar's language -->