### PR TITLE
SSOSettings: List for the MT-Settings store

### DIFF
--- a/pkg/registry/apis/iam/sso/mtsettings_store.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store.go
@@ -18,7 +18,9 @@ import (
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	iamv0 "github.com/grafana/grafana/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/login/social"
 	settingsvc "github.com/grafana/grafana/pkg/services/setting"
+	"github.com/grafana/grafana/pkg/services/ssosettings"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -127,9 +129,58 @@ func (s *MTSettingsStore) Create(ctx context.Context, obj runtime.Object, create
 	return s.Get(ctx, ssoSetting.Name, &metav1.GetOptions{})
 }
 
-// List implements rest.Lister.
-func (s *MTSettingsStore) List(_ context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
-	return nil, s.notImplemented("list", "")
+// List implements rest.Lister. It assembles one SSOSetting per configured
+// provider from that provider's MT-Settings rows. Providers with no rows are
+// omitted, secrets are redacted, and results follow the canonical provider
+// order.
+func (s *MTSettingsStore) List(ctx context.Context, _ *internalversion.ListOptions) (runtime.Object, error) {
+	if s.reader == nil {
+		return nil, s.notImplemented("list", "")
+	}
+
+	rows, err := s.reader.List(ctx, ssoSectionsSelector())
+	if err != nil {
+		return nil, apierrors.NewInternalError(err)
+	}
+
+	byProvider := make(map[string][]*settingsvc.Setting)
+	for _, row := range rows {
+		provider := strings.TrimPrefix(row.Section, "auth.")
+		byProvider[provider] = append(byProvider[provider], row)
+	}
+
+	list := &iamv0.SSOSettingList{}
+	for _, provider := range ssoProviders() {
+		provRows, ok := byProvider[provider]
+		if !ok {
+			continue
+		}
+		list.Items = append(list.Items, *redactSecrets(rowsToSSOSetting(ctx, provider, provRows)))
+	}
+	return list, nil
+}
+
+// ssoProviders is the set of providers the SSOSetting kind serves: the OAuth
+// providers plus SAML. LDAP is excluded — MT-Settings has no representation for
+// its nested config (mirrors the backfill).
+func ssoProviders() []string {
+	return append(append([]string{}, ssosettings.AllOAuthProviders...), social.SAMLProviderName)
+}
+
+// ssoSectionsSelector matches every SSO provider section in one List call.
+func ssoSectionsSelector() metav1.LabelSelector {
+	providers := ssoProviders()
+	sections := make([]string, 0, len(providers))
+	for _, p := range providers {
+		sections = append(sections, sectionFor(p))
+	}
+	return metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "section",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   sections,
+		}},
+	}
 }
 
 // Update implements rest.Updater with the desired-state reconcile: upsert every

--- a/pkg/registry/apis/iam/sso/mtsettings_store_test.go
+++ b/pkg/registry/apis/iam/sso/mtsettings_store_test.go
@@ -3,6 +3,7 @@ package sso
 import (
 	"context"
 	"net/http"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,19 +52,32 @@ func newFakeSettings(seed []*settingsvc.Setting) *fakeSettings {
 }
 
 func (f *fakeSettings) List(_ context.Context, sel metav1.LabelSelector) ([]*settingsvc.Setting, error) {
-	section := sel.MatchLabels["section"]
 	var out []*settingsvc.Setting
 	for _, r := range f.seeded {
-		if r.Section == section {
+		if sectionMatches(sel, r.Section) {
 			out = append(out, r)
 		}
 	}
 	for _, r := range f.us {
-		if r.Section == section {
+		if sectionMatches(sel, r.Section) {
 			out = append(out, r)
 		}
 	}
 	return out, nil
+}
+
+// sectionMatches supports the two selector shapes the store issues: an exact
+// MatchLabels section (Get) and a section-In expression (List).
+func sectionMatches(sel metav1.LabelSelector, section string) bool {
+	if want, ok := sel.MatchLabels["section"]; ok {
+		return section == want
+	}
+	for _, req := range sel.MatchExpressions {
+		if req.Key == "section" && req.Operator == metav1.LabelSelectorOpIn {
+			return slices.Contains(req.Values, section)
+		}
+	}
+	return false
 }
 
 func (f *fakeSettings) Upsert(_ context.Context, s *settingsvc.Setting) error {
@@ -338,21 +352,6 @@ func TestMTSettingsStore(t *testing.T) {
 				assert.Equal(t, "abc", f.upserts["client_id"])
 			},
 		},
-		{
-			name: "List is not implemented",
-			rows: nil,
-			op: func(s *MTSettingsStore) (runtime.Object, bool, error) {
-				o, e := s.List(nsCtx(), nil)
-				return o, false, e
-			},
-			assert: func(t *testing.T, sso *iamv0.SSOSetting, _ bool, err error, _ *fakeSettings) {
-				require.Error(t, err)
-				status, ok := err.(apierrors.APIStatus)
-				require.True(t, ok)
-				assert.Equal(t, int32(http.StatusNotImplemented), status.Status().Code)
-				assert.Nil(t, sso)
-			},
-		},
 	}
 
 	for _, tc := range tests {
@@ -363,6 +362,55 @@ func TestMTSettingsStore(t *testing.T) {
 			tc.assert(t, sso, ok, err, f)
 		})
 	}
+}
+
+func TestMTSettingsStore_List(t *testing.T) {
+	t.Run("one item per configured provider, canonical order, redacted", func(t *testing.T) {
+		f := newFakeSettings([]*settingsvc.Setting{
+			usRow("auth.github", "enabled", "true"),
+			usRow("auth.github", "client_secret", "supersecret"),
+			defaultRow("auth.saml", "name", "SAML"),
+			// ldap (no MT representation) and non-auth sections are never listed
+			usRow("auth.ldap", "enabled", "true"),
+			usRow("smtp", "host", "localhost"),
+		})
+
+		obj, err := NewMTSettingsStore(f, f).List(nsCtx(), nil)
+		require.NoError(t, err)
+		list, ok := obj.(*iamv0.SSOSettingList)
+		require.True(t, ok)
+
+		require.Len(t, list.Items, 2)
+		// OAuth providers precede SAML; ldap/smtp are excluded.
+		assert.Equal(t, "github", list.Items[0].Name)
+		assert.Equal(t, "saml", list.Items[1].Name)
+		assert.Equal(t, "stacks-11", list.Items[0].Namespace)
+
+		// github carries a us override -> source db; the secret is redacted.
+		assert.Equal(t, iamv0.SourceDB, list.Items[0].Spec.Source)
+		assert.Equal(t, setting.RedactedPassword, list.Items[0].Spec.Settings.Object["client_secret"])
+		assert.Equal(t, "true", list.Items[0].Spec.Settings.Object["enabled"])
+
+		// saml has only a default-layer row -> source system.
+		assert.Equal(t, iamv0.SourceSystem, list.Items[1].Spec.Source)
+	})
+
+	t.Run("empty list when no provider has rows", func(t *testing.T) {
+		f := newFakeSettings(nil)
+		obj, err := NewMTSettingsStore(f, f).List(nsCtx(), nil)
+		require.NoError(t, err)
+		list, ok := obj.(*iamv0.SSOSettingList)
+		require.True(t, ok)
+		assert.Empty(t, list.Items)
+	})
+
+	t.Run("without a reader, list is not implemented", func(t *testing.T) {
+		_, err := NewMTSettingsStore(nil, nil).List(nsCtx(), nil)
+		require.Error(t, err)
+		status, ok := err.(apierrors.APIStatus)
+		require.True(t, ok)
+		assert.Equal(t, int32(http.StatusNotImplemented), status.Status().Code)
+	})
 }
 
 // TestRedactSecretsNestedLDAP covers LDAP's nested servers config, whose secrets


### PR DESCRIPTION
## Summary
Implements `List` for the SSOSetting kind's MT-Settings store (previously a 501 stub). It assembles one `SSOSetting` per configured provider from that provider's MT-Settings rows, so listing the kind works once reads are served from MT-Settings.

Part of the SSO Settings → MT-Settings migration (Stage 3.5).

Fixes grafana/identity-access-team#2385

## What
- `MTSettingsStore.List`: a single `reader.List` with a `section In (auth.<provider>…)` selector across the OAuth providers plus SAML, grouped per provider and assembled via the existing `rowsToSSOSetting` + `redactSecrets`, in canonical provider order. LDAP is excluded (no MT-Settings representation, mirroring the backfill). Providers with no rows are omitted; an unconfigured store still returns 501.

## Why
The kind's `List` was left as a stub while the write and backfill paths were proven. It is needed before reads are served from MT-Settings.

## Test plan
- Unit tests: multi-provider list in canonical order, secret redaction, ldap/non-auth sections excluded, empty result, and the unconfigured-store 501.
- `make lint-go` and `gofmt -s` clean; `go test` and `go vet` pass.
