### PR TITLE
Provisioning: tolerate quota lookup failures for existing repositories

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -701,7 +701,6 @@ func (TokenStatus) OpenAPIModelName() string {
 }
 
 // QuotaStatus represents the quota limits configured for this repository.
-// These values come from static configuration and are read-only.
 type QuotaStatus struct {
 	// MaxRepositories is the maximum number of repositories allowed.
 	// 0 means unlimited.
@@ -710,6 +709,10 @@ type QuotaStatus struct {
 	// MaxResourcesPerRepository is the maximum number of resources allowed per repository.
 	// 0 means unlimited.
 	MaxResourcesPerRepository int64 `json:"maxResourcesPerRepository,omitempty"`
+
+	// StaleSince is when the controller started using cached quota limits after a refresh failed.
+	// It is expressed as Unix milliseconds. 0 means the quota limits are fresh.
+	StaleSince int64 `json:"staleSince,omitempty"`
 }
 
 func (QuotaStatus) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -710,9 +710,9 @@ type QuotaStatus struct {
 	// 0 means unlimited.
 	MaxResourcesPerRepository int64 `json:"maxResourcesPerRepository,omitempty"`
 
-	// StaleSince is when the controller started using cached quota limits after a refresh failed.
-	// It is expressed as Unix milliseconds. 0 means the quota limits are fresh.
-	StaleSince int64 `json:"staleSince,omitempty"`
+	// UpdatedAt is when the controller last successfully refreshed these quota limits.
+	// It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.
+	UpdatedAt int64 `json:"updatedAt,omitempty"`
 }
 
 func (QuotaStatus) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -2289,7 +2289,7 @@ func schema_pkg_apis_provisioning_v0alpha1_QuotaStatus(ref common.ReferenceCallb
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "QuotaStatus represents the quota limits configured for this repository. These values come from static configuration and are read-only.",
+				Description: "QuotaStatus represents the quota limits configured for this repository.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"maxRepositories": {
@@ -2302,6 +2302,13 @@ func schema_pkg_apis_provisioning_v0alpha1_QuotaStatus(ref common.ReferenceCallb
 					"maxResourcesPerRepository": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"staleSince": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -2306,9 +2306,9 @@ func schema_pkg_apis_provisioning_v0alpha1_QuotaStatus(ref common.ReferenceCallb
 							Format:      "int64",
 						},
 					},
-					"staleSince": {
+					"updatedAt": {
 						SchemaProps: spec.SchemaProps{
-							Description: "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
+							Description: "UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/quotastatus.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/quotastatus.go
@@ -8,7 +8,6 @@ package v0alpha1
 // with apply.
 //
 // QuotaStatus represents the quota limits configured for this repository.
-// These values come from static configuration and are read-only.
 type QuotaStatusApplyConfiguration struct {
 	// MaxRepositories is the maximum number of repositories allowed.
 	// 0 means unlimited.
@@ -16,6 +15,9 @@ type QuotaStatusApplyConfiguration struct {
 	// MaxResourcesPerRepository is the maximum number of resources allowed per repository.
 	// 0 means unlimited.
 	MaxResourcesPerRepository *int64 `json:"maxResourcesPerRepository,omitempty"`
+	// StaleSince is when the controller started using cached quota limits after a refresh failed.
+	// It is expressed as Unix milliseconds. 0 means the quota limits are fresh.
+	StaleSince *int64 `json:"staleSince,omitempty"`
 }
 
 // QuotaStatusApplyConfiguration constructs a declarative configuration of the QuotaStatus type for use with
@@ -37,5 +39,13 @@ func (b *QuotaStatusApplyConfiguration) WithMaxRepositories(value int64) *QuotaS
 // If called multiple times, the MaxResourcesPerRepository field is set to the value of the last call.
 func (b *QuotaStatusApplyConfiguration) WithMaxResourcesPerRepository(value int64) *QuotaStatusApplyConfiguration {
 	b.MaxResourcesPerRepository = &value
+	return b
+}
+
+// WithStaleSince sets the StaleSince field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the StaleSince field is set to the value of the last call.
+func (b *QuotaStatusApplyConfiguration) WithStaleSince(value int64) *QuotaStatusApplyConfiguration {
+	b.StaleSince = &value
 	return b
 }

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/quotastatus.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/quotastatus.go
@@ -15,9 +15,9 @@ type QuotaStatusApplyConfiguration struct {
 	// MaxResourcesPerRepository is the maximum number of resources allowed per repository.
 	// 0 means unlimited.
 	MaxResourcesPerRepository *int64 `json:"maxResourcesPerRepository,omitempty"`
-	// StaleSince is when the controller started using cached quota limits after a refresh failed.
-	// It is expressed as Unix milliseconds. 0 means the quota limits are fresh.
-	StaleSince *int64 `json:"staleSince,omitempty"`
+	// UpdatedAt is when the controller last successfully refreshed these quota limits.
+	// It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.
+	UpdatedAt *int64 `json:"updatedAt,omitempty"`
 }
 
 // QuotaStatusApplyConfiguration constructs a declarative configuration of the QuotaStatus type for use with
@@ -42,10 +42,10 @@ func (b *QuotaStatusApplyConfiguration) WithMaxResourcesPerRepository(value int6
 	return b
 }
 
-// WithStaleSince sets the StaleSince field in the declarative configuration to the given value
+// WithUpdatedAt sets the UpdatedAt field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the StaleSince field is set to the value of the last call.
-func (b *QuotaStatusApplyConfiguration) WithStaleSince(value int64) *QuotaStatusApplyConfiguration {
-	b.StaleSince = &value
+// If called multiple times, the UpdatedAt field is set to the value of the last call.
+func (b *QuotaStatusApplyConfiguration) WithUpdatedAt(value int64) *QuotaStatusApplyConfiguration {
+	b.UpdatedAt = &value
 	return b
 }

--- a/apps/provisioning/pkg/quotas/quotas.go
+++ b/apps/provisioning/pkg/quotas/quotas.go
@@ -121,23 +121,37 @@ type QuotaGetter interface {
 // FixedQuotaGetter returns fixed quota values from static configuration.
 type FixedQuotaGetter struct {
 	quotaStatus atomic.Value // stores provisioning.QuotaStatus
+	forcedError atomic.Value // stores fixedQuotaGetterError for test-only failure injection
+}
+
+type fixedQuotaGetterError struct {
+	err error
 }
 
 // NewFixedQuotaGetter creates a new FixedQuotaGetter from QuotaStatus.
 func NewFixedQuotaGetter(quotaStatus provisioning.QuotaStatus) *FixedQuotaGetter {
 	f := &FixedQuotaGetter{}
 	f.quotaStatus.Store(quotaStatus)
+	f.forcedError.Store(fixedQuotaGetterError{})
 	return f
 }
 
 // GetQuotaStatus returns the configured quota limits as a QuotaStatus.
 func (f *FixedQuotaGetter) GetQuotaStatus(_ context.Context, _ string) (provisioning.QuotaStatus, error) {
+	if state := f.forcedError.Load().(fixedQuotaGetterError); state.err != nil {
+		return provisioning.QuotaStatus{}, state.err
+	}
 	return f.quotaStatus.Load().(provisioning.QuotaStatus), nil
 }
 
 // SetQuotaStatus updates the quota status, allowing runtime changes (primarily for testing).
 func (f *FixedQuotaGetter) SetQuotaStatus(status provisioning.QuotaStatus) {
 	f.quotaStatus.Store(status)
+}
+
+// SetError makes GetQuotaStatus return err. This method exists only to support tests.
+func (f *FixedQuotaGetter) SetError(err error) {
+	f.forcedError.Store(fixedQuotaGetterError{err: err})
 }
 
 var _ QuotaGetter = (*FixedQuotaGetter)(nil)

--- a/apps/provisioning/pkg/quotas/quotas_test.go
+++ b/apps/provisioning/pkg/quotas/quotas_test.go
@@ -582,6 +582,22 @@ func TestFixedQuotaGetter_SetQuotaStatus(t *testing.T) {
 	assert.Equal(t, int64(2), status.MaxRepositories)
 }
 
+func TestFixedQuotaGetter_SetError(t *testing.T) {
+	ctx := context.Background()
+	getter := NewFixedQuotaGetter(provisioning.QuotaStatus{MaxRepositories: 10})
+	lookupErr := errors.New("quota service failed")
+
+	getter.SetError(lookupErr)
+	status, err := getter.GetQuotaStatus(ctx, "ns")
+	require.ErrorIs(t, err, lookupErr)
+	assert.Equal(t, provisioning.QuotaStatus{}, status)
+
+	getter.SetError(nil)
+	status, err = getter.GetQuotaStatus(ctx, "ns")
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), status.MaxRepositories)
+}
+
 func TestFixedQuotaGetter_ImplementsInterface(t *testing.T) {
 	// Verify that FixedQuotaGetter implements QuotaGetter interface
 	var _ QuotaGetter = (*FixedQuotaGetter)(nil)

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -106,7 +106,15 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 	// Get quota status for the namespace
 	quotaStatus, err := v.quotaGetter.GetQuotaStatus(ctx, cfg.Namespace)
 	if err != nil {
-		return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("failed to get quota status: %w", err))}
+		// If the quota getter throws an error, and the resource is new, return such error as we don't have quota for it.
+		if cfg.Status.ObservedGeneration == 0 {
+			return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("failed to get quota status: %w", err))}
+		}
+
+		// Otherwise, retrieve the status quota
+		quotaStatus = provisioning.QuotaStatus{
+			MaxRepositories: cfg.Status.Quota.MaxRepositories,
+		}
 	}
 
 	// Check repository limit (0 = unlimited, > 0 = use value).

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -106,14 +106,19 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 	// Get quota status for the namespace
 	quotaStatus, err := v.quotaGetter.GetQuotaStatus(ctx, cfg.Namespace)
 	if err != nil {
-		// If the quota getter throws an error, and the resource is new, return such error as we don't have quota for it.
-		if cfg.Status.ObservedGeneration == 0 {
-			return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("failed to get quota status: %w", err))}
+		isExistingRepo := false
+		for i := range all {
+			if all[i].Name == cfg.Name {
+				quotaStatus = all[i].Status.Quota
+				isExistingRepo = true
+				break
+			}
 		}
 
-		// Otherwise, retrieve the status quota
-		quotaStatus = provisioning.QuotaStatus{
-			MaxRepositories: cfg.Status.Quota.MaxRepositories,
+		// A repository is new only when it is absent from storage. ObservedGeneration may remain zero
+		// when the first reconciliation fails after caching quota.
+		if !isExistingRepo {
+			return field.ErrorList{field.InternalError(field.NewPath(""), fmt.Errorf("failed to get quota status: %w", err))}
 		}
 	}
 

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -859,7 +859,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_QuotaLookupError(t *testing.
 			wantErrContains: "failed to get quota status: quota service failed",
 		},
 		{
-			name: "observed repository uses cached quota",
+			name: "repository absent from storage returns lookup error despite observed generation",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "observed-repo", Namespace: "default"},
 				Status: provisioning.RepositoryStatus{
@@ -870,19 +870,20 @@ func TestVerifyAgainstExistingRepositoriesValidator_QuotaLookupError(t *testing.
 			existingRepos: []provisioning.Repository{
 				{ObjectMeta: metav1.ObjectMeta{Name: "other-repo"}},
 			},
-			wantErrContains: "Maximum number of 1 repositories reached",
+			wantErrContains: "failed to get quota status: quota service failed",
 		},
 		{
-			name: "observed repository update is allowed",
+			name: "persisted unobserved repository update uses cached quota",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "observed-repo", Namespace: "default"},
-				Status: provisioning.RepositoryStatus{
-					ObservedGeneration: 1,
-					Quota:              provisioning.QuotaStatus{MaxRepositories: 1},
-				},
 			},
 			existingRepos: []provisioning.Repository{
-				{ObjectMeta: metav1.ObjectMeta{Name: "observed-repo"}},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "observed-repo"},
+					Status: provisioning.RepositoryStatus{
+						Quota: provisioning.QuotaStatus{MaxRepositories: 1},
+					},
+				},
 				{ObjectMeta: metav1.ObjectMeta{Name: "other-repo"}},
 			},
 		},

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -838,6 +839,70 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			}
 
 			assert.Empty(t, errList)
+		})
+	}
+}
+
+func TestVerifyAgainstExistingRepositoriesValidator_QuotaLookupError(t *testing.T) {
+	lookupErr := errors.New("quota service failed")
+	tests := []struct {
+		name            string
+		cfg             *provisioning.Repository
+		existingRepos   []provisioning.Repository
+		wantErrContains string
+	}{
+		{
+			name: "new repository returns quota lookup error",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+			},
+			wantErrContains: "failed to get quota status: quota service failed",
+		},
+		{
+			name: "observed repository uses cached quota",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "observed-repo", Namespace: "default"},
+				Status: provisioning.RepositoryStatus{
+					ObservedGeneration: 1,
+					Quota:              provisioning.QuotaStatus{MaxRepositories: 1},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{ObjectMeta: metav1.ObjectMeta{Name: "other-repo"}},
+			},
+			wantErrContains: "Maximum number of 1 repositories reached",
+		},
+		{
+			name: "observed repository update is allowed",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "observed-repo", Namespace: "default"},
+				Status: provisioning.RepositoryStatus{
+					ObservedGeneration: 1,
+					Quota:              provisioning.QuotaStatus{MaxRepositories: 1},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{ObjectMeta: metav1.ObjectMeta{Name: "observed-repo"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "other-repo"}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &verifyTestStorage{repositories: tt.existingRepos}
+			getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{MaxRepositories: 10})
+			getter.SetError(lookupErr)
+			validator := NewVerifyAgainstExistingRepositoriesValidator(NewStorageLister(store), getter)
+
+			errList := validator.Validate(context.Background(), tt.cfg)
+			if tt.wantErrContains == "" {
+				assert.Empty(t, errList)
+				return
+			}
+
+			require.NotEmpty(t, errList)
+			assert.Contains(t, errList.ToAggregate().Error(), tt.wantErrContains)
 		})
 	}
 }

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -2049,6 +2049,8 @@ export type QuotaStatus = {
   maxRepositories?: number;
   /** MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited. */
   maxResourcesPerRepository?: number;
+  /** StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh. */
+  staleSince?: number;
 };
 export type ResourceCount = {
   count: number;

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -2049,8 +2049,8 @@ export type QuotaStatus = {
   maxRepositories?: number;
   /** MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited. */
   maxResourcesPerRepository?: number;
-  /** StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh. */
-  staleSince?: number;
+  /** UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet. */
+  updatedAt?: number;
 };
 export type ResourceCount = {
   count: number;

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -5196,7 +5196,7 @@
         }
       },
       "QuotaStatus": {
-        "description": "QuotaStatus represents the quota limits configured for this repository. These values come from static configuration and are read-only.",
+        "description": "QuotaStatus represents the quota limits configured for this repository.",
         "type": "object",
         "properties": {
           "maxRepositories": {
@@ -5206,6 +5206,11 @@
           },
           "maxResourcesPerRepository": {
             "description": "MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "staleSince": {
+            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
             "type": "integer",
             "format": "int64"
           }

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -5209,8 +5209,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "staleSince": {
-            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
+          "updatedAt": {
+            "description": "UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.",
             "type": "integer",
             "format": "int64"
           }

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4931,7 +4931,7 @@
         }
       },
       "QuotaStatus": {
-        "description": "QuotaStatus represents the quota limits configured for this repository. These values come from static configuration and are read-only.",
+        "description": "QuotaStatus represents the quota limits configured for this repository.",
         "type": "object",
         "properties": {
           "maxRepositories": {
@@ -4941,6 +4941,11 @@
           },
           "maxResourcesPerRepository": {
             "description": "MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "staleSince": {
+            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
             "type": "integer",
             "format": "int64"
           }

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -4944,8 +4944,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "staleSince": {
-            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
+          "updatedAt": {
+            "description": "UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.",
             "type": "integer",
             "format": "int64"
           }

--- a/pkg/registry/apis/provisioning/controller/quota_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics.go
@@ -6,7 +6,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var repositoryQuotaStalenessBuckets = []float64{0, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400}
+var repositoryQuotaStalenessBuckets = []float64{
+	0,
+	time.Minute.Seconds(),
+	(5 * time.Minute).Seconds(),
+	(15 * time.Minute).Seconds(),
+	(30 * time.Minute).Seconds(),
+	time.Hour.Seconds(),
+	(3 * time.Hour).Seconds(),
+	(6 * time.Hour).Seconds(),
+	(12 * time.Hour).Seconds(),
+	(24 * time.Hour).Seconds(),
+}
 
 type repositoryQuotaMetrics struct {
 	staleness prometheus.Histogram

--- a/pkg/registry/apis/provisioning/controller/quota_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var repositoryQuotaStalenessBuckets = []float64{0, 60, 300, 900, 1800, 3600, 10800, 21600, 43200, 86400}
+
+type repositoryQuotaMetrics struct {
+	staleness prometheus.Histogram
+}
+
+func registerRepositoryQuotaMetrics(registry prometheus.Registerer) *repositoryQuotaMetrics {
+	staleness := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "grafana_provisioning_repository_quota_staleness_seconds",
+		Help:    "Age of cached repository quota limits used after a quota refresh failure.",
+		Buckets: repositoryQuotaStalenessBuckets,
+	})
+	registry.MustRegister(staleness)
+
+	return &repositoryQuotaMetrics{staleness: staleness}
+}
+
+func (m *repositoryQuotaMetrics) observeStaleness(age time.Duration) {
+	if m == nil {
+		return
+	}
+	if age < 0 {
+		age = 0
+	}
+	m.staleness.Observe(age.Seconds())
+}

--- a/pkg/registry/apis/provisioning/controller/quota_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics.go
@@ -6,6 +6,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// Use finer resolution during the first hour of quota-service failures, then
+// track prolonged reliance on cached quota at 3, 6, 12, and 24 hours.
 var repositoryQuotaStalenessBuckets = []float64{
 	0,
 	time.Minute.Seconds(),

--- a/pkg/registry/apis/provisioning/controller/quota_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics.go
@@ -6,9 +6,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Use finer resolution during the first hour of quota-service failures, then
-// track prolonged reliance on cached quota at 3, 6, 12, and 24 hours.
-var repositoryQuotaStalenessBuckets = []float64{
+// Use finer resolution during the first hour after the last successful quota
+// refresh, then track prolonged reliance on cached quota at 3, 6, 12, and 24 hours.
+var repositoryQuotaAgeBuckets = []float64{
 	0,
 	time.Minute.Seconds(),
 	(5 * time.Minute).Seconds(),
@@ -22,26 +22,38 @@ var repositoryQuotaStalenessBuckets = []float64{
 }
 
 type repositoryQuotaMetrics struct {
-	staleness prometheus.Histogram
+	age     prometheus.Histogram
+	changes prometheus.Counter
 }
 
 func registerRepositoryQuotaMetrics(registry prometheus.Registerer) *repositoryQuotaMetrics {
-	staleness := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "grafana_provisioning_repository_quota_staleness_seconds",
+	age := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "grafana_provisioning_repository_quota_age_seconds",
 		Help:    "Age of cached repository quota limits used after a quota refresh failure.",
-		Buckets: repositoryQuotaStalenessBuckets,
+		Buckets: repositoryQuotaAgeBuckets,
 	})
-	registry.MustRegister(staleness)
+	changes := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "grafana_provisioning_repository_quota_changes_total",
+		Help: "Total number of repository quota limit changes observed by the controller.",
+	})
+	registry.MustRegister(age, changes)
 
-	return &repositoryQuotaMetrics{staleness: staleness}
+	return &repositoryQuotaMetrics{age: age, changes: changes}
 }
 
-func (m *repositoryQuotaMetrics) observeStaleness(age time.Duration) {
+func (m *repositoryQuotaMetrics) observeAge(age time.Duration) {
 	if m == nil {
 		return
 	}
 	if age < 0 {
 		age = 0
 	}
-	m.staleness.Observe(age.Seconds())
+	m.age.Observe(age.Seconds())
+}
+
+func (m *repositoryQuotaMetrics) recordChange() {
+	if m == nil {
+		return
+	}
+	m.changes.Inc()
 }

--- a/pkg/registry/apis/provisioning/controller/quota_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics.go
@@ -22,8 +22,9 @@ var repositoryQuotaAgeBuckets = []float64{
 }
 
 type repositoryQuotaMetrics struct {
-	age     prometheus.Histogram
-	changes prometheus.Counter
+	age           prometheus.Histogram
+	refreshTotal  prometheus.Counter
+	refreshErrors prometheus.Counter
 }
 
 func registerRepositoryQuotaMetrics(registry prometheus.Registerer) *repositoryQuotaMetrics {
@@ -32,13 +33,17 @@ func registerRepositoryQuotaMetrics(registry prometheus.Registerer) *repositoryQ
 		Help:    "Age of cached repository quota limits used after a quota refresh failure.",
 		Buckets: repositoryQuotaAgeBuckets,
 	})
-	changes := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "grafana_provisioning_repository_quota_changes_total",
-		Help: "Total number of repository quota limit changes observed by the controller.",
+	refreshTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "grafana_provisioning_repository_quota_refresh_total",
+		Help: "Total number of repository quota refreshes that changed limits.",
 	})
-	registry.MustRegister(age, changes)
+	refreshErrors := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "grafana_provisioning_repository_quota_refresh_errors_total",
+		Help: "Total number of failed repository quota refreshes.",
+	})
+	registry.MustRegister(age, refreshTotal, refreshErrors)
 
-	return &repositoryQuotaMetrics{age: age, changes: changes}
+	return &repositoryQuotaMetrics{age: age, refreshTotal: refreshTotal, refreshErrors: refreshErrors}
 }
 
 func (m *repositoryQuotaMetrics) observeAge(age time.Duration) {
@@ -51,9 +56,16 @@ func (m *repositoryQuotaMetrics) observeAge(age time.Duration) {
 	m.age.Observe(age.Seconds())
 }
 
-func (m *repositoryQuotaMetrics) recordChange() {
+func (m *repositoryQuotaMetrics) recordRefresh() {
 	if m == nil {
 		return
 	}
-	m.changes.Inc()
+	m.refreshTotal.Inc()
+}
+
+func (m *repositoryQuotaMetrics) recordRefreshError() {
+	if m == nil {
+		return
+	}
+	m.refreshErrors.Inc()
 }

--- a/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const repositoryQuotaStalenessMetric = "grafana_provisioning_repository_quota_staleness_seconds"
+
+func TestRepositoryQuotaMetrics_ObserveStaleness(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	metrics := registerRepositoryQuotaMetrics(reg)
+
+	metrics.observeStaleness(5 * time.Minute)
+	metrics.observeStaleness(-time.Minute)
+
+	family := gatherMetrics(t, reg)[repositoryQuotaStalenessMetric]
+	require.NotNil(t, family)
+	require.Len(t, family.GetMetric(), 1)
+	histogram := family.GetMetric()[0].GetHistogram()
+	assert.Equal(t, uint64(2), histogram.GetSampleCount())
+	assert.InDelta(t, 300, histogram.GetSampleSum(), 0.001)
+}
+
+func TestRepositoryQuotaMetrics_NilSafe(t *testing.T) {
+	var metrics *repositoryQuotaMetrics
+	assert.NotPanics(t, func() {
+		metrics.observeStaleness(time.Minute)
+	})
+}

--- a/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	repositoryQuotaAgeMetric     = "grafana_provisioning_repository_quota_age_seconds"
-	repositoryQuotaChangesMetric = "grafana_provisioning_repository_quota_changes_total"
+	repositoryQuotaAgeMetric           = "grafana_provisioning_repository_quota_age_seconds"
+	repositoryQuotaRefreshMetric       = "grafana_provisioning_repository_quota_refresh_total"
+	repositoryQuotaRefreshErrorsMetric = "grafana_provisioning_repository_quota_refresh_errors_total"
 )
 
 func TestRepositoryQuotaMetrics_ObserveAge(t *testing.T) {
@@ -29,20 +30,23 @@ func TestRepositoryQuotaMetrics_ObserveAge(t *testing.T) {
 	assert.InDelta(t, 300, histogram.GetSampleSum(), 0.001)
 }
 
-func TestRepositoryQuotaMetrics_RecordChange(t *testing.T) {
+func TestRepositoryQuotaMetrics_RecordRefresh(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	metrics := registerRepositoryQuotaMetrics(reg)
 
-	metrics.recordChange()
-	metrics.recordChange()
+	metrics.recordRefresh()
+	metrics.recordRefresh()
+	metrics.recordRefreshError()
 
-	assert.Equal(t, 2.0, counterValue(t, reg, repositoryQuotaChangesMetric))
+	assert.Equal(t, 2.0, counterValue(t, reg, repositoryQuotaRefreshMetric))
+	assert.Equal(t, 1.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 }
 
 func TestRepositoryQuotaMetrics_NilSafe(t *testing.T) {
 	var metrics *repositoryQuotaMetrics
 	assert.NotPanics(t, func() {
 		metrics.observeAge(time.Minute)
-		metrics.recordChange()
+		metrics.recordRefresh()
+		metrics.recordRefreshError()
 	})
 }

--- a/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/quota_metrics_test.go
@@ -9,16 +9,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const repositoryQuotaStalenessMetric = "grafana_provisioning_repository_quota_staleness_seconds"
+const (
+	repositoryQuotaAgeMetric     = "grafana_provisioning_repository_quota_age_seconds"
+	repositoryQuotaChangesMetric = "grafana_provisioning_repository_quota_changes_total"
+)
 
-func TestRepositoryQuotaMetrics_ObserveStaleness(t *testing.T) {
+func TestRepositoryQuotaMetrics_ObserveAge(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	metrics := registerRepositoryQuotaMetrics(reg)
 
-	metrics.observeStaleness(5 * time.Minute)
-	metrics.observeStaleness(-time.Minute)
+	metrics.observeAge(5 * time.Minute)
+	metrics.observeAge(-time.Minute)
 
-	family := gatherMetrics(t, reg)[repositoryQuotaStalenessMetric]
+	family := gatherMetrics(t, reg)[repositoryQuotaAgeMetric]
 	require.NotNil(t, family)
 	require.Len(t, family.GetMetric(), 1)
 	histogram := family.GetMetric()[0].GetHistogram()
@@ -26,9 +29,20 @@ func TestRepositoryQuotaMetrics_ObserveStaleness(t *testing.T) {
 	assert.InDelta(t, 300, histogram.GetSampleSum(), 0.001)
 }
 
+func TestRepositoryQuotaMetrics_RecordChange(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	metrics := registerRepositoryQuotaMetrics(reg)
+
+	metrics.recordChange()
+	metrics.recordChange()
+
+	assert.Equal(t, 2.0, counterValue(t, reg, repositoryQuotaChangesMetric))
+}
+
 func TestRepositoryQuotaMetrics_NilSafe(t *testing.T) {
 	var metrics *repositoryQuotaMetrics
 	assert.NotPanics(t, func() {
-		metrics.observeStaleness(time.Minute)
+		metrics.observeAge(time.Minute)
+		metrics.recordChange()
 	})
 }

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -87,6 +87,7 @@ type RepositoryController struct {
 	registry                      prometheus.Registerer
 	tracer                        tracing.Tracer
 	quotaGetter                   quotas.QuotaGetter
+	quotaMetrics                  *repositoryQuotaMetrics
 	tokenMetrics                  *repositoryTokenMetrics
 	incrementalPolicy             repository.IncrementalSyncPolicy
 	webhookSecretRotationInterval time.Duration
@@ -120,6 +121,7 @@ func NewRepositoryController(
 ) *RepositoryController {
 	finalizerMetrics := registerFinalizerMetrics(registry)
 	repoTokenMetrics := registerRepositoryTokenMetrics(registry)
+	quotaMetrics := registerRepositoryQuotaMetrics(registry)
 
 	rc := &RepositoryController{
 		client:    provisioningClient,
@@ -153,6 +155,7 @@ func NewRepositoryController(
 		minSyncInterval:               minSyncInterval,
 		drainTimeout:                  drainTimeout,
 		quotaGetter:                   quotaGetter,
+		quotaMetrics:                  quotaMetrics,
 		tokenMetrics:                  repoTokenMetrics,
 		incrementalPolicy:             incrementalPolicy,
 		webhookSecretRotationInterval: webhookSecretRotationInterval,
@@ -507,6 +510,28 @@ func isQuotaExceeded(conditions []v1.Condition) bool {
 	return false
 }
 
+func (rc *RepositoryController) resolveQuotaStatus(ctx context.Context, obj *provisioning.Repository) (provisioning.QuotaStatus, error) {
+	quotaStatus, err := rc.quotaGetter.GetQuotaStatus(ctx, obj.Namespace)
+	if err == nil {
+		quotaStatus.StaleSince = 0
+		return quotaStatus, nil
+	}
+
+	if obj.Status.ObservedGeneration == 0 {
+		return provisioning.QuotaStatus{}, fmt.Errorf("failed to get quota status: %w", err)
+	}
+
+	now := time.Now()
+	quotaStatus = obj.Status.Quota
+	if quotaStatus.StaleSince == 0 {
+		quotaStatus.StaleSince = now.UnixMilli()
+		logging.FromContext(ctx).Warn("failed to refresh quota status; using cached limits", "error", err)
+	}
+
+	rc.quotaMetrics.observeStaleness(now.Sub(time.UnixMilli(quotaStatus.StaleSince)))
+	return quotaStatus, nil
+}
+
 func (rc *RepositoryController) determineSyncStrategy(
 	ctx context.Context,
 	obj *provisioning.Repository,
@@ -757,9 +782,9 @@ func (rc *RepositoryController) process(key string) (err error) {
 
 	// Check quota state early - before trigger evaluation
 	// This allows blocked repos to check if they can unblock even without other triggers
-	newQuota, err := rc.quotaGetter.GetQuotaStatus(ctx, namespace)
+	newQuota, err := rc.resolveQuotaStatus(ctx, obj)
 	if err != nil {
-		return fmt.Errorf("failed to get quota status: %w", err)
+		return err
 	}
 	quotaCtx, quotaSpan := rc.tracer.Start(ctx, "provisioning.controller.check_quota", repoSpanAttrs(obj))
 	quotaCondition, err := rc.quotaChecker.RepositoryQuotaConditions(quotaCtx, namespace, newQuota)
@@ -806,8 +831,15 @@ func (rc *RepositoryController) process(key string) (err error) {
 		}
 	}()
 
-	hasQuotaChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
+	hasQuotaLimitsChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
 		obj.Status.Quota.MaxResourcesPerRepository != newQuota.MaxResourcesPerRepository
+	if obj.Status.Quota != newQuota {
+		patchOperations = append(patchOperations, map[string]interface{}{
+			"op":    "replace",
+			"path":  "/status/quota",
+			"value": newQuota,
+		})
+	}
 
 	var shouldGenerateToken bool
 	if obj.Spec.Connection != nil && obj.Spec.Connection.Name != "" {
@@ -841,7 +873,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	case shouldGenerateToken:
 		reason = "token_generation"
 		logger.Info("repository token needs to be generated", "connection", obj.Spec.Connection.Name)
-	case hasQuotaChanged:
+	case hasQuotaLimitsChanged:
 		reason = "quota_changed"
 		logger.Info("quota changed", "quota", newQuota)
 	case len(obj.Spec.Workflows) > 0 && repository.GetID(obj.Status.Webhook).IsEmpty():
@@ -856,15 +888,6 @@ func (rc *RepositoryController) process(key string) (err error) {
 		return nil
 	}
 	span.SetAttributes(attribute.String("reconcile.reason", reason))
-
-	// Set quota information from configuration (only if changed)
-	if hasQuotaChanged {
-		patchOperations = append(patchOperations, map[string]interface{}{
-			"op":    "replace",
-			"path":  "/status/quota",
-			"value": newQuota,
-		})
-	}
 
 	if shouldGenerateToken {
 		logger.Info("updating token for repository")

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -831,7 +831,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 		}
 	}()
 
-	hasQuotaLimitsChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
+	hasQuotaChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
 		obj.Status.Quota.MaxResourcesPerRepository != newQuota.MaxResourcesPerRepository
 	if obj.Status.Quota != newQuota {
 		patchOperations = append(patchOperations, map[string]interface{}{
@@ -873,7 +873,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	case shouldGenerateToken:
 		reason = "token_generation"
 		logger.Info("repository token needs to be generated", "connection", obj.Spec.Connection.Name)
-	case hasQuotaLimitsChanged:
+	case hasQuotaChanged:
 		reason = "quota_changed"
 		logger.Info("quota changed", "quota", newQuota)
 	case len(obj.Spec.Workflows) > 0 && repository.GetID(obj.Status.Webhook).IsEmpty():

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -510,6 +510,9 @@ func isQuotaExceeded(conditions []v1.Condition) bool {
 	return false
 }
 
+// resolveQuotaStatus retrieves current quota limits, falling back to the cached status for observed
+// repositories when the lookup fails and tracking how long that cache has been stale. New repositories
+// return the lookup error because they do not have a known valid cached quota.
 func (rc *RepositoryController) resolveQuotaStatus(ctx context.Context, obj *provisioning.Repository) (provisioning.QuotaStatus, error) {
 	quotaStatus, err := rc.quotaGetter.GetQuotaStatus(ctx, obj.Namespace)
 	if err == nil {

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -511,12 +511,12 @@ func isQuotaExceeded(conditions []v1.Condition) bool {
 }
 
 // resolveQuotaStatus retrieves current quota limits, falling back to the cached status for observed
-// repositories when the lookup fails and tracking how long that cache has been stale. New repositories
-// return the lookup error because they do not have a known valid cached quota.
+// repositories when the lookup fails. New repositories return the lookup error because they do not
+// have a known valid cached quota.
 func (rc *RepositoryController) resolveQuotaStatus(ctx context.Context, obj *provisioning.Repository) (provisioning.QuotaStatus, error) {
 	quotaStatus, err := rc.quotaGetter.GetQuotaStatus(ctx, obj.Namespace)
 	if err == nil {
-		quotaStatus.StaleSince = 0
+		quotaStatus.UpdatedAt = time.Now().UnixMilli()
 		return quotaStatus, nil
 	}
 
@@ -524,14 +524,9 @@ func (rc *RepositoryController) resolveQuotaStatus(ctx context.Context, obj *pro
 		return provisioning.QuotaStatus{}, fmt.Errorf("failed to get quota status: %w", err)
 	}
 
-	now := time.Now()
 	quotaStatus = obj.Status.Quota
-	if quotaStatus.StaleSince == 0 {
-		quotaStatus.StaleSince = now.UnixMilli()
-		logging.FromContext(ctx).Warn("failed to refresh quota status; using cached limits", "error", err)
-	}
-
-	rc.quotaMetrics.observeStaleness(now.Sub(time.UnixMilli(quotaStatus.StaleSince)))
+	logging.FromContext(ctx).Warn("failed to refresh quota status; using cached limits", "error", err, "quota_updated_at", quotaStatus.UpdatedAt)
+	rc.quotaMetrics.observeAge(time.Since(time.UnixMilli(quotaStatus.UpdatedAt)))
 	return quotaStatus, nil
 }
 
@@ -836,12 +831,14 @@ func (rc *RepositoryController) process(key string) (err error) {
 
 	hasQuotaChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
 		obj.Status.Quota.MaxResourcesPerRepository != newQuota.MaxResourcesPerRepository
-	if obj.Status.Quota != newQuota {
-		patchOperations = append(patchOperations, map[string]interface{}{
-			"op":    "replace",
-			"path":  "/status/quota",
-			"value": newQuota,
-		})
+	if hasQuotaChanged {
+		logger.Info("quota changed",
+			"previous_max_repositories", obj.Status.Quota.MaxRepositories,
+			"max_repositories", newQuota.MaxRepositories,
+			"previous_max_resources_per_repository", obj.Status.Quota.MaxResourcesPerRepository,
+			"max_resources_per_repository", newQuota.MaxResourcesPerRepository,
+		)
+		rc.quotaMetrics.recordChange()
 	}
 
 	var shouldGenerateToken bool
@@ -878,7 +875,6 @@ func (rc *RepositoryController) process(key string) (err error) {
 		logger.Info("repository token needs to be generated", "connection", obj.Spec.Connection.Name)
 	case hasQuotaChanged:
 		reason = "quota_changed"
-		logger.Info("quota changed", "quota", newQuota)
 	case len(obj.Spec.Workflows) > 0 && repository.GetID(obj.Status.Webhook).IsEmpty():
 		reason = "webhook_missing"
 		logger.Info("webhook missing, reconciling")
@@ -891,6 +887,14 @@ func (rc *RepositoryController) process(key string) (err error) {
 		return nil
 	}
 	span.SetAttributes(attribute.String("reconcile.reason", reason))
+
+	if hasQuotaChanged {
+		patchOperations = append(patchOperations, map[string]interface{}{
+			"op":    "replace",
+			"path":  "/status/quota",
+			"value": newQuota,
+		})
+	}
 
 	if shouldGenerateToken {
 		logger.Info("updating token for repository")
@@ -1101,6 +1105,15 @@ func (rc *RepositoryController) process(key string) (err error) {
 	// determine the sync strategy and sync status to apply
 	syncOptions := rc.determineSyncStrategy(ctx, obj, repo, shouldResync, isOverQuota, healthStatus)
 	patchOperations = append(patchOperations, rc.determineSyncStatusOps(obj, syncOptions, healthStatus)...)
+	// Persist a timestamp-only quota refresh with other status changes so it does not
+	// create its own informer update and reconciliation loop.
+	if !hasQuotaChanged && obj.Status.Quota != newQuota && len(patchOperations) > 0 {
+		patchOperations = append(patchOperations, map[string]interface{}{
+			"op":    "replace",
+			"path":  "/status/quota",
+			"value": newQuota,
+		})
+	}
 
 	// Apply all patch operations
 	if patchErr := applyPatches(); patchErr != nil {

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -519,6 +519,7 @@ func (rc *RepositoryController) resolveQuotaStatus(ctx context.Context, obj *pro
 		quotaStatus.UpdatedAt = time.Now().UnixMilli()
 		return quotaStatus, nil
 	}
+	rc.quotaMetrics.recordRefreshError()
 
 	if obj.Status.ObservedGeneration == 0 {
 		return provisioning.QuotaStatus{}, fmt.Errorf("failed to get quota status: %w", err)
@@ -832,13 +833,13 @@ func (rc *RepositoryController) process(key string) (err error) {
 	hasQuotaChanged := obj.Status.Quota.MaxRepositories != newQuota.MaxRepositories ||
 		obj.Status.Quota.MaxResourcesPerRepository != newQuota.MaxResourcesPerRepository
 	if hasQuotaChanged {
-		logger.Info("quota changed",
+		logger.Info("quota refreshed",
 			"previous_max_repositories", obj.Status.Quota.MaxRepositories,
 			"max_repositories", newQuota.MaxRepositories,
 			"previous_max_resources_per_repository", obj.Status.Quota.MaxResourcesPerRepository,
 			"max_resources_per_repository", newQuota.MaxResourcesPerRepository,
 		)
-		rc.quotaMetrics.recordChange()
+		rc.quotaMetrics.recordRefresh()
 	}
 
 	var shouldGenerateToken bool

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -947,6 +948,122 @@ func (c *capturePatcher) findPatchOp(path string) (map[string]interface{}, bool)
 	return nil, false
 }
 
+func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
+	lookupErr := errors.New("quota service failed")
+
+	t.Run("new repository returns lookup error", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{MaxRepositories: 10})
+		getter.SetError(lookupErr)
+		rc := &RepositoryController{
+			quotaGetter:  getter,
+			quotaMetrics: registerRepositoryQuotaMetrics(reg),
+		}
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
+			Status:     provisioning.RepositoryStatus{ObservedGeneration: 0},
+		}
+
+		status, err := rc.resolveQuotaStatus(context.Background(), repo)
+		require.ErrorIs(t, err, lookupErr)
+		assert.ErrorContains(t, err, "failed to get quota status")
+		assert.Equal(t, provisioning.QuotaStatus{}, status)
+		assert.Equal(t, uint64(0), histogramCount(t, reg, repositoryQuotaStalenessMetric))
+	})
+
+	t.Run("existing repository starts using cached quota", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
+		getter.SetError(lookupErr)
+		rc := &RepositoryController{
+			quotaGetter:  getter,
+			quotaMetrics: registerRepositoryQuotaMetrics(reg),
+		}
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
+			Status: provisioning.RepositoryStatus{
+				ObservedGeneration: 1,
+				Quota: provisioning.QuotaStatus{
+					MaxRepositories:           5,
+					MaxResourcesPerRepository: 100,
+				},
+			},
+		}
+		before := time.Now().UnixMilli()
+
+		status, err := rc.resolveQuotaStatus(context.Background(), repo)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), status.MaxRepositories)
+		assert.Equal(t, int64(100), status.MaxResourcesPerRepository)
+		assert.GreaterOrEqual(t, status.StaleSince, before)
+		assert.LessOrEqual(t, status.StaleSince, time.Now().UnixMilli())
+		assert.Equal(t, uint64(1), histogramCount(t, reg, repositoryQuotaStalenessMetric))
+	})
+
+	t.Run("repeated failure preserves stale timestamp and records age", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
+		getter.SetError(lookupErr)
+		rc := &RepositoryController{
+			quotaGetter:  getter,
+			quotaMetrics: registerRepositoryQuotaMetrics(reg),
+		}
+		staleSince := time.Now().Add(-5 * time.Minute).UnixMilli()
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
+			Status: provisioning.RepositoryStatus{
+				ObservedGeneration: 1,
+				Quota: provisioning.QuotaStatus{
+					MaxRepositories: 5,
+					StaleSince:      staleSince,
+				},
+			},
+		}
+
+		status, err := rc.resolveQuotaStatus(context.Background(), repo)
+		require.NoError(t, err)
+		assert.Equal(t, staleSince, status.StaleSince)
+		family := gatherMetrics(t, reg)[repositoryQuotaStalenessMetric]
+		histogram := family.GetMetric()[0].GetHistogram()
+		assert.Equal(t, uint64(1), histogram.GetSampleCount())
+		assert.InDelta(t, 300, histogram.GetSampleSum(), 1)
+		firstAge := histogram.GetSampleSum()
+
+		repo.Status.Quota = status
+		status, err = rc.resolveQuotaStatus(context.Background(), repo)
+		require.NoError(t, err)
+		assert.Equal(t, staleSince, status.StaleSince)
+		histogram = gatherMetrics(t, reg)[repositoryQuotaStalenessMetric].GetMetric()[0].GetHistogram()
+		assert.Equal(t, uint64(2), histogram.GetSampleCount())
+		assert.GreaterOrEqual(t, histogram.GetSampleSum()-firstAge, firstAge)
+	})
+
+	t.Run("successful refresh clears stale timestamp", func(t *testing.T) {
+		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{
+			MaxRepositories:           8,
+			MaxResourcesPerRepository: 200,
+			StaleSince:                time.Now().Add(-time.Hour).UnixMilli(),
+		})
+		rc := &RepositoryController{quotaGetter: getter}
+		repo := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
+			Status: provisioning.RepositoryStatus{
+				ObservedGeneration: 1,
+				Quota: provisioning.QuotaStatus{
+					MaxRepositories: 5,
+					StaleSince:      time.Now().Add(-5 * time.Minute).UnixMilli(),
+				},
+			},
+		}
+
+		status, err := rc.resolveQuotaStatus(context.Background(), repo)
+		require.NoError(t, err)
+		assert.Equal(t, int64(8), status.MaxRepositories)
+		assert.Equal(t, int64(200), status.MaxResourcesPerRepository)
+		assert.Zero(t, status.StaleSince)
+	})
+}
+
 // repoIDHandlerStub is a minimal repository.Repository that also implements
 // repository.RepoIDHandler, so tests can drive the RepoID backfill branch in
 // process() without needing a real gitlab/github repository.
@@ -1273,6 +1390,101 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 							"expected NamespaceQuota condition to be present")
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestRepositoryController_process_QuotaFreshnessOnlyPatchDoesNotForceReconciliation(t *testing.T) {
+	lookupErr := errors.New("quota service failed")
+	errorGetter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
+	errorGetter.SetError(lookupErr)
+	testCases := []struct {
+		name             string
+		quota            provisioning.QuotaStatus
+		getter           quotas.QuotaGetter
+		expectStaleSince bool
+	}{
+		{
+			name:             "first failed refresh marks cached quota stale",
+			quota:            provisioning.QuotaStatus{MaxRepositories: 5, MaxResourcesPerRepository: 100},
+			getter:           errorGetter,
+			expectStaleSince: true,
+		},
+		{
+			name: "successful refresh clears stale marker",
+			quota: provisioning.QuotaStatus{
+				MaxRepositories:           5,
+				MaxResourcesPerRepository: 100,
+				StaleSince:                time.Now().Add(-5 * time.Minute).UnixMilli(),
+			},
+			getter: quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{
+				MaxRepositories:           5,
+				MaxResourcesPerRepository: 100,
+			}),
+			expectStaleSince: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "repo",
+					Namespace:  "default",
+					Generation: 1,
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.LocalRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+				},
+				Status: provisioning.RepositoryStatus{
+					ObservedGeneration: 1,
+					Health: provisioning.HealthStatus{
+						Healthy: true,
+						Checked: time.Now().UnixMilli(),
+					},
+					Quota: tc.quota,
+				},
+			}
+
+			indexer := cache.NewIndexer(
+				cache.MetaNamespaceKeyFunc,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+			)
+			require.NoError(t, indexer.Add(repo))
+			repoGetter := informer.NewCachedRepositoryGetter(listers.NewRepositoryLister(indexer))
+
+			patcher := &capturePatcher{}
+			healthMetrics := NewMockHealthMetricsRecorder(t)
+			healthMetrics.EXPECT().RecordHealthCheck(mock.Anything, mock.Anything, mock.Anything).Maybe()
+			healthChecker := NewRepositoryHealthChecker(patcher, repository.NewTester(), healthMetrics)
+			repoFactory := repository.NewMockFactory(t)
+
+			rc := &RepositoryController{
+				repos:         repoGetter,
+				quotaGetter:   tc.getter,
+				quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
+				healthChecker: healthChecker,
+				statusPatcher: patcher,
+				repoFactory:   repoFactory,
+				logger:        logging.DefaultLogger.With("logger", loggerName),
+				tracer:        tracing.InitializeTracerForTest(),
+			}
+
+			err := rc.process("default/repo")
+			require.NoError(t, err)
+			repoFactory.AssertNotCalled(t, "Build", mock.Anything, mock.Anything)
+			require.Len(t, patcher.ops, 1)
+			quotaOp, found := patcher.findPatchOp("/status/quota")
+			require.True(t, found)
+			patchedQuota := quotaOp["value"].(provisioning.QuotaStatus)
+			assert.Equal(t, int64(5), patchedQuota.MaxRepositories)
+			assert.Equal(t, int64(100), patchedQuota.MaxResourcesPerRepository)
+			if tc.expectStaleSince {
+				assert.NotZero(t, patchedQuota.StaleSince)
+			} else {
+				assert.Zero(t, patchedQuota.StaleSince)
 			}
 		})
 	}

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -969,6 +969,8 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to get quota status")
 		assert.Equal(t, provisioning.QuotaStatus{}, status)
 		assert.Equal(t, uint64(0), histogramCount(t, reg, repositoryQuotaAgeMetric))
+		assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshMetric))
+		assert.Equal(t, 1.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 	})
 
 	t.Run("existing repository uses cached quota and its refresh timestamp", func(t *testing.T) {
@@ -998,6 +1000,8 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		assert.Equal(t, int64(100), status.MaxResourcesPerRepository)
 		assert.Equal(t, updatedAt, status.UpdatedAt)
 		assert.Equal(t, uint64(1), histogramCount(t, reg, repositoryQuotaAgeMetric))
+		assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshMetric))
+		assert.Equal(t, 1.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 	})
 
 	t.Run("repeated failure preserves refresh timestamp and records increasing age", func(t *testing.T) {
@@ -1036,15 +1040,21 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		histogram = gatherMetrics(t, reg)[repositoryQuotaAgeMetric].GetMetric()[0].GetHistogram()
 		assert.Equal(t, uint64(2), histogram.GetSampleCount())
 		assert.GreaterOrEqual(t, histogram.GetSampleSum()-firstAge, firstAge)
+		assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshMetric))
+		assert.Equal(t, 2.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 	})
 
 	t.Run("successful refresh updates timestamp", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
 		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{
 			MaxRepositories:           8,
 			MaxResourcesPerRepository: 200,
 			UpdatedAt:                 time.Now().Add(-time.Hour).UnixMilli(),
 		})
-		rc := &RepositoryController{quotaGetter: getter}
+		rc := &RepositoryController{
+			quotaGetter:  getter,
+			quotaMetrics: registerRepositoryQuotaMetrics(reg),
+		}
 		repo := &provisioning.Repository{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
 			Status: provisioning.RepositoryStatus{
@@ -1063,6 +1073,8 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		assert.Equal(t, int64(200), status.MaxResourcesPerRepository)
 		assert.GreaterOrEqual(t, status.UpdatedAt, before)
 		assert.LessOrEqual(t, status.UpdatedAt, time.Now().UnixMilli())
+		assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshMetric))
+		assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 	})
 }
 
@@ -1255,6 +1267,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 		newQuota         provisioning.QuotaStatus
 		expectReconcile  bool
 		expectQuotaPatch bool
+		expectRefreshes  float64
 	}{
 		{
 			name: "quota change triggers reconciliation and patches status",
@@ -1268,6 +1281,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 			},
 			expectReconcile:  true,
 			expectQuotaPatch: true,
+			expectRefreshes:  1,
 		},
 		{
 			name: "unchanged quota skips reconciliation",
@@ -1281,6 +1295,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 			},
 			expectReconcile:  false,
 			expectQuotaPatch: false,
+			expectRefreshes:  0,
 		},
 	}
 
@@ -1360,12 +1375,8 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 
 			err := rc.process(namespace + "/" + repoName)
 			assert.NoError(t, err)
-			expectedChanges := 0.0
-			if tc.oldQuota.MaxRepositories != tc.newQuota.MaxRepositories ||
-				tc.oldQuota.MaxResourcesPerRepository != tc.newQuota.MaxResourcesPerRepository {
-				expectedChanges = 1
-			}
-			assert.Equal(t, expectedChanges, counterValue(t, reg, repositoryQuotaChangesMetric))
+			assert.Equal(t, tc.expectRefreshes, counterValue(t, reg, repositoryQuotaRefreshMetric))
+			assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
 
 			if tc.expectReconcile {
 				assert.NotEmpty(t, patcher.ops,

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -968,10 +968,10 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		require.ErrorIs(t, err, lookupErr)
 		assert.ErrorContains(t, err, "failed to get quota status")
 		assert.Equal(t, provisioning.QuotaStatus{}, status)
-		assert.Equal(t, uint64(0), histogramCount(t, reg, repositoryQuotaStalenessMetric))
+		assert.Equal(t, uint64(0), histogramCount(t, reg, repositoryQuotaAgeMetric))
 	})
 
-	t.Run("existing repository starts using cached quota", func(t *testing.T) {
+	t.Run("existing repository uses cached quota and its refresh timestamp", func(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
 		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
 		getter.SetError(lookupErr)
@@ -979,6 +979,7 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 			quotaGetter:  getter,
 			quotaMetrics: registerRepositoryQuotaMetrics(reg),
 		}
+		updatedAt := time.Now().Add(-time.Minute).UnixMilli()
 		repo := &provisioning.Repository{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
 			Status: provisioning.RepositoryStatus{
@@ -986,21 +987,20 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 				Quota: provisioning.QuotaStatus{
 					MaxRepositories:           5,
 					MaxResourcesPerRepository: 100,
+					UpdatedAt:                 updatedAt,
 				},
 			},
 		}
-		before := time.Now().UnixMilli()
 
 		status, err := rc.resolveQuotaStatus(context.Background(), repo)
 		require.NoError(t, err)
 		assert.Equal(t, int64(5), status.MaxRepositories)
 		assert.Equal(t, int64(100), status.MaxResourcesPerRepository)
-		assert.GreaterOrEqual(t, status.StaleSince, before)
-		assert.LessOrEqual(t, status.StaleSince, time.Now().UnixMilli())
-		assert.Equal(t, uint64(1), histogramCount(t, reg, repositoryQuotaStalenessMetric))
+		assert.Equal(t, updatedAt, status.UpdatedAt)
+		assert.Equal(t, uint64(1), histogramCount(t, reg, repositoryQuotaAgeMetric))
 	})
 
-	t.Run("repeated failure preserves stale timestamp and records age", func(t *testing.T) {
+	t.Run("repeated failure preserves refresh timestamp and records increasing age", func(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
 		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
 		getter.SetError(lookupErr)
@@ -1008,22 +1008,22 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 			quotaGetter:  getter,
 			quotaMetrics: registerRepositoryQuotaMetrics(reg),
 		}
-		staleSince := time.Now().Add(-5 * time.Minute).UnixMilli()
+		updatedAt := time.Now().Add(-5 * time.Minute).UnixMilli()
 		repo := &provisioning.Repository{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "repo"},
 			Status: provisioning.RepositoryStatus{
 				ObservedGeneration: 1,
 				Quota: provisioning.QuotaStatus{
 					MaxRepositories: 5,
-					StaleSince:      staleSince,
+					UpdatedAt:       updatedAt,
 				},
 			},
 		}
 
 		status, err := rc.resolveQuotaStatus(context.Background(), repo)
 		require.NoError(t, err)
-		assert.Equal(t, staleSince, status.StaleSince)
-		family := gatherMetrics(t, reg)[repositoryQuotaStalenessMetric]
+		assert.Equal(t, updatedAt, status.UpdatedAt)
+		family := gatherMetrics(t, reg)[repositoryQuotaAgeMetric]
 		histogram := family.GetMetric()[0].GetHistogram()
 		assert.Equal(t, uint64(1), histogram.GetSampleCount())
 		assert.InDelta(t, 300, histogram.GetSampleSum(), 1)
@@ -1032,17 +1032,17 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 		repo.Status.Quota = status
 		status, err = rc.resolveQuotaStatus(context.Background(), repo)
 		require.NoError(t, err)
-		assert.Equal(t, staleSince, status.StaleSince)
-		histogram = gatherMetrics(t, reg)[repositoryQuotaStalenessMetric].GetMetric()[0].GetHistogram()
+		assert.Equal(t, updatedAt, status.UpdatedAt)
+		histogram = gatherMetrics(t, reg)[repositoryQuotaAgeMetric].GetMetric()[0].GetHistogram()
 		assert.Equal(t, uint64(2), histogram.GetSampleCount())
 		assert.GreaterOrEqual(t, histogram.GetSampleSum()-firstAge, firstAge)
 	})
 
-	t.Run("successful refresh clears stale timestamp", func(t *testing.T) {
+	t.Run("successful refresh updates timestamp", func(t *testing.T) {
 		getter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{
 			MaxRepositories:           8,
 			MaxResourcesPerRepository: 200,
-			StaleSince:                time.Now().Add(-time.Hour).UnixMilli(),
+			UpdatedAt:                 time.Now().Add(-time.Hour).UnixMilli(),
 		})
 		rc := &RepositoryController{quotaGetter: getter}
 		repo := &provisioning.Repository{
@@ -1051,16 +1051,18 @@ func TestRepositoryController_resolveQuotaStatus(t *testing.T) {
 				ObservedGeneration: 1,
 				Quota: provisioning.QuotaStatus{
 					MaxRepositories: 5,
-					StaleSince:      time.Now().Add(-5 * time.Minute).UnixMilli(),
+					UpdatedAt:       time.Now().Add(-5 * time.Minute).UnixMilli(),
 				},
 			},
 		}
+		before := time.Now().UnixMilli()
 
 		status, err := rc.resolveQuotaStatus(context.Background(), repo)
 		require.NoError(t, err)
 		assert.Equal(t, int64(8), status.MaxRepositories)
 		assert.Equal(t, int64(200), status.MaxResourcesPerRepository)
-		assert.Zero(t, status.StaleSince)
+		assert.GreaterOrEqual(t, status.UpdatedAt, before)
+		assert.LessOrEqual(t, status.UpdatedAt, time.Now().UnixMilli())
 	})
 }
 
@@ -1286,6 +1288,8 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 		t.Run(tc.name, func(t *testing.T) {
 			namespace := "default"
 			repoName := "test-repo"
+			reg := prometheus.NewPedanticRegistry()
+			quotaMetrics := registerRepositoryQuotaMetrics(reg)
 
 			repo := &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1344,6 +1348,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 			rc := &RepositoryController{
 				repos:         repoGetter,
 				quotaGetter:   quotas.NewFixedQuotaGetter(tc.newQuota),
+				quotaMetrics:  quotaMetrics,
 				quotaChecker:  NewRepositoryQuotaChecker(repoGetter),
 				healthChecker: healthChecker,
 				statusPatcher: patcher,
@@ -1355,6 +1360,12 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 
 			err := rc.process(namespace + "/" + repoName)
 			assert.NoError(t, err)
+			expectedChanges := 0.0
+			if tc.oldQuota.MaxRepositories != tc.newQuota.MaxRepositories ||
+				tc.oldQuota.MaxResourcesPerRepository != tc.newQuota.MaxResourcesPerRepository {
+				expectedChanges = 1
+			}
+			assert.Equal(t, expectedChanges, counterValue(t, reg, repositoryQuotaChangesMetric))
 
 			if tc.expectReconcile {
 				assert.NotEmpty(t, patcher.ops,
@@ -1369,7 +1380,10 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 				assert.True(t, found, "expected /status/quota patch operation")
 				if found {
 					assert.Equal(t, "replace", quotaOp["op"])
-					assert.Equal(t, tc.newQuota, quotaOp["value"])
+					patchedQuota := quotaOp["value"].(provisioning.QuotaStatus)
+					assert.Equal(t, tc.newQuota.MaxRepositories, patchedQuota.MaxRepositories)
+					assert.Equal(t, tc.newQuota.MaxResourcesPerRepository, patchedQuota.MaxResourcesPerRepository)
+					assert.NotZero(t, patchedQuota.UpdatedAt)
 				}
 
 				condOp, found := patcher.findPatchOp("/status/conditions")
@@ -1395,34 +1409,25 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 	}
 }
 
-func TestRepositoryController_process_QuotaFreshnessOnlyPatchDoesNotForceReconciliation(t *testing.T) {
+func TestRepositoryController_process_QuotaTimestampOnlyDoesNotForceStatusPatch(t *testing.T) {
 	lookupErr := errors.New("quota service failed")
 	errorGetter := quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{})
 	errorGetter.SetError(lookupErr)
+	updatedAt := time.Now().Add(-5 * time.Minute).UnixMilli()
 	testCases := []struct {
-		name             string
-		quota            provisioning.QuotaStatus
-		getter           quotas.QuotaGetter
-		expectStaleSince bool
+		name   string
+		getter quotas.QuotaGetter
 	}{
 		{
-			name:             "first failed refresh marks cached quota stale",
-			quota:            provisioning.QuotaStatus{MaxRepositories: 5, MaxResourcesPerRepository: 100},
-			getter:           errorGetter,
-			expectStaleSince: true,
+			name:   "failed refresh keeps cached timestamp",
+			getter: errorGetter,
 		},
 		{
-			name: "successful refresh clears stale marker",
-			quota: provisioning.QuotaStatus{
-				MaxRepositories:           5,
-				MaxResourcesPerRepository: 100,
-				StaleSince:                time.Now().Add(-5 * time.Minute).UnixMilli(),
-			},
+			name: "successful refresh waits for an existing reconciliation patch",
 			getter: quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{
 				MaxRepositories:           5,
 				MaxResourcesPerRepository: 100,
 			}),
-			expectStaleSince: false,
 		},
 	}
 
@@ -1444,7 +1449,11 @@ func TestRepositoryController_process_QuotaFreshnessOnlyPatchDoesNotForceReconci
 						Healthy: true,
 						Checked: time.Now().UnixMilli(),
 					},
-					Quota: tc.quota,
+					Quota: provisioning.QuotaStatus{
+						MaxRepositories:           5,
+						MaxResourcesPerRepository: 100,
+						UpdatedAt:                 updatedAt,
+					},
 				},
 			}
 
@@ -1475,17 +1484,7 @@ func TestRepositoryController_process_QuotaFreshnessOnlyPatchDoesNotForceReconci
 			err := rc.process("default/repo")
 			require.NoError(t, err)
 			repoFactory.AssertNotCalled(t, "Build", mock.Anything, mock.Anything)
-			require.Len(t, patcher.ops, 1)
-			quotaOp, found := patcher.findPatchOp("/status/quota")
-			require.True(t, found)
-			patchedQuota := quotaOp["value"].(provisioning.QuotaStatus)
-			assert.Equal(t, int64(5), patchedQuota.MaxRepositories)
-			assert.Equal(t, int64(100), patchedQuota.MaxResourcesPerRepository)
-			if tc.expectStaleSince {
-				assert.NotZero(t, patchedQuota.StaleSince)
-			} else {
-				assert.Zero(t, patchedQuota.StaleSince)
-			}
+			assert.Empty(t, patcher.ops)
 		})
 	}
 }
@@ -2735,6 +2734,8 @@ func applyCapturedPatches(t *testing.T, repo *provisioning.Repository, ops []map
 			repo.Status.FieldErrors = op["value"].([]provisioning.ErrorDetails)
 		case path == "/status/observedGeneration":
 			repo.Status.ObservedGeneration = op["value"].(int64)
+		case path == "/status/quota":
+			repo.Status.Quota = op["value"].(provisioning.QuotaStatus)
 		case path == "/status/conditions":
 			repo.Status.Conditions = op["value"].([]metav1.Condition)
 		case path == "/status/conditions/-":
@@ -2923,7 +2924,7 @@ func TestRepositoryController_process_FailedFlushDoesNotDuplicatePatches(t *test
 	require.NoError(t, indexer.Add(repo))
 	repoLister := listers.NewRepositoryLister(indexer)
 
-	// This repo fixture deterministically produces 4 patch ops (health,
+	// This repo fixture deterministically produces 5 patch ops (quota, health,
 	// observedGeneration, two condition adds) on the one and only expected
 	// call; fieldErrors is not patched since both sides are already empty.
 	statusPatcher := mocks.NewStatusPatcher(t)
@@ -2931,6 +2932,7 @@ func TestRepositoryController_process_FailedFlushDoesNotDuplicatePatches(t *test
 		On(
 			"Patch",
 			mock.Anything, mock.AnythingOfType("*v0alpha1.Repository"),
+			mock.AnythingOfType("map[string]interface {}"),
 			mock.AnythingOfType("map[string]interface {}"),
 			mock.AnythingOfType("map[string]interface {}"),
 			mock.AnythingOfType("map[string]interface {}"),

--- a/pkg/tests/apis/helper.go
+++ b/pkg/tests/apis/helper.go
@@ -277,6 +277,10 @@ func (c *K8sTestHelper) SetQuotaStatus(status provisioning.QuotaStatus) {
 	c.env.QuotaGetter.(*quotas.FixedQuotaGetter).SetQuotaStatus(status)
 }
 
+func (c *K8sTestHelper) SetQuotaError(err error) {
+	c.env.QuotaGetter.(*quotas.FixedQuotaGetter).SetError(err)
+}
+
 func (c *K8sTestHelper) GetListenerAddress() string {
 	return c.listenerAddress
 }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5615,7 +5615,7 @@
         }
       },
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.QuotaStatus": {
-        "description": "QuotaStatus represents the quota limits configured for this repository. These values come from static configuration and are read-only.",
+        "description": "QuotaStatus represents the quota limits configured for this repository.",
         "type": "object",
         "properties": {
           "maxRepositories": {
@@ -5625,6 +5625,11 @@
           },
           "maxResourcesPerRepository": {
             "description": "MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "staleSince": {
+            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
             "type": "integer",
             "format": "int64"
           }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -5628,8 +5628,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "staleSince": {
-            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
+          "updatedAt": {
+            "description": "UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.",
             "type": "integer",
             "format": "int64"
           }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -5350,7 +5350,7 @@
         }
       },
       "com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v1beta1.QuotaStatus": {
-        "description": "QuotaStatus represents the quota limits configured for this repository. These values come from static configuration and are read-only.",
+        "description": "QuotaStatus represents the quota limits configured for this repository.",
         "type": "object",
         "properties": {
           "maxRepositories": {
@@ -5360,6 +5360,11 @@
           },
           "maxResourcesPerRepository": {
             "description": "MaxResourcesPerRepository is the maximum number of resources allowed per repository. 0 means unlimited.",
+            "type": "integer",
+            "format": "int64"
+          },
+          "staleSince": {
+            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
             "type": "integer",
             "format": "int64"
           }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -5363,8 +5363,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "staleSince": {
-            "description": "StaleSince is when the controller started using cached quota limits after a refresh failed. It is expressed as Unix milliseconds. 0 means the quota limits are fresh.",
+          "updatedAt": {
+            "description": "UpdatedAt is when the controller last successfully refreshed these quota limits. It is expressed as Unix milliseconds. 0 means the quota limits have not been refreshed yet.",
             "type": "integer",
             "format": "int64"
           }

--- a/pkg/tests/apis/provisioning/quota/helpers_test.go
+++ b/pkg/tests/apis/provisioning/quota/helpers_test.go
@@ -14,6 +14,10 @@ var env = common.NewSharedEnv(common.WithoutProvisioningFolderMetadata)
 func sharedHelper(t *testing.T) *common.ProvisioningTestHelper {
 	t.Helper()
 	helper := env.GetCleanHelper(t)
+	helper.SetQuotaError(nil)
+	t.Cleanup(func() {
+		helper.SetQuotaError(nil)
+	})
 	helper.SetQuotaStatus(provisioning.QuotaStatus{})
 	helper.GetEnv().GithubRepoFactory.Client = ghmock.NewMockedHTTPClient()
 	return helper

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -39,7 +39,7 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		SkipSync:   true,
 	})
 
-	baselineCount, baselineSum := quotaStalenessHistogram(t, helper)
+	baselineCount, _ := quotaStalenessHistogram(t, helper)
 	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
 	helper.SetQuotaError(lookupErr)
 
@@ -64,20 +64,22 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		}
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		count, _ := quotaStalenessHistogram(t, helper)
-		assert.Greater(collect, count, baselineCount)
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-
-	agedStaleSince := time.Now().Add(-5 * time.Minute).UnixMilli()
-	patchRepositoryStatus(t, helper, repoName, map[string]any{
-		"quota": map[string]any{"staleSince": agedStaleSince},
-	})
-
+	var firstCount uint64
+	var firstSum float64
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		count, sum := quotaStalenessHistogram(t, helper)
-		assert.Greater(collect, count, baselineCount)
-		assert.GreaterOrEqual(collect, sum-baselineSum, 250.0)
+		if assert.Greater(collect, count, baselineCount) {
+			firstCount = count
+			firstSum = sum
+		}
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	time.Sleep(time.Second)
+	helper.TriggerRepositoryReconciliation(t, repoName)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		count, sum := quotaStalenessHistogram(t, helper)
+		assert.Greater(collect, count, firstCount)
+		assert.Greater(collect, sum, firstSum)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	refreshedQuota := provisioning.QuotaStatus{

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
+// TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails verifies that existing repository updates
+// use cached quota during lookup failures, new repositories remain rejected, and recovery refreshes quota status.
 func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *testing.T) {
 	helper := sharedHelper(t)
 	initialQuota := provisioning.QuotaStatus{

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -1,28 +1,17 @@
 package quota
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"net/http"
 	"testing"
-	"time"
 
-	dto "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
-	apis "github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
-
-const repositoryQuotaStalenessMetricName = "grafana_provisioning_repository_quota_staleness_seconds"
 
 func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *testing.T) {
 	helper := sharedHelper(t)
@@ -39,14 +28,8 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		SkipSync:   true,
 	})
 
-	baselineCount, _ := quotaStalenessHistogram(t, helper)
 	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
 	helper.SetQuotaError(lookupErr)
-
-	staleHealthChecked := time.Now().Add(-10 * time.Minute).UnixMilli()
-	patchRepositoryStatus(t, helper, repoName, map[string]any{
-		"health": map[string]any{"checked": staleHealthChecked},
-	})
 
 	var staleSince int64
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -57,30 +40,11 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
-		assert.Greater(collect, repo.Status.Health.Checked, staleHealthChecked)
 		assert.Equal(collect, repo.Generation, repo.Status.ObservedGeneration)
 		if assert.NotZero(collect, repo.Status.Quota.StaleSince) {
 			staleSince = repo.Status.Quota.StaleSince
 		}
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-
-	var firstCount uint64
-	var firstSum float64
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		count, sum := quotaStalenessHistogram(t, helper)
-		if assert.Greater(collect, count, baselineCount) {
-			firstCount = count
-			firstSum = sum
-		}
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-
-	time.Sleep(time.Second)
-	helper.TriggerRepositoryReconciliation(t, repoName)
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		count, sum := quotaStalenessHistogram(t, helper)
-		assert.Greater(collect, count, firstCount)
-		assert.Greater(collect, sum, firstSum)
-	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+	}, 2*common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	refreshedQuota := provisioning.QuotaStatus{
 		MaxRepositories:           8,
@@ -112,40 +76,4 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	assert.NotZero(t, staleSince)
-}
-
-func patchRepositoryStatus(t *testing.T, helper *common.ProvisioningTestHelper, repoName string, status map[string]any) {
-	t.Helper()
-	patch, err := json.Marshal(map[string]any{"status": status})
-	require.NoError(t, err)
-	_, err = helper.Repositories.Resource.Patch(
-		t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status",
-	)
-	require.NoError(t, err)
-}
-
-func quotaStalenessHistogram(t *testing.T, helper *common.ProvisioningTestHelper) (uint64, float64) {
-	t.Helper()
-	rsp := apis.DoRequest(helper.K8sTestHelper, apis.RequestParams{
-		User:   helper.Org1.Admin,
-		Path:   "/metrics",
-		Accept: "text/plain",
-	}, &struct{}{})
-	require.NotNil(t, rsp.Response)
-	require.Equal(t, http.StatusOK, rsp.Response.StatusCode)
-
-	parser := expfmt.NewTextParser(model.UTF8Validation)
-	families, err := parser.TextToMetricFamilies(bytes.NewReader(rsp.Body))
-	require.NoError(t, err)
-	family := families[repositoryQuotaStalenessMetricName]
-	require.NotNil(t, family)
-	return histogramValues(t, family)
-}
-
-func histogramValues(t *testing.T, family *dto.MetricFamily) (uint64, float64) {
-	t.Helper()
-	require.Len(t, family.GetMetric(), 1)
-	histogram := family.GetMetric()[0].GetHistogram()
-	require.NotNil(t, histogram)
-	return histogram.GetSampleCount(), histogram.GetSampleSum()
 }

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -1,0 +1,149 @@
+package quota
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	apis "github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+const repositoryQuotaStalenessMetricName = "grafana_provisioning_repository_quota_staleness_seconds"
+
+func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *testing.T) {
+	helper := sharedHelper(t)
+	initialQuota := provisioning.QuotaStatus{
+		MaxRepositories:           5,
+		MaxResourcesPerRepository: 100,
+	}
+	helper.SetQuotaStatus(initialQuota)
+
+	const repoName = "stale-quota-repo"
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:       repoName,
+		SyncTarget: "folder",
+		SkipSync:   true,
+	})
+
+	baselineCount, baselineSum := quotaStalenessHistogram(t, helper)
+	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
+	helper.SetQuotaError(lookupErr)
+
+	staleHealthChecked := time.Now().Add(-10 * time.Minute).UnixMilli()
+	patchRepositoryStatus(t, helper, repoName, map[string]any{
+		"health": map[string]any{"checked": staleHealthChecked},
+	})
+
+	var staleSince int64
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
+		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
+		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
+		assert.Greater(collect, repo.Status.Health.Checked, staleHealthChecked)
+		assert.Equal(collect, repo.Generation, repo.Status.ObservedGeneration)
+		if assert.NotZero(collect, repo.Status.Quota.StaleSince) {
+			staleSince = repo.Status.Quota.StaleSince
+		}
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		count, _ := quotaStalenessHistogram(t, helper)
+		assert.Greater(collect, count, baselineCount)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	agedStaleSince := time.Now().Add(-5 * time.Minute).UnixMilli()
+	patchRepositoryStatus(t, helper, repoName, map[string]any{
+		"quota": map[string]any{"staleSince": agedStaleSince},
+	})
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		count, sum := quotaStalenessHistogram(t, helper)
+		assert.Greater(collect, count, baselineCount)
+		assert.GreaterOrEqual(collect, sum-baselineSum, 250.0)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	refreshedQuota := provisioning.QuotaStatus{
+		MaxRepositories:           8,
+		MaxResourcesPerRepository: 200,
+	}
+	helper.SetQuotaStatus(refreshedQuota)
+	helper.SetQuotaError(nil)
+	helper.TriggerRepositoryReconciliation(t, repoName)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+		if !assert.NoError(collect, err) {
+			return
+		}
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
+		assert.Equal(collect, refreshedQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
+		assert.Equal(collect, refreshedQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
+		assert.Zero(collect, repo.Status.Quota.StaleSince)
+
+		quota, found, nestedErr := nestedField(obj.Object, "status", "quota")
+		if !assert.NoError(collect, nestedErr) || !assert.True(collect, found) {
+			return
+		}
+		quotaMap, ok := quota.(map[string]interface{})
+		if assert.True(collect, ok) {
+			_, found = quotaMap["staleSince"]
+			assert.False(collect, found, "staleSince should be removed after quota refresh recovers")
+		}
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	assert.NotZero(t, staleSince)
+}
+
+func patchRepositoryStatus(t *testing.T, helper *common.ProvisioningTestHelper, repoName string, status map[string]any) {
+	t.Helper()
+	patch, err := json.Marshal(map[string]any{"status": status})
+	require.NoError(t, err)
+	_, err = helper.Repositories.Resource.Patch(
+		t.Context(), repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status",
+	)
+	require.NoError(t, err)
+}
+
+func quotaStalenessHistogram(t *testing.T, helper *common.ProvisioningTestHelper) (uint64, float64) {
+	t.Helper()
+	rsp := apis.DoRequest(helper.K8sTestHelper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Path:   "/metrics",
+		Accept: "text/plain",
+	}, &struct{}{})
+	require.NotNil(t, rsp.Response)
+	require.Equal(t, http.StatusOK, rsp.Response.StatusCode)
+
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(bytes.NewReader(rsp.Body))
+	require.NoError(t, err)
+	family := families[repositoryQuotaStalenessMetricName]
+	require.NotNil(t, family)
+	return histogramValues(t, family)
+}
+
+func histogramValues(t *testing.T, family *dto.MetricFamily) (uint64, float64) {
+	t.Helper()
+	require.Len(t, family.GetMetric(), 1)
+	histogram := family.GetMetric()[0].GetHistogram()
+	require.NotNil(t, histogram)
+	return histogram.GetSampleCount(), histogram.GetSampleSum()
+}

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
@@ -25,30 +26,49 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repoName,
 		SyncTarget: "folder",
+		SkipSync:   true,
 	})
-
-	obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
-	require.NoError(t, err)
-	repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
-	require.Equal(t, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
-	require.Equal(t, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
-	require.Equal(t, repo.Generation, repo.Status.ObservedGeneration)
-	require.Zero(t, repo.Status.Quota.StaleSince)
-
-	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
-	helper.SetQuotaError(lookupErr)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
-		if !assert.NoError(collect, err) {
-			return
-		}
+		assert.NoError(collect, err)
 		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
 		assert.Equal(collect, repo.Generation, repo.Status.ObservedGeneration)
+		assert.Zero(collect, repo.Status.Quota.StaleSince)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+	require.NoError(t, err)
+	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
+	helper.SetQuotaError(lookupErr)
+
+	const updatedTitle = "Updated while quota lookup fails"
+	require.NoError(t, unstructured.SetNestedField(repoObj.Object, updatedTitle, "spec", "title"))
+	updatedObj, err := helper.Repositories.Resource.Update(t.Context(), repoObj, metav1.UpdateOptions{FieldValidation: "Strict"})
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+		assert.NoError(collect, err)
+		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
+		assert.Equal(collect, updatedTitle, repo.Spec.Title)
+		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
+		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
+		assert.Equal(collect, updatedObj.GetGeneration(), repo.Status.ObservedGeneration)
 		assert.NotZero(collect, repo.Status.Quota.StaleSince)
-	}, 2*common.WaitTimeoutDefault, common.WaitIntervalDefault)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+
+	newRepo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{
+		"Name":          "new-repo-during-quota-error",
+		"SyncEnabled":   false,
+		"SyncTarget":    "folder",
+		"Path":          helper.ProvisioningPath,
+		"WorkflowsJSON": `[]`,
+	})
+	_, err = helper.Repositories.Resource.Create(t.Context(), newRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+	require.ErrorContains(t, err, "failed to get quota status")
 
 	refreshedQuota := provisioning.QuotaStatus{
 		MaxRepositories:           8,

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -25,13 +25,19 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 	helper.CreateLocalRepo(t, common.TestRepo{
 		Name:       repoName,
 		SyncTarget: "folder",
-		SkipSync:   true,
 	})
+
+	obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
+	require.NoError(t, err)
+	repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
+	require.Equal(t, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
+	require.Equal(t, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
+	require.Equal(t, repo.Generation, repo.Status.ObservedGeneration)
+	require.Zero(t, repo.Status.Quota.StaleSince)
 
 	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
 	helper.SetQuotaError(lookupErr)
 
-	var staleSince int64
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		obj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 		if !assert.NoError(collect, err) {
@@ -41,9 +47,7 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
 		assert.Equal(collect, repo.Generation, repo.Status.ObservedGeneration)
-		if assert.NotZero(collect, repo.Status.Quota.StaleSince) {
-			staleSince = repo.Status.Quota.StaleSince
-		}
+		assert.NotZero(collect, repo.Status.Quota.StaleSince)
 	}, 2*common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	refreshedQuota := provisioning.QuotaStatus{
@@ -74,6 +78,4 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 			assert.False(collect, found, "staleSince should be removed after quota refresh recovers")
 		}
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-
-	assert.NotZero(t, staleSince)
 }

--- a/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
+++ b/pkg/tests/apis/provisioning/quota/quota_staleness_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
-// TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails verifies that existing repository updates
+// TestIntegrationProvisioning_RepositoryUsesCachedQuotaWhenRefreshFails verifies that existing repository updates
 // use cached quota during lookup failures, new repositories remain rejected, and recovery refreshes quota status.
-func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *testing.T) {
+func TestIntegrationProvisioning_RepositoryUsesCachedQuotaWhenRefreshFails(t *testing.T) {
 	helper := sharedHelper(t)
 	initialQuota := provisioning.QuotaStatus{
 		MaxRepositories:           5,
@@ -38,11 +38,13 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
 		assert.Equal(collect, repo.Generation, repo.Status.ObservedGeneration)
-		assert.Zero(collect, repo.Status.Quota.StaleSince)
+		assert.NotZero(collect, repo.Status.Quota.UpdatedAt)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	repoObj, err := helper.Repositories.Resource.Get(t.Context(), repoName, metav1.GetOptions{})
 	require.NoError(t, err)
+	initialUpdatedAt := common.MustFromUnstructured[provisioning.Repository](t, repoObj).Status.Quota.UpdatedAt
+	require.NotZero(t, initialUpdatedAt)
 	lookupErr := apierrors.NewInternalError(errors.New("quota service returned 500"))
 	helper.SetQuotaError(lookupErr)
 
@@ -59,7 +61,7 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		assert.Equal(collect, initialQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, initialQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
 		assert.Equal(collect, updatedObj.GetGeneration(), repo.Status.ObservedGeneration)
-		assert.NotZero(collect, repo.Status.Quota.StaleSince)
+		assert.Equal(collect, initialUpdatedAt, repo.Status.Quota.UpdatedAt)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 	newRepo := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{
@@ -88,16 +90,11 @@ func TestIntegrationProvisioning_RepositoryUsesStaleQuotaWhenRefreshFails(t *tes
 		repo := common.MustFromUnstructured[provisioning.Repository](t, obj)
 		assert.Equal(collect, refreshedQuota.MaxRepositories, repo.Status.Quota.MaxRepositories)
 		assert.Equal(collect, refreshedQuota.MaxResourcesPerRepository, repo.Status.Quota.MaxResourcesPerRepository)
-		assert.Zero(collect, repo.Status.Quota.StaleSince)
+		assert.Greater(collect, repo.Status.Quota.UpdatedAt, initialUpdatedAt)
 
-		quota, found, nestedErr := nestedField(obj.Object, "status", "quota")
-		if !assert.NoError(collect, nestedErr) || !assert.True(collect, found) {
-			return
-		}
-		quotaMap, ok := quota.(map[string]interface{})
-		if assert.True(collect, ok) {
-			_, found = quotaMap["staleSince"]
-			assert.False(collect, found, "staleSince should be removed after quota refresh recovers")
-		}
+		updatedAt, found, nestedErr := unstructured.NestedInt64(obj.Object, "status", "quota", "updatedAt")
+		assert.NoError(collect, nestedErr)
+		assert.True(collect, found, "updatedAt should be persisted after quota refresh recovers")
+		assert.Equal(collect, repo.Status.Quota.UpdatedAt, updatedAt)
 	}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 }


### PR DESCRIPTION
**What is this feature?**

Makes repository quota reconciliation resilient to quota lookup failures. The controller still returns the wrapped lookup error for new or unobserved repositories, while existing repositories continue reconciling with the cached quota limits in status. Admission validation likewise allows updates to repositories already present in storage while continuing to reject new repositories when quota cannot be resolved.

Successful quota refreshes record the last refresh time in `status.quota.updatedAt`. Timestamp-only changes are persisted alongside another reconciliation status update, avoiding an extra request and informer feedback loop. Actual quota limit changes continue to trigger reconciliation.

Quota behavior is exposed through:

- `grafana_provisioning_repository_quota_age_seconds`, which observes the age of cached limits used after a refresh failure.
- `grafana_provisioning_repository_quota_refresh_total`, which counts refreshes that change configured limits.
- `grafana_provisioning_repository_quota_refresh_errors_total`, which counts failed refreshes.
- Structured logs for cached-quota fallback and refreshes that change limits, including the previous and new limits.

**Why do we need this feature?**

A temporary quota-service failure currently stops reconciliation for every repository. Existing repositories already have usable quota limits in status and should continue health checks and other reconciliation work while the service recovers.

Persisting the last successful refresh time and exposing quota metrics makes prolonged failures and runtime override changes visible to operators.

**Who is this feature for?**

Operators and users of Git Sync repository provisioning.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

- New repositories retain fail-closed behavior.
- Existing repositories fall back for any quota lookup error, not only HTTP 500 responses.
- Cached quota has no hard expiry; informer resync retries the lookup.
- Go API, apply-configuration, OpenAPI snapshot, and generated TypeScript artifacts are updated.
- Relevant unit tests, `make gofmt`, and `make lint-go-diff` pass.
- Integration coverage is included but was not run locally.
