### PR TITLE
Dashboards: Fix Assistant silently dropping links on newly added panels

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -1,5 +1,6 @@
 import {
   DataQueryErrorType,
+  DataTopic,
   FieldType,
   getDefaultTimeRange,
   LoadingState,
@@ -11,11 +12,13 @@ import { config } from '@grafana/runtime';
 import { SceneDataNode, SceneDataTransformer, sceneGraph, type VizPanel } from '@grafana/scenes';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
 import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { DashboardMutationClient } from '../DashboardMutationClient';
 import type { PanelElementEntry, PanelElementsData, MutationResult } from '../types';
@@ -820,6 +823,11 @@ describe('Panel mutation commands', () => {
 
       const elementName = await addPanel(client, 'Transform Panel');
 
+      // The field is documented as "Replace all transformations", so the panel has to start with one
+      // for the assertion to tell replacing apart from appending.
+      const seeded = scene.state.body.getVizPanels()[0].state.$data;
+      (seeded as SceneDataTransformer).setState({ transformations: [{ id: 'reduce', options: {} }] });
+
       const result = await client.execute({
         type: 'UPDATE_PANEL',
         payload: {
@@ -852,18 +860,20 @@ describe('Panel mutation commands', () => {
       expect(result.success).toBe(true);
       const body = scene.state.body as unknown as DefaultGridLayoutManager;
       const dataProvider = body.getVizPanels()[0].state.$data;
-      expect(dataProvider).toBeDefined();
-      if (dataProvider && 'state' in dataProvider) {
-        const transformerState = dataProvider.state as { transformations?: Array<Record<string, unknown>> };
-        expect(transformerState.transformations).toBeDefined();
-        expect(transformerState.transformations![0]).toMatchObject({
+      // The command only writes transformations to a `SceneDataTransformer`, so anything else here
+      // means it silently skipped the update. Asserted rather than guarded: a conditional read lets
+      // that failure mode pass as a green test.
+      expect(dataProvider).toBeInstanceOf(SceneDataTransformer);
+      // Length first: without it, appending to the seeded `reduce` would leave index 0 correct.
+      expect((dataProvider as SceneDataTransformer).state.transformations).toEqual([
+        {
           id: 'limit',
           disabled: false,
           filter: { id: 'byName', options: 'temperature' },
-          topic: 'series',
+          topic: DataTopic.Series,
           options: { limitField: 10 },
-        });
-      }
+        },
+      ]);
     });
 
     it('updates panel description', async () => {
@@ -902,6 +912,51 @@ describe('Panel mutation commands', () => {
       expect(result.success).toBe(true);
       const body = scene.state.body as unknown as DefaultGridLayoutManager;
       expect(body.getVizPanels()[0].state.displayMode).toBe('transparent');
+    });
+
+    /**
+     * `spec.links` is written by finding the panel's `VizPanelLinks` among its `titleItems`. There are
+     * two shapes in the wild: `getDefaultVizPanel` (every UI "add panel" entry point) builds the holder
+     * with no `rawLinks` key at all, while every deserialization path passes one. ADD_PANEL goes through
+     * `buildVizPanel`, so these tests swap the holder explicitly rather than relying on the helper.
+     */
+    describe('panel links', () => {
+      const runbook = { title: 'Runbook', url: 'https://example.com/runbook' };
+
+      async function updateLinksOn(titleItems: VizPanelLinks[]) {
+        const scene = buildPanelScene();
+        const client = new DashboardMutationClient(scene);
+        const elementName = await addPanel(client, 'Links Panel');
+
+        const panel = scene.state.body.getVizPanels().find((p) => p.state.title === 'Links Panel')!;
+        panel.setState({ titleItems });
+
+        const result = await client.execute({
+          type: 'UPDATE_PANEL',
+          payload: { element: { name: elementName }, panel: { kind: 'Panel', spec: { links: [runbook] } } },
+        });
+
+        return { result, panel };
+      }
+
+      it('sets links on a panel built by getDefaultVizPanel, whose holder has no rawLinks key', async () => {
+        const { result, panel } = await updateLinksOn([new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })]);
+
+        expect(result.success).toBe(true);
+        expect(dashboardSceneGraph.getPanelLinks(panel)?.state.rawLinks).toEqual([runbook]);
+      });
+
+      it('replaces the links on a panel deserialized with an existing rawLinks array', async () => {
+        const { result, panel } = await updateLinksOn([
+          new VizPanelLinks({
+            rawLinks: [{ title: 'Old', url: 'https://example.com/old' }],
+            menu: new VizPanelLinksMenu({}),
+          }),
+        ]);
+
+        expect(result.success).toBe(true);
+        expect(dashboardSceneGraph.getPanelLinks(panel)?.state.rawLinks).toEqual([runbook]);
+      });
     });
 
     it('changes plugin type via vizConfig.group', async () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -11,12 +11,15 @@ import { mergeWith, cloneDeep, isArray } from 'lodash';
 import type * as z from 'zod';
 
 import { type FieldConfigSource } from '@grafana/data';
+import { SceneDataTransformer } from '@grafana/scenes';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
 import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getElements, panelQueryKindToSceneQuery } from '../../serialization/layoutSerializers/utils';
+import { transformDataTopic } from '../../serialization/transformToV2TypesUtils';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
 import { getQueryRunnerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
 import { serializeResultLayoutItem } from './panelSerialization';
@@ -39,34 +42,6 @@ function mergeReplacingArrays(
   });
 }
 
-interface DataTransformerLike {
-  state: { transformations?: unknown[]; $data?: unknown };
-  setState: (state: { transformations?: unknown[] }) => void;
-  reprocessTransformations: () => void;
-}
-
-interface RawLinksHolder {
-  state: { rawLinks: unknown };
-  setState: (state: Record<string, unknown>) => void;
-}
-
-function hasRawLinks(item: unknown): item is RawLinksHolder {
-  if (!item || typeof item !== 'object' || !('state' in item) || !('setState' in item)) {
-    return false;
-  }
-  const { state } = item;
-  return typeof state === 'object' && state !== null && 'rawLinks' in state && typeof item.setState === 'function';
-}
-
-function isDataTransformer(data: unknown): data is DataTransformerLike {
-  if (!data || typeof data !== 'object' || !('state' in data)) {
-    return false;
-  }
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  const state = (data as DataTransformerLike).state;
-  return typeof state === 'object' && Array.isArray(state?.transformations);
-}
-
 export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
   name: 'UPDATE_PANEL',
   description: payloads.updatePanel.description ?? '',
@@ -81,6 +56,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
 
     try {
       const { element, panel } = payload;
+      const warnings: string[] = [];
       const elementName = element.name;
       const spec = panel?.spec;
 
@@ -113,14 +89,14 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
         }
 
         if (spec.links !== undefined) {
-          const titleItems = vizPanel.state.titleItems;
-          if (Array.isArray(titleItems)) {
-            for (const item of titleItems) {
-              if (hasRawLinks(item)) {
-                item.setState({ rawLinks: spec.links });
-                break;
-              }
-            }
+          // Same lookup the serializer reads links back through, so writer and reader agree on which
+          // object holds them. A duck-type on `rawLinks` would miss the holder `getDefaultVizPanel`
+          // builds, which omits the key until something writes it.
+          const panelLinks = dashboardSceneGraph.getPanelLinks(vizPanel);
+          if (panelLinks) {
+            panelLinks.setState({ rawLinks: spec.links });
+          } else {
+            warnings.push('links ignored: this panel has no links holder in its titleItems.');
           }
         }
 
@@ -164,13 +140,15 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
             queryRunner.runQueries();
           }
 
-          if (dataSpec.transformations !== undefined && isDataTransformer(dataPipeline)) {
+          if (dataSpec.transformations !== undefined && dataPipeline instanceof SceneDataTransformer) {
+            // Spread rather than enumerate, matching the mapper in `layoutSerializers/utils.ts`: a field
+            // added to `transformationKindSchema.spec` then reaches the scene from both paths instead of
+            // being silently dropped here. `topic` is restated because the schema types it as a string
+            // union and the scene wants the `DataTopic` enum.
             const transformations = dataSpec.transformations.map((t: TransformationKind) => ({
               id: t.group,
-              disabled: t.spec.disabled,
-              filter: t.spec.filter,
-              topic: t.spec.topic,
-              options: t.spec.options,
+              ...t.spec,
+              topic: transformDataTopic(t.spec.topic),
             }));
             dataPipeline.setState({ transformations });
             dataPipeline.reprocessTransformations();
@@ -238,6 +216,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
             newValue: updatedElement,
           },
         ],
+        warnings: warnings.length > 0 ? warnings : undefined,
       };
     } catch (error) {
       return {


### PR DESCRIPTION
**What is this feature?**

Fixes a bug preventing the assistant from updating panel links via UPDATE_PANEL.

Asking the Assistant to add a link to a panel you'd just added is broken. The write was discarded and the command reported success. This PR fixes that bug.

**Why do we need this feature?**

To keep the Assistant and other functionality using UPDATE_PANEL from silently reporting failures as success.

**Reproduction**
To reproduce the bug, create a new panel (test datasource, time series) and ask the assistant to "Add a link titled "Runbook" pointing to example.com/runbook to "panel D"'s time series using field overrides by name on this dashboard." Ensure it doesn't add a regular panel link without field overrides.
The assistant reports success, but nothing is added. 

**Who is this feature for?**

Anyone driving `UPDATE_PANEL` with `spec.links` against a UI-created panel.

**Behavior changes**

| | Before | After |
| --- | --- | --- |
| `spec.links` on a UI-created panel | discarded, `success: true` | written |
| Panel with no link holder at all | silent no-op | returns a warning, per `addPanel.ts` |
| Transformation mapper | enumerates 4 fields of `t.spec` | spreads `t.spec`, so new schema fields aren't dropped |

**Which issue(s) does this PR fix?**:

None filed — found while refactoring.

**Special notes for your reviewer:**

- The `isDataTransformer` / `hasRawLinks` duck-types become `instanceof SceneDataTransformer`.
  Same runtime check, real type behind it — which is what lets `topic` go through
  `transformDataTopic` (an identity mapper; absent stays absent).
- One test tightened: it asserted `toMatchObject` on index 0 of a panel with no seeded
  transformations, so appending passed as replacing. Now seeds a `reduce` and asserts the
  whole array. Verified red.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — n/a
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. — n/a