### PR TITLE
AuthN: Handle canceled client requests quietly

### DIFF
--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -82,7 +82,12 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 
 		resp, err := c.Authenticate(ctx, req)
 		if err != nil {
-			s.log.FromContext(ctx).Error("Client authentication error", "client", c.Name(), "error", err)
+			logger := s.log.FromContext(ctx)
+			if errors.Is(ctx.Err(), context.Canceled) {
+				logger.Debug("Client authentication canceled", "client", c.Name(), "error", err)
+			} else {
+				logger.Error("Client authentication error", "client", c.Name(), "error", err)
+			}
 			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()})
 			return nil, err
 		}

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -29,6 +29,21 @@ type mockClient struct {
 	gotAuthCtx context.Context
 }
 
+type recordingLogger struct {
+	debug []string
+	error []string
+}
+
+func (l *recordingLogger) New(...any) *log.ConcreteLogger { return log.NewNopLogger() }
+func (l *recordingLogger) Log(...any) error               { return nil }
+func (l *recordingLogger) Debug(msg string, _ ...any)     { l.debug = append(l.debug, msg) }
+func (l *recordingLogger) Info(string, ...any)            {}
+func (l *recordingLogger) Warn(string, ...any)            {}
+func (l *recordingLogger) Error(msg string, _ ...any)     { l.error = append(l.error, msg) }
+func (l *recordingLogger) FromContext(context.Context) log.Logger {
+	return l
+}
+
 func (m *mockClient) Name() string { return m.name }
 
 func (m *mockClient) Test(ctx context.Context, _ *authnv1.AuthenticateRequest) bool {
@@ -172,6 +187,33 @@ func TestAuthenticate(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Contains(t, err.Error(), "internal failure")
+	})
+
+	t.Run("client cancellation propagates without fallthrough", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		svc := NewService(tracing.InitializeTracerForTest())
+		logger := &recordingLogger{}
+		svc.log = logger
+		svc.RegisterClient(&mockClient{
+			name:       "canceled-client",
+			testResult: true,
+			authError:  context.Canceled,
+		})
+		svc.RegisterClient(&mockClient{
+			name:       "backup-client",
+			testResult: true,
+			authResponse: &authnv1.AuthenticateResponse{
+				Code:  authnv1.AuthenticateCode_AUTHENTICATE_CODE_OK,
+				Token: "should-not-reach",
+			},
+		})
+
+		resp, err := svc.Authenticate(ctx, req)
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Nil(t, resp)
+		assert.Equal(t, []string{"Client authentication canceled"}, logger.debug)
+		assert.Empty(t, logger.error)
 	})
 
 	t.Run("nil request returns FAILED with errExpectedNamespace", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Treats an authentication client error as a debug log when the request context has been canceled. Error propagation and client dispatch behavior are unchanged.

**Why do we need this feature?**

Request cancellation is expected when a caller disconnects and should not be reported as a server error.

**Who is this feature for?**

Operators of the gRPC authentication server.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

The lower log level is limited to contexts for which ctx.Err() is context.Canceled. Other client errors retain error-level logging.

Tests:

- go test ./pkg/services/authn/authnserver
- go vet ./pkg/services/authn/authnserver

Please check that:
- [x] It works as expected from a user's perspective.
- [x] This is not a new pre-GA feature or configuration option.
- [x] No documentation update is required for this internal log-level correction.
