### PR TITLE
Fix build: ensure `getLogger` is called after the loggers registry is initialised

### DIFF
--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -7,8 +7,6 @@ import { type BackendSrvRequest, getBackendSrv } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
 import { appEvents } from 'app/core/app_events';
 
-const logger = getLogger('features.alerting');
-
 type ExtendedBackendSrvRequest = BackendSrvRequest & {
   /**
    * Data to send with a request. Maps to the `data` property on a `BackendSrvRequest`
@@ -58,6 +56,8 @@ export type AlertingApiExtraOptions = {
 const backendSrvBaseQuery =
   (): BaseQueryFn<BaseQueryFnArgs> =>
   async ({ body, notificationOptions = {}, ...requestOptions }, api, extraOptions?: AlertingApiExtraOptions) => {
+    const logger = getLogger('features.alerting');
+
     const { errorMessage, showErrorAlert, successMessage, showSuccessAlert } = notificationOptions;
     const { hideErrorMessage } = extraOptions || {};
 

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -5,8 +5,6 @@ import { type FetchError, isFetchError } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
 import { appEvents } from 'app/core/app_events';
 
-const logger = getLogger('features.alerting');
-
 function isErrorLike(error: unknown): error is Error {
   return Boolean(error && typeof error === 'object' && 'message' in error);
 }
@@ -151,6 +149,8 @@ export function withAppEvents<T>(
 
 export const UNKNOW_ERROR = 'Unknown Error';
 export function messageFromError(e: Error | FetchError | SerializedError): string {
+  const logger = getLogger('features.alerting');
+
   if (isFetchError(e)) {
     if (e.data?.message) {
       let msg = e.data?.message;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes placement of `getLogger` calls following https://github.com/grafana/grafana/pull/131319

**Why do we need this feature?**

- so we can develop again!

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
