### PR TITLE
PanelEditNext: Fix transformation editors ignoring the transformation's own filter

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorInputData.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorInputData.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import {
+  type DataFrame,
+  type DataTransformerInfo,
+  FieldType,
+  LoadingState,
+  type PanelData,
+  type TransformerRegistryItem,
+  dateTime,
+} from '@grafana/data';
+
+import { TransformationEditorPanel } from './TransformationEditorRenderer';
+import { type Transformation } from './types';
+
+// The real hook and the real `transformDataFrame` run here — this file exists to check what an
+// editor is actually handed, which is the thing the hook-level tests can only assert indirectly.
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => ({ replace: (v: string) => v }),
+}));
+
+/** The frames the editor received, in order, so an assertion can name them. */
+let receivedInput: DataFrame[] = [];
+
+jest.mock('./TransformationEditor', () => ({
+  TransformationEditor: ({ inputData }: { inputData: DataFrame[] }) => {
+    receivedInput = inputData;
+    return <div data-testid="transformation-editor">{inputData.map((frame) => frame.refId).join(',')}</div>;
+  },
+}));
+
+jest.mock('./TransformationFilterDisplay', () => ({
+  TransformationFilterEditor: () => <div data-testid="transformation-filter-display" />,
+}));
+
+const mockTransformation: DataTransformerInfo = {
+  id: 'organize',
+  name: 'Organize fields by name',
+  operator: jest.fn(),
+};
+
+const mockRegistryItem: TransformerRegistryItem = {
+  id: 'organize',
+  name: 'Organize fields by name',
+  transformation: () => Promise.resolve(mockTransformation),
+  editor: () => null,
+  imageDark: '',
+  imageLight: '',
+};
+
+function makeOrganize(filterOptions?: string): Transformation {
+  return {
+    transformId: 'organize',
+    transformConfig: {
+      id: 'organize',
+      options: { excludeByName: { Min: true }, includeByName: {}, indexByName: {}, renameByName: {} },
+      ...(filterOptions != null && { filter: { id: 'byRefId', options: filterOptions } }),
+    },
+    registryItem: mockRegistryItem,
+  };
+}
+
+/** One frame per query, which is the shape two `random_walk_table` targets return. */
+function makePanelData(): PanelData {
+  const field = { name: 'Min', type: FieldType.number, config: {}, values: [1] };
+
+  return {
+    state: LoadingState.Done,
+    timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-6h', to: 'now' } },
+    series: [
+      { refId: 'A', name: 'A-series', fields: [field], length: 1 },
+      { refId: 'B', name: 'B-series', fields: [field], length: 1 },
+    ],
+  };
+}
+
+function panel(transformation: Transformation, transformations = [transformation]) {
+  return (
+    <TransformationEditorPanel
+      transformation={transformation}
+      transformations={transformations}
+      data={makePanelData()}
+      updateTransformation={jest.fn()}
+    />
+  );
+}
+
+describe('the input an editor is handed', () => {
+  beforeEach(() => {
+    receivedInput = [];
+  });
+
+  it('narrows to the frames the transformation own filter admits', async () => {
+    // The shape from the bug report: two queries returning one frame each, a single Organize
+    // transformation filtered to refId A. The panel renders fine because `transformDataFrame`
+    // applies that filter, but the editor used to be handed both frames and so reported
+    // "Organize fields only works with a single frame" on a panel that was configured correctly.
+    // The filter is stored in the regex form a dashboard actually writes, not a bare refId.
+    render(panel(makeOrganize('/^(?:A)$/')));
+
+    await waitFor(() => expect(screen.getByTestId('transformation-editor')).toHaveTextContent('A'));
+
+    expect(receivedInput.map((frame) => frame.refId)).toEqual(['A']);
+    // The assertion that matters for the reported symptom: one frame, so the editor has no reason
+    // to claim it cannot work with what it was given.
+    expect(receivedInput).toHaveLength(1);
+  });
+
+  it('hands over every frame when the transformation has no filter', async () => {
+    // The other half of the same behaviour — narrowing has to be the filter's doing, not something
+    // that quietly drops frames from an unfiltered transformation.
+    render(panel(makeOrganize()));
+
+    await waitFor(() => expect(screen.getByTestId('transformation-editor')).toHaveTextContent('A,B'));
+
+    expect(receivedInput.map((frame) => frame.refId)).toEqual(['A', 'B']);
+  });
+});

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorInputData.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationEditorInputData.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 import {
   type DataFrame,
@@ -8,13 +8,17 @@ import {
   type PanelData,
   type TransformerRegistryItem,
   dateTime,
+  standardTransformersRegistry,
 } from '@grafana/data';
+import { filterFieldsByNameTransformer } from '@grafana/data/internal';
 
 import { TransformationEditorPanel } from './TransformationEditorRenderer';
 import { type Transformation } from './types';
 
-// The real hook and the real `transformDataFrame` run here — this file exists to check what an
-// editor is actually handed, which is the thing the hook-level tests can only assert indirectly.
+// The real hook runs here — this file exists to check what an editor is actually handed, which is
+// the thing the hook-level tests can only assert indirectly. Where a transformation precedes the
+// selected one, the real `transformDataFrame` runs too; with nothing preceding it the replay
+// short-circuits and never subscribes, which is why only one case below registers a transformer.
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => ({ replace: (v: string) => v }),
@@ -26,7 +30,7 @@ let receivedInput: DataFrame[] = [];
 jest.mock('./TransformationEditor', () => ({
   TransformationEditor: ({ inputData }: { inputData: DataFrame[] }) => {
     receivedInput = inputData;
-    return <div data-testid="transformation-editor">{inputData.map((frame) => frame.refId).join(',')}</div>;
+    return <div data-testid="transformation-editor" />;
   },
 }));
 
@@ -61,16 +65,28 @@ function makeOrganize(filterOptions?: string): Transformation {
   };
 }
 
+/** A field filter, as a transformation that can sit ahead of the one under test. */
+function makeFieldFilter(): Transformation {
+  return {
+    transformId: 'filterFieldsByName',
+    transformConfig: { id: 'filterFieldsByName', options: { include: { names: ['Min'] } } },
+    registryItem: undefined,
+  };
+}
+
 /** One frame per query, which is the shape two `random_walk_table` targets return. */
 function makePanelData(): PanelData {
-  const field = { name: 'Min', type: FieldType.number, config: {}, values: [1] };
+  const fields = [
+    { name: 'Min', type: FieldType.number, config: {}, values: [1] },
+    { name: 'Max', type: FieldType.number, config: {}, values: [2] },
+  ];
 
   return {
     state: LoadingState.Done,
     timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-6h', to: 'now' } },
     series: [
-      { refId: 'A', name: 'A-series', fields: [field], length: 1 },
-      { refId: 'B', name: 'B-series', fields: [field], length: 1 },
+      { refId: 'A', name: 'A-series', fields, length: 1 },
+      { refId: 'B', name: 'B-series', fields, length: 1 },
     ],
   };
 }
@@ -91,7 +107,7 @@ describe('the input an editor is handed', () => {
     receivedInput = [];
   });
 
-  it('narrows to the frames the transformation own filter admits', async () => {
+  it("narrows to the frames the transformation's own filter admits", () => {
     // The shape from the bug report: two queries returning one frame each, a single Organize
     // transformation filtered to refId A. The panel renders fine because `transformDataFrame`
     // applies that filter, but the editor used to be handed both frames and so reported
@@ -99,21 +115,48 @@ describe('the input an editor is handed', () => {
     // The filter is stored in the regex form a dashboard actually writes, not a bare refId.
     render(panel(makeOrganize('/^(?:A)$/')));
 
-    await waitFor(() => expect(screen.getByTestId('transformation-editor')).toHaveTextContent('A'));
-
     expect(receivedInput.map((frame) => frame.refId)).toEqual(['A']);
-    // The assertion that matters for the reported symptom: one frame, so the editor has no reason
-    // to claim it cannot work with what it was given.
-    expect(receivedInput).toHaveLength(1);
   });
 
-  it('hands over every frame when the transformation has no filter', async () => {
+  it('hands over every frame when the transformation has no filter', () => {
     // The other half of the same behaviour — narrowing has to be the filter's doing, not something
     // that quietly drops frames from an unfiltered transformation.
     render(panel(makeOrganize()));
 
-    await waitFor(() => expect(screen.getByTestId('transformation-editor')).toHaveTextContent('A,B'));
-
     expect(receivedInput.map((frame) => frame.refId)).toEqual(['A', 'B']);
+  });
+
+  describe('with a transformation ahead of it in the pipeline', () => {
+    // The preceding stage is replayed through the real `transformDataFrame`, so this is the case
+    // that checks the filter narrows what that stage produced rather than the raw query data.
+    beforeAll(() => {
+      standardTransformersRegistry.setInit(() => [
+        {
+          id: filterFieldsByNameTransformer.id,
+          name: filterFieldsByNameTransformer.name,
+          description: filterFieldsByNameTransformer.description,
+          transformation: () => Promise.resolve(filterFieldsByNameTransformer),
+          editor: () => null,
+          imageDark: '',
+          imageLight: '',
+        },
+      ]);
+    });
+
+    it('narrows the preceding stage output, not the raw query data', async () => {
+      const fieldFilter = makeFieldFilter();
+      const organize = makeOrganize('/^(?:A)$/');
+
+      render(panel(organize, [fieldFilter, organize]));
+
+      // Replaying the preceding stage resolves a render later, so this one genuinely waits — and it
+      // waits on the field names rather than the refIds, because the refIds already read `['A']`
+      // while the replay is in flight and would let the assertion pass against the stand-in frames.
+      // Only `Min` survives, which is the preceding transformation's doing — proof the editor is
+      // reading that stage's output and not the two-field frames the query produced.
+      await waitFor(() => expect(receivedInput[0].fields.map((field) => field.name)).toEqual(['Min']));
+
+      expect(receivedInput.map((frame) => frame.refId)).toEqual(['A']);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/frameMatcher.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/frameMatcher.ts
@@ -1,0 +1,27 @@
+import { type DataTransformerConfig, type FrameMatcher, getFrameMatchers } from '@grafana/data';
+
+/**
+ * The matcher for a transformation's frame filter, or nothing if that filter cannot be built into
+ * one.
+ *
+ * `getFrameMatchers` throws on a matcher id it does not know, and `byName` runs its option through
+ * `stringToJsRegex`, which throws on a `/`-prefixed string that is not a complete `/pattern/flags` —
+ * a variable resolving to a path is enough. The pipeline's own call sits behind the replay's error
+ * handling; callers here run during render, where a throw would take the editor down with it, so a
+ * filter that cannot be built leaves the frames unnarrowed instead.
+ *
+ * Pass the config as the replay ran it, not the one Scene state holds: a `$var` in the filter
+ * resolves before `transformDataFrame` sees it, so matching on the literal would narrow to nothing.
+ */
+export function frameMatcherFor(config: DataTransformerConfig | undefined): FrameMatcher | undefined {
+  if (!config?.filter?.options) {
+    return undefined;
+  }
+
+  try {
+    return getFrameMatchers(config.filter);
+  } catch (err) {
+    console.error('Failed to build a transformation filter for the panel editor', err);
+    return undefined;
+  }
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/testUtils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/testUtils.ts
@@ -1,9 +1,9 @@
-import { type DataFrame } from '@grafana/data';
+import { type DataFrame, type MatcherConfig } from '@grafana/data';
 
 import { type Transformation } from '../types';
 
-export function makeTransformation(id: string): Transformation {
-  return { transformId: id, transformConfig: { id, options: {} }, registryItem: undefined };
+export function makeTransformation(id: string, filter?: MatcherConfig): Transformation {
+  return { transformId: id, transformConfig: { id, options: {}, filter }, registryItem: undefined };
 }
 
 /** Named frames, so an assertion can say which frame reached an editor rather than how many did. */

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationDebugData.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationDebugData.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 
-import { type DataFrame, type DataTransformerConfig, type FrameMatcher, getFrameMatchers } from '@grafana/data';
+import { type DataFrame } from '@grafana/data';
 
 import { type Transformation } from '../types';
 
+import { frameMatcherFor } from './frameMatcher';
 import { NO_CONFIGS, isInterpolatable, precedingTransformations, useFrameReplay } from './useTransformedFrames';
 
 interface UseTransformationDebugDataOptions {
@@ -20,29 +21,6 @@ interface TransformationDebugData {
 
 /** Stable identity, so a closed drawer does not re-render everything reading this. */
 const NO_DEBUG_DATA: TransformationDebugData = { input: [], output: [] };
-
-/**
- * The matcher for the filter as the replay ran it, or nothing if that filter cannot be built into
- * one.
- *
- * `getFrameMatchers` throws on a matcher id it does not know, and `byName` runs its option through
- * `stringToJsRegex`, which throws on a `/`-prefixed string that is not a complete `/pattern/flags` —
- * a variable resolving to a path is enough. The pipeline's own call sits behind the replay's error
- * handling; this one runs during render, where a throw would take the drawer down with it, so a
- * filter that cannot be built shows the input unnarrowed instead.
- */
-function frameMatcherFor(config: DataTransformerConfig | undefined): FrameMatcher | undefined {
-  if (!config?.filter?.options) {
-    return undefined;
-  }
-
-  try {
-    return getFrameMatchers(config.filter);
-  } catch (err) {
-    console.error('Failed to build a transformation filter for the panel editor', err);
-    return undefined;
-  }
-}
 
 /**
  * Replays the pipeline around the selected transformation for the debug view: input is everything

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { Observable } from 'rxjs';
 
-import { type DataFrame, transformDataFrame } from '@grafana/data';
+import { type DataFrame, FrameMatcherID, transformDataFrame } from '@grafana/data';
 
 import { type Transformation } from '../types';
 
@@ -15,7 +15,9 @@ jest.mock('@grafana/data', () => ({
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getTemplateSrv: () => ({ replace: (v: string) => v }),
+  // `$pickedRefId` resolves to `B`, so a test can tell a filter matched on the resolved value apart
+  // from one that matched on the literal.
+  getTemplateSrv: () => ({ replace: (v: string) => v.replace(/\$pickedRefId/g, 'B') }),
 }));
 
 const mockTransformDataFrame = jest.mocked(transformDataFrame);
@@ -200,6 +202,107 @@ describe('useTransformationInputData', () => {
     // The joined frame this pipeline last produced, not the two unjoined ones it never emits.
     expect(result.current).toBe(mockPipelineOutput);
     expect(result.current).not.toBe(newRawData);
+  });
+
+  describe('the selected transformation own frame filter', () => {
+    // `transformDataFrame` narrows to these itself before running the transformation and merges the
+    // rest back afterwards, so the editor has to be shown the same narrowed set. Otherwise an
+    // Organize editor behind a filter picking one frame still reports on every frame in the panel.
+    const framesByRefId: DataFrame[] = [
+      { refId: 'A', name: 'A-series', fields: [], length: 0 },
+      { refId: 'B', name: 'B-series', fields: [], length: 0 },
+    ];
+
+    it('narrows the raw data when nothing precedes the filtered transformation', () => {
+      const transformations = [makeTransformation('organize', { id: FrameMatcherID.byRefId, options: 'B' })];
+
+      const { result } = renderHook(() =>
+        useTransformationInputData({
+          selectedTransformation: transformations[0],
+          allTransformations: transformations,
+          rawData: framesByRefId,
+        })
+      );
+
+      expect(result.current).toEqual([framesByRefId[1]]);
+      expect(mockTransformDataFrame).not.toHaveBeenCalled();
+    });
+
+    it('narrows what the preceding transformations produced', () => {
+      const transformations = [
+        makeTransformation('merge'),
+        makeTransformation('organize', { id: FrameMatcherID.byRefId, options: 'A' }),
+      ];
+      mockTransformDataFrame.mockReturnValue(
+        new Observable((subscriber) => {
+          subscriber.next(framesByRefId);
+        })
+      );
+
+      const { result } = renderHook(() =>
+        useTransformationInputData({
+          selectedTransformation: transformations[1],
+          allTransformations: transformations,
+          rawData,
+        })
+      );
+
+      // Narrowed after the preceding stage ran, not before it: the filter applies to that stage's
+      // output, which is what the pipeline hands the transformation.
+      expect(mockTransformDataFrame).toHaveBeenCalledWith(
+        [transformations[0].transformConfig],
+        rawData,
+        expect.any(Object)
+      );
+      expect(result.current).toEqual([framesByRefId[0]]);
+    });
+
+    it('narrows by the resolved value of a filter written as a variable', () => {
+      const transformations = [makeTransformation('organize', { id: FrameMatcherID.byRefId, options: '$pickedRefId' })];
+
+      const { result } = renderHook(() =>
+        useTransformationInputData({
+          selectedTransformation: transformations[0],
+          allTransformations: transformations,
+          rawData: framesByRefId,
+        })
+      );
+
+      // `B`, the value the pipeline matched on — not the literal `$pickedRefId`, which matches nothing.
+      expect(result.current).toEqual([framesByRefId[1]]);
+    });
+
+    it('leaves the frames unnarrowed when the filter cannot be built into a matcher', () => {
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      // `byName` runs its option through `stringToJsRegex`, which throws on a `/`-prefixed string
+      // that is not a complete `/pattern/flags`.
+      const transformations = [makeTransformation('organize', { id: FrameMatcherID.byName, options: '/etc/hosts' })];
+
+      const { result } = renderHook(() =>
+        useTransformationInputData({
+          selectedTransformation: transformations[0],
+          allTransformations: transformations,
+          rawData: framesByRefId,
+        })
+      );
+
+      expect(result.current).toBe(framesByRefId);
+    });
+
+    it('passes the frames through untouched when the transformation has no filter', () => {
+      const transformations = [makeTransformation('organize')];
+
+      const { result } = renderHook(() =>
+        useTransformationInputData({
+          selectedTransformation: transformations[0],
+          allTransformations: transformations,
+          rawData: framesByRefId,
+        })
+      );
+
+      // Same reference, so an editor memoizing on its input does not rerun for an unfiltered pipeline.
+      expect(result.current).toBe(framesByRefId);
+    });
   });
 
   it('cleans up the subscription when the component unmounts', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
@@ -4,7 +4,14 @@ import { type DataFrame } from '@grafana/data';
 
 import { type Transformation } from '../types';
 
-import { NO_CONFIGS, precedingTransformations, useTransformedFrames } from './useTransformedFrames';
+import { frameMatcherFor } from './frameMatcher';
+import {
+  NO_CONFIGS,
+  isInterpolatable,
+  precedingTransformations,
+  useInterpolatedConfigs,
+  useTransformedFrames,
+} from './useTransformedFrames';
 
 interface UseTransformationInputDataOptions {
   selectedTransformation: Transformation | null;
@@ -14,11 +21,12 @@ interface UseTransformationInputDataOptions {
 
 /**
  * Returns the input data for the selected transformation — the output of everything before it in
- * the pipeline (see {@link precedingTransformations}).
+ * the pipeline (see {@link precedingTransformations}), narrowed to the frames its own filter admits.
  *
  * Without this, editors always see raw query data regardless of where they sit in the pipeline.
  * That causes false errors like "Organize fields only works with a single frame" even when
- * a Join earlier in the pipeline has already merged the frames.
+ * a Join earlier in the pipeline has already merged the frames, or when the transformation's own
+ * filter picks out the single frame it runs over.
  *
  * @param selectedTransformation - The transformation currently open in the editor.
  * @param allTransformations - The full ordered list of transformations in the pipeline.
@@ -38,5 +46,24 @@ export function useTransformationInputData({
     [selectedTransformation, allTransformations]
   );
 
-  return useTransformedFrames(precedingConfigs, rawData);
+  const precedingOutput = useTransformedFrames(precedingConfigs, rawData);
+
+  // Interpolated the same way the replay interpolates the configs it runs, so a filter written as
+  // `$var` narrows by the value the pipeline matched on rather than by the literal.
+  const selfConfigs = useMemo(
+    () => (selectedTransformation ? [selectedTransformation.transformConfig] : NO_CONFIGS),
+    [selectedTransformation]
+  );
+  const [interpolatedSelf] = useInterpolatedConfigs(selfConfigs);
+
+  return useMemo(() => {
+    // The transformation only ever runs over the frames its filter admits — `transformDataFrame`
+    // applies that filter itself and merges the rest back afterwards — so the editor has to be shown
+    // the same narrowed set. Otherwise an Organize editor sits behind a filter that picks one frame
+    // and still reports on all of them.
+    const matcher =
+      interpolatedSelf && isInterpolatable(interpolatedSelf) ? frameMatcherFor(interpolatedSelf) : undefined;
+
+    return matcher ? precedingOutput.filter((frame) => matcher(frame)) : precedingOutput;
+  }, [interpolatedSelf, precedingOutput]);
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformationInputData.ts
@@ -61,8 +61,7 @@ export function useTransformationInputData({
     // applies that filter itself and merges the rest back afterwards — so the editor has to be shown
     // the same narrowed set. Otherwise an Organize editor sits behind a filter that picks one frame
     // and still reports on all of them.
-    const matcher =
-      interpolatedSelf && isInterpolatable(interpolatedSelf) ? frameMatcherFor(interpolatedSelf) : undefined;
+    const matcher = isInterpolatable(interpolatedSelf) ? frameMatcherFor(interpolatedSelf) : undefined;
 
     return matcher ? precedingOutput.filter((frame) => matcher(frame)) : precedingOutput;
   }, [interpolatedSelf, precedingOutput]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformedFrames.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useTransformedFrames.ts
@@ -98,7 +98,7 @@ function isSameConfig(a: TransformationConfigs[number], b: TransformationConfigs
  * objects in Scene state still hold the literal `$var`. The resolved options are the only thing that
  * moves, so they are the only thing an effect can key on.
  */
-function useInterpolatedConfigs(configs: TransformationConfigs): TransformationConfigs {
+export function useInterpolatedConfigs(configs: TransformationConfigs): TransformationConfigs {
   return useStableArray(interpolateConfigs(configs), isSameConfig);
 }
 


### PR DESCRIPTION
**What is this feature?**

Applies a transformation's own frame filter to the data handed to its editor in PanelEditNext. `useTransformationInputData` replayed everything preceding the transformation but skipped the filter the transformation itself runs behind, so editors were shown frames the pipeline never gives them.

**Why do we need this feature?**

On a panel with two queries returning one frame each and a single Organize fields transformation filtered to refId A, the editor sees both frames and reports "Organize fields only works with a single frame" — on a panel that is configured correctly and renders correctly. The classic editor applies the filter (`TransformationOperationRow`), which is why it behaves. The debug drawer already narrowed correctly; only the editor input path was missed.

That narrowing is now shared between the two via `frameMatcherFor`, and reads the interpolated config, so a filter written as `$var` matches the value the pipeline matched on rather than the literal.

**Who is this feature for?**

Anyone using filtered transformations in the new query editor.

**Which issue(s) does this PR fix?**:

Fixes #131699

**Special notes for your reviewer:**

The debug hook and the input hook each narrow independently — they reach the interpolated config by different routes but agree. I didn't merge them because the debug view also needs the un-narrowed frames for its output pane. Happy to unify if you'd prefer a single owner for "what does this transformation receive".

Out of scope, same shape of bug: a transformation with `topic: annotations` is run by the pipeline over `data.annotations` but its editor is still shown `data.series`. Affects the classic editor too, so it's filed separately as #132263.

Covered by hook-level tests and a component test asserting what the editor is actually handed — including a case with a transformation ahead of it in the pipeline, where the real `transformDataFrame` runs. Both fail without the fix.

**Before**

<!-- attach 6-without-fix.png -->
<img width="1700" height="1000" alt="6-without-fix" src="https://github.com/user-attachments/assets/d24f35c6-f37d-44a6-94fe-05c2009c1014" />


**After**

<!-- attach 5-new-editor.png -->
<img width="1700" height="1000" alt="5-new-editor" src="https://github.com/user-attachments/assets/04ce1bbd-3725-4ab2-9b32-b5197c82331d" />


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — `queryEditorNext`
- [ ] The docs are updated — N/A, bug fix in a preview feature.
