### PR TITLE
Rspack: Align target across entire pipeline

### DIFF
--- a/scripts/rspack/rspack.common.ts
+++ b/scripts/rspack/rspack.common.ts
@@ -1,5 +1,4 @@
 import rspack, { type Configuration, type RuleSetRule } from '@rspack/core';
-import browserslist from 'browserslist';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -24,12 +23,8 @@ export const swcRule: RuleSetRule = {
     options: {
       jsc: {
         parser: { syntax: 'typescript', tsx: true },
-        // `development` defaults to the compiler mode. Leaving it on routes JSX through
-        // jsxDEV, which embeds the absolute source path of every call site and makes the
-        // bundle hash differently per checkout directory.
-        transform: { react: { runtime: 'automatic', development: false } },
+        transform: { react: { runtime: 'automatic' } },
       },
-      env: { targets: browserslist().join(', ') },
     },
   },
   type: 'javascript/auto',
@@ -76,12 +71,10 @@ export const sassRule: RuleSetRule = {
 };
 
 export default (env: Env = {}): Configuration => ({
-  target: 'web',
+  target: 'browserslist',
 
-  // Rspack only parses AMD `define` branches when this is set. Without it, UMD wrappers in
-  // node_modules keep their runtime `define.amd` check, which passes because systemjs
-  // installs a global `define`. Those modules register as AMD, export nothing, and Grafana
-  // crashes at boot with a green build.
+  // We need this so Rspack processes AMD modules that live in our npm dependencies otherwise the SystemJS define
+  // function will be used and the module will end up in the SystemJS registry instead of Rspack's module registry.
   amd: {},
 
   entry: {
@@ -98,8 +91,8 @@ export default (env: Env = {}): Configuration => ({
     asyncWebAssembly: true,
   },
   output: {
-    // `path` and `publicPath` must agree: disk layout, URL and CDN path are one string.
     clean: true,
+    // keep `path` and `publicPath` aligned otherwise 404s will occur.
     path: path.resolve(import.meta.dirname, '../../public/build/rspack'),
     filename: (pathData) => {
       if (pathData.chunk?.name === 'boot') {
@@ -150,8 +143,7 @@ export default (env: Env = {}): Configuration => ({
   },
   ignoreWarnings: [
     /export .* was not found in/,
-    // Function form because rspack's warning message carries extra formatting, which an
-    // anchored message regex never matches.
+    // Has to be a function, not a regex - rspack's warning text has extra formatting that an anchored regex won't match.
     (warning) =>
       warning.message.includes('Critical dependency: the request of a dependency is an expression') &&
       warning.module != null &&
@@ -177,8 +169,7 @@ export default (env: Env = {}): Configuration => ({
   module: {
     parser: {
       javascript: {
-        // Rspack raises missing ESM exports as hard errors. Downgraded so ignoreWarnings
-        // above can swallow them, as it does under webpack.
+        // Rspack raises missing ESM exports as errors which fail builds - treat them as warnings instead.
         exportsPresence: 'warn',
       },
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR aligns the "target" used across all of Rspack tool chain to keep things consistent.

**Why do we need this feature?**

The current config only sets a target for ts compilation via swc however other plugins such as the swc minifier and lightningcss plugin aren't given targets. This means we're compiling to match our browserlist but then minifying using a different target which _could_ cause runtime issues. Additionally without being explicit we're reliant on their defaults which could change during rspack dependency updates

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

The e2e test wip commit will be removed before merge - using it to give some clarity this config change doesn't break something obvious.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
