### PR TITLE
Dashboards: Fix Classic model returning v2 JSON when saving a provisioned dashboard

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -1,0 +1,154 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { type Dashboard } from '@grafana/schema';
+import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { handyTestingSchema } from '@grafana/schema/apis/dashboard.grafana.app/v2/examples';
+import { type DashboardMeta } from 'app/types/dashboard';
+
+import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+
+import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
+import { SaveProvisionedDashboardForm } from './SaveProvisionedDashboardForm';
+import { type DashboardChangeInfo } from './shared';
+
+jest.mock(
+  'react-virtualized-auto-sizer',
+  () =>
+    ({ children }: AutoSizerProps) =>
+      children({ width: 1000, height: 1000, scaledWidth: 1, scaledHeight: 1 })
+);
+
+// Monaco can't boot web workers in jsdom
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: ({ value }: { value: string }) => <textarea data-testid="code-editor" readOnly value={value} />,
+}));
+
+jest.mock('app/features/dashboard/api/dashboard_api', () => ({
+  ...jest.requireActual('app/features/dashboard/api/dashboard_api'),
+  getDashboardAPI: jest.fn().mockResolvedValue({
+    getDashboardDTO: jest.fn().mockResolvedValue({
+      apiVersion: 'dashboard.grafana.app/v2beta1',
+      kind: 'Dashboard',
+      metadata: { name: 'my-uid' },
+      spec: {},
+    }),
+  }),
+}));
+
+let cleanUp = () => {};
+
+afterEach(() => {
+  cleanUp();
+  cleanUp = () => {};
+});
+
+describe('SaveProvisionedDashboardForm', () => {
+  describe('Classic model', () => {
+    it('converts a v2 save model to v1 so the JSON can go back into file provisioning', async () => {
+      await renderForm({ changedSaveModel: handyTestingSchema });
+
+      await userEvent.click(await screen.findByText('Advanced options'));
+      await userEvent.click(await screen.findByRole('radio', { name: 'Classic' }));
+
+      const json = readEditorJson();
+
+      expect(json.schemaVersion).toBeDefined();
+      expect(Array.isArray(json.panels)).toBe(true);
+      expect(json.panels.length).toBeGreaterThan(0);
+      expect(json.uid).toBe('my-uid');
+      expect(Array.isArray(json.templating.list)).toBe(true);
+
+      expect(json.elements).toBeUndefined();
+      expect(json.layout).toBeUndefined();
+      expect(json.timeSettings).toBeUndefined();
+      expect(json.cursorSync).toBeUndefined();
+    });
+
+    it('converts to v1 when the dashboard has no k8s metadata and the model picker is hidden', async () => {
+      await renderForm({ changedSaveModel: handyTestingSchema, meta: { provisioned: true } });
+
+      expect(screen.queryByRole('radio', { name: 'Classic' })).not.toBeInTheDocument();
+
+      const json = readEditorJson();
+
+      expect(json.schemaVersion).toBeDefined();
+      expect(Array.isArray(json.panels)).toBe(true);
+      expect(json.uid).toBe('my-uid');
+      expect(json.elements).toBeUndefined();
+    });
+
+    it('leaves a v1 save model untouched', async () => {
+      const v1Model: Dashboard = {
+        title: 'a v1 dashboard',
+        uid: 'my-uid',
+        schemaVersion: 41,
+        panels: [{ id: 1, type: 'timeseries', title: 'panel' }],
+        editable: true,
+      };
+
+      await renderForm({ changedSaveModel: v1Model, meta: { provisioned: true } });
+
+      expect(readEditorJson()).toEqual(v1Model);
+    });
+  });
+});
+
+function readEditorJson() {
+  const editor = screen.getByTestId<HTMLTextAreaElement>('code-editor');
+  return JSON.parse(editor.value);
+}
+
+async function renderForm({
+  changedSaveModel,
+  meta,
+}: {
+  changedSaveModel: Dashboard | DashboardV2Spec;
+  meta?: DashboardMeta;
+}) {
+  const dashboard = transformSaveModelToScene({
+    dashboard: {
+      title: 'hello',
+      uid: 'my-uid',
+      schemaVersion: 41,
+      panels: [],
+      version: 10,
+    },
+    meta: meta ?? {
+      provisioned: true,
+      provisionedExternalId: 'dashboard.json',
+      k8s: { name: 'my-uid', generation: 10, resourceVersion: '1', creationTimestamp: '2026-01-01T00:00:00Z' },
+    },
+  });
+
+  dashboard.setState({ $data: undefined });
+  cleanUp();
+  cleanUp = dashboard.activate();
+  dashboard.onEnterEditMode();
+  dashboard.openSaveDrawer({});
+
+  const drawer = dashboard.state.overlay as SaveDashboardDrawer;
+
+  const changeInfo: DashboardChangeInfo = {
+    changedSaveModel,
+    initialSaveModel: changedSaveModel,
+    diffs: {},
+    diffCount: 0,
+    hasChanges: true,
+    hasTimeChanges: false,
+    hasVariableValueChanges: false,
+    hasRefreshChange: false,
+  };
+
+  render(
+    <TestProvider>
+      <SaveProvisionedDashboardForm dashboard={dashboard} drawer={drawer} changeInfo={changeInfo} />
+    </TestProvider>
+  );
+
+  // the V2 resource fetch runs on mount even when Classic is selected
+  await act(async () => {});
+}

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -77,6 +77,17 @@ describe('SaveProvisionedDashboardForm', () => {
       expect(json.cursorSync).toBeUndefined();
     });
 
+    it('warns that v2 only features are lost, but only for the classic model', async () => {
+      await renderForm(buildV2Scene(v2SpecWithTwoPanels()));
+
+      expect(screen.queryByText(/cannot be represented in the classic format/)).not.toBeInTheDocument();
+
+      await userEvent.click(await screen.findByText('Advanced options'));
+      await userEvent.click(await screen.findByRole('radio', { name: 'Classic' }));
+
+      expect(await screen.findByText(/cannot be represented in the classic format/)).toBeInTheDocument();
+    });
+
     it('serializes a v2 dashboard that uses rows rather than crashing the form', async () => {
       await renderForm(buildV2Scene(withRowsLayout(v2SpecWithTwoPanels())));
 
@@ -104,6 +115,7 @@ describe('SaveProvisionedDashboardForm', () => {
       await renderForm(dashboard, v1Model);
 
       expect(readEditorJson()).toEqual(v1Model);
+      expect(screen.queryByText(/cannot be represented in the classic format/)).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -4,11 +4,20 @@ import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { type Dashboard } from '@grafana/schema';
-import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
-import { handyTestingSchema } from '@grafana/schema/apis/dashboard.grafana.app/v2/examples';
-import { type DashboardMeta } from 'app/types/dashboard';
+import {
+  defaultGridLayoutItemKind,
+  defaultPanelKind,
+  defaultSpec as defaultDashboardV2Spec,
+  type RowsLayoutKind,
+  type Spec as DashboardV2Spec,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { type DashboardDataDTO } from 'app/types/dashboard';
 
+import { type DashboardScene } from '../scene/DashboardScene';
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
+import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 
 import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { SaveProvisionedDashboardForm } from './SaveProvisionedDashboardForm';
@@ -48,8 +57,8 @@ afterEach(() => {
 
 describe('SaveProvisionedDashboardForm', () => {
   describe('Classic model', () => {
-    it('converts a v2 save model to v1 so the JSON can go back into file provisioning', async () => {
-      await renderForm({ changedSaveModel: handyTestingSchema });
+    it('serializes a v2 dashboard to v1 so the JSON can go back into file provisioning', async () => {
+      await renderForm(buildV2Scene(v2SpecWithTwoPanels()));
 
       await userEvent.click(await screen.findByText('Advanced options'));
       await userEvent.click(await screen.findByRole('radio', { name: 'Classic' }));
@@ -59,8 +68,8 @@ describe('SaveProvisionedDashboardForm', () => {
       expect(json.schemaVersion).toBeDefined();
       expect(Array.isArray(json.panels)).toBe(true);
       expect(json.panels.length).toBeGreaterThan(0);
+      expect(json.panels.map((panel: { title: string }) => panel.title)).toEqual(['First', 'Second']);
       expect(json.uid).toBe('my-uid');
-      expect(Array.isArray(json.templating.list)).toBe(true);
 
       expect(json.elements).toBeUndefined();
       expect(json.layout).toBeUndefined();
@@ -68,29 +77,31 @@ describe('SaveProvisionedDashboardForm', () => {
       expect(json.cursorSync).toBeUndefined();
     });
 
-    it('converts to v1 when the dashboard has no k8s metadata and the model picker is hidden', async () => {
-      await renderForm({ changedSaveModel: handyTestingSchema, meta: { provisioned: true } });
+    it('serializes a v2 dashboard that uses rows rather than crashing the form', async () => {
+      await renderForm(buildV2Scene(withRowsLayout(v2SpecWithTwoPanels())));
 
-      expect(screen.queryByRole('radio', { name: 'Classic' })).not.toBeInTheDocument();
+      await userEvent.click(await screen.findByText('Advanced options'));
+      await userEvent.click(await screen.findByRole('radio', { name: 'Classic' }));
 
       const json = readEditorJson();
 
       expect(json.schemaVersion).toBeDefined();
-      expect(Array.isArray(json.panels)).toBe(true);
-      expect(json.uid).toBe('my-uid');
+      expect(json.panels.some((panel: { type: string }) => panel.type === 'row')).toBe(true);
       expect(json.elements).toBeUndefined();
+      expect(json.layout).toBeUndefined();
     });
 
     it('leaves a v1 save model untouched', async () => {
-      const v1Model: Dashboard = {
+      const v1Model: DashboardDataDTO = {
         title: 'a v1 dashboard',
         uid: 'my-uid',
         schemaVersion: 41,
         panels: [{ id: 1, type: 'timeseries', title: 'panel' }],
         editable: true,
       };
+      const dashboard = transformSaveModelToScene({ dashboard: v1Model, meta: { provisioned: true } });
 
-      await renderForm({ changedSaveModel: v1Model, meta: { provisioned: true } });
+      await renderForm(dashboard, v1Model);
 
       expect(readEditorJson()).toEqual(v1Model);
     });
@@ -102,29 +113,70 @@ function readEditorJson() {
   return JSON.parse(editor.value);
 }
 
-async function renderForm({
-  changedSaveModel,
-  meta,
-}: {
-  changedSaveModel: Dashboard | DashboardV2Spec;
-  meta?: DashboardMeta;
-}) {
-  const dashboard = transformSaveModelToScene({
-    dashboard: {
-      title: 'hello',
-      uid: 'my-uid',
-      schemaVersion: 41,
-      panels: [],
-      version: 10,
+function v2SpecWithTwoPanels(): DashboardV2Spec {
+  const titles = ['First', 'Second'];
+
+  return {
+    ...defaultDashboardV2Spec(),
+    title: 'a provisioned dashboard',
+    elements: Object.fromEntries(
+      titles.map((title, index) => [
+        `panel-${index + 1}`,
+        { ...defaultPanelKind(), spec: { ...defaultPanelKind().spec, id: index + 1, title } },
+      ])
+    ),
+    layout: {
+      kind: 'GridLayout',
+      spec: {
+        items: titles.map((_, index) => ({
+          ...defaultGridLayoutItemKind(),
+          spec: {
+            ...defaultGridLayoutItemKind().spec,
+            element: { kind: 'ElementReference', name: `panel-${index + 1}` },
+            x: 0,
+            y: index * 8,
+            width: 12,
+            height: 8,
+          },
+        })),
+      },
     },
-    meta: meta ?? {
-      provisioned: true,
-      provisionedExternalId: 'dashboard.json',
-      k8s: { name: 'my-uid', generation: 10, resourceVersion: '1', creationTimestamp: '2026-01-01T00:00:00Z' },
+  };
+}
+
+/** Nests the grid layout inside a single row, so the scene uses RowsLayoutManager. */
+function withRowsLayout(spec: DashboardV2Spec): DashboardV2Spec {
+  const layout: RowsLayoutKind = {
+    kind: 'RowsLayout',
+    spec: {
+      rows: [{ kind: 'RowsLayoutRow', spec: { title: 'A row', layout: spec.layout } }],
     },
+  };
+
+  return { ...spec, layout };
+}
+
+function buildV2Scene(spec: DashboardV2Spec): DashboardScene {
+  return transformSaveModelSchemaV2ToScene({
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    kind: 'DashboardWithAccessInfo',
+    spec,
+    metadata: {
+      name: 'my-uid',
+      generation: 10,
+      resourceVersion: '1',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+    },
+    access: {},
+  });
+}
+
+async function renderForm(dashboard: DashboardScene, changedSaveModel?: Dashboard | DashboardV2Spec) {
+  dashboard.setState({
+    $data: undefined,
+    meta: { ...dashboard.state.meta, provisioned: true, provisionedExternalId: 'dashboard.json' },
   });
 
-  dashboard.setState({ $data: undefined });
   cleanUp();
   cleanUp = dashboard.activate();
   dashboard.onEnterEditMode();
@@ -133,8 +185,8 @@ async function renderForm({
   const drawer = dashboard.state.overlay as SaveDashboardDrawer;
 
   const changeInfo: DashboardChangeInfo = {
-    changedSaveModel,
-    initialSaveModel: changedSaveModel,
+    changedSaveModel: changedSaveModel ?? transformSceneToSaveModelSchemaV2(dashboard),
+    initialSaveModel: transformSceneToSaveModel(dashboard),
     diffs: {},
     diffCount: 0,
     hasChanges: true,

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -1,10 +1,11 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import { omit } from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import { useAsync } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
   Alert,
@@ -17,6 +18,7 @@ import {
   RadioButtonGroup,
   Spinner,
   TextLink,
+  useStyles2,
 } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -38,6 +40,7 @@ export interface Props {
 }
 
 export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: Props) {
+  const styles = useStyles2(getStyles);
   const hasK8sMeta = Boolean(dashboard.state.meta.k8s);
   const [exportFormat, setExportFormat] = useState<ExportFormat>(
     hasK8sMeta ? ExportFormat.V2Resource : ExportFormat.Classic
@@ -152,7 +155,12 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
         )}
 
         {isLossyClassicModel && (
-          <Alert title="" severity="warning" bottomSpacing={0} className={styles.warning}>
+          <Alert
+            title=""
+            severity="warning"
+            bottomSpacing={0}
+            className={cx(styles.warning, hasK8sMeta && styles.warningBelowOptions)}
+          >
             <Trans i18nKey="dashboard-scene.resource-export.classic-v2-warning">
               This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in
               the classic format and may be lost.
@@ -203,18 +211,25 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
   );
 }
 
-const styles = {
-  container: css({
-    height: '100%',
-    display: 'flex',
-  }),
-  json: css({
-    flexGrow: 1,
-    maxHeight: '800px',
-  }),
-  // Alert's wrapper sets flexGrow: 1, which in this column layout makes it swallow all the
-  // free space instead of the JSON editor below it.
-  warning: css({
-    flexGrow: 0,
-  }),
-};
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css({
+      height: '100%',
+      display: 'flex',
+    }),
+    json: css({
+      flexGrow: 1,
+      maxHeight: '800px',
+    }),
+    // Alert's wrapper sets flexGrow: 1, which in this column layout makes it swallow all the
+    // free space instead of the JSON editor below it.
+    warning: css({
+      flexGrow: 0,
+    }),
+    // The advanced options row adds its own bottom margin on top of the Stack's gap. Drop one of
+    // them so the warning sits as close to the controls as it does in the export drawer.
+    warningBelowOptions: css({
+      marginTop: theme.spacing(-2),
+    }),
+  };
+}

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -7,6 +7,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { Trans, t } from '@grafana/i18n';
 import {
+  Alert,
   Button,
   ClipboardButton,
   Stack,
@@ -80,6 +81,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
 
   const isK8sMode = exportFormat === ExportFormat.V2Resource && hasK8sMeta;
   const displayJson = isK8sMode ? (k8sResource.value ?? '') : classicJson;
+  const isLossyClassicModel = !isK8sMode && isDashboardV2Spec(changedSaveModel);
 
   const saveToFile = useCallback(() => {
     const blob = new Blob([displayJson], {
@@ -147,6 +149,15 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
               </Stack>
             </Box>
           </QueryOperationRow>
+        )}
+
+        {isLossyClassicModel && (
+          <Alert title="" severity="warning">
+            <Trans i18nKey="dashboard-scene.resource-export.classic-v2-warning">
+              This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in
+              the classic format and may be lost.
+            </Trans>
+          </Alert>
         )}
 
         <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -152,7 +152,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
         )}
 
         {isLossyClassicModel && (
-          <Alert title="" severity="warning">
+          <Alert title="" severity="warning" bottomSpacing={0} className={styles.warning}>
             <Trans i18nKey="dashboard-scene.resource-export.classic-v2-warning">
               This dashboard uses the V2 schema. Features like tabs and conditional rendering cannot be represented in
               the classic format and may be lost.
@@ -211,5 +211,10 @@ const styles = {
   json: css({
     flexGrow: 1,
     maxHeight: '800px',
+  }),
+  // Alert's wrapper sets flexGrow: 1, which in this column layout makes it swallow all the
+  // free space instead of the JSON editor below it.
+  warning: css({
+    flexGrow: 0,
   }),
 };

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -18,13 +18,12 @@ import {
   TextLink,
 } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
-import { type ObjectMeta } from 'app/features/apiserver/types';
-import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 
 import { type DashboardScene } from '../scene/DashboardScene';
+import { getDashboardSceneSerializer } from '../serialization/DashboardSceneSerializer';
 import { convertSpecToWireFormat } from '../serialization/transformationCompat';
 
 import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
@@ -38,8 +37,7 @@ export interface Props {
 }
 
 export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: Props) {
-  const k8sMeta = dashboard.state.meta.k8s;
-  const hasK8sMeta = Boolean(k8sMeta);
+  const hasK8sMeta = Boolean(dashboard.state.meta.k8s);
   const [exportFormat, setExportFormat] = useState<ExportFormat>(
     hasK8sMeta ? ExportFormat.V2Resource : ExportFormat.Classic
   );
@@ -47,22 +45,16 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
 
   const { changedSaveModel } = changeInfo;
   const classicJson = useMemo(() => {
-    if (!isDashboardV2Spec(changedSaveModel)) {
-      return JSON.stringify(changedSaveModel, null, 2);
-    }
+    // The changed model is a v2 spec whenever the scene serializes to v2, but this JSON is pasted
+    // back into file-based provisioning, which only accepts v1. Ask the v1 serializer for the same
+    // save model a non-provisioned dashboard produces, so both paths stay in step and the unsaved
+    // local edits survive.
+    const classicModel = isDashboardV2Spec(changedSaveModel)
+      ? getDashboardSceneSerializer('v1').getSaveModel(dashboard)
+      : changedSaveModel;
 
-    // The scene serializes to v2 whenever the dashboard uses the new layouts, but this JSON is
-    // pasted back into file-based provisioning, which only accepts v1. Converting here rather than
-    // reading the v1 API is what keeps the unsaved local edits in the output.
-    const metadata: ObjectMeta = {
-      ...k8sMeta,
-      name: k8sMeta?.name ?? uid ?? '',
-      resourceVersion: k8sMeta?.resourceVersion ?? '',
-      creationTimestamp: k8sMeta?.creationTimestamp ?? '',
-    };
-
-    return JSON.stringify(transformDashboardV2SpecToV1(changedSaveModel, metadata), null, 2);
-  }, [changedSaveModel, k8sMeta, uid]);
+    return JSON.stringify(classicModel, null, 2);
+  }, [changedSaveModel, dashboard]);
 
   const k8sResource = useAsync(async () => {
     if (exportFormat !== ExportFormat.V2Resource || !uid) {

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -18,6 +18,8 @@ import {
   TextLink,
 } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
+import { type ObjectMeta } from 'app/features/apiserver/types';
+import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
@@ -36,14 +38,31 @@ export interface Props {
 }
 
 export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: Props) {
-  const hasK8sMeta = Boolean(dashboard.state.meta.k8s);
+  const k8sMeta = dashboard.state.meta.k8s;
+  const hasK8sMeta = Boolean(k8sMeta);
   const [exportFormat, setExportFormat] = useState<ExportFormat>(
     hasK8sMeta ? ExportFormat.V2Resource : ExportFormat.Classic
   );
   const uid = dashboard.state.uid;
 
   const { changedSaveModel } = changeInfo;
-  const classicJson = useMemo(() => JSON.stringify(changedSaveModel, null, 2), [changedSaveModel]);
+  const classicJson = useMemo(() => {
+    if (!isDashboardV2Spec(changedSaveModel)) {
+      return JSON.stringify(changedSaveModel, null, 2);
+    }
+
+    // The scene serializes to v2 whenever the dashboard uses the new layouts, but this JSON is
+    // pasted back into file-based provisioning, which only accepts v1. Converting here rather than
+    // reading the v1 API is what keeps the unsaved local edits in the output.
+    const metadata: ObjectMeta = {
+      ...k8sMeta,
+      name: k8sMeta?.name ?? uid ?? '',
+      resourceVersion: k8sMeta?.resourceVersion ?? '',
+      creationTimestamp: k8sMeta?.creationTimestamp ?? '',
+    };
+
+    return JSON.stringify(transformDashboardV2SpecToV1(changedSaveModel, metadata), null, 2);
+  }, [changedSaveModel, k8sMeta, uid]);
 
   const k8sResource = useAsync(async () => {
     if (exportFormat !== ExportFormat.V2Resource || !uid) {

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1440,7 +1440,7 @@ function transformToV1VariableTypes(variable: TypedVariableModelV2): VariableTyp
   }
 }
 
-export function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
+function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
   const annotations = (spec.annotations ?? []).map(transformV2ToV1AnnotationQuery);
 
   const gnetId = metadata.annotations?.[AnnoKeyDashboardGnetId];

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1440,7 +1440,7 @@ function transformToV1VariableTypes(variable: TypedVariableModelV2): VariableTyp
   }
 }
 
-function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
+export function transformDashboardV2SpecToV1(spec: DashboardV2Spec, metadata: ObjectMeta): DashboardDataDTO {
   const annotations = (spec.annotations ?? []).map(transformV2ToV1AnnotationQuery);
 
   const gnetId = metadata.annotations?.[AnnoKeyDashboardGnetId];


### PR DESCRIPTION
**What is this feature?**

Selecting **Model: Classic** when saving a provisioned dashboard now always produces a v1 dashboard JSON.

The drawer stringified the changed save model unchanged. That model is a v2 spec whenever the scene serializes to v2, so "Classic" emitted `elements`, `layout`, `timeSettings` and `cursorSync`, with no `schemaVersion`, `panels` or `uid`. Dropping that file into a `type: file` provisioning directory fails with:

```
error="dashboard appears to be in v2 format. Please use the /apis/dashboard.grafana.app/v2 API"
```

The fix asks the v1 serializer for the model instead, so Classic is built the same way a non-provisioned dashboard builds its save model:

```ts
const classicModel = isDashboardV2Spec(changedSaveModel)
  ? getDashboardSceneSerializer('v1').getSaveModel(dashboard)
  : changedSaveModel;
```

**Why do we need this feature?**

There is currently no way to get a v1 JSON out of the UI for a provisioned dashboard you have edited, so file based provisioning cannot be updated from Grafana.

Only the save drawer was affected. The export drawer reads the v1 API and was always correct, but it is blocked while you have unsaved changes, so it cannot cover this case.

**Who is this feature for?**

Anyone using file based provisioning who edits a provisioned dashboard in the UI and copies the JSON back into their repository or ConfigMap.

**Before / after**

Saving a provisioned dashboard that uses the V2 schema, with **Model: Classic** selected. Captured from a locally running Grafana with a v2 dashboard provisioned from a file.

| Before | After |
|---|---|
| <img width="430" src="https://github.com/grafana/grafana/raw/cb5bc6f7973cb0e760a185ce9d15d1351a763011/.screenshots/provisioned-classic-v1/before.png" /> | <img width="430" src="https://github.com/grafana/grafana/raw/cb5bc6f7973cb0e760a185ce9d15d1351a763011/.screenshots/provisioned-classic-v1/after.png" /> |

Before, Classic gives `annotations: [{kind: AnnotationQuery}]`, `cursorSync`, `elements`, `panel-1`, and no `panels` or `schemaVersion`. After, it gives `annotations.list`, `editable`, `graphTooltip`, `links` and `panels` with `gridPos`, plus the lossy-conversion warning.

For comparison, the **export** drawer's Classic on the same dashboard, which this PR does not touch. It already produced v1 and already showed that warning, and the save drawer now matches it:

<img width="430" src="https://github.com/grafana/grafana/raw/cb5bc6f7973cb0e760a185ce9d15d1351a763011/.screenshots/provisioned-classic-v1/export.png" />

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/126641

**Special notes for your reviewer:**

- A v1 model is passed through untouched, so the `saveTimeRange` / `saveVariables` / `saveRefresh` checkboxes are unchanged. Only the v2 case is affected.
- The classic model is lossy for v2 only features, so the drawer now shows the same warning the export drawer already shows, reusing its string rather than adding a second copy of the same sentence.
- That alert needed `flexGrow: 0`. `Alert`'s wrapper hard-codes `flexGrow: 1`, which in this column layout made it 239px tall for two lines of text and squeezed the JSON editor into a 160px sliver. With it reset the editor keeps the slack: 337px in the same drawer.
- Tests cover a grid layout, a rows layout, the warning and the v1 passthrough.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

