### PR TITLE
Apiserver: Preserve incoming client trace on /apis requests

### DIFF
--- a/pkg/services/apiserver/reparent_tracer.go
+++ b/pkg/services/apiserver/reparent_tracer.go
@@ -1,0 +1,99 @@
+package apiserver
+
+import (
+	"context"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+	componentbasetracing "k8s.io/component-base/tracing"
+)
+
+// reparentingTracerProvider counteracts the Kubernetes apiserver's "public
+// endpoint" request tracing.
+//
+// The upstream tracing filter (k8s.io/apiserver/pkg/endpoints/filters.WithTracing,
+// installed inside DefaultBuildHandlerChain after authentication) runs otelhttp
+// with WithPublicEndpointFn. For every caller that is not system:masters or
+// system:monitoring — i.e. every normal user — otelhttp starts the request span
+// as a NEW ROOT and demotes the incoming trace context to a mere link. The
+// result is that a single /apis request is recorded as two disconnected traces:
+// the client trace stops at the authentication filter and everything after it
+// gets a fresh trace ID.
+//
+// Public-endpoint mode exists so an untrusted client cannot pick trace IDs or
+// force sampling. In Grafana the gateway in front of the apiserver already owns
+// that trust boundary, so re-rooting again at this interior hop protects nothing
+// and only splits traces. This provider re-parents such spans back onto the
+// linked remote context so the client trace continues unbroken. Honoring the
+// remote context also lets the (trusted) client's sampling decision flow
+// through, which is the intended behaviour once the gateway is the boundary.
+type reparentingTracerProvider struct {
+	componentbasetracing.TracerProvider
+}
+
+// newReparentingTracerProvider wraps tp so spans started in otelhttp
+// public-endpoint mode are re-parented onto their incoming remote context.
+func newReparentingTracerProvider(tp componentbasetracing.TracerProvider) componentbasetracing.TracerProvider {
+	return reparentingTracerProvider{TracerProvider: tp}
+}
+
+func (p reparentingTracerProvider) Tracer(name string, opts ...oteltrace.TracerOption) oteltrace.Tracer {
+	return reparentingTracer{Tracer: p.TracerProvider.Tracer(name, opts...)}
+}
+
+type reparentingTracer struct {
+	oteltrace.Tracer
+}
+
+func (t reparentingTracer) Start(ctx context.Context, name string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	ctx, opts = reparentPublicEndpointSpan(ctx, opts)
+	return t.Tracer.Start(ctx, name, opts...)
+}
+
+// reparentPublicEndpointSpan detects the span-start options otelhttp produces in
+// public-endpoint mode — WithNewRoot() plus the incoming remote span context as a
+// link — and rewrites them so the span becomes a child of that remote context
+// instead of a detached new root. Every other Start call is returned unchanged:
+// only spans that are both new-root and carry a remote link are affected.
+func reparentPublicEndpointSpan(ctx context.Context, opts []oteltrace.SpanStartOption) (context.Context, []oteltrace.SpanStartOption) {
+	cfg := oteltrace.NewSpanStartConfig(opts...)
+	if !cfg.NewRoot() {
+		return ctx, opts
+	}
+	parent, remainingLinks, found := extractRemoteParent(cfg.Links())
+	if !found {
+		return ctx, opts
+	}
+
+	ctx = oteltrace.ContextWithRemoteSpanContext(ctx, parent)
+
+	// Rebuild the options without WithNewRoot so the remote parent is honored,
+	// preserving everything else otelhttp set (attributes, span kind, timestamp,
+	// and any non-parent links).
+	rebuilt := make([]oteltrace.SpanStartOption, 0, 4)
+	if attrs := cfg.Attributes(); len(attrs) > 0 {
+		rebuilt = append(rebuilt, oteltrace.WithAttributes(attrs...))
+	}
+	if len(remainingLinks) > 0 {
+		rebuilt = append(rebuilt, oteltrace.WithLinks(remainingLinks...))
+	}
+	if ts := cfg.Timestamp(); !ts.IsZero() {
+		rebuilt = append(rebuilt, oteltrace.WithTimestamp(ts))
+	}
+	rebuilt = append(rebuilt, oteltrace.WithSpanKind(cfg.SpanKind()))
+	return ctx, rebuilt
+}
+
+// extractRemoteParent returns the first remote link — the incoming trace context
+// otelhttp preserved as a link in public-endpoint mode — to use as the parent,
+// along with the remaining links to keep.
+func extractRemoteParent(links []oteltrace.Link) (oteltrace.SpanContext, []oteltrace.Link, bool) {
+	for i, l := range links {
+		if l.SpanContext.IsValid() && l.SpanContext.IsRemote() {
+			remaining := make([]oteltrace.Link, 0, len(links)-1)
+			remaining = append(remaining, links[:i]...)
+			remaining = append(remaining, links[i+1:]...)
+			return l.SpanContext, remaining, true
+		}
+	}
+	return oteltrace.SpanContext{}, links, false
+}

--- a/pkg/services/apiserver/reparent_tracer_test.go
+++ b/pkg/services/apiserver/reparent_tracer_test.go
@@ -1,0 +1,111 @@
+package apiserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+func remoteSpanContext(t *testing.T) oteltrace.SpanContext {
+	t.Helper()
+	tid, err := oteltrace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	sid, err := oteltrace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+	return oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: oteltrace.FlagsSampled,
+		Remote:     true,
+	})
+}
+
+func newRecordingProvider(t *testing.T) (oteltrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	base := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = base.Shutdown(context.Background()) })
+	return newReparentingTracerProvider(base), sr
+}
+
+// publicEndpointStart mimics the span-start options otelhttp emits in
+// public-endpoint mode: a new root plus the incoming remote context as a link.
+func publicEndpointStart(remote oteltrace.SpanContext) []oteltrace.SpanStartOption {
+	return []oteltrace.SpanStartOption{
+		oteltrace.WithAttributes(attribute.String("http.method", "GET")),
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithNewRoot(),
+		oteltrace.WithLinks(oteltrace.Link{SpanContext: remote}),
+	}
+}
+
+func TestReparentingTracer(t *testing.T) {
+	t.Run("re-parents a public-endpoint new-root span onto the remote context", func(t *testing.T) {
+		tp, sr := newRecordingProvider(t)
+		remote := remoteSpanContext(t)
+
+		_, span := tp.Tracer("test").Start(context.Background(), "KubernetesAPI", publicEndpointStart(remote)...)
+		span.End()
+
+		ended := sr.Ended()
+		require.Len(t, ended, 1)
+		got := ended[0]
+
+		// The span continues the client's trace and is parented to the remote span.
+		require.Equal(t, remote.TraceID(), got.SpanContext().TraceID(), "should continue the incoming trace")
+		require.Equal(t, remote.SpanID(), got.Parent().SpanID(), "should be parented to the remote span")
+		require.True(t, got.Parent().IsRemote())
+
+		// Other start options are preserved and the consumed remote link is dropped.
+		require.Equal(t, oteltrace.SpanKindServer, got.SpanKind())
+		require.Empty(t, got.Links(), "the remote link becomes the parent and is not kept as a link")
+		require.Contains(t, got.Attributes(), attribute.String("http.method", "GET"))
+	})
+
+	t.Run("leaves a plain new-root span (no remote link) untouched", func(t *testing.T) {
+		tp, sr := newRecordingProvider(t)
+
+		_, span := tp.Tracer("test").Start(context.Background(), "root", oteltrace.WithNewRoot())
+		span.End()
+
+		got := sr.Ended()[0]
+		require.False(t, got.Parent().IsValid(), "should remain a root span")
+	})
+
+	t.Run("ignores a non-remote link on a new-root span", func(t *testing.T) {
+		tp, sr := newRecordingProvider(t)
+		local := oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+			TraceID: remoteSpanContext(t).TraceID(),
+			SpanID:  remoteSpanContext(t).SpanID(),
+			// Remote is false: an ordinary link, not an incoming trace context.
+		})
+
+		_, span := tp.Tracer("test").Start(context.Background(), "root",
+			oteltrace.WithNewRoot(),
+			oteltrace.WithLinks(oteltrace.Link{SpanContext: local}),
+		)
+		span.End()
+
+		got := sr.Ended()[0]
+		require.False(t, got.Parent().IsValid(), "non-remote links must not trigger re-parenting")
+		require.Len(t, got.Links(), 1, "the link is preserved")
+	})
+
+	t.Run("does not alter a normal parented span", func(t *testing.T) {
+		tp, sr := newRecordingProvider(t)
+		remote := remoteSpanContext(t)
+		ctx := oteltrace.ContextWithRemoteSpanContext(context.Background(), remote)
+
+		_, span := tp.Tracer("test").Start(ctx, "child", oteltrace.WithSpanKind(oteltrace.SpanKindServer))
+		span.End()
+
+		got := sr.Ended()[0]
+		require.Equal(t, remote.TraceID(), got.SpanContext().TraceID())
+		require.Equal(t, remote.SpanID(), got.Parent().SpanID())
+	})
+}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -365,6 +365,11 @@ func (s *service) start(ctx context.Context) error {
 	serverConfig.Authorization.Authorizer = s.authorizer
 	serverConfig.Authentication.Authenticator = authenticator.NewAuthenticator(serverConfig.Authentication.Authenticator)
 	serverConfig.TracerProvider = s.tracing.GetTracerProvider()
+	if s.features.IsEnabledGlobally(featuremgmt.FlagApiserverPreserveTraceContext) {
+		// Keep the incoming client trace on /apis requests instead of letting the
+		// upstream public-endpoint tracing filter start a detached new root.
+		serverConfig.TracerProvider = newReparentingTracerProvider(serverConfig.TracerProvider)
+	}
 
 	// setup loopback transport for the aggregator server
 	transport := &grafanaapiserveroptions.RoundTripperFunc{Ready: make(chan struct{})}

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -227,6 +227,15 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:            "apiserverPreserveTraceContext",
+			Description:     "Continue the incoming client trace on /apis requests instead of starting a new root span for non-privileged callers",
+			Stage:           FeatureStageExperimental,
+			RequiresRestart: true,
+			Owner:           grafanaAppPlatformSquad,
+			Expression:      "false",
+			Generate:        Generate{LegacyGo: true},
+		},
+		{
 			Name:            "provisioningFolderMetadata",
 			Description:     "Allow setting folder metadata for provisioned folders",
 			Stage:           FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -24,6 +24,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-14,awsAssumeRolePerDatasourceExternalId,experimental,@grafana/data-sources-plugins,false,false,false
 2023-07-13,mlExpressions,experimental,@grafana/alerting-squad,false,false,false
 2023-10-06,grafanaAPIServerWithExperimentalAPIs,experimental,@grafana/grafana-app-platform-squad,true,true,false
+2026-08-27,apiserverPreserveTraceContext,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningFolderMetadata,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2026-05-22,provisioning.readmes,preview,@grafana/grafana-app-platform-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -79,6 +79,10 @@ const (
 	// Register experimental APIs with the k8s API server, including all datasources
 	FlagGrafanaAPIServerWithExperimentalAPIs = "grafanaAPIServerWithExperimentalAPIs"
 
+	// FlagApiserverPreserveTraceContext
+	// Continue the incoming client trace on /apis requests instead of starting a new root span for non-privileged callers
+	FlagApiserverPreserveTraceContext = "apiserverPreserveTraceContext"
+
 	// FlagProvisioningFolderMetadata
 	// Allow setting folder metadata for provisioned folders
 	FlagProvisioningFolderMetadata = "provisioningFolderMetadata"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1033,6 +1033,20 @@
     },
     {
       "metadata": {
+        "name": "apiserverPreserveTraceContext",
+        "resourceVersion": "1787846936186",
+        "creationTimestamp": "2026-08-27T16:08:56Z"
+      },
+      "spec": {
+        "description": "Continue the incoming client trace on /apis requests instead of starting a new root span for non-privileged callers",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "appPlatformGrpcClientAuth",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2024-10-14T10:47:18Z"


### PR DESCRIPTION
## What this PR does

`/apis/*` requests are currently recorded as **two disconnected traces**. The client-side trace stops at the apiserver's authentication filter; everything after it (route handler, search, unified storage, authz) lands in a separate root trace with a new trace ID. This makes latency debugging of `/apis` calls (e.g. a slow `/dashboards/trash`) hard, because the expensive spans can't be reached by following the client trace ID.

### Root cause

The k8s apiserver tracing filter (`k8s.io/apiserver/pkg/endpoints/filters.WithTracing`, installed inside `DefaultBuildHandlerChain` **after** authentication) runs otelhttp with `WithPublicEndpointFn(notSystemPrivilegedGroup)`. For every caller that is **not** `system:masters` or `system:monitoring` — i.e. every normal user — otelhttp starts the request span as a **new root** (`trace.WithNewRoot()`) and demotes the incoming trace context to a **link**.

Public-endpoint mode exists so an untrusted client cannot pick trace IDs or force sampling. In Grafana the **gateway in front of the apiserver already owns that trust boundary** (it terminates and re-issues trace context), so re-rooting again at this interior hop protects nothing and only splits traces.

### The fix

An **opt-in** tracer-provider wrapper (`reparentingTracerProvider`) installed on `serverConfig.TracerProvider`. On `Tracer.Start` it detects the exact option shape otelhttp emits in public-endpoint mode — `WithNewRoot()` **plus** the incoming remote span context as a link — and rewrites it so the span becomes a **child** of that remote context instead of a detached new root. Every other `Start` call is passed through untouched.

Gated behind the experimental `apiserverPreserveTraceContext` feature toggle (default off, `RequiresRestart`), so merging changes no behavior until it is enabled.

### Deliberate tradeoff

Re-parenting onto the (remote) client context means the client's **sampling decision now flows through** — which is precisely what public-endpoint mode was preventing. That is the intended behavior *once we accept the gateway as the trust boundary*, and it is why this is opt-in rather than the default.

## Why not patch the upstream filter / change `WithPublicEndpointFn`?

`WithPublicEndpointFn(notSystemPrivilegedGroup)` lives in vendored k8s apiserver code with no configuration seam. Wrapping the `TracerProvider` we already inject (`pkg/services/apiserver/service.go`) keeps the change entirely on the Grafana side, with no vendor patch to carry.

## Relationship to existing tracing machinery

Grafana already recovers upstream context across the aggregator (which strips the standard `traceparent`) via the `Grafana-Upstream-Traceparent` header and `WithExtractUpstreamTraceLink` — but deliberately as a **link, not a parent**. This PR is a change to that link-vs-parent policy for the public-endpoint re-rooting case, scoped to the apiserver request span and gated behind a toggle. Owners of that convention should weigh in on whether the link semantics are load-bearing (sampling-cost control, MT tenant isolation) before this is enabled by default.

That convention's provenance (for reviewer context):

- `WithExtractUpstreamTraceLink` (reads `Grafana-Upstream-Traceparent`, adds it as a span **link**) was introduced by @konsalex in #117686 ("feat: add explicit tracer header"), approved by @radiohead and @amalavet.
- The `tracing_log.go` fallback that also reads the header was added by @janthoe in #118613 ("fix(apiserver): add traceID to HTTP request logs when span context is noop").

cc @konsalex @radiohead @amalavet @janthoe — this changes the link-vs-parent behavior your work established; please weigh in on whether the link semantics are intentional here. (The proxy that *injects* `Grafana-Upstream-Traceparent` lives outside this repo.)

## Testing

- `pkg/services/apiserver/reparent_tracer_test.go` uses the real OTel SDK span recorder to verify:
  - a public-endpoint-style `Start` (new root + remote link) is re-parented onto the remote context and continues its trace, with the consumed link dropped and other options (span kind, attributes) preserved;
  - a plain new-root span (no remote link) stays a root;
  - a new-root span with a **non-remote** link is left untouched;
  - a normally-parented span is unchanged.

```
go test ./pkg/services/apiserver/ -run TestReparentingTracer
```

## Notes

- Scope: all `/apis/*` requests from non-privileged users, only when the toggle is enabled.
- Blast radius when enabled: MT apiserver / app-sdk / enterprise inherit this behavior.

Fixes grafana/git-ui-sync-project#1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
