### PR TITLE
Dashboards: Show values preview for data source variables in the edit pane

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
@@ -3,11 +3,12 @@
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { JSX } from 'react';
+import { lastValueFrom } from 'rxjs';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { DataSourceVariable } from '@grafana/scenes';
 
-import { DataSourceVariableEditor } from './DataSourceVariableEditor';
+import { DataSourceVariableEditor, getDataSourceVariableOptions } from './DataSourceVariableEditor';
 
 //mock getDataSourceInstanceList() to return a list of datasources
 const dsList = [
@@ -156,6 +157,56 @@ describe('DataSourceVariableEditor', () => {
     await user.click(includeAllCheckbox);
     expect(includeAllCheckbox).toBeChecked();
     expect(onRunQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getDataSourceVariableOptions', () => {
+  const renderPreviewItem = (variable: DataSourceVariable) => {
+    const previewItem = getDataSourceVariableOptions(variable).find(
+      (item) => item.props.id === 'datasource-options-preview'
+    );
+    expect(previewItem).toBeDefined();
+
+    return render(previewItem!.props.render(previewItem!));
+  };
+
+  const previewedValues = async (findAllByTestId: ReturnType<typeof render>['findAllByTestId']) => {
+    const rendered = await findAllByTestId(
+      selectors.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption
+    );
+
+    return rendered.map((option) => option.textContent);
+  };
+
+  it('renders a values preview listing the resolved data source instances', async () => {
+    const variable = new DataSourceVariable({
+      name: 'dsVariable',
+      type: 'datasource',
+      pluginId: 'dsTestDataSource',
+    });
+    await lastValueFrom(variable.validateAndUpdate!());
+
+    const { findAllByTestId } = renderPreviewItem(variable);
+
+    expect(await previewedValues(findAllByTestId)).toEqual([
+      'DataSourceInstance1',
+      'DataSourceInstance2',
+      'ABCDataSourceInstance',
+    ]);
+  });
+
+  it('narrows the previewed values to those matching the name filter', async () => {
+    const variable = new DataSourceVariable({
+      name: 'dsVariable',
+      type: 'datasource',
+      pluginId: 'dsTestDataSource',
+      regex: '/Instance2$/',
+    });
+    await lastValueFrom(variable.validateAndUpdate!());
+
+    const { findAllByTestId } = renderPreviewItem(variable);
+
+    expect(await previewedValues(findAllByTestId)).toEqual(['DataSourceInstance2']);
   });
 });
 

--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
@@ -110,7 +110,7 @@ interface InputProps {
 function DataSourceValuesPreview({ variable }: InputProps) {
   const { options, staticOptions } = useGetAllVariableOptions(variable);
 
-  return <VariableValuesPreview options={options} staticOptions={staticOptions} />;
+  return <VariableValuesPreview options={options} staticOptions={staticOptions} pageSize={5} />;
 }
 
 function DataSourceTypeSelect({ variable, id }: InputProps) {

--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.tsx
@@ -10,6 +10,7 @@ import { Combobox, type ComboboxOption, Input } from '@grafana/ui';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { DataSourceVariableForm } from '../components/DataSourceVariableForm';
+import { useGetAllVariableOptions, VariableValuesPreview } from '../components/VariableValuesPreview';
 import { getOptionDataSourceTypes } from '../utils';
 
 interface DataSourceVariableEditorProps {
@@ -93,12 +94,23 @@ export function getDataSourceVariableOptions(variable: SceneVariable): OptionsPa
       ),
       render: ({ props }) => <DataSourceNameFilter id={props.id} variable={variable} />,
     }),
+    new OptionsPaneItemDescriptor({
+      id: 'datasource-options-preview',
+      skipField: true,
+      render: () => <DataSourceValuesPreview variable={variable} />,
+    }),
   ];
 }
 
 interface InputProps {
   variable: DataSourceVariable;
   id?: string;
+}
+
+function DataSourceValuesPreview({ variable }: InputProps) {
+  const { options, staticOptions } = useGetAllVariableOptions(variable);
+
+  return <VariableValuesPreview options={options} staticOptions={staticOptions} />;
 }
 
 function DataSourceTypeSelect({ variable, id }: InputProps) {


### PR DESCRIPTION
## What is this feature?

Data source variables now show a "Preview of values" section in the dashboard edit pane, listing the instances the variable resolves to.

| Before | After |
|---|---|
| <img width="440" src="https://github.com/grafana/grafana/raw/3186a72cd7abad271fb528793ddbce52d88f8af1/.screenshots/ds-variable-preview/before.png" /> | <img width="440" src="https://github.com/grafana/grafana/raw/3186a72cd7abad271fb528793ddbce52d88f8af1/.screenshots/ds-variable-preview/after.png" /> |

## Why do we need this feature?

The edit pane builds each variable type's options through `getOptions`. `getDataSourceVariableOptions` registered only **Type** and **Name filter**, so data source variables had no values preview anywhere in the pane. Custom and query variables have one through their modal editors, which is why they show a preview and data source variables do not.

The full page settings form does render it, but it is unreachable once `dashboardNewLayouts` and `grafana.dashboardSettingsRedesign` are on (both GA, default on), so today no surface previews this variable type.

## Which issue(s) does this PR fix?

Reported through support: editing a data source variable shows no "Preview of values", while a custom variable on the same dashboard shows it correctly.

## Special notes for your reviewer

Rendered inline rather than behind an "Open variable editor" modal like custom and query. Data source options come from `getDataSourceSrv().getList({ pluginId })`, which is synchronous and local, so there is no query round trip to hide behind a modal.

Reusing `useGetAllVariableOptions` means the preview follows the resolved options, so it respects the Name filter regex.

**Question for the reviewer:** should this carry a `backport v13.2.x`? Backports are meant for critical bugs and this is display only, but users on 13.2 have no surface at all that previews data source variable values.
