### PR TITLE
Support querying multiple databases from a single Datasource

### DIFF
--- a/packages/grafana-sql/src/components/DatabaseSelector.tsx
+++ b/packages/grafana-sql/src/components/DatabaseSelector.tsx
@@ -1,0 +1,40 @@
+import { useAsync } from 'react-use';
+
+import { type SelectableValue, toOption } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Select } from '@grafana/ui';
+
+import { type DB, type ResourceSelectorProps } from '../types';
+
+export interface DatabaseSelectorProps extends ResourceSelectorProps {
+  db: DB;
+  database: string | undefined;
+  onChange: (v: SelectableValue) => void;
+  inputId?: string | undefined;
+}
+
+export const DatabaseSelector = ({ db, database, onChange, inputId }: DatabaseSelectorProps) => {
+  const state = useAsync(async () => {
+    if (!db.databases) {
+      return [];
+    }
+    const databases = await db.databases();
+    return databases.map(toOption);
+  }, []);
+
+  return (
+    <Select
+      aria-label={t('grafana-sql.components.database-selector.aria-label-database-selector', 'Database selector')}
+      inputId={inputId}
+      value={database ?? null}
+      options={state.value}
+      onChange={onChange}
+      disabled={state.loading}
+      isLoading={state.loading}
+      menuShouldPortal={true}
+      isClearable={true}
+      allowCustomValue={true}
+      placeholder={t('grafana-sql.components.database-selector.placeholder-default', 'Default')}
+    />
+  );
+};

--- a/packages/grafana-sql/src/components/DatasetSelector.tsx
+++ b/packages/grafana-sql/src/components/DatasetSelector.tsx
@@ -4,63 +4,54 @@ import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Select } from '@grafana/ui';
 
-import { type DB, type ResourceSelectorProps, type SQLDialect, toOption } from '../types';
+import { type DB, type ResourceSelectorProps, toOption } from '../types';
 
 export interface DatasetSelectorProps extends ResourceSelectorProps {
   db: DB;
   dataset: string | undefined;
+  database: string | undefined;
   preconfiguredDataset: string;
-  dialect: SQLDialect;
   onChange: (v: SelectableValue) => void;
   inputId?: string | undefined;
 }
 
 export const DatasetSelector = ({
   dataset,
+  database,
   db,
-  dialect,
   onChange,
   inputId,
   preconfiguredDataset,
 }: DatasetSelectorProps) => {
   /*
-    The behavior of this component - for MSSQL and MySQL datasources - is based on whether the user chose to create a datasource
-    with or without a default database (preconfiguredDataset). If the user configured a default database, this selector
-    should only allow that single preconfigured database option to be selected. If the user chose to NOT assign/configure a default database,
-    then the user should be able to use this component to choose between multiple databases available to the datasource.
+    The behavior of this component is based on whether the user chose to create a datasource
+    with or without a default database (preconfiguredDataset). If the user configured a default database,
+    this selector should only allow that single preconfigured database option to be selected.
+    If the user chose to NOT assign/configure a default database, then the user should be able to
+    use this component to choose between multiple databases available to the datasource.
   */
-  // `hasPreconfigCondition` is true if either 1) the sql datasource has a preconfigured default database,
-  // OR if 2) the datasource is Postgres. In either case the only option available to the user is the preconfigured database.
-  const hasPreconfigCondition = !!preconfiguredDataset || dialect === 'postgres';
+  const hasPreconfigCondition = !!preconfiguredDataset;
 
   const state = useAsync(async () => {
-    // If a default database is already configured for a MSSQL or MySQL data source, OR the data source is Postgres, no need to fetch other databases.
     if (hasPreconfigCondition) {
-      // Set the current database to the preconfigured database.
-      onChange(toOption(preconfiguredDataset));
       return [toOption(preconfiguredDataset)];
     }
 
-    // If there is no preconfigured database, but there is a selected dataset, set the current database to the selected dataset.
-    if (dataset) {
-      onChange(toOption(dataset));
-    }
-
-    // Otherwise, fetch all databases available to the datasource.
-    const datasets = await db.datasets();
+    const datasets = await db.datasets(database);
     return datasets.map(toOption);
-  }, []);
+  }, [database]);
 
   return (
     <Select
       aria-label={t('grafana-sql.components.dataset-selector.aria-label-dataset-selector', 'Dataset selector')}
       inputId={inputId}
-      value={dataset}
+      value={dataset ?? null}
       options={state.value}
       onChange={onChange}
       disabled={state.loading}
       isLoading={state.loading}
       menuShouldPortal={true}
+      isClearable={true}
     />
   );
 };

--- a/packages/grafana-sql/src/components/QueryHeader.tsx
+++ b/packages/grafana-sql/src/components/QueryHeader.tsx
@@ -20,6 +20,7 @@ import {
 } from '../types';
 
 import { ConfirmModal } from './ConfirmModal';
+import { DatabaseSelector } from './DatabaseSelector';
 import { DatasetSelector } from './DatasetSelector';
 import { TableSelector } from './TableSelector';
 
@@ -103,14 +104,21 @@ export function QueryHeader({
     onChange(next);
   };
 
-  const onDatasetChange = (e: SelectableValue) => {
-    if (e.value === query.dataset) {
+  const onDatabaseChange = (e: SelectableValue | null) => {
+    const value = e?.value ?? undefined;
+    if (value === query.database) {
       return;
     }
 
-    const next = {
+    if (editorMode === EditorMode.Code) {
+      onChange({ ...query, database: value });
+      return;
+    }
+
+    const next: SQLQuery = {
       ...query,
-      dataset: e.value,
+      database: value,
+      dataset: undefined,
       table: undefined,
       sql: undefined,
       rawSql: '',
@@ -119,14 +127,32 @@ export function QueryHeader({
     onChange(next);
   };
 
-  const onTableChange = (e: SelectableValue) => {
-    if (e.value === query.table) {
+  const onDatasetChange = (e: SelectableValue | null) => {
+    const value = e?.value ?? undefined;
+    if (value === query.dataset) {
+      return;
+    }
+
+    const next = {
+      ...query,
+      dataset: value,
+      table: undefined,
+      sql: undefined,
+      rawSql: '',
+    };
+
+    onChange(next);
+  };
+
+  const onTableChange = (e: SelectableValue | null) => {
+    const value = e?.value ?? undefined;
+    if (value === query.table) {
       return;
     }
 
     const next: SQLQuery = {
       ...query,
-      table: e.value,
+      table: value,
       sql: undefined,
       rawSql: '',
     };
@@ -323,18 +349,44 @@ export function QueryHeader({
         />
       </EditorHeader>
 
+      {editorMode === EditorMode.Code && !!db.databases && (
+        <>
+          <Space v={0.5} />
+          <EditorRow>
+            <EditorField label={db.labels?.get('database') ?? t('grafana-sql.components.query-header.label-database', 'Database')} width={25}>
+              <DatabaseSelector
+                db={db}
+                inputId={`sql-database-${htmlId}`}
+                database={query.database}
+                onChange={onDatabaseChange}
+              />
+            </EditorField>
+          </EditorRow>
+        </>
+      )}
+
       {editorMode === EditorMode.Builder && (
         <>
           <Space v={0.5} />
           <EditorRow>
+            {!!db.databases && (
+              <EditorField label={db.labels?.get('database') ?? t('grafana-sql.components.query-header.label-database', 'Database')} width={25}>
+                <DatabaseSelector
+                  db={db}
+                  inputId={`sql-database-${htmlId}`}
+                  database={query.database}
+                  onChange={onDatabaseChange}
+                />
+              </EditorField>
+            )}
             {datasetDropdownIsAvailable() && (
-              <EditorField label={t('grafana-sql.components.query-header.label-dataset', 'Dataset')} width={25}>
+              <EditorField label={db.labels?.get('dataset') ?? t('grafana-sql.components.query-header.label-dataset', 'Dataset')} width={25}>
                 <DatasetSelector
                   db={db}
                   inputId={`sql-dataset-${htmlId}`}
                   dataset={query.dataset}
-                  dialect={dialect}
-                  preconfiguredDataset={preconfiguredDataset}
+                  database={query.database}
+                  preconfiguredDataset={(db.databases || dialect === 'postgres') ? '' : preconfiguredDataset}
                   onChange={onDatasetChange}
                 />
               </EditorField>
@@ -343,7 +395,8 @@ export function QueryHeader({
               <TableSelector
                 db={db}
                 inputId={`sql-tableselect-${htmlId}`}
-                dataset={query.dataset || preconfiguredDataset}
+                dataset={query.dataset || ((db.databases || dialect === 'postgres') ? undefined : preconfiguredDataset)}
+                database={query.database}
                 table={query.table}
                 onChange={onTableChange}
               />

--- a/packages/grafana-sql/src/components/SqlComponents.test.tsx
+++ b/packages/grafana-sql/src/components/SqlComponents.test.tsx
@@ -18,12 +18,12 @@ describe('DatasetSelector', () => {
     });
   });
 
-  it('should not query the database if Postgres instance, and no preconfigured database', async () => {
-    const mockProps = buildMockDatasetSelectorProps({ dialect: 'postgres' });
+  it('should query datasets for Postgres instance when no preconfigured database', async () => {
+    const mockProps = buildMockDatasetSelectorProps();
     render(<DatasetSelector {...mockProps} />);
 
     await waitFor(() => {
-      expect(mockProps.db.datasets).not.toHaveBeenCalled();
+      expect(mockProps.db.datasets).toHaveBeenCalled();
     });
   });
 

--- a/packages/grafana-sql/src/components/SqlComponents.testHelpers.ts
+++ b/packages/grafana-sql/src/components/SqlComponents.testHelpers.ts
@@ -21,7 +21,7 @@ export function buildMockDatasetSelectorProps(overrides?: Partial<DatasetSelecto
   return {
     db: buildMockDB(),
     dataset: '',
-    dialect: 'other',
+    database: undefined,
     onChange: jest.fn(),
     preconfiguredDataset: '',
     ...overrides,

--- a/packages/grafana-sql/src/components/TableSelector.tsx
+++ b/packages/grafana-sql/src/components/TableSelector.tsx
@@ -11,20 +11,21 @@ export interface TableSelectorProps extends ResourceSelectorProps {
   db: DB;
   table: string | undefined;
   dataset: string | undefined;
+  database?: string | undefined;
   onChange: (v: SelectableValue) => void;
   inputId?: string | undefined;
 }
 
-export const TableSelector = ({ db, dataset, table, className, onChange, inputId }: TableSelectorProps) => {
+export const TableSelector = ({ db, dataset, database, table, className, onChange, inputId }: TableSelectorProps) => {
   const state = useAsync(async () => {
     // No need to attempt to fetch tables for an unknown dataset.
     if (!dataset) {
       return [];
     }
 
-    const tables = await db.tables(dataset);
+    const tables = await db.tables(dataset, database);
     return tables.map(toOption);
-  }, [dataset]);
+  }, [dataset, database]);
 
   return (
     <Select
@@ -33,11 +34,12 @@ export const TableSelector = ({ db, dataset, table, className, onChange, inputId
       aria-label={t('grafana-sql.components.table-selector.aria-label-table-selector', 'Table selector')}
       inputId={inputId}
       data-testid={selectors.components.SQLQueryEditor.headerTableSelector}
-      value={table}
+      value={table ?? null}
       options={state.value}
       onChange={onChange}
       isLoading={state.loading}
       menuShouldPortal={true}
+      isClearable={true}
       placeholder={
         state.loading
           ? t('grafana-sql.components.table-selector.placeholder-loading', 'Loading tables')

--- a/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
@@ -22,7 +22,7 @@ export const VisualEditor = ({ query, db, queryRowFilter, onChange, onValidate, 
   const state = useAsync(async () => {
     const fields = await db.fields(query);
     return fields;
-  }, [db, query.dataset, query.table]);
+  }, [db, query.database, query.dataset, query.table]);
 
   return (
     <>

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -121,6 +121,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       datasource: this.getRef(),
       rawSql: this.templateSrv.replace(target.rawSql, scopedVars, this.interpolateVariable),
       format: target.format,
+      database: target.database ? this.templateSrv.replace(target.database, scopedVars) : undefined,
     };
   }
 
@@ -150,15 +151,13 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   }
 
   private checkForDatabaseIssue(request: DataQueryRequest<SQLQuery>) {
-    // If the datasource is Postgres and there is no default database configured - either never configured or removed - return a database issue.
-    if (this.type === 'grafana-postgresql-datasource' && !this.preconfiguredDatabase) {
-      return `You do not currently have a default database configured for this data source. Postgres requires a default
-             database with which to connect. Please configure one through the Data Sources Configuration page, or if you
-             are using a provisioning file, update that configuration file with a default database.`;
-    }
-
     // No need to check for database change/update issues if the datasource is being used in Explore.
     if (request.app !== CoreApp.Explore) {
+      // Skip this check for datasources that support multi-database via an explicit database selector.
+      if (this.db.databases) {
+        return;
+      }
+
       /*
         If a preconfigured datasource database has been added/updated - and the user has built ANY number of queries using a
         database OTHER than the preconfigured one, return a database issue - since those databases are no longer available.
@@ -224,7 +223,10 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   // NOTE: this always runs with the `@grafana/data/getDefaultTimeRange` time range
   async runSql<T extends object>(query: string, options?: RunSQLOptions) {
     const range = getDefaultTimeRange();
-    const frame = await this.runMetaQuery({ rawSql: query, format: QueryFormat.Table, refId: options?.refId }, range);
+    const frame = await this.runMetaQuery(
+      { rawSql: query, format: QueryFormat.Table, refId: options?.refId, database: options?.database },
+      range
+    );
     return new DataFrameView<T>(frame);
   }
 
@@ -265,4 +267,5 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
 
 interface RunSQLOptions extends LegacyMetricFindQueryOptions {
   refId?: string;
+  database?: string;
 }

--- a/packages/grafana-sql/src/types.ts
+++ b/packages/grafana-sql/src/types.ts
@@ -47,6 +47,7 @@ export interface SQLQuery extends DataQuery {
   alias?: string;
   format?: QueryFormat;
   rawSql?: string;
+  database?: string;
   dataset?: string;
   table?: string;
   sql?: SQLExpression;
@@ -108,8 +109,9 @@ export interface SQLSelectableValue extends SelectableValue {
 
 export interface DB {
   init?: (datasourceId?: string) => Promise<boolean>;
-  datasets: () => Promise<string[]>;
-  tables: (dataset?: string) => Promise<string[]>;
+  databases?: () => Promise<string[]>;
+  datasets: (database?: string) => Promise<string[]>;
+  tables: (dataset?: string, database?: string) => Promise<string[]>;
   fields: (query: SQLQuery, order?: boolean) => Promise<SQLSelectableValue[]>;
   validateQuery: (query: SQLQuery, range?: TimeRange) => Promise<ValidationResults>;
   dispose?: (dsID?: string) => void;
@@ -117,6 +119,7 @@ export interface DB {
   getEditorLanguageDefinition: () => LanguageDefinition;
   toRawSql: (query: SQLQuery) => string;
   functions: () => Func[];
+  labels?: Map<string, string>;
 }
 
 export interface FuncParameter {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a companion PR to support multi-database functionality in the grafana-postgresql-datasource plugin. Please see the PR in that repo for more context and screenshots: https://github.com/grafana/grafana-postgresql-datasource/pull/166.

Essentially, this extends the `@grafana/sql` interface to support the multi-database feature implemented there. 

All changes here should be backward compatible.


   - Added optional databases field to DB interface — when present, a database selector dropdown is rendered in the query editor
  - datasets() and tables() now accept an optional database parameter for cross-database queries
  - Added database?: string to SQLQuery to persist the selected database per query
  - New DatabaseSelector component, rendered in both Code and Builder modes when opted in
  - Changing database in Builder mode cascades (clears dataset/table/sql); in Code mode it only updates the routing
  - Added optional labels map to DB for custom UI labels (e.g. "Schema" instead of "Dataset")

**Why do we need this feature?**

A postgres server can have multiple databases; users are defined globally, and the same user can potentially connect to and query multiple databases on the same server.

If I have a postgres server with hundreds of databases, this means I need to create a separate Grafana data source for each one, even if a single set of credentials can access them all. This results in burdensome administrative workflows for shared server environments with respect to making databases available in grafana to query, and with respect to password rotation.

This change allows creating one data source that can query any database on the postgres server that the user has access to.

It was possible to do this entirely in the grafana-postgresql-datasource repo, but required some DOM manipulation that was very brittle to work around the limitations of the `@grafana/sql` library. Instead, I've chosen to extend the interface to produce a more robust implementation.

**Who is this feature for?**

Administrators of shared Postgres database servers that host many databases.

**Which issue(s) does this PR fix?**:

None that I know of in this repo.

Please see the post in the grafana community where I initially proposed the idea: https://community.grafana.com/t/overriding-database-field-in-panel-editor/164250

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**AI Disclosure**

AI was used to aid in the development of this feature.