### PR TITLE
Tooltip: Add instrumentation for assistant button

### DIFF
--- a/public/app/core/components/AssistantTooltip/AssistantTooltipButton.tsx
+++ b/public/app/core/components/AssistantTooltip/AssistantTooltipButton.tsx
@@ -1,8 +1,9 @@
 import { css } from '@emotion/css';
 
 import { ASSISTANT_PLUGIN_ID, useAssistant } from '@grafana/assistant';
-import { type DataFrame, type GrafanaTheme2, type InterpolateFunction, store } from '@grafana/data';
+import { type DataFrame, type GrafanaTheme2, type InterpolateFunction, store, usePluginContext } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { Button, useStyles2 } from '@grafana/ui';
 import {
   getComponentMetaFromComponentId,
@@ -40,6 +41,7 @@ export function AssistantTooltipButton({
   const { isAvailable, openAssistant } = useAssistant();
   const { isOpen, dockedComponentId } = useExtensionSidebarContext();
   const { fullscreenWorkspaceActive } = useFullscreenWorkspace();
+  const pluginContext = usePluginContext();
   const styles = useStyles2(getStyles);
 
   if (!isAvailable || !openAssistant) {
@@ -65,6 +67,10 @@ export function AssistantTooltipButton({
     if (items.length === 0) {
       return;
     }
+
+    reportInteraction('grafana_tooltip_add_to_assistant_clicked', {
+      visualizationType: pluginContext?.meta?.id ?? 'unknown',
+    });
 
     openAssistant({
       origin: 'grafana/panel-tooltip',


### PR DESCRIPTION
This PR adds instrumentation for when clicking on the "Send to Assistant" button. The event is `grafana_tooltip_add_to_assistant_clicked`.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
