### PR TITLE
Alerting: Sort data query in refID order

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -462,7 +462,13 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.AlertRule) (*ngmodels.
 	}
 	domainRule.IntervalSeconds = int64(time.Duration(interval).Seconds())
 
-	for refID, expression := range k8sRule.Spec.Expressions {
+	refIDs := make([]string, 0, len(k8sRule.Spec.Expressions))
+	for refID := range k8sRule.Spec.Expressions {
+		refIDs = append(refIDs, refID)
+	}
+	slices.Sort(refIDs)
+	for _, refID := range refIDs {
+		expression := k8sRule.Spec.Expressions[refID]
 		domainQuery, err := convertToDomainQuery(expression, refID)
 		if err != nil {
 			return nil, err

--- a/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat_test.go
@@ -83,6 +83,29 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
 
+func TestExpressionsConvertToDomainInRefIDOrder(t *testing.T) {
+	rule := ngmodels.RuleGen.With(ngmodels.RuleGen.WithOrgID(1)).GenerateRef()
+	rule.Record = nil
+	query := rule.Data[0]
+	refIDs := []string{"H", "G", "F", "E", "D", "C", "B", "A"}
+	rule.Data = make([]ngmodels.AlertQuery, 0, len(refIDs))
+	for _, refID := range refIDs {
+		q := query
+		q.RefID = refID
+		rule.Data = append(rule.Data, q)
+	}
+	rule.Condition = "D"
+
+	k8sRule, err := convertToK8sResource(1, rule, utils.ManagerProperties{}, nsMapperForTest())
+	require.NoError(t, err)
+
+	domainRule, _, err := convertToDomainModel(1, k8sRule)
+	require.NoError(t, err)
+	for i, refID := range []string{"A", "B", "C", "D", "E", "F", "G", "H"} {
+		assert.Equal(t, refID, domainRule.Data[i].RefID)
+	}
+}
+
 func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
 	mapper := nsMapperForTest()
 	gen := ngmodels.RuleGen

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat.go
@@ -307,7 +307,13 @@ func convertToBaseDomainModel(orgID int64, k8sRule *model.RecordingRule) (*ngmod
 	for k, v := range k8sRule.Spec.Labels {
 		domainRule.Labels[k] = string(v)
 	}
-	for refID, expression := range k8sRule.Spec.Expressions {
+	refIDs := make([]string, 0, len(k8sRule.Spec.Expressions))
+	for refID := range k8sRule.Spec.Expressions {
+		refIDs = append(refIDs, refID)
+	}
+	slices.Sort(refIDs)
+	for _, refID := range refIDs {
+		expression := k8sRule.Spec.Expressions[refID]
 		domainQuery, err := convertToDomainQuery(expression, refID)
 		if err != nil {
 			return nil, err

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat_test.go
@@ -76,6 +76,28 @@ func TestConvertDeletedToK8sResources(t *testing.T) {
 	require.NotNil(t, got.DeletionTimestamp, "deleted rule should carry a deletion timestamp")
 }
 
+func TestExpressionsConvertToDomainInRefIDOrder(t *testing.T) {
+	rule := ngmodels.RuleGen.With(ngmodels.RuleGen.WithOrgID(1), ngmodels.RuleGen.WithAllRecordingRules()).GenerateRef()
+	query := rule.Data[0]
+	refIDs := []string{"H", "G", "F", "E", "D", "C", "B", "A"}
+	rule.Data = make([]ngmodels.AlertQuery, 0, len(refIDs))
+	for _, refID := range refIDs {
+		q := query
+		q.RefID = refID
+		rule.Data = append(rule.Data, q)
+	}
+	rule.Record.From = "D"
+
+	k8sRule, err := convertToK8sResource(1, rule, utils.ManagerProperties{}, nsMapperForTest())
+	require.NoError(t, err)
+
+	domainRule, _, err := convertToDomainModel(1, k8sRule)
+	require.NoError(t, err)
+	for i, refID := range []string{"A", "B", "C", "D", "E", "F", "G", "H"} {
+		assert.Equal(t, refID, domainRule.Data[i].RefID)
+	}
+}
+
 func TestPrometheusRuleDefinitionRoundTrip(t *testing.T) {
 	mapper := nsMapperForTest()
 	gen := ngmodels.RuleGen


### PR DESCRIPTION
The app-platform rule API uses map for query struct. On the back end we store it as array, and therefore legacy version APIs detect diff for even noop requests. 

This PR changes compat layer to sort the expressions by refID before converting to list, which makes it a bit more consistent. 