### PR TITLE
grafana-router: add group helper

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -172,6 +172,17 @@ func groupFromPath(path string) string {
 	return rest
 }
 
+// GroupFromPath is the exported form of groupFromPath.
+// Returns "" for anything not under /apis/<group>,
+// including the bare /apis root -- there is no single group to attribute a
+// root-discovery or non-/apis request to.
+func GroupFromPath(path string) string {
+	if path == apisPrefix || path == apisPrefix+"/" || (path != apisPrefix && !strings.HasPrefix(path, apisPrefix+"/")) {
+		return ""
+	}
+	return groupFromPath(path)
+}
+
 // serveAPIGroupList synthesizes the /apis root (APIGroupList) from the current
 // group snapshot.
 func (cr *GrafanaRouter) serveAPIGroupList(w http.ResponseWriter, req *http.Request) {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -183,6 +183,17 @@ func GroupFromPath(path string) string {
 	return groupFromPath(path)
 }
 
+// KnownGroup reports whether group has a live backend in the current
+// snapshot. group is otherwise an arbitrary, client-controlled path segment
+// (see GroupFromPath) -- callers that turn it into metric label values must
+// check this first, or an attacker/typo/scan against /apis/<anything> mints a
+// new label (and, for native histograms, a new series) per unique string.
+func (cr *GrafanaRouter) KnownGroup(group string) bool {
+	handlers := *cr.snapshot.Load()
+	_, ok := handlers[group]
+	return ok
+}
+
 // serveAPIGroupList synthesizes the /apis root (APIGroupList) from the current
 // group snapshot.
 func (cr *GrafanaRouter) serveAPIGroupList(w http.ResponseWriter, req *http.Request) {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -135,6 +135,53 @@ func TestServeRootDocsWithETag(t *testing.T) {
 	}
 }
 
+func TestGroupFromPath(t *testing.T) {
+	cases := []struct {
+		path      string
+		wantGroup string
+	}{
+		{"/apis/dashboard.grafana.app", "dashboard.grafana.app"},
+		{"/apis/dashboard.grafana.app/v1alpha1/dashboards", "dashboard.grafana.app"},
+		{"/apis/dashboard.grafana.app/", "dashboard.grafana.app"},
+		// no single group to attribute the bare /apis root to
+		{"/apis", ""},
+		{"/apis/", ""},
+		// not under /apis at all
+		{"/openapi/v3", ""},
+		{"/healthz", ""},
+		{"", ""},
+		// prefix collision, not a real /apis boundary
+		{"/apisfoo", ""},
+		// arbitrary, client-controlled -- GroupFromPath doesn't validate
+		// against known backends, callers must check KnownGroup themselves
+		{"/apis/whatever-a-client-sends", "whatever-a-client-sends"},
+	}
+	for _, tc := range cases {
+		if got := GroupFromPath(tc.path); got != tc.wantGroup {
+			t.Errorf("GroupFromPath(%q) = %q, want %q", tc.path, got, tc.wantGroup)
+		}
+	}
+}
+
+func TestKnownGroup(t *testing.T) {
+	s := withGroups("dashboard.grafana.app", "folder.grafana.app")
+
+	cases := []struct {
+		group string
+		want  bool
+	}{
+		{"dashboard.grafana.app", true},
+		{"folder.grafana.app", true},
+		{"unknown.grafana.app", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := s.KnownGroup(tc.group); got != tc.want {
+			t.Errorf("KnownGroup(%q) = %v, want %v", tc.group, got, tc.want)
+		}
+	}
+}
+
 func TestParseOpenAPIGroupVersionPath(t *testing.T) {
 	cases := []struct {
 		path        string


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a couple of helpers so the group parsing logic can be used from enterprise, as well as known groups can be determined.

**Why do we need this feature?**

Code reuse

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
