### PR TITLE
Library panels: Enforce write authorization across storage modes

### DIFF
--- a/pkg/registry/apis/dashboard/library_panel_access_storage.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage.go
@@ -45,9 +45,25 @@ type libraryPanelAccessStorage struct {
 }
 
 var (
-	_ rest.StandardStorage = (*libraryPanelAccessStorage)(nil)
-	_ rest.TableConvertor  = (*libraryPanelAccessStorage)(nil)
+	_ libraryPanelStorage    = (*libraryPanelAccessStorage)(nil)
+	_ rest.TableConvertor    = (*libraryPanelAccessStorage)(nil)
+	_ rest.Watcher           = (*libraryPanelAccessStorageWithWatch)(nil)
+	_ rest.CollectionDeleter = (*libraryPanelAccessStorageWithDeleteCollection)(nil)
 )
+
+type libraryPanelAccessStorageWithWatch struct {
+	*libraryPanelAccessStorage
+	watcher rest.Watcher
+}
+
+type libraryPanelAccessStorageWithDeleteCollection struct {
+	*libraryPanelAccessStorage
+}
+
+type libraryPanelAccessStorageWithWatchAndDeleteCollection struct {
+	*libraryPanelAccessStorageWithDeleteCollection
+	watcher rest.Watcher
+}
 
 func newLibraryPanelAccessStorage(
 	store libraryPanelStorage,
@@ -55,9 +71,9 @@ func newLibraryPanelAccessStorage(
 	authorizeUpdate libraryPanelUpdateAuthorizer,
 	validateDelete libraryPanelDeleteValidator,
 	validateFolder libraryPanelFolderValidator,
-) *libraryPanelAccessStorage {
+) libraryPanelStorage {
 	table, _ := store.(rest.TableConvertor)
-	return &libraryPanelAccessStorage{
+	storage := &libraryPanelAccessStorage{
 		store:           store,
 		table:           table,
 		resource:        schema.GroupResource{Group: "dashboard.grafana.app", Resource: "librarypanels"},
@@ -66,6 +82,25 @@ func newLibraryPanelAccessStorage(
 		validateDelete:  validateDelete,
 		validateFolder:  validateFolder,
 	}
+	watcher, canWatch := store.(rest.Watcher)
+	_, canDeleteCollection := store.(rest.CollectionDeleter)
+	switch {
+	case canWatch && canDeleteCollection:
+		return &libraryPanelAccessStorageWithWatchAndDeleteCollection{
+			libraryPanelAccessStorageWithDeleteCollection: &libraryPanelAccessStorageWithDeleteCollection{
+				libraryPanelAccessStorage: storage,
+			},
+			watcher: watcher,
+		}
+	case canWatch:
+		return &libraryPanelAccessStorageWithWatch{
+			libraryPanelAccessStorage: storage,
+			watcher:                   watcher,
+		}
+	case canDeleteCollection:
+		return &libraryPanelAccessStorageWithDeleteCollection{libraryPanelAccessStorage: storage}
+	}
+	return storage
 }
 
 func (s *libraryPanelAccessStorage) New() runtime.Object     { return s.store.New() }
@@ -91,12 +126,12 @@ func (s *libraryPanelAccessStorage) List(ctx context.Context, options *metainter
 	return s.store.List(ctx, options)
 }
 
-func (s *libraryPanelAccessStorage) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	watcher, ok := s.store.(rest.Watcher)
-	if !ok {
-		return nil, apierrors.NewMethodNotSupported(s.resource, "watch")
-	}
-	return watcher.Watch(ctx, options)
+func (s *libraryPanelAccessStorageWithWatch) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	return s.watcher.Watch(ctx, options)
+}
+
+func (s *libraryPanelAccessStorageWithWatchAndDeleteCollection) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	return s.watcher.Watch(ctx, options)
 }
 
 func (s *libraryPanelAccessStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
@@ -162,6 +197,6 @@ func (s *libraryPanelAccessStorage) Delete(ctx context.Context, name string, del
 	return s.store.Delete(ctx, name, deleteValidation, options)
 }
 
-func (s *libraryPanelAccessStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *metainternalversion.ListOptions) (runtime.Object, error) {
+func (s *libraryPanelAccessStorageWithDeleteCollection) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *metainternalversion.ListOptions) (runtime.Object, error) {
 	return nil, apierrors.NewMethodNotSupported(s.resource, "deletecollection")
 }

--- a/pkg/registry/apis/dashboard/library_panel_access_storage.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage.go
@@ -12,6 +12,7 @@ import (
 	requestcontext "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
@@ -184,14 +185,20 @@ func (s *libraryPanelAccessStorage) Update(ctx context.Context, name string, obj
 }
 
 func (s *libraryPanelAccessStorage) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	obj, err := s.store.Get(ctx, name, &metav1.GetOptions{})
+	namespace := requestcontext.NamespaceValue(ctx)
+	// The lookup only materializes the panel's authorization target. In legacy
+	// storage, Get applies the independent read permission, but delete must remain
+	// available to roles that grant delete without read. Use a namespace-scoped
+	// service identity for the lookup, then authorize and delete as the caller.
+	lookupCtx := identity.WithServiceIdentityForSingleNamespaceContext(ctx, namespace)
+	obj, err := s.store.Get(lookupCtx, name, &metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
-	if err := s.authorize(ctx, obj, utils.VerbDelete, requestcontext.NamespaceValue(ctx)); err != nil {
+	if err := s.authorize(ctx, obj, utils.VerbDelete, namespace); err != nil {
 		return nil, false, err
 	}
-	if err := s.validateDelete(ctx, name, requestcontext.NamespaceValue(ctx)); err != nil {
+	if err := s.validateDelete(ctx, name, namespace); err != nil {
 		return nil, false, err
 	}
 	return s.store.Delete(ctx, name, deleteValidation, options)

--- a/pkg/registry/apis/dashboard/library_panel_access_storage.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage.go
@@ -21,13 +21,21 @@ type libraryPanelUpdateAuthorizer func(ctx context.Context, oldObj, newObj runti
 type libraryPanelDeleteValidator func(ctx context.Context, name, namespace string) error
 type libraryPanelFolderValidator func(ctx context.Context, obj runtime.Object) error
 
-// libraryPanelAccessStorage enforces writes at the standalone storage boundary.
-// Standalone app-platform API servers do not reliably populate old objects for
+type libraryPanelStorage interface {
+	rest.Storage
+	rest.Getter
+	rest.Lister
+	rest.CreaterUpdater
+	rest.GracefulDeleter
+}
+
+// libraryPanelAccessStorage enforces writes at the storage boundary.
+// App-platform API servers do not reliably populate old objects for
 // update/delete admission, so admission alone can otherwise allow those writes.
 // Materializing UpdatedObjectInfo here also gives PATCH the existing object it
 // needs before the unified store performs the update.
 type libraryPanelAccessStorage struct {
-	store           rest.StandardStorage
+	store           libraryPanelStorage
 	table           rest.TableConvertor
 	resource        schema.GroupResource
 	authorize       libraryPanelAuthorizer
@@ -42,7 +50,7 @@ var (
 )
 
 func newLibraryPanelAccessStorage(
-	store rest.StandardStorage,
+	store libraryPanelStorage,
 	authorize libraryPanelAuthorizer,
 	authorizeUpdate libraryPanelUpdateAuthorizer,
 	validateDelete libraryPanelDeleteValidator,
@@ -84,7 +92,11 @@ func (s *libraryPanelAccessStorage) List(ctx context.Context, options *metainter
 }
 
 func (s *libraryPanelAccessStorage) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	return s.store.Watch(ctx, options)
+	watcher, ok := s.store.(rest.Watcher)
+	if !ok {
+		return nil, apierrors.NewMethodNotSupported(s.resource, "watch")
+	}
+	return watcher.Watch(ctx, options)
 }
 
 func (s *libraryPanelAccessStorage) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {

--- a/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	requestcontext "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
@@ -59,7 +61,7 @@ func TestLibraryPanelAccessStorageMaterializesAndAuthorizesUpdate(t *testing.T) 
 	require.Equal(t, "patched", description)
 }
 
-func TestLibraryPanelAccessStorageRejectsDeniedUpdateAndDelete(t *testing.T) {
+func TestLibraryPanelAccessStorageRejectsDeniedWrites(t *testing.T) {
 	panel := testLibraryPanel("panel-a", "general")
 	backend := &recordingLibraryPanelStorage{object: panel}
 	denied := apierrors.NewForbidden(
@@ -70,7 +72,7 @@ func TestLibraryPanelAccessStorageRejectsDeniedUpdateAndDelete(t *testing.T) {
 	storage := newLibraryPanelAccessStorage(
 		backend,
 		func(_ context.Context, _ runtime.Object, verb, _ string) error {
-			if verb == utils.VerbDelete {
+			if verb == utils.VerbCreate || verb == utils.VerbDelete {
 				return denied
 			}
 			return nil
@@ -80,7 +82,10 @@ func TestLibraryPanelAccessStorageRejectsDeniedUpdateAndDelete(t *testing.T) {
 		func(context.Context, runtime.Object) error { return nil },
 	)
 
-	_, _, err := storage.Update(context.Background(), panel.GetName(), rest.DefaultUpdatedObjectInfo(panel.DeepCopy()), nil, nil, false, &metav1.UpdateOptions{})
+	_, err := storage.Create(context.Background(), panel, nil, &metav1.CreateOptions{})
+	require.ErrorIs(t, err, denied)
+
+	_, _, err = storage.Update(context.Background(), panel.GetName(), rest.DefaultUpdatedObjectInfo(panel.DeepCopy()), nil, nil, false, &metav1.UpdateOptions{})
 	require.ErrorIs(t, err, denied)
 	require.False(t, backend.updateCalled)
 
@@ -149,11 +154,56 @@ func TestLibraryPanelAccessStorageValidatesDestinationFolder(t *testing.T) {
 	require.False(t, backend.updateCalled)
 }
 
+func TestLibraryPanelAccessStoragePreservesWatchSupport(t *testing.T) {
+	expected := watch.NewFake()
+	backend := &watchableLibraryPanelStorage{
+		nonWatchableLibraryPanelStorage: &nonWatchableLibraryPanelStorage{},
+		watcher:                         expected,
+	}
+	storage := newLibraryPanelAccessStorage(
+		backend,
+		func(context.Context, runtime.Object, string, string) error { return nil },
+		func(context.Context, runtime.Object, runtime.Object, string) error { return nil },
+		func(context.Context, string, string) error { return nil },
+		func(context.Context, runtime.Object) error { return nil },
+	)
+
+	actual, err := storage.Watch(context.Background(), &metainternalversion.ListOptions{})
+	require.NoError(t, err)
+	require.Same(t, expected, actual)
+}
+
+func TestLibraryPanelAccessStorageRejectsWatchWhenSelectedStorageCannotWatch(t *testing.T) {
+	storage := newLibraryPanelAccessStorage(
+		&nonWatchableLibraryPanelStorage{},
+		func(context.Context, runtime.Object, string, string) error { return nil },
+		func(context.Context, runtime.Object, runtime.Object, string) error { return nil },
+		func(context.Context, string, string) error { return nil },
+		func(context.Context, runtime.Object) error { return nil },
+	)
+
+	_, err := storage.Watch(context.Background(), &metainternalversion.ListOptions{})
+	require.True(t, apierrors.IsMethodNotSupported(err))
+}
+
 type recordingLibraryPanelStorage struct {
 	rest.StandardStorage
 	object       runtime.Object
 	updateCalled bool
 	deleteCalled bool
+}
+
+type nonWatchableLibraryPanelStorage struct {
+	libraryPanelStorage
+}
+
+type watchableLibraryPanelStorage struct {
+	*nonWatchableLibraryPanelStorage
+	watcher watch.Interface
+}
+
+func (s *watchableLibraryPanelStorage) Watch(context.Context, *metainternalversion.ListOptions) (watch.Interface, error) {
+	return s.watcher, nil
 }
 
 func (s *recordingLibraryPanelStorage) Get(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
@@ -168,12 +168,14 @@ func TestLibraryPanelAccessStoragePreservesWatchSupport(t *testing.T) {
 		func(context.Context, runtime.Object) error { return nil },
 	)
 
-	actual, err := storage.Watch(context.Background(), &metainternalversion.ListOptions{})
+	watcher, ok := storage.(rest.Watcher)
+	require.True(t, ok)
+	actual, err := watcher.Watch(context.Background(), &metainternalversion.ListOptions{})
 	require.NoError(t, err)
 	require.Same(t, expected, actual)
 }
 
-func TestLibraryPanelAccessStorageRejectsWatchWhenSelectedStorageCannotWatch(t *testing.T) {
+func TestLibraryPanelAccessStorageDoesNotAdvertiseWatchWhenSelectedStorageCannotWatch(t *testing.T) {
 	storage := newLibraryPanelAccessStorage(
 		&nonWatchableLibraryPanelStorage{},
 		func(context.Context, runtime.Object, string, string) error { return nil },
@@ -182,7 +184,24 @@ func TestLibraryPanelAccessStorageRejectsWatchWhenSelectedStorageCannotWatch(t *
 		func(context.Context, runtime.Object) error { return nil },
 	)
 
-	_, err := storage.Watch(context.Background(), &metainternalversion.ListOptions{})
+	_, ok := storage.(rest.Watcher)
+	require.False(t, ok)
+	_, ok = storage.(rest.CollectionDeleter)
+	require.False(t, ok)
+}
+
+func TestLibraryPanelAccessStoragePreservesDeleteCollectionCapability(t *testing.T) {
+	storage := newLibraryPanelAccessStorage(
+		&collectionDeletingLibraryPanelStorage{nonWatchableLibraryPanelStorage: &nonWatchableLibraryPanelStorage{}},
+		func(context.Context, runtime.Object, string, string) error { return nil },
+		func(context.Context, runtime.Object, runtime.Object, string) error { return nil },
+		func(context.Context, string, string) error { return nil },
+		func(context.Context, runtime.Object) error { return nil },
+	)
+
+	deleter, ok := storage.(rest.CollectionDeleter)
+	require.True(t, ok)
+	_, err := deleter.DeleteCollection(context.Background(), nil, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{})
 	require.True(t, apierrors.IsMethodNotSupported(err))
 }
 
@@ -200,6 +219,14 @@ type nonWatchableLibraryPanelStorage struct {
 type watchableLibraryPanelStorage struct {
 	*nonWatchableLibraryPanelStorage
 	watcher watch.Interface
+}
+
+type collectionDeletingLibraryPanelStorage struct {
+	*nonWatchableLibraryPanelStorage
+}
+
+func (s *collectionDeletingLibraryPanelStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *metainternalversion.ListOptions) (runtime.Object, error) {
+	return nil, nil
 }
 
 func (s *watchableLibraryPanelStorage) Watch(context.Context, *metainternalversion.ListOptions) (watch.Interface, error) {

--- a/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
+++ b/pkg/registry/apis/dashboard/library_panel_access_storage_test.go
@@ -16,6 +16,7 @@ import (
 	requestcontext "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
@@ -123,6 +124,36 @@ func TestLibraryPanelAccessStorageRejectsConnectedDelete(t *testing.T) {
 	require.False(t, backend.deleteCalled)
 }
 
+func TestLibraryPanelAccessStorageDeleteLookupDoesNotRequireCallerReadAccess(t *testing.T) {
+	panel := testLibraryPanel("panel-a", "general")
+	backend := &deleteOnlyLibraryPanelStorage{
+		recordingLibraryPanelStorage: &recordingLibraryPanelStorage{object: panel},
+	}
+	var authorizeUsedCaller bool
+	storage := newLibraryPanelAccessStorage(
+		backend,
+		func(ctx context.Context, obj runtime.Object, verb, namespace string) error {
+			authorizeUsedCaller = !identity.IsServiceIdentity(ctx)
+			require.Same(t, panel, obj)
+			require.Equal(t, utils.VerbDelete, verb)
+			require.Equal(t, "stacks-1", namespace)
+			return nil
+		},
+		func(context.Context, runtime.Object, runtime.Object, string) error { return nil },
+		func(context.Context, string, string) error { return nil },
+		func(context.Context, runtime.Object) error { return nil },
+	)
+
+	ctx := requestcontext.WithNamespace(context.Background(), "stacks-1")
+	ctx = identity.WithRequester(ctx, &identity.StaticRequester{OrgID: 1})
+	_, deleted, err := storage.Delete(ctx, panel.GetName(), nil, &metav1.DeleteOptions{})
+	require.NoError(t, err)
+	require.True(t, deleted)
+	require.True(t, backend.lookupUsedServiceIdentity)
+	require.True(t, authorizeUsedCaller)
+	require.True(t, backend.deleteCalled)
+}
+
 func TestLibraryPanelAccessStorageValidatesDestinationFolder(t *testing.T) {
 	oldPanel := testLibraryPanel("panel-a", "source")
 	backend := &recordingLibraryPanelStorage{object: oldPanel}
@@ -225,12 +256,25 @@ type collectionDeletingLibraryPanelStorage struct {
 	*nonWatchableLibraryPanelStorage
 }
 
+type deleteOnlyLibraryPanelStorage struct {
+	*recordingLibraryPanelStorage
+	lookupUsedServiceIdentity bool
+}
+
 func (s *collectionDeletingLibraryPanelStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *metainternalversion.ListOptions) (runtime.Object, error) {
 	return nil, nil
 }
 
 func (s *watchableLibraryPanelStorage) Watch(context.Context, *metainternalversion.ListOptions) (watch.Interface, error) {
 	return s.watcher, nil
+}
+
+func (s *deleteOnlyLibraryPanelStorage) Get(ctx context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	s.lookupUsedServiceIdentity = identity.IsServiceIdentity(ctx)
+	if !s.lookupUsedServiceIdentity {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "librarypanels"}, "panel-a")
+	}
+	return s.object, nil
 }
 
 func (s *recordingLibraryPanelStorage) Get(context.Context, string, *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1287,10 +1287,19 @@ func (b *DashboardsAPIBuilder) storageForVersion(
 			return err
 		}
 		libraryGr := libraryPanels.GroupResource()
-		storage[libraryPanels.StoragePath()], err = opts.DualWriteBuilder(libraryGr, legacyLibraryStore, unifiedLibraryStore)
+		libraryStorage, err := opts.DualWriteBuilder(libraryGr, legacyLibraryStore, unifiedLibraryStore)
 		if err != nil {
 			return err
 		}
+		// The Kubernetes API bypasses the legacy HTTP route's write guard. Wrap the
+		// mode-selected store so authorization remains enforced in every migration mode.
+		storage[libraryPanels.StoragePath()] = newLibraryPanelAccessStorage(
+			libraryStorage,
+			b.authorizeLibraryPanel,
+			b.authorizeLibraryPanelUpdate,
+			b.validateLibraryPanelDelete,
+			b.validateLibraryPanelFolder,
+		)
 	}
 
 	// Snapshots - only v0alpha1

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -548,6 +548,9 @@ func (b *DashboardsAPIBuilder) validateLibraryPanelDelete(ctx context.Context, n
 }
 
 func (b *DashboardsAPIBuilder) validateLibraryPanelFolder(ctx context.Context, obj runtime.Object) error {
+	if auth, ok := authlib.AuthInfoFrom(ctx); ok && identity.IsProvisioningServiceIdentity(auth) {
+		return nil
+	}
 	_, folderUID, err := libraryPanelAuthorizationTarget(obj)
 	if err != nil {
 		return err

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -14,9 +14,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
 
+	dashinternal "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration"
@@ -24,9 +29,11 @@ import (
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	apiserverbuilder "github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
@@ -307,6 +314,71 @@ func TestDashboardAPIBuilder_StandaloneLibraryPanelAdmissionEnforcesAccess(t *te
 				Name:      "panel-a",
 			}, gotRequest)
 			require.Equal(t, tt.expectedFolder, gotFolder)
+		})
+	}
+}
+
+func TestDashboardAPIBuilder_EmbeddedLibraryPanelFinalStorageKeepsAccessBoundary(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, dashv0.AddToScheme(scheme))
+	codecs := serializer.NewCodecFactory(scheme)
+	optsGetter, err := apistore.NewRESTOptionsGetterMemory(storagebackend.Config{
+		Codec: codecs.LegacyCodec(dashv0.LibraryPanelResourceInfo.GroupVersion()),
+	}, nil)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		selectStorage func(legacy, unified grafanarest.Storage) grafanarest.Storage
+	}{
+		{
+			name: "legacy storage selected",
+			selectStorage: func(legacy, _ grafanarest.Storage) grafanarest.Storage {
+				return legacy
+			},
+		},
+		{
+			name: "unified storage selected",
+			selectStorage: func(_, unified grafanarest.Storage) grafanarest.Storage {
+				return unified
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var selectedStorage grafanarest.Storage
+			builder := &DashboardsAPIBuilder{}
+			groupInfo := &genericapiserver.APIGroupInfo{
+				VersionedResourcesStorageMap: map[string]map[string]rest.Storage{},
+			}
+			err := builder.storageForVersion(
+				groupInfo,
+				apiserverbuilder.APIGroupOptions{
+					Scheme:     scheme,
+					OptsGetter: optsGetter,
+					DualWriteBuilder: func(_ schema.GroupResource, legacy, unified grafanarest.Storage) (grafanarest.Storage, error) {
+						selectedStorage = tt.selectStorage(legacy, unified)
+						return selectedStorage, nil
+					},
+				},
+				dashv0.DashboardResourceInfo,
+				&dashv0.LibraryPanelResourceInfo,
+				nil,
+				func(runtime.Object, *dashinternal.DashboardAccess) (runtime.Object, error) {
+					return &dashv0.DashboardWithAccessInfo{}, nil
+				},
+			)
+			require.NoError(t, err)
+
+			versionStorage := groupInfo.VersionedResourcesStorageMap[dashv0.LibraryPanelResourceInfo.GroupVersion().Version]
+			installedStorage := versionStorage[dashv0.LibraryPanelResourceInfo.StoragePath()]
+			require.IsType(t, &libraryPanelAccessStorage{}, installedStorage)
+			wrapper := installedStorage.(*libraryPanelAccessStorage)
+			require.Same(t, selectedStorage, wrapper.store)
+
+			_, dashboardWrapped := versionStorage[dashv0.DashboardResourceInfo.StoragePath()].(*libraryPanelAccessStorage)
+			require.False(t, dashboardWrapped, "library panel authorization must not wrap dashboard storage")
 		})
 	}
 }

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -373,14 +373,33 @@ func TestDashboardAPIBuilder_EmbeddedLibraryPanelFinalStorageKeepsAccessBoundary
 
 			versionStorage := groupInfo.VersionedResourcesStorageMap[dashv0.LibraryPanelResourceInfo.GroupVersion().Version]
 			installedStorage := versionStorage[dashv0.LibraryPanelResourceInfo.StoragePath()]
-			require.IsType(t, &libraryPanelAccessStorage{}, installedStorage)
-			wrapper := installedStorage.(*libraryPanelAccessStorage)
+			var wrapper *libraryPanelAccessStorage
+			switch typed := installedStorage.(type) {
+			case *libraryPanelAccessStorage:
+				wrapper = typed
+			case *libraryPanelAccessStorageWithWatch:
+				wrapper = typed.libraryPanelAccessStorage
+			case *libraryPanelAccessStorageWithDeleteCollection:
+				wrapper = typed.libraryPanelAccessStorage
+			case *libraryPanelAccessStorageWithWatchAndDeleteCollection:
+				wrapper = typed.libraryPanelAccessStorage
+			}
+			ok := wrapper != nil
+			require.True(t, ok)
 			require.Same(t, selectedStorage, wrapper.store)
 
 			_, dashboardWrapped := versionStorage[dashv0.DashboardResourceInfo.StoragePath()].(*libraryPanelAccessStorage)
 			require.False(t, dashboardWrapped, "library panel authorization must not wrap dashboard storage")
 		})
 	}
+}
+
+func TestDashboardAPIBuilder_LibraryPanelFolderValidationAllowsProvisioningIdentity(t *testing.T) {
+	ctx, _, err := identity.WithProvisioningIdentity(t.Context(), "stacks-1")
+	require.NoError(t, err)
+
+	builder := &DashboardsAPIBuilder{}
+	require.NoError(t, builder.validateLibraryPanelFolder(ctx, testLibraryPanel("panel-a", "provisioned-folder")))
 }
 
 func TestDashboardAPIBuilder_StandaloneLibraryPanelMoveRequiresSourceAndDestinationAccess(t *testing.T) {

--- a/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
@@ -510,81 +510,102 @@ func TestIntegrationLibraryPanelPreservesStatusMissingInUnifiedStorage(t *testin
 	require.Equal(t, int64(100), missing["maxDataPoints"])
 }
 
-func TestIntegrationLibraryPanelMode5EnforcesWritePermissions(t *testing.T) {
+func TestIntegrationLibraryPanelStorageModesEnforceWritePermissions(t *testing.T) {
 	// Regression guard for the authorization bypass reproduced on the combined
 	// hosted POC: https://github.com/grafana/grafana/pull/130108#issuecomment-5189622165
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
-		DisableAnonymous: true,
-		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-			"librarypanels.dashboard.grafana.app": {DualWriterMode: grafanarest.Mode5},
-		},
-	})
-	ctx := createTestContext(t, helper, helper.Org1)
-	adminClient := getResourceClient(t, ctx.Helper, ctx.AdminUser, getLibraryElementGVR())
-	editorClient := getResourceClient(t, ctx.Helper, ctx.EditorUser, getLibraryElementGVR())
-	viewerClient := getResourceClient(t, ctx.Helper, ctx.ViewerUser, getLibraryElementGVR())
-	// Hosted storage-boundary regression: https://github.com/grafana/grafana/pull/130108#issuecomment-5192500857
-	viewerServiceAccountClient := getServiceAccountResourceClient(t, ctx.Helper, ctx.ViewerServiceAccountToken, ctx.OrgID, getLibraryElementGVR())
+	tests := []struct {
+		name string
+		mode grafanarest.DualWriterMode
+	}{
+		{name: "legacy", mode: grafanarest.Mode0},
+		{name: "dual write", mode: grafanarest.Mode1},
+		{name: "unified", mode: grafanarest.Mode5},
+	}
 
-	panel := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": dashboardV0.APIGroup + "/" + dashboardV0.VERSION,
-		"kind":       "LibraryPanel",
-		"metadata": map[string]interface{}{
-			"name": "viewer-write-probe",
-		},
-		"spec": map[string]interface{}{
-			"type":        "text",
-			"title":       "Viewer write probe",
-			"panelTitle":  "Viewer write probe",
-			"options":     map[string]interface{}{},
-			"fieldConfig": map[string]interface{}{},
-		},
-	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				DisableAnonymous: true,
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"librarypanels.dashboard.grafana.app": {DualWriterMode: tt.mode},
+				},
+			})
+			ctx := createTestContext(t, helper, helper.Org1)
+			adminClient := getResourceClient(t, ctx.Helper, ctx.AdminUser, getLibraryElementGVR())
+			editorClient := getResourceClient(t, ctx.Helper, ctx.EditorUser, getLibraryElementGVR())
+			viewerClient := getResourceClient(t, ctx.Helper, ctx.ViewerUser, getLibraryElementGVR())
+			// Hosted storage-boundary regression: https://github.com/grafana/grafana/pull/130108#issuecomment-5192500857
+			viewerServiceAccountClient := getServiceAccountResourceClient(t, ctx.Helper, ctx.ViewerServiceAccountToken, ctx.OrgID, getLibraryElementGVR())
 
-	created, err := adminClient.Resource.Create(context.Background(), panel, v1.CreateOptions{})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = adminClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
-	})
-	_, err = viewerClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
-	require.NoError(t, err, "Viewer should retain read access")
+			panel := &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": dashboardV0.APIGroup + "/" + dashboardV0.VERSION,
+				"kind":       "LibraryPanel",
+				"metadata": map[string]interface{}{
+					"name": fmt.Sprintf("viewer-write-probe-%d", tt.mode),
+				},
+				"spec": map[string]interface{}{
+					"type":        "text",
+					"title":       "Viewer write probe",
+					"panelTitle":  "Viewer write probe",
+					"options":     map[string]interface{}{},
+					"fieldConfig": map[string]interface{}{},
+				},
+			}}
 
-	viewerUpdate := created.DeepCopy()
-	require.NoError(t, unstructured.SetNestedField(viewerUpdate.Object, "Viewer must not update this", "spec", "description"))
-	_, err = viewerClient.Resource.Update(context.Background(), viewerUpdate, v1.UpdateOptions{})
-	require.True(t, apierrors.IsForbidden(err), "Viewer update must be forbidden, got %v", err)
+			created, err := adminClient.Resource.Create(context.Background(), panel, v1.CreateOptions{})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = adminClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
+			})
+			_, err = viewerClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
+			require.NoError(t, err, "Viewer should retain read access")
 
-	err = viewerClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
-	require.True(t, apierrors.IsForbidden(err), "Viewer delete must be forbidden, got %v", err)
+			viewerUpdate := created.DeepCopy()
+			require.NoError(t, unstructured.SetNestedField(viewerUpdate.Object, "Viewer must not update this", "spec", "description"))
+			_, err = viewerClient.Resource.Update(context.Background(), viewerUpdate, v1.UpdateOptions{})
+			require.True(t, apierrors.IsForbidden(err), "Viewer update must be forbidden, got %v", err)
 
-	serviceAccountUpdate := created.DeepCopy()
-	require.NoError(t, unstructured.SetNestedField(serviceAccountUpdate.Object, "Viewer service account must not update this", "spec", "description"))
-	_, err = viewerServiceAccountClient.Resource.Update(context.Background(), serviceAccountUpdate, v1.UpdateOptions{})
-	require.True(t, apierrors.IsForbidden(err), "Viewer service account update must be forbidden, got %v", err)
+			err = viewerClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
+			require.True(t, apierrors.IsForbidden(err), "Viewer delete must be forbidden, got %v", err)
 
-	err = viewerServiceAccountClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
-	require.True(t, apierrors.IsForbidden(err), "Viewer service account delete must be forbidden, got %v", err)
+			serviceAccountUpdate := created.DeepCopy()
+			require.NoError(t, unstructured.SetNestedField(serviceAccountUpdate.Object, "Viewer service account must not update this", "spec", "description"))
+			_, err = viewerServiceAccountClient.Resource.Update(context.Background(), serviceAccountUpdate, v1.UpdateOptions{})
+			require.True(t, apierrors.IsForbidden(err), "Viewer service account update must be forbidden, got %v", err)
 
-	unchanged, err := adminClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
-	require.NoError(t, err)
-	_, found, err := unstructured.NestedString(unchanged.Object, "spec", "description")
-	require.NoError(t, err)
-	require.False(t, found, "Viewer update unexpectedly persisted")
+			err = viewerServiceAccountClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{})
+			require.True(t, apierrors.IsForbidden(err), "Viewer service account delete must be forbidden, got %v", err)
 
-	editorUpdate := unchanged.DeepCopy()
-	require.NoError(t, unstructured.SetNestedField(editorUpdate.Object, "Editor may update this", "spec", "description"))
-	updated, err := editorClient.Resource.Update(context.Background(), editorUpdate, v1.UpdateOptions{})
-	require.NoError(t, err)
-	description, found, err := unstructured.NestedString(updated.Object, "spec", "description")
-	require.NoError(t, err)
-	require.True(t, found)
-	require.Equal(t, "Editor may update this", description)
+			unchanged, err := adminClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
+			require.NoError(t, err)
+			_, found, err := unstructured.NestedString(unchanged.Object, "spec", "description")
+			require.NoError(t, err)
+			require.False(t, found, "Viewer update unexpectedly persisted")
 
-	require.NoError(t, editorClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{}))
-	_, err = adminClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
-	require.True(t, apierrors.IsNotFound(err), "Editor delete did not remove the panel: %v", err)
+			editorUpdate := unchanged.DeepCopy()
+			require.NoError(t, unstructured.SetNestedField(editorUpdate.Object, "Editor may update this", "spec", "description"))
+			updated, err := editorClient.Resource.Update(context.Background(), editorUpdate, v1.UpdateOptions{})
+			require.NoError(t, err)
+			description, found, err := unstructured.NestedString(updated.Object, "spec", "description")
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, "Editor may update this", description)
+
+			// The legacy store does not implement dry-run, and dual-write dry-run
+			// delegates only to unified storage. Verify dry-run where it is supported.
+			if tt.mode == grafanarest.Mode5 {
+				require.NoError(t, editorClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{DryRun: []string{v1.DryRunAll}}))
+				_, err = adminClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
+				require.NoError(t, err, "dry-run delete removed the panel")
+			}
+
+			require.NoError(t, editorClient.Resource.Delete(context.Background(), panel.GetName(), v1.DeleteOptions{}))
+			_, err = adminClient.Resource.Get(context.Background(), panel.GetName(), v1.GetOptions{})
+			require.True(t, apierrors.IsNotFound(err), "Editor delete did not remove the panel: %v", err)
+		})
+	}
 }
 
 func TestIntegrationLibraryPanelMode5SupportsAdvertisedPatchTypes(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Enforces library panel create, update, and delete authorization at the final embedded storage boundary selected after legacy, dual-write, or unified routing. The wrapper materializes existing objects when update and delete authorization needs them, preserves the selected store's optional capabilities, and keeps Git Sync provisioning compatible with repository-managed folders.

**Why do we need this feature?**

The direct Kubernetes API path does not pass through the legacy HTTP route guard, and App Platform API servers do not reliably populate old objects for update and delete admission. Applying authorization only to unified storage therefore leaves other migration modes inconsistently protected. Wrapping the final selected store enforces the same authorization invariant in every supported mode.

**Who is this feature for?**

Users testing the experimental App Platform library panels API and Git Sync library panel provisioning.

**Which issue(s) does this PR fix?**:

Related to #131670

**Testing**

- `go test ./pkg/registry/apis/dashboard`
- `go test ./pkg/services/libraryelements`
- `go test ./pkg/storage/legacysql/dualwrite`
- `go test ./pkg/tests/apis/dashboard/integration -run '^TestIntegrationLibraryPanel' -count=1`
- `go test ./pkg/tests/apis/provisioning -run '^TestIntegrationLibraryPanels_(ProvisionedFolders|UnprovisionedFolders)$' -count=1`
- Added a public API permission matrix covering representative legacy, dual-write, and unified storage modes.
- Ran mt-tilt with standalone `dashboard-apiserver` and embedded Grafana built from exact PR head `217a3790b754c07710d5aeb84928b3a985ba647e`.
- Verified Viewer reads remain allowed while create, PUT, PATCH, and DELETE return `403`, with rejected writes leaving the resource unchanged.
- Verified Editor PUT, PATCH, dry-run DELETE, and real DELETE succeed.
- Verified a custom `RoleNone` user with only `library.panels:write` can still read and update a panel.
- Verified the feature-toggle-off legacy `/api/library-elements` create, read, update, authorization-denial, and delete workflows.
- Verified provisioned and unprovisioned Git Sync library panel workflows.

**Special notes for your reviewer:**

- The user-facing legacy API migration path remains behind `libraryelements.kubernetesLibraryPanels`.
- This PR does not change registration or exposure of the direct App Platform `/apis` endpoint.
- No documentation change is needed because this corrects authorization behavior for an experimental API.
