### PR TITLE
OpenFeature: Log initialization errors in Faro

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -61,20 +61,25 @@ export function getOFREPWebProvider() {
 }
 
 export async function initOpenFeature() {
-  OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
-  OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
+  try {
+    OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
+    OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
 
-  const lsProvider = getLocalStorageProvider();
-  const ofProvider = getOFREPWebProvider();
+    const lsProvider = getLocalStorageProvider();
+    const ofProvider = getOFREPWebProvider();
 
-  await OpenFeature.setProviderAndWait(
-    GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
-    new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
-    {
-      targetingKey: config.namespace,
-      ...config.openFeatureContext,
-    }
-  );
+    await OpenFeature.setProviderAndWait(
+      GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
+      new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
+      {
+        targetingKey: config.namespace,
+        ...config.openFeatureContext,
+      }
+    );
+  } catch (err) {
+    console.error('Failed to initialize OpenFeature provider', err);
+    logError(new Error('Failed to initialize OpenFeature provider', { cause: err }));
+  }
 }
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -61,25 +61,20 @@ export function getOFREPWebProvider() {
 }
 
 export async function initOpenFeature() {
-  try {
-    OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
-    OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
+  OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
+  OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
 
-    const lsProvider = getLocalStorageProvider();
-    const ofProvider = getOFREPWebProvider();
+  const lsProvider = getLocalStorageProvider();
+  const ofProvider = getOFREPWebProvider();
 
-    await OpenFeature.setProviderAndWait(
-      GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
-      new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
-      {
-        targetingKey: config.namespace,
-        ...config.openFeatureContext,
-      }
-    );
-  } catch (err) {
-    console.error('Failed to initialize OpenFeature provider', err);
-    logError(new Error('Failed to initialize OpenFeature provider', { cause: err }));
-  }
+  await OpenFeature.setProviderAndWait(
+    GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
+    new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
+    {
+      targetingKey: config.namespace,
+      ...config.openFeatureContext,
+    }
+  );
 }
 
 /**

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -39,6 +39,7 @@ import {
   setPanelScreenshotService,
   setPluginFunctionsHook,
   setMegaMenuOpenHook,
+  logError,
 } from '@grafana/runtime';
 import {
   getPanelPluginMetas,
@@ -160,6 +161,15 @@ export class GrafanaApp {
       initSystemJSHooks();
       initializeLoggersRegistry();
 
+      // Capture any error generated to pass to Faro once available.
+      let openFeatureError: unknown;
+      try {
+        await initOpenFeature();
+      } catch (err) {
+        openFeatureError = err;
+        console.error('Failed to initialize OpenFeature provider', err);
+      }
+
       const initI18nPromise = initializeI18n({
         language: contextSrv.user.language,
         ns: NAMESPACES,
@@ -179,11 +189,13 @@ export class GrafanaApp {
       setBackendSrv(backendSrv);
       await initEchoSrv();
 
+      // This needs to be done after the `initEchoSrv` since that initializes Faro.
+      if (openFeatureError) {
+        logError(new Error('Failed to initialize OpenFeature provider', { cause: openFeatureError }));
+      }
+
       // This needs to be done after the `initEchoSrv` since it is being used under the hood.
       startMeasure('frontend_app_init');
-
-      // This needs to be done after the `initEchoSrv` so that Faro is available.
-      await initOpenFeature();
 
       if (config.featureToggles.cujTracking) {
         setJourneyTracker(new JourneyTrackerImpl());

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -160,11 +160,7 @@ export class GrafanaApp {
       initSystemJSHooks();
       initializeLoggersRegistry();
 
-      try {
-        await initOpenFeature();
-      } catch (err) {
-        console.error('Failed to initialize OpenFeature provider', err);
-      }
+      await initOpenFeature();
 
       const initI18nPromise = initializeI18n({
         language: contextSrv.user.language,

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -160,8 +160,6 @@ export class GrafanaApp {
       initSystemJSHooks();
       initializeLoggersRegistry();
 
-      await initOpenFeature();
-
       const initI18nPromise = initializeI18n({
         language: contextSrv.user.language,
         ns: NAMESPACES,
@@ -180,8 +178,12 @@ export class GrafanaApp {
 
       setBackendSrv(backendSrv);
       await initEchoSrv();
+
       // This needs to be done after the `initEchoSrv` since it is being used under the hood.
       startMeasure('frontend_app_init');
+
+      // This needs to be done after the `initEchoSrv` so that Faro is available.
+      await initOpenFeature();
 
       if (config.featureToggles.cujTracking) {
         setJourneyTracker(new JourneyTrackerImpl());


### PR DESCRIPTION
**What is this feature?**

When OpenFeature fails to initialize, log the error in Faro.

**Why do we need this feature?**

So that we can better alert on OpenFeature failures on the frontend that would prevent Grafana and its plugins from loading preview features correctly.

Ctx: https://grafanalabs.enterprise.slack.com/archives/C0BT31BEGUB

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
