### PR TITLE
Search: []app.Manifest → ...*app.ManifestData- #13350

### DIFF
--- a/pkg/registry/apis/search/manifest_fields_test.go
+++ b/pkg/registry/apis/search/manifest_fields_test.go
@@ -56,7 +56,7 @@ func resourceNameFor(kind app.ManifestVersionKind) string {
 // its search fields would reject every custom field, so this checks the real
 // compiled-in manifests rather than a test fixture.
 func TestDashboardCustomFieldsResolveOnEveryServedVersion(t *testing.T) {
-	provider := resource.NewManifestBackedProvider(resource.AppManifests())
+	provider := resource.NewManifestBackedProvider(resource.AppManifests()...)
 
 	versions := servedVersions(t, dashboardGroup, dashboardResource)
 	// Guard against the manifest shrinking to a single version and this test

--- a/pkg/registry/apis/search/manifest_fields_test.go
+++ b/pkg/registry/apis/search/manifest_fields_test.go
@@ -25,10 +25,10 @@ func servedVersions(t *testing.T, group, resourceName string) []string {
 
 	var out []string
 	for _, m := range resource.AppManifests() {
-		if m.ManifestData == nil || m.ManifestData.Group != group {
+		if m == nil || m.Group != group {
 			continue
 		}
-		for _, version := range m.ManifestData.Versions {
+		for _, version := range m.Versions {
 			if !version.Served {
 				continue
 			}

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -3,7 +3,6 @@ package search
 import (
 	"fmt"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	rulesmanifest "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/manifestdata"
@@ -59,7 +58,7 @@ func buildSearchColumns() map[string]*resourcepb.ResourceTableColumnDefinition {
 		fieldFolder: std.Field(fieldFolder),
 	}
 
-	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
+	provider := resource.NewManifestBackedProvider(rulesmanifest.LocalManifest().ManifestData)
 	for _, gr := range []schema.GroupResource{
 		alertrule.ResourceInfo.GroupResource(),
 		recordingrule.ResourceInfo.GroupResource(),

--- a/pkg/registry/apps/alerting/rules/search/fields.go
+++ b/pkg/registry/apps/alerting/rules/search/fields.go
@@ -59,7 +59,7 @@ func buildSearchColumns() map[string]*resourcepb.ResourceTableColumnDefinition {
 		fieldFolder: std.Field(fieldFolder),
 	}
 
-	provider := resource.NewManifestBackedProvider([]app.Manifest{rulesmanifest.LocalManifest()})
+	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
 	for _, gr := range []schema.GroupResource{
 		alertrule.ResourceInfo.GroupResource(),
 		recordingrule.ResourceInfo.GroupResource(),

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -436,7 +436,7 @@ func legacyResponse(t *testing.T, rule *ngmodels.AlertRule) *resourcepb.Resource
 // that no kind declares has no column definition to encode against.
 func TestResultColumnsCoverSearchFields(t *testing.T) {
 	want := map[string]struct{}{fieldTitle: {}, fieldFolder: {}}
-	provider := resource.NewManifestBackedProvider([]app.Manifest{rulesmanifest.LocalManifest()})
+	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
 	for _, gr := range []schema.GroupResource{
 		alertrule.ResourceInfo.GroupResource(),
 		recordingrule.ResourceInfo.GroupResource(),
@@ -461,7 +461,7 @@ func TestResultColumnsCoverSearchFields(t *testing.T) {
 // the value at request time, and a unified hit would decode against a type it
 // was not encoded with.
 func TestSearchFieldsAgreeAcrossKinds(t *testing.T) {
-	provider := resource.NewManifestBackedProvider([]app.Manifest{rulesmanifest.LocalManifest()})
+	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
 	fieldsFor := func(gr schema.GroupResource) map[string]resource.SearchFieldDefinition {
 		out := map[string]resource.SearchFieldDefinition{}
 		for _, sfd := range provider.Fields(schema.GroupVersionResource{Group: gr.Group, Resource: gr.Resource}) {

--- a/pkg/registry/apps/alerting/rules/search/query_test.go
+++ b/pkg/registry/apps/alerting/rules/search/query_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
@@ -436,7 +435,7 @@ func legacyResponse(t *testing.T, rule *ngmodels.AlertRule) *resourcepb.Resource
 // that no kind declares has no column definition to encode against.
 func TestResultColumnsCoverSearchFields(t *testing.T) {
 	want := map[string]struct{}{fieldTitle: {}, fieldFolder: {}}
-	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
+	provider := resource.NewManifestBackedProvider(rulesmanifest.LocalManifest().ManifestData)
 	for _, gr := range []schema.GroupResource{
 		alertrule.ResourceInfo.GroupResource(),
 		recordingrule.ResourceInfo.GroupResource(),
@@ -461,7 +460,7 @@ func TestResultColumnsCoverSearchFields(t *testing.T) {
 // the value at request time, and a unified hit would decode against a type it
 // was not encoded with.
 func TestSearchFieldsAgreeAcrossKinds(t *testing.T) {
-	provider := resource.NewManifestBackedProvider([]*app.ManifestData{rulesmanifest.LocalManifest().ManifestData})
+	provider := resource.NewManifestBackedProvider(rulesmanifest.LocalManifest().ManifestData)
 	fieldsFor := func(gr schema.GroupResource) map[string]resource.SearchFieldDefinition {
 		out := map[string]resource.SearchFieldDefinition{}
 		for _, sfd := range provider.Fields(schema.GroupVersionResource{Group: gr.Group, Resource: gr.Resource}) {

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -6,9 +6,10 @@
 package searchroutes
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/grafana/grafana-app-sdk/app"
 	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	searchapi "github.com/grafana/grafana/pkg/registry/apis/search"
@@ -78,7 +79,7 @@ func Build(
 //
 // Panics on a bad declaration, because in a compiled-in manifest that is a bug.
 func BuildFromManifests(
-	manifests []app.Manifest,
+	manifests []*app.ManifestData,
 	searchEnabled bool,
 	trashEnabled bool,
 	tracer tracing.Tracer,
@@ -107,7 +108,7 @@ func BuildFromManifests(
 // Returns an error rather than panicking, because manifests read at runtime can
 // be malformed without this build being at fault.
 func BuildForServedGroupVersions(
-	manifests []app.Manifest,
+	manifests []*app.ManifestData,
 	served map[schema.GroupVersion]bool,
 	searchEnabled bool,
 	trashEnabled bool,
@@ -130,14 +131,14 @@ func BuildForServedGroupVersions(
 	byGroupVersion := map[schema.GroupVersion][]searchapi.Route{}
 
 	for _, m := range manifests {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
-		for _, version := range m.ManifestData.Versions {
+		for _, version := range m.Versions {
 			if !version.Served {
 				continue
 			}
-			gv := schema.GroupVersion{Group: m.ManifestData.Group, Version: version.Name}
+			gv := schema.GroupVersion{Group: m.Group, Version: version.Name}
 			if !served[gv] {
 				continue
 			}

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -122,7 +122,7 @@ func BuildForServedGroupVersions(
 		return nil, nil
 	}
 
-	provider, err := resource.ManifestBackedProvider(manifests)
+	provider, err := resource.ManifestBackedProvider(manifests...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/apiserver/searchroutes/searchroutes_test.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes_test.go
@@ -86,8 +86,8 @@ func TestBuild_SearchFieldsEnrolAKind(t *testing.T) {
 	gv := schema.GroupVersion{Group: "playlist.grafana.app", Version: "v0alpha1"}
 	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
 
-	playlists := func(fields []app.ManifestVersionKindSearchField) []app.Manifest {
-		return []app.Manifest{{ManifestData: &app.ManifestData{
+	playlists := func(fields []app.ManifestVersionKindSearchField) []*app.ManifestData {
+		return []*app.ManifestData{{
 			Group: gv.Group,
 			Versions: []app.ManifestVersion{{
 				Name:   gv.Version,
@@ -99,7 +99,7 @@ func TestBuild_SearchFieldsEnrolAKind(t *testing.T) {
 					SearchFields: fields,
 				}},
 			}},
-		}}}
+		}}
 	}
 
 	t.Run("no fields, not enrolled", func(t *testing.T) {
@@ -164,12 +164,12 @@ func TestBuild_EnrolmentIsPerKindNotPerGroup(t *testing.T) {
 func TestBuild_MountsEveryServedVersion(t *testing.T) {
 	var dashboardGVs []schema.GroupVersion
 	for _, m := range resource.AppManifests() {
-		if m.ManifestData == nil || m.ManifestData.Group != "dashboard.grafana.app" {
+		if m == nil || m.Group != "dashboard.grafana.app" {
 			continue
 		}
-		for _, v := range m.ManifestData.Versions {
+		for _, v := range m.Versions {
 			if v.Served {
-				dashboardGVs = append(dashboardGVs, schema.GroupVersion{Group: m.ManifestData.Group, Version: v.Name})
+				dashboardGVs = append(dashboardGVs, schema.GroupVersion{Group: m.Group, Version: v.Name})
 			}
 		}
 	}
@@ -191,12 +191,12 @@ func TestBuild_MountsEveryServedVersion(t *testing.T) {
 func TestBuild_MountsNotebooksOnDeclaringVersionOnly(t *testing.T) {
 	var dashboardGVs []schema.GroupVersion
 	for _, m := range resource.AppManifests() {
-		if m.ManifestData == nil || m.ManifestData.Group != "dashboard.grafana.app" {
+		if m == nil || m.Group != "dashboard.grafana.app" {
 			continue
 		}
-		for _, v := range m.ManifestData.Versions {
+		for _, v := range m.Versions {
 			if v.Served {
-				dashboardGVs = append(dashboardGVs, schema.GroupVersion{Group: m.ManifestData.Group, Version: v.Name})
+				dashboardGVs = append(dashboardGVs, schema.GroupVersion{Group: m.Group, Version: v.Name})
 			}
 		}
 	}
@@ -221,12 +221,12 @@ func allServedGroupVersions(t *testing.T) []schema.GroupVersion {
 
 	var gvs []schema.GroupVersion
 	for _, m := range resource.AppManifests() {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
-		for _, v := range m.ManifestData.Versions {
+		for _, v := range m.Versions {
 			if v.Served {
-				gvs = append(gvs, schema.GroupVersion{Group: m.ManifestData.Group, Version: v.Name})
+				gvs = append(gvs, schema.GroupVersion{Group: m.Group, Version: v.Name})
 			}
 		}
 	}
@@ -303,8 +303,8 @@ func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
 	gv := schema.GroupVersion{Group: "dashboard.grafana.app", Version: "v1"}
 	builders := []builder.APIGroupBuilder{&fakeBuilder{gvs: []schema.GroupVersion{gv}}}
 
-	dashboards := func(search *app.ManifestVersionKindSearch) []app.Manifest {
-		return []app.Manifest{{ManifestData: &app.ManifestData{
+	dashboards := func(search *app.ManifestVersionKindSearch) []*app.ManifestData {
+		return []*app.ManifestData{{
 			Group: gv.Group,
 			Versions: []app.ManifestVersion{{
 				Name:   gv.Version,
@@ -320,7 +320,7 @@ func TestBuild_ManifestOptOutIsHonoured(t *testing.T) {
 					},
 				}},
 			}},
-		}}}
+		}}
 	}
 	optOut := func(v bool) *bool { return &v }
 
@@ -357,8 +357,8 @@ func TestServedGroupVersions_CoversBothRegistrationPaths(t *testing.T) {
 }
 
 // todoManifest is an ext app group, which no builder or installer knows about.
-func todoManifest(gv schema.GroupVersion, fieldType, capability string) []app.Manifest {
-	return []app.Manifest{{ManifestData: &app.ManifestData{
+func todoManifest(gv schema.GroupVersion, fieldType, capability string) []*app.ManifestData {
+	return []*app.ManifestData{{
 		Group: gv.Group,
 		Versions: []app.ManifestVersion{{
 			Name:   gv.Version,
@@ -372,7 +372,7 @@ func todoManifest(gv schema.GroupVersion, fieldType, capability string) []app.Ma
 				},
 			}},
 		}},
-	}}}
+	}}
 }
 
 func TestBuildForServedGroupVersions_MountsWithoutBuildersOrInstallers(t *testing.T) {

--- a/pkg/storage/unified/resource/app_manifests.go
+++ b/pkg/storage/unified/resource/app_manifests.go
@@ -29,30 +29,30 @@ import (
 	shorturl "github.com/grafana/grafana/apps/shorturl/pkg/apis"
 )
 
-func AppManifests() []app.Manifest {
+func AppManifests() []*app.ManifestData {
 	// TODO: don't use hardcoded list of manifests when possible.
-	return []app.Manifest{
-		advisor.LocalManifest(),
-		alerting_notifications.LocalManifest(),
-		alerting_rules.LocalManifest(),
-		annotation.LocalManifest(),
-		collections.LocalManifest(),
-		correlations.LocalManifest(),
-		dashboard.LocalManifest(),
-		dashvalidator.LocalManifest(),
-		dashvalidator1.LocalManifest(),
-		example.LocalManifest(),
-		folder.LocalManifest(),
-		iam.LocalManifest(),
-		live.LocalManifest(),
-		logsdrilldown.LocalManifest(),
-		playlist.LocalManifest(),
-		plugins.LocalManifest(),
-		preferences.LocalManifest(),
-		provisioning.LocalManifest(),
-		quotas.LocalManifest(),
-		secret.LocalManifest(),
-		shorturl.LocalManifest(),
-		alerting_historian.LocalManifest(),
+	return []*app.ManifestData{
+		advisor.LocalManifest().ManifestData,
+		alerting_notifications.LocalManifest().ManifestData,
+		alerting_rules.LocalManifest().ManifestData,
+		annotation.LocalManifest().ManifestData,
+		collections.LocalManifest().ManifestData,
+		correlations.LocalManifest().ManifestData,
+		dashboard.LocalManifest().ManifestData,
+		dashvalidator.LocalManifest().ManifestData,
+		dashvalidator1.LocalManifest().ManifestData,
+		example.LocalManifest().ManifestData,
+		folder.LocalManifest().ManifestData,
+		iam.LocalManifest().ManifestData,
+		live.LocalManifest().ManifestData,
+		logsdrilldown.LocalManifest().ManifestData,
+		playlist.LocalManifest().ManifestData,
+		plugins.LocalManifest().ManifestData,
+		preferences.LocalManifest().ManifestData,
+		provisioning.LocalManifest().ManifestData,
+		quotas.LocalManifest().ManifestData,
+		secret.LocalManifest().ManifestData,
+		shorturl.LocalManifest().ManifestData,
+		alerting_historian.LocalManifest().ManifestData,
 	}
 }

--- a/pkg/storage/unified/resource/generate_manifests.sh
+++ b/pkg/storage/unified/resource/generate_manifests.sh
@@ -73,9 +73,9 @@ echo "$EXTERNAL_MANIFESTS" | $AWK 'NF { print "\t" $1 " \"" $2 "\"" }' >> "$OUTP
 cat >> "$OUTPUT_FILE" << 'MIDDLE'
 )
 
-func AppManifests() []app.Manifest {
+func AppManifests() []*app.ManifestData {
 	// TODO: don't use hardcoded list of manifests when possible.
-	return []app.Manifest{
+	return []*app.ManifestData{
 MIDDLE
 
 # Generate manifest calls with same duplicate handling
@@ -95,11 +95,11 @@ $AWK '{
       seen[pkg] = 1
     }
 
-    print "\t\t" pkg ".LocalManifest(),"
+    print "\t\t" pkg ".LocalManifest().ManifestData,"
   }
 }' "$TEMP_FILE" >> "$OUTPUT_FILE"
 
-echo "$EXTERNAL_MANIFESTS" | $AWK 'NF { print "\t\t" $1 ".LocalManifest()," }' >> "$OUTPUT_FILE"
+echo "$EXTERNAL_MANIFESTS" | $AWK 'NF { print "\t\t" $1 ".LocalManifest().ManifestData," }' >> "$OUTPUT_FILE"
 
 # Close function
 cat >> "$OUTPUT_FILE" << 'FOOTER'

--- a/pkg/storage/unified/resource/list_with_selectors.go
+++ b/pkg/storage/unified/resource/list_with_selectors.go
@@ -179,7 +179,7 @@ func (s *server) useSelectorSearch(req *resourcepb.ListRequest) bool {
 
 	// TODO have a way of including enterprise manifests
 	manifests := AppManifestsWithKinds(AppManifests())
-	return slices.ContainsFunc(manifests, func(m app.Manifest) bool {
-		return m.ManifestData.Group == req.Options.Key.Group
+	return slices.ContainsFunc(manifests, func(m *app.ManifestData) bool {
+		return m.Group == req.Options.Key.Group
 	})
 }

--- a/pkg/storage/unified/resource/list_with_selectors.go
+++ b/pkg/storage/unified/resource/list_with_selectors.go
@@ -178,7 +178,7 @@ func (s *server) useSelectorSearch(req *resourcepb.ListRequest) bool {
 	}
 
 	// TODO have a way of including enterprise manifests
-	manifests := AppManifestsWithKinds(AppManifests())
+	manifests := AppManifestsWithKinds(AppManifests()...)
 	return slices.ContainsFunc(manifests, func(m *app.ManifestData) bool {
 		return m.Group == req.Options.Key.Group
 	})

--- a/pkg/storage/unified/resource/manifest_watcher.go
+++ b/pkg/storage/unified/resource/manifest_watcher.go
@@ -107,14 +107,14 @@ type ManifestWatcher struct {
 	log          log.Logger
 	client       dynamic.Interface
 	pollInterval time.Duration
-	onChange     func([]app.Manifest)
+	onChange     func([]*app.ManifestData)
 	metrics      *manifestWatcherMetrics
 
 	// byName is the current snapshot, keyed by apiserver object name. The name key
 	// lets a poll keep a known manifest when the same object later fails to
 	// convert. Manifests() derives the ordered slice from it.
 	mu       sync.RWMutex
-	byName   map[string]app.Manifest
+	byName   map[string]*app.ManifestData
 	lastHash string
 }
 
@@ -192,7 +192,7 @@ func manifestAuthWrapper(exchanger authnlib.TokenExchanger) transport.WrapperFun
 // NewManifestWatcher creates a ManifestWatcher as a dskit service. The initial
 // poll runs in the starting state, so anything that waits for Running observes a
 // populated snapshot. onChange may be nil.
-func NewManifestWatcher(cfg ManifestWatcherConfig, reg prometheus.Registerer, onChange func([]app.Manifest)) (*ManifestWatcher, error) {
+func NewManifestWatcher(cfg ManifestWatcherConfig, reg prometheus.Registerer, onChange func([]*app.ManifestData)) (*ManifestWatcher, error) {
 	restCfg, err := newManifestRESTConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("building manifest REST config: %w", err)
@@ -216,7 +216,7 @@ func NewManifestWatcher(cfg ManifestWatcherConfig, reg prometheus.Registerer, on
 
 // newManifestWatcher builds the watcher without a service, so tests can drive
 // poll cycles directly.
-func newManifestWatcher(client dynamic.Interface, pollInterval time.Duration, onChange func([]app.Manifest), logger log.Logger) *ManifestWatcher {
+func newManifestWatcher(client dynamic.Interface, pollInterval time.Duration, onChange func([]*app.ManifestData), logger log.Logger) *ManifestWatcher {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -230,7 +230,7 @@ func newManifestWatcher(client dynamic.Interface, pollInterval time.Duration, on
 }
 
 // Manifests returns the current snapshot as an ordered slice.
-func (w *ManifestWatcher) Manifests() []app.Manifest {
+func (w *ManifestWatcher) Manifests() []*app.ManifestData {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 	return sortedManifests(w.byName)
@@ -318,8 +318,8 @@ func (w *ManifestWatcher) runPollCycle(ctx context.Context) {
 // object fails to convert, its previously known version (from prev) is kept so a
 // transient parse failure can't drop its search fields; a genuinely unknown
 // object is skipped.
-func (w *ManifestWatcher) list(ctx context.Context, prev map[string]app.Manifest) (map[string]app.Manifest, error) {
-	result := make(map[string]app.Manifest)
+func (w *ManifestWatcher) list(ctx context.Context, prev map[string]*app.ManifestData) (map[string]*app.ManifestData, error) {
+	result := make(map[string]*app.ManifestData)
 	var continueToken string
 	for {
 		select {
@@ -362,13 +362,13 @@ func (w *ManifestWatcher) list(ctx context.Context, prev map[string]app.Manifest
 // sortedManifests returns the map values ordered by apiserver object name. The
 // name is unique, so the published snapshot and its hash are deterministic even
 // when two objects share a group and app name.
-func sortedManifests(byName map[string]app.Manifest) []app.Manifest {
+func sortedManifests(byName map[string]*app.ManifestData) []*app.ManifestData {
 	names := make([]string, 0, len(byName))
 	for name := range byName {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	out := make([]app.Manifest, 0, len(byName))
+	out := make([]*app.ManifestData, 0, len(byName))
 	for _, name := range names {
 		out = append(out, byName[name])
 	}
@@ -376,39 +376,39 @@ func sortedManifests(byName map[string]app.Manifest) []app.Manifest {
 }
 
 // ManifestFromUnstructured converts an AppManifest apiserver object (v1alpha2)
-// to an app.Manifest.
+// to app.ManifestData.
 //
 // Exported so a server that fetches AppManifests with its own client gets the
 // same conversion the watcher uses, rather than a second one that could disagree
 // about what a manifest means.
-func ManifestFromUnstructured(item *unstructured.Unstructured) (app.Manifest, error) {
+func ManifestFromUnstructured(item *unstructured.Unstructured) (*app.ManifestData, error) {
 	specRaw, ok := item.Object["spec"]
 	if !ok {
-		return app.Manifest{}, fmt.Errorf("appmanifest %q has no spec", item.GetName())
+		return nil, fmt.Errorf("appmanifest %q has no spec", item.GetName())
 	}
 	specJSON, err := json.Marshal(specRaw)
 	if err != nil {
-		return app.Manifest{}, fmt.Errorf("marshaling spec: %w", err)
+		return nil, fmt.Errorf("marshaling spec: %w", err)
 	}
 	var spec appmanifestv1alpha2.AppManifestSpec
 	if err := json.Unmarshal(specJSON, &spec); err != nil {
-		return app.Manifest{}, fmt.Errorf("unmarshaling spec: %w", err)
+		return nil, fmt.Errorf("unmarshaling spec: %w", err)
 	}
 	data, err := spec.ToManifestData()
 	if err != nil {
-		return app.Manifest{}, fmt.Errorf("converting spec to manifest data: %w", err)
+		return nil, fmt.Errorf("converting spec to manifest data: %w", err)
 	}
-	return app.NewEmbeddedManifest(data), nil
+	return &data, nil
 }
 
 // hashManifests returns a stable hash of the manifest set, used to skip
 // publishing when a poll returns no real change. The input is already ordered by
 // sortedManifests (by unique object name), so the hash is deterministic.
-func hashManifests(manifests []app.Manifest) (string, error) {
+func hashManifests(manifests []*app.ManifestData) (string, error) {
 	datas := make([]app.ManifestData, 0, len(manifests))
 	for _, m := range manifests {
-		if m.ManifestData != nil {
-			datas = append(datas, *m.ManifestData)
+		if m != nil {
+			datas = append(datas, *m)
 		}
 	}
 	b, err := json.Marshal(datas)

--- a/pkg/storage/unified/resource/manifest_watcher_test.go
+++ b/pkg/storage/unified/resource/manifest_watcher_test.go
@@ -117,8 +117,8 @@ func TestManifestWatcher_PollConvertsManifests(t *testing.T) {
 	require.Len(t, got, 2)
 	groups := map[string]bool{}
 	for _, m := range got {
-		require.NotNil(t, m.ManifestData)
-		groups[m.ManifestData.Group] = true
+		require.NotNil(t, m)
+		groups[m.Group] = true
 	}
 	require.True(t, groups["dashboard.grafana.app"])
 	require.True(t, groups["folder.grafana.app"])
@@ -130,8 +130,8 @@ func TestManifestWatcher_OnChangeFiresOnlyWhenChanged(t *testing.T) {
 	)
 
 	var calls int
-	var last []app.Manifest
-	w := newManifestWatcher(client, 0, func(m []app.Manifest) {
+	var last []*app.ManifestData
+	w := newManifestWatcher(client, 0, func(m []*app.ManifestData) {
 		calls++
 		last = m
 	}, nil)
@@ -211,7 +211,7 @@ func TestManifestWatcher_PicksUpChangesOnNextPoll(t *testing.T) {
 		testAppManifestObj("m-dashboards", "dashboards", "dashboard.grafana.app", "Dashboard", "title"),
 	)
 	var calls int
-	w := newManifestWatcher(client, 0, func([]app.Manifest) { calls++ }, nil)
+	w := newManifestWatcher(client, 0, func([]*app.ManifestData) { calls++ }, nil)
 
 	w.runPollCycle(t.Context())
 	require.Len(t, w.Manifests(), 1)
@@ -248,7 +248,7 @@ func TestManifestWatcher_KeepsPreviousManifestOnParseFailure(t *testing.T) {
 
 	got := w.Manifests()
 	require.Len(t, got, 1)
-	require.Equal(t, "dashboard.grafana.app", got[0].ManifestData.Group)
+	require.Equal(t, "dashboard.grafana.app", got[0].Group)
 }
 
 func TestManifestWatcher_KeepPreviousSurvivesRename(t *testing.T) {
@@ -256,7 +256,7 @@ func TestManifestWatcher_KeepPreviousSurvivesRename(t *testing.T) {
 		testAppManifestObj("A", "dashboards", "dashboard.grafana.app", "Dashboard", "title"),
 	)
 	var calls int
-	w := newManifestWatcher(client, 0, func([]app.Manifest) { calls++ }, nil)
+	w := newManifestWatcher(client, 0, func([]*app.ManifestData) { calls++ }, nil)
 	w.runPollCycle(t.Context())
 	require.Equal(t, 1, calls)
 
@@ -298,7 +298,7 @@ func TestManifestWatcher_SkipsManifestThatFailsToConvert(t *testing.T) {
 
 	got := w.Manifests()
 	require.Len(t, got, 1)
-	require.Equal(t, "dashboard.grafana.app", got[0].ManifestData.Group)
+	require.Equal(t, "dashboard.grafana.app", got[0].Group)
 }
 
 func TestNewManifestWatcherConfig(t *testing.T) {

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -21,7 +21,7 @@ var manifestMergeLogger = log.New("search-manifest-merge")
 // Panics on an invalid declaration, like NewMapProvider, because in a
 // compiled-in manifest that is a bug. Runtime callers use
 // ManifestBackedProvider instead.
-func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {
+func NewManifestBackedProvider(manifests []*app.ManifestData) SearchFieldsProvider {
 	p, err := ManifestBackedProvider(manifests)
 	if err != nil {
 		panic(err.Error())
@@ -32,15 +32,7 @@ func NewManifestBackedProvider(manifests []app.Manifest) SearchFieldsProvider {
 // ManifestBackedProvider is NewManifestBackedProvider's error-returning form,
 // for manifests read at runtime, which can be malformed without this build
 // being at fault.
-func ManifestBackedProvider(manifests []app.Manifest) (SearchFieldsProvider, error) {
-	data := make([]*app.ManifestData, len(manifests))
-	for i, m := range manifests {
-		data[i] = m.ManifestData
-	}
-	return NewSearchFieldsProvider(data)
-}
-
-func NewSearchFieldsProvider(manifests []*app.ManifestData) (SearchFieldsProvider, error) {
+func ManifestBackedProvider(manifests []*app.ManifestData) (SearchFieldsProvider, error) {
 	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	preferred := map[schema.GroupResource]string{}
 
@@ -112,18 +104,18 @@ func manifestSearchFieldsToDefinitions(in []app.ManifestVersionKindSearchField) 
 
 // manifestDeclaredKindKeys returns the (group, resource) key of every kind that
 // declares at least one search field in any version.
-func manifestDeclaredKindKeys(manifests []app.Manifest) map[LowerGroupResource]bool {
+func manifestDeclaredKindKeys(manifests []*app.ManifestData) map[LowerGroupResource]bool {
 	keys := map[LowerGroupResource]bool{}
 	for _, m := range manifests {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
-		for _, version := range m.ManifestData.Versions {
+		for _, version := range m.Versions {
 			for _, kind := range version.Kinds {
 				if len(kind.SearchFields) == 0 {
 					continue
 				}
-				keys[NewLowerGroupResource(m.ManifestData.Group, ManifestResourceName(kind))] = true
+				keys[NewLowerGroupResource(m.Group, ManifestResourceName(kind))] = true
 			}
 		}
 	}
@@ -134,7 +126,7 @@ func manifestDeclaredKindKeys(manifests []app.Manifest) map[LowerGroupResource]b
 // drives bleve mappings. Every kind that declares search fields in its manifest
 // is mapped to a single manifest-backed provider; each entry queries it for its
 // own (group, resource).
-func SearchFieldProviders(manifests []app.Manifest) (map[LowerGroupResource]SearchFieldsProvider, error) {
+func SearchFieldProviders(manifests []*app.ManifestData) (map[LowerGroupResource]SearchFieldsProvider, error) {
 	declared := manifestDeclaredKindKeys(manifests)
 	out := make(map[LowerGroupResource]SearchFieldsProvider, len(declared))
 	if len(declared) == 0 {
@@ -170,7 +162,7 @@ func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchField
 // ApplyManifests rebuilds the registry from the built-in and live manifest sets
 // and swaps them in. On error the registry is left unchanged, so a bad reload
 // keeps the current search fields.
-func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []app.Manifest) error {
+func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []*app.ManifestData) error {
 	merged := MergeManifestsByKind(builtin, live)
 	selectable, hashes, providers, err := SearchFieldsForManifests(merged)
 	if err != nil {
@@ -182,7 +174,7 @@ func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []app.Manifest
 
 // SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from one
 // manifest list, so a reload can rebuild them together and keep them consistent.
-func SearchFieldsForManifests(manifests []app.Manifest) (
+func SearchFieldsForManifests(manifests []*app.ManifestData) (
 	selectable map[LowerGroupResource][]string,
 	hashes map[LowerGroupResource]string,
 	providers map[LowerGroupResource]SearchFieldsProvider,
@@ -210,15 +202,15 @@ func SearchFieldsForManifests(manifests []app.Manifest) (
 // Manifests within one source share a priority. A well-formed source declares
 // each kind in a single manifest; if two manifests in the same source declare
 // the same kind, the first is used and a warning is logged.
-func MergeManifestsByKind(sources ...[]app.Manifest) []app.Manifest {
+func MergeManifestsByKind(sources ...[]*app.ManifestData) []*app.ManifestData {
 	// Highest-priority source first, so lower-priority sources drop a kind a
 	// higher one already claimed.
 	claimedBy := map[LowerGroupResource]kindClaim{}
-	var merged []app.Manifest
+	var merged []*app.ManifestData
 	for i := len(sources) - 1; i >= 0; i-- {
 		warnDuplicateKindsWithinSource(sources[i])
 		for _, m := range sources[i] {
-			if m.ManifestData == nil {
+			if m == nil {
 				merged = append(merged, m)
 				continue
 			}
@@ -236,15 +228,15 @@ func MergeManifestsByKind(sources ...[]app.Manifest) []app.Manifest {
 // search fields for the same kind. That should not happen (a manifest is one
 // app with a unique group, carrying all its kinds), so this only surfaces a
 // malformed source; the merge keeps the first manifest's declaration.
-func warnDuplicateKindsWithinSource(src []app.Manifest) {
+func warnDuplicateKindsWithinSource(src []*app.ManifestData) {
 	seen := map[LowerGroupResource]string{}
 	for _, m := range src {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
-		group := m.ManifestData.Group
+		group := m.Group
 		declared := map[LowerGroupResource]bool{}
-		for _, v := range m.ManifestData.Versions {
+		for _, v := range m.Versions {
 			for _, k := range v.Kinds {
 				if declaresSearchFields(k) {
 					declared[NewLowerGroupResource(group, ManifestResourceName(k))] = true
@@ -254,10 +246,10 @@ func warnDuplicateKindsWithinSource(src []app.Manifest) {
 		for key := range declared {
 			if first, ok := seen[key]; ok {
 				manifestMergeLogger.Warn("multiple manifests in one source declare search fields for the same kind, using the first",
-					"group", key.Group, "resource", key.Resource, "first", first, "duplicate", m.ManifestData.AppName)
+					"group", key.Group, "resource", key.Resource, "first", first, "duplicate", m.AppName)
 				continue
 			}
-			seen[key] = m.ManifestData.AppName
+			seen[key] = m.AppName
 		}
 	}
 }
@@ -280,11 +272,11 @@ type kindClaim struct {
 // records the ones it keeps. ok is false only when no kind survives, so a
 // manifest whose kinds carry only selectable fields is kept: the merge output
 // also drives selectable-field wiring, not just search fields.
-func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClaim) (app.Manifest, bool) {
-	group := m.ManifestData.Group
-	appName := m.ManifestData.AppName
+func pruneClaimedKinds(m *app.ManifestData, claimedBy map[LowerGroupResource]kindClaim) (*app.ManifestData, bool) {
+	group := m.Group
+	appName := m.AppName
 
-	md := *m.ManifestData
+	md := *m
 	versions := make([]app.ManifestVersion, 0, len(md.Versions))
 	kept := map[LowerGroupResource]bool{}
 	declaredVersions := map[LowerGroupResource]map[string]bool{}
@@ -323,10 +315,10 @@ func pruneClaimedKinds(m app.Manifest, claimedBy map[LowerGroupResource]kindClai
 	}
 
 	if !anyKind {
-		return app.Manifest{}, false
+		return nil, false
 	}
 	md.Versions = versions
-	return app.Manifest{ManifestData: &md, Location: m.Location}, true
+	return &md, true
 }
 
 // logOverriddenKind logs a kind dropped in favor of a higher-priority source. It

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -21,8 +21,8 @@ var manifestMergeLogger = log.New("search-manifest-merge")
 // Panics on an invalid declaration, like NewMapProvider, because in a
 // compiled-in manifest that is a bug. Runtime callers use
 // ManifestBackedProvider instead.
-func NewManifestBackedProvider(manifests []*app.ManifestData) SearchFieldsProvider {
-	p, err := ManifestBackedProvider(manifests)
+func NewManifestBackedProvider(manifests ...*app.ManifestData) SearchFieldsProvider {
+	p, err := ManifestBackedProvider(manifests...)
 	if err != nil {
 		panic(err.Error())
 	}
@@ -32,7 +32,7 @@ func NewManifestBackedProvider(manifests []*app.ManifestData) SearchFieldsProvid
 // ManifestBackedProvider is NewManifestBackedProvider's error-returning form,
 // for manifests read at runtime, which can be malformed without this build
 // being at fault.
-func ManifestBackedProvider(manifests []*app.ManifestData) (SearchFieldsProvider, error) {
+func ManifestBackedProvider(manifests ...*app.ManifestData) (SearchFieldsProvider, error) {
 	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	preferred := map[schema.GroupResource]string{}
 
@@ -126,7 +126,7 @@ func manifestDeclaredKindKeys(manifests []*app.ManifestData) map[LowerGroupResou
 // drives bleve mappings. Every kind that declares search fields in its manifest
 // is mapped to a single manifest-backed provider; each entry queries it for its
 // own (group, resource).
-func SearchFieldProviders(manifests []*app.ManifestData) (map[LowerGroupResource]SearchFieldsProvider, error) {
+func SearchFieldProviders(manifests ...*app.ManifestData) (map[LowerGroupResource]SearchFieldsProvider, error) {
 	declared := manifestDeclaredKindKeys(manifests)
 	out := make(map[LowerGroupResource]SearchFieldsProvider, len(declared))
 	if len(declared) == 0 {
@@ -135,7 +135,7 @@ func SearchFieldProviders(manifests []*app.ManifestData) (map[LowerGroupResource
 
 	// A single manifest-backed provider covers every declared kind; each map
 	// entry queries it for its own (group, resource).
-	manifestProvider, err := ManifestBackedProvider(manifests)
+	manifestProvider, err := ManifestBackedProvider(manifests...)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func SearchFieldsHashesForProviders(providers map[LowerGroupResource]SearchField
 // keeps the current search fields.
 func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []*app.ManifestData) error {
 	merged := MergeManifestsByKind(builtin, live)
-	selectable, hashes, providers, err := SearchFieldsForManifests(merged)
+	selectable, hashes, providers, err := SearchFieldsForManifests(merged...)
 	if err != nil {
 		return err
 	}
@@ -174,18 +174,18 @@ func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []*app.Manifes
 
 // SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from one
 // manifest list, so a reload can rebuild them together and keep them consistent.
-func SearchFieldsForManifests(manifests []*app.ManifestData) (
+func SearchFieldsForManifests(manifests ...*app.ManifestData) (
 	selectable map[LowerGroupResource][]string,
 	hashes map[LowerGroupResource]string,
 	providers map[LowerGroupResource]SearchFieldsProvider,
 	err error,
 ) {
-	providers, err = SearchFieldProviders(manifests)
+	providers, err = SearchFieldProviders(manifests...)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	hashes = SearchFieldsHashesForProviders(providers)
-	selectable = SelectableFieldsForManifests(manifests)
+	selectable = SelectableFieldsForManifests(manifests...)
 	return selectable, hashes, providers, nil
 }
 

--- a/pkg/storage/unified/resource/search_field_manifest.go
+++ b/pkg/storage/unified/resource/search_field_manifest.go
@@ -12,15 +12,9 @@ import (
 
 var manifestMergeLogger = log.New("search-manifest-merge")
 
-// NewManifestBackedProvider builds a SearchFieldsProvider from the search
-// fields declared in the given app manifests. It walks every version's kinds,
-// converts each declared field into a SearchFieldDefinition, and returns the
-// same map-backed provider NewMapProvider produces, so the per-field and
-// cross-version consistency checks apply here too.
-//
-// Panics on an invalid declaration, like NewMapProvider, because in a
-// compiled-in manifest that is a bug. Runtime callers use
-// ManifestBackedProvider instead.
+// NewManifestBackedProvider is ManifestBackedProvider for compiled-in
+// manifests, where an invalid declaration is a bug rather than bad input, so it
+// panics instead of returning an error.
 func NewManifestBackedProvider(manifests ...*app.ManifestData) SearchFieldsProvider {
 	p, err := ManifestBackedProvider(manifests...)
 	if err != nil {
@@ -29,9 +23,11 @@ func NewManifestBackedProvider(manifests ...*app.ManifestData) SearchFieldsProvi
 	return p
 }
 
-// ManifestBackedProvider is NewManifestBackedProvider's error-returning form,
-// for manifests read at runtime, which can be malformed without this build
-// being at fault.
+// ManifestBackedProvider builds a SearchFieldsProvider from the search fields
+// declared across every version's kinds. It returns the same map-backed
+// provider NewMapProvider does, so the per-field and cross-version consistency
+// checks apply here too. Manifests read at runtime can be malformed without
+// this build being at fault, hence the error rather than a panic.
 func ManifestBackedProvider(manifests ...*app.ManifestData) (SearchFieldsProvider, error) {
 	fields := map[schema.GroupVersionResource][]SearchFieldDefinition{}
 	preferred := map[schema.GroupResource]string{}
@@ -133,8 +129,6 @@ func SearchFieldProviders(manifests ...*app.ManifestData) (map[LowerGroupResourc
 		return out, nil
 	}
 
-	// A single manifest-backed provider covers every declared kind; each map
-	// entry queries it for its own (group, resource).
 	manifestProvider, err := ManifestBackedProvider(manifests...)
 	if err != nil {
 		return nil, err
@@ -172,8 +166,8 @@ func ApplyManifests(registry *SearchFieldsRegistry, builtin, live []*app.Manifes
 	return nil
 }
 
-// SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from one
-// manifest list, so a reload can rebuild them together and keep them consistent.
+// SearchFieldsForManifests builds a SearchFieldsRegistry's three inputs from the
+// same manifests, so a reload can rebuild them together and keep them consistent.
 func SearchFieldsForManifests(manifests ...*app.ManifestData) (
 	selectable map[LowerGroupResource][]string,
 	hashes map[LowerGroupResource]string,

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func manifestWithSearchFields() app.Manifest {
-	return app.Manifest{ManifestData: &app.ManifestData{
+func manifestWithSearchFields() *app.ManifestData {
+	return &app.ManifestData{
 		Group:            "widgets.example.test",
 		PreferredVersion: "v2",
 		Versions: []app.ManifestVersion{
@@ -36,11 +36,11 @@ func manifestWithSearchFields() app.Manifest {
 				}},
 			},
 		},
-	}}
+	}
 }
 
 func TestNewManifestBackedProvider(t *testing.T) {
-	p := NewManifestBackedProvider([]app.Manifest{manifestWithSearchFields()})
+	p := NewManifestBackedProvider([]*app.ManifestData{manifestWithSearchFields()})
 
 	v2 := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v2", Resource: "widgets"}
 	got := p.Fields(v2)
@@ -74,7 +74,7 @@ func TestNewManifestBackedProvider(t *testing.T) {
 func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.T) {
 	// No plural and no explicit preferredVersion: resource defaults to kind+"s"
 	// (lower-cased) and the last declaring version is preferred.
-	p := NewManifestBackedProvider([]app.Manifest{{ManifestData: &app.ManifestData{
+	p := NewManifestBackedProvider([]*app.ManifestData{{
 		Group: "widgets.example.test",
 		Versions: []app.ManifestVersion{
 			{Name: "v1", Kinds: []app.ManifestVersionKind{{
@@ -86,7 +86,7 @@ func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.
 				SearchFields: []app.ManifestVersionKindSearchField{{Name: "name", Path: "spec.name", Type: "string", Capabilities: []string{"filter"}}},
 			}}},
 		},
-	}}})
+	}})
 
 	gvr := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v1", Resource: "gadgets"}
 	require.Len(t, p.Fields(gvr), 1)
@@ -94,7 +94,7 @@ func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.
 }
 
 func TestSearchFieldProviders_MapsDeclaredKinds(t *testing.T) {
-	got, err := SearchFieldProviders([]app.Manifest{manifestWithSearchFields()})
+	got, err := SearchFieldProviders([]*app.ManifestData{manifestWithSearchFields()})
 	require.NoError(t, err)
 
 	// The one kind that declares search fields is present and provider-backed.
@@ -109,15 +109,15 @@ func TestSearchFieldProviders_MapsDeclaredKinds(t *testing.T) {
 
 func TestSearchFieldProviders_NoManifestDeclarationsIsEmpty(t *testing.T) {
 	// A manifest that declares no search fields yields an empty map.
-	manifestNoFields := app.Manifest{ManifestData: &app.ManifestData{
+	manifestNoFields := &app.ManifestData{
 		Group: "widgets.example.test",
 		Versions: []app.ManifestVersion{{
 			Name:  "v1",
 			Kinds: []app.ManifestVersionKind{{Kind: "Widget", Plural: "widgets"}},
 		}},
-	}}
+	}
 
-	got, err := SearchFieldProviders([]app.Manifest{manifestNoFields})
+	got, err := SearchFieldProviders([]*app.ManifestData{manifestNoFields})
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -125,7 +125,7 @@ func TestSearchFieldProviders_NoManifestDeclarationsIsEmpty(t *testing.T) {
 func TestSearchFieldProviders_InvalidManifestReturnsError(t *testing.T) {
 	// A runtime manifest source can carry an invalid declaration; the path must
 	// surface it as an error rather than panicking.
-	invalid := app.Manifest{ManifestData: &app.ManifestData{
+	invalid := &app.ManifestData{
 		Group: "widgets.example.test",
 		Versions: []app.ManifestVersion{{
 			Name: "v1",
@@ -137,20 +137,20 @@ func TestSearchFieldProviders_InvalidManifestReturnsError(t *testing.T) {
 				},
 			}},
 		}},
-	}}
+	}
 
-	got, err := SearchFieldProviders([]app.Manifest{invalid})
+	got, err := SearchFieldProviders([]*app.ManifestData{invalid})
 	require.Error(t, err)
 	assert.Nil(t, got)
 
 	// Same set through the constructor a runtime caller uses.
-	p, err := ManifestBackedProvider([]app.Manifest{invalid})
+	p, err := ManifestBackedProvider([]*app.ManifestData{invalid})
 	require.Error(t, err)
 	assert.Nil(t, p)
 }
 
-func mergeTestManifest(appName, group string, versions ...app.ManifestVersion) app.Manifest {
-	return app.Manifest{ManifestData: &app.ManifestData{AppName: appName, Group: group, Versions: versions}}
+func mergeTestManifest(appName, group string, versions ...app.ManifestVersion) *app.ManifestData {
+	return &app.ManifestData{AppName: appName, Group: group, Versions: versions}
 }
 
 func mergeTestKind(kind, field string) app.ManifestVersionKind {
@@ -164,7 +164,7 @@ func mergeTestKind(kind, field string) app.ManifestVersionKind {
 }
 
 // fieldNames lets a test assert whose declaration of a kind survived a merge.
-func fieldNames(t *testing.T, manifests []app.Manifest, group, version, resource string) []string {
+func fieldNames(t *testing.T, manifests []*app.ManifestData, group, version, resource string) []string {
 	t.Helper()
 	p, err := ManifestBackedProvider(manifests)
 	require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestMergeManifestsByKind(t *testing.T) {
 		builtin := mergeTestManifest("builtin", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "one")}})
 		live := mergeTestManifest("live", "b.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Bar", "two")}})
 
-		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+		merged := MergeManifestsByKind([]*app.ManifestData{builtin}, []*app.ManifestData{live})
 
 		require.Equal(t, []string{"one"}, fieldNames(t, merged, "a.test", "v1", "foos"))
 		require.Equal(t, []string{"two"}, fieldNames(t, merged, "b.test", "v1", "bars"))
@@ -197,7 +197,7 @@ func TestMergeManifestsByKind(t *testing.T) {
 			app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "live_v1")}},
 		)
 
-		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+		merged := MergeManifestsByKind([]*app.ManifestData{builtin}, []*app.ManifestData{live})
 
 		// Whole kind comes from the winner: v2 is gone, not kept from built-in.
 		require.Equal(t, []string{"live_v1"}, fieldNames(t, merged, "g.test", "v1", "foos"))
@@ -208,10 +208,10 @@ func TestMergeManifestsByKind(t *testing.T) {
 		builtin := mergeTestManifest("builtin", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtin")}})
 		live := mergeTestManifest("live", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "live")}})
 
-		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+		merged := MergeManifestsByKind([]*app.ManifestData{builtin}, []*app.ManifestData{live})
 
 		require.Len(t, merged, 1)
-		require.Equal(t, "live", merged[0].ManifestData.AppName)
+		require.Equal(t, "live", merged[0].AppName)
 	})
 
 	t.Run("a source without search fields for a kind does not override another source", func(t *testing.T) {
@@ -221,7 +221,7 @@ func TestMergeManifestsByKind(t *testing.T) {
 		// search fields.
 		live := mergeTestManifest("live", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{{Kind: "Foo", Plural: "foos", SelectableFields: []string{"spec.x"}}}})
 
-		merged := MergeManifestsByKind([]app.Manifest{builtin}, []app.Manifest{live})
+		merged := MergeManifestsByKind([]*app.ManifestData{builtin}, []*app.ManifestData{live})
 
 		require.Equal(t, []string{"builtin"}, fieldNames(t, merged, "g.test", "v1", "foos"))
 	})
@@ -232,7 +232,7 @@ func TestMergeManifestsByKind(t *testing.T) {
 		a := mergeTestManifest("a", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "first")}})
 		b := mergeTestManifest("b", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "second")}})
 
-		merged := MergeManifestsByKind([]app.Manifest{a, b})
+		merged := MergeManifestsByKind([]*app.ManifestData{a, b})
 
 		require.Equal(t, []string{"first"}, fieldNames(t, merged, "g.test", "v1", "foos"))
 	})
@@ -241,7 +241,7 @@ func TestMergeManifestsByKind(t *testing.T) {
 		// Its kinds declare only selectable fields (no search fields), and the merge
 		// output drives selectable-field wiring too, so it must not be dropped.
 		kind := app.ManifestVersionKind{Kind: "Foo", Plural: "foos", SelectableFields: []string{"spec.x"}}
-		in := []app.Manifest{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
+		in := []*app.ManifestData{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
 
 		merged := MergeManifestsByKind(in)
 
@@ -250,16 +250,16 @@ func TestMergeManifestsByKind(t *testing.T) {
 	})
 
 	t.Run("manifests without data pass through", func(t *testing.T) {
-		merged := MergeManifestsByKind([]app.Manifest{{ManifestData: nil}})
+		merged := MergeManifestsByKind([]*app.ManifestData{nil})
 		require.Len(t, merged, 1)
-		require.Nil(t, merged[0].ManifestData)
+		require.Nil(t, merged[0])
 	})
 }
 
 func TestSearchFieldsForManifests(t *testing.T) {
 	kind := mergeTestKind("Foo", "one")
 	kind.SelectableFields = []string{"spec.two"}
-	manifests := []app.Manifest{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
+	manifests := []*app.ManifestData{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
 
 	selectable, hashes, providers, err := SearchFieldsForManifests(manifests)
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestSearchFieldsForManifests(t *testing.T) {
 
 func TestApplyManifests(t *testing.T) {
 	registry := NewSearchFieldsRegistry(nil, nil, nil)
-	builtin := []app.Manifest{
+	builtin := []*app.ManifestData{
 		mergeTestManifest("builtin", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "builtinfield")}}),
 	}
 	require.NoError(t, ApplyManifests(registry, builtin, nil))
@@ -292,7 +292,7 @@ func TestApplyManifests(t *testing.T) {
 
 	// A live source overrides the same kind with a different field. The registry
 	// must reflect the live declaration and its hash must change.
-	live := []app.Manifest{
+	live := []*app.ManifestData{
 		mergeTestManifest("live", "a.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{mergeTestKind("Foo", "livefield")}}),
 	}
 	require.NoError(t, ApplyManifests(registry, builtin, live))

--- a/pkg/storage/unified/resource/search_field_manifest_test.go
+++ b/pkg/storage/unified/resource/search_field_manifest_test.go
@@ -40,7 +40,7 @@ func manifestWithSearchFields() *app.ManifestData {
 }
 
 func TestNewManifestBackedProvider(t *testing.T) {
-	p := NewManifestBackedProvider([]*app.ManifestData{manifestWithSearchFields()})
+	p := NewManifestBackedProvider(manifestWithSearchFields())
 
 	v2 := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v2", Resource: "widgets"}
 	got := p.Fields(v2)
@@ -74,7 +74,7 @@ func TestNewManifestBackedProvider(t *testing.T) {
 func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.T) {
 	// No plural and no explicit preferredVersion: resource defaults to kind+"s"
 	// (lower-cased) and the last declaring version is preferred.
-	p := NewManifestBackedProvider([]*app.ManifestData{{
+	p := NewManifestBackedProvider(&app.ManifestData{
 		Group: "widgets.example.test",
 		Versions: []app.ManifestVersion{
 			{Name: "v1", Kinds: []app.ManifestVersionKind{{
@@ -86,7 +86,7 @@ func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.
 				SearchFields: []app.ManifestVersionKindSearchField{{Name: "name", Path: "spec.name", Type: "string", Capabilities: []string{"filter"}}},
 			}}},
 		},
-	}})
+	})
 
 	gvr := schema.GroupVersionResource{Group: "widgets.example.test", Version: "v1", Resource: "gadgets"}
 	require.Len(t, p.Fields(gvr), 1)
@@ -94,7 +94,7 @@ func TestNewManifestBackedProvider_DefaultsPluralAndPreferredVersion(t *testing.
 }
 
 func TestSearchFieldProviders_MapsDeclaredKinds(t *testing.T) {
-	got, err := SearchFieldProviders([]*app.ManifestData{manifestWithSearchFields()})
+	got, err := SearchFieldProviders(manifestWithSearchFields())
 	require.NoError(t, err)
 
 	// The one kind that declares search fields is present and provider-backed.
@@ -117,7 +117,7 @@ func TestSearchFieldProviders_NoManifestDeclarationsIsEmpty(t *testing.T) {
 		}},
 	}
 
-	got, err := SearchFieldProviders([]*app.ManifestData{manifestNoFields})
+	got, err := SearchFieldProviders(manifestNoFields)
 	require.NoError(t, err)
 	assert.Empty(t, got)
 }
@@ -139,12 +139,12 @@ func TestSearchFieldProviders_InvalidManifestReturnsError(t *testing.T) {
 		}},
 	}
 
-	got, err := SearchFieldProviders([]*app.ManifestData{invalid})
+	got, err := SearchFieldProviders(invalid)
 	require.Error(t, err)
 	assert.Nil(t, got)
 
 	// Same set through the constructor a runtime caller uses.
-	p, err := ManifestBackedProvider([]*app.ManifestData{invalid})
+	p, err := ManifestBackedProvider(invalid)
 	require.Error(t, err)
 	assert.Nil(t, p)
 }
@@ -166,7 +166,7 @@ func mergeTestKind(kind, field string) app.ManifestVersionKind {
 // fieldNames lets a test assert whose declaration of a kind survived a merge.
 func fieldNames(t *testing.T, manifests []*app.ManifestData, group, version, resource string) []string {
 	t.Helper()
-	p, err := ManifestBackedProvider(manifests)
+	p, err := ManifestBackedProvider(manifests...)
 	require.NoError(t, err)
 	fields := p.Fields(schema.GroupVersionResource{Group: group, Version: version, Resource: resource})
 	names := make([]string, 0, len(fields))
@@ -245,8 +245,8 @@ func TestMergeManifestsByKind(t *testing.T) {
 
 		merged := MergeManifestsByKind(in)
 
-		require.NotEmpty(t, SelectableFieldsForManifests(merged))
-		require.Equal(t, SelectableFieldsForManifests(in), SelectableFieldsForManifests(merged))
+		require.NotEmpty(t, SelectableFieldsForManifests(merged...))
+		require.Equal(t, SelectableFieldsForManifests(in...), SelectableFieldsForManifests(merged...))
 	})
 
 	t.Run("manifests without data pass through", func(t *testing.T) {
@@ -261,15 +261,15 @@ func TestSearchFieldsForManifests(t *testing.T) {
 	kind.SelectableFields = []string{"spec.two"}
 	manifests := []*app.ManifestData{mergeTestManifest("app", "g.test", app.ManifestVersion{Name: "v1", Kinds: []app.ManifestVersionKind{kind}})}
 
-	selectable, hashes, providers, err := SearchFieldsForManifests(manifests)
+	selectable, hashes, providers, err := SearchFieldsForManifests(manifests...)
 	require.NoError(t, err)
 
 	// The three inputs all come from the same manifests.
-	wantProviders, err := SearchFieldProviders(manifests)
+	wantProviders, err := SearchFieldProviders(manifests...)
 	require.NoError(t, err)
 	require.Equal(t, wantProviders, providers)
 	require.Equal(t, SearchFieldsHashesForProviders(wantProviders), hashes)
-	require.Equal(t, SelectableFieldsForManifests(manifests), selectable)
+	require.Equal(t, SelectableFieldsForManifests(manifests...), selectable)
 
 	// The kind declares both search and selectable fields, so none is empty.
 	require.NotEmpty(t, providers)

--- a/pkg/storage/unified/resource/selectable_fields.go
+++ b/pkg/storage/unified/resource/selectable_fields.go
@@ -9,10 +9,10 @@ import (
 // SelectableFields returns a map keyed by (group, kind) to the list of
 // selectable fields for known manifests.
 func SelectableFields() map[LowerGroupResource][]string {
-	return SelectableFieldsForManifests(AppManifests())
+	return SelectableFieldsForManifests(AppManifests()...)
 }
 
-func AppManifestsWithKinds(manifiests []*app.ManifestData) []*app.ManifestData {
+func AppManifestsWithKinds(manifiests ...*app.ManifestData) []*app.ManifestData {
 	// Include manifests with kinds in any version.
 	filtered := make([]*app.ManifestData, 0, len(manifiests))
 	for _, m := range manifiests {
@@ -36,7 +36,7 @@ func AppManifestsWithKinds(manifiests []*app.ManifestData) []*app.ManifestData {
 // SelectableFieldsForManifests returns a map keyed by (group, kind) to the list
 // of selectable fields (across all versions). Each kind is also keyed by
 // (group, plural), pointing to the same fields.
-func SelectableFieldsForManifests(manifests []*app.ManifestData) map[LowerGroupResource][]string {
+func SelectableFieldsForManifests(manifests ...*app.ManifestData) map[LowerGroupResource][]string {
 	fields := map[LowerGroupResource][]string{}
 	for _, m := range manifests {
 		if m == nil {

--- a/pkg/storage/unified/resource/selectable_fields.go
+++ b/pkg/storage/unified/resource/selectable_fields.go
@@ -12,15 +12,15 @@ func SelectableFields() map[LowerGroupResource][]string {
 	return SelectableFieldsForManifests(AppManifests())
 }
 
-func AppManifestsWithKinds(manifiests []app.Manifest) []app.Manifest {
+func AppManifestsWithKinds(manifiests []*app.ManifestData) []*app.ManifestData {
 	// Include manifests with kinds in any version.
-	filtered := make([]app.Manifest, 0, len(manifiests))
+	filtered := make([]*app.ManifestData, 0, len(manifiests))
 	for _, m := range manifiests {
-		if m.ManifestData == nil {
+		if m == nil {
 			continue
 		}
 		hasKinds := false
-		for _, v := range m.ManifestData.Versions {
+		for _, v := range m.Versions {
 			if len(v.Kinds) > 0 {
 				hasKinds = true
 				break
@@ -36,9 +36,12 @@ func AppManifestsWithKinds(manifiests []app.Manifest) []app.Manifest {
 // SelectableFieldsForManifests returns a map keyed by (group, kind) to the list
 // of selectable fields (across all versions). Each kind is also keyed by
 // (group, plural), pointing to the same fields.
-func SelectableFieldsForManifests(manifests []app.Manifest) map[LowerGroupResource][]string {
+func SelectableFieldsForManifests(manifests []*app.ManifestData) map[LowerGroupResource][]string {
 	fields := map[LowerGroupResource][]string{}
 	for _, m := range manifests {
+		if m == nil {
+			continue
+		}
 		for k, v := range selectableFieldsForManifest(m) {
 			fields[k] = v
 		}
@@ -46,11 +49,11 @@ func SelectableFieldsForManifests(manifests []app.Manifest) map[LowerGroupResour
 	return fields
 }
 
-func selectableFieldsForManifest(m app.Manifest) map[LowerGroupResource][]string {
+func selectableFieldsForManifest(m *app.ManifestData) map[LowerGroupResource][]string {
 	kindFields := map[string]map[string]bool{}
 	kinds := map[string]app.ManifestVersionKind{}
 
-	for _, version := range m.ManifestData.Versions {
+	for _, version := range m.Versions {
 		for _, kind := range version.Kinds {
 			if len(kind.SelectableFields) > 0 {
 				kinds[kind.Kind] = kind
@@ -73,8 +76,8 @@ func selectableFieldsForManifest(m app.Manifest) map[LowerGroupResource][]string
 		}
 		slices.Sort(fs)
 
-		fields[NewLowerGroupResource(m.ManifestData.Group, v.Kind)] = fs
-		fields[NewLowerGroupResource(m.ManifestData.Group, v.Plural)] = fs
+		fields[NewLowerGroupResource(m.Group, v.Kind)] = fs
+		fields[NewLowerGroupResource(m.Group, v.Plural)] = fs
 	}
 
 	return fields

--- a/pkg/storage/unified/resource/selectable_fields.go
+++ b/pkg/storage/unified/resource/selectable_fields.go
@@ -12,8 +12,9 @@ func SelectableFields() map[LowerGroupResource][]string {
 	return SelectableFieldsForManifests(AppManifests()...)
 }
 
+// AppManifestsWithKinds keeps only the manifests declaring a kind in some
+// version.
 func AppManifestsWithKinds(manifiests ...*app.ManifestData) []*app.ManifestData {
-	// Include manifests with kinds in any version.
 	filtered := make([]*app.ManifestData, 0, len(manifiests))
 	for _, m := range manifiests {
 		if m == nil {

--- a/pkg/storage/unified/resource/selectable_fields_test.go
+++ b/pkg/storage/unified/resource/selectable_fields_test.go
@@ -11,7 +11,7 @@ import (
 func TestAppManifestsCanFilterOutManifestsWithNoKinds(t *testing.T) {
 	all := AppManifests()
 	for _, m := range AppManifestsWithKinds(all) {
-		if m.ManifestData.AppName == "provisioning" {
+		if m.AppName == "provisioning" {
 			t.Errorf("should not have a provisioning manifest as it has no kinds defined")
 		}
 	}
@@ -19,7 +19,7 @@ func TestAppManifestsCanFilterOutManifestsWithNoKinds(t *testing.T) {
 
 func TestSelectableFieldsForManifests(t *testing.T) {
 	// No selectable fields
-	m1 := app.NewEmbeddedManifest(app.ManifestData{
+	m1 := &app.ManifestData{
 		Group: "test1.grafana.app",
 		Versions: []app.ManifestVersion{
 			{
@@ -32,10 +32,10 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
 	// One version with selectable fields.
-	m2 := app.NewEmbeddedManifest(app.ManifestData{
+	m2 := &app.ManifestData{
 		Group: "test2.grafana.app",
 		Versions: []app.ManifestVersion{
 			{
@@ -52,10 +52,10 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
 	// Multiple versions with repeated and new fields.
-	m3 := app.NewEmbeddedManifest(app.ManifestData{
+	m3 := &app.ManifestData{
 		Group: "test3.grafana.app",
 		Versions: []app.ManifestVersion{
 			{
@@ -107,10 +107,10 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
 	// Multiple kinds in the same manifest.
-	m4 := app.NewEmbeddedManifest(app.ManifestData{
+	m4 := &app.ManifestData{
 		Group: "test4.grafana.app",
 		Versions: []app.ManifestVersion{
 			{
@@ -133,9 +133,9 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 				},
 			},
 		},
-	})
+	}
 
-	fields := SelectableFieldsForManifests([]app.Manifest{m1, m2, m3, m4})
+	fields := SelectableFieldsForManifests([]*app.ManifestData{m1, m2, m3, m4})
 	expected := map[LowerGroupResource][]string{
 		// Nothing for test1.grafana.app, as there were no selectable fields.
 		NewLowerGroupResource("test2.grafana.app", "testkind"):  {"spec.field1", "spec.field2"},

--- a/pkg/storage/unified/resource/selectable_fields_test.go
+++ b/pkg/storage/unified/resource/selectable_fields_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAppManifestsCanFilterOutManifestsWithNoKinds(t *testing.T) {
 	all := AppManifests()
-	for _, m := range AppManifestsWithKinds(all) {
+	for _, m := range AppManifestsWithKinds(all...) {
 		if m.AppName == "provisioning" {
 			t.Errorf("should not have a provisioning manifest as it has no kinds defined")
 		}
@@ -135,7 +135,7 @@ func TestSelectableFieldsForManifests(t *testing.T) {
 		},
 	}
 
-	fields := SelectableFieldsForManifests([]*app.ManifestData{m1, m2, m3, m4})
+	fields := SelectableFieldsForManifests(m1, m2, m3, m4)
 	expected := map[LowerGroupResource][]string{
 		// Nothing for test1.grafana.app, as there were no selectable fields.
 		NewLowerGroupResource("test2.grafana.app", "testkind"):  {"spec.field1", "spec.field2"},

--- a/pkg/storage/unified/search/bleve_mappings_golden_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_golden_test.go
@@ -75,7 +75,7 @@ func TestBleveMappingsGoldenJSON(t *testing.T) {
 
 	// In production the mapping's provider comes from the shared registry, built
 	// from the app manifests, not from the builder. Mirror that here.
-	manifestProvider := resource.NewManifestBackedProvider(resource.AppManifests())
+	manifestProvider := resource.NewManifestBackedProvider(resource.AppManifests()...)
 
 	cases := []struct {
 		name string

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
-// rulesManifests is the rule kinds' manifest; the tests derive the rule search
-// fields from it the way the shared registry does in production.
+// rulesManifestData is the rule kinds' manifest; the tests derive the rule
+// search fields from it the way the shared registry does in production.
 var rulesManifestData = rulesmanifest.LocalManifest().ManifestData
 
 var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifestData)

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -61,7 +61,7 @@ func recordingRuleKey(name string) *resourcepb.ResourceKey {
 // registry-backed builders extract them, as they do in production.
 func rulesTestRegistry(t *testing.T) *resource.SearchFieldsRegistry {
 	t.Helper()
-	sel, hashes, providers, err := resource.SearchFieldsForManifests(rulesManifests...)
+	sel, hashes, providers, err := resource.SearchFieldsForManifests(rulesManifestData)
 	require.NoError(t, err)
 	return resource.NewSearchFieldsRegistry(sel, hashes, providers)
 }

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,9 +17,9 @@ import (
 
 // rulesManifests is the rule kinds' manifest; the tests derive the rule search
 // fields from it the way the shared registry does in production.
-var rulesManifests = []*app.ManifestData{rulesmanifest.LocalManifest().ManifestData}
+var rulesManifestData = rulesmanifest.LocalManifest().ManifestData
 
-var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifests)
+var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifestData)
 
 // Field names as declared in apps/alerting/rules/kinds/{alertRule,recordingRule}.cue.
 // Only type, labels, annotations and datasourceUIDs remain as Go constants in
@@ -62,7 +61,7 @@ func recordingRuleKey(name string) *resourcepb.ResourceKey {
 // registry-backed builders extract them, as they do in production.
 func rulesTestRegistry(t *testing.T) *resource.SearchFieldsRegistry {
 	t.Helper()
-	sel, hashes, providers, err := resource.SearchFieldsForManifests(rulesManifests)
+	sel, hashes, providers, err := resource.SearchFieldsForManifests(rulesManifests...)
 	require.NoError(t, err)
 	return resource.NewSearchFieldsRegistry(sel, hashes, providers)
 }

--- a/pkg/storage/unified/search/builders/alertingrules_test.go
+++ b/pkg/storage/unified/search/builders/alertingrules_test.go
@@ -18,7 +18,7 @@ import (
 
 // rulesManifests is the rule kinds' manifest; the tests derive the rule search
 // fields from it the way the shared registry does in production.
-var rulesManifests = []app.Manifest{rulesmanifest.LocalManifest()}
+var rulesManifests = []*app.ManifestData{rulesmanifest.LocalManifest().ManifestData}
 
 var rulesSearchFieldsProvider = resource.NewManifestBackedProvider(rulesManifests)
 

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"sort"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	dashboardapp "github.com/grafana/grafana/apps/dashboard/pkg/apis"
@@ -48,7 +47,7 @@ const DASHBOARD_ERRORS_TODAY = "errors_today"
 // fields (no resource path); DashboardDocumentBuilder fills them in from the
 // parsed spec and the usage-insights stats.
 var DashboardSearchFields = resource.NewManifestBackedProvider(
-	[]*app.ManifestData{dashboardapp.LocalManifest().ManifestData},
+	dashboardapp.LocalManifest().ManifestData,
 ).Fields(dashV1.DashboardResourceInfo.GroupVersionResource())
 
 func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.DocumentBuilderInfo, error) {

--- a/pkg/storage/unified/search/builders/dashboard.go
+++ b/pkg/storage/unified/search/builders/dashboard.go
@@ -48,7 +48,7 @@ const DASHBOARD_ERRORS_TODAY = "errors_today"
 // fields (no resource path); DashboardDocumentBuilder fills them in from the
 // parsed spec and the usage-insights stats.
 var DashboardSearchFields = resource.NewManifestBackedProvider(
-	[]app.Manifest{dashboardapp.LocalManifest()},
+	[]*app.ManifestData{dashboardapp.LocalManifest().ManifestData},
 ).Fields(dashV1.DashboardResourceInfo.GroupVersionResource())
 
 func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.DocumentBuilderInfo, error) {

--- a/pkg/storage/unified/search/builders/document_test.go
+++ b/pkg/storage/unified/search/builders/document_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	iam "github.com/grafana/grafana/apps/iam/pkg/apis"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -51,7 +52,7 @@ func doSnapshotTests(t *testing.T, builder resource.DocumentBuilder, kind string
 // registry-backed builders extract them, as they do in production.
 func iamTestRegistry(t *testing.T) *resource.SearchFieldsRegistry {
 	t.Helper()
-	sel, hashes, providers, err := resource.SearchFieldsForManifests(iamManifests)
+	sel, hashes, providers, err := resource.SearchFieldsForManifests(iam.LocalManifest().ManifestData)
 	require.NoError(t, err)
 	return resource.NewSearchFieldsRegistry(sel, hashes, providers)
 }

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -11,7 +11,7 @@ import (
 // iamManifests is the slice the IAM builders pass to the standard document
 // builder. It carries the selectable-field declarations the builder uses to
 // populate IndexableDocument.SelectableFields for IAM kinds.
-var iamManifests = []app.Manifest{iam.LocalManifest()}
+var iamManifests = []*app.ManifestData{iam.LocalManifest().ManifestData}
 
 // iamProvider is shared by all IAM builders and their exported field sets, so
 // the manifest is parsed once.

--- a/pkg/storage/unified/search/builders/user.go
+++ b/pkg/storage/unified/search/builders/user.go
@@ -1,21 +1,14 @@
 package builders
 
 import (
-	"github.com/grafana/grafana-app-sdk/app"
-
 	iam "github.com/grafana/grafana/apps/iam/pkg/apis"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// iamManifests is the slice the IAM builders pass to the standard document
-// builder. It carries the selectable-field declarations the builder uses to
-// populate IndexableDocument.SelectableFields for IAM kinds.
-var iamManifests = []*app.ManifestData{iam.LocalManifest().ManifestData}
-
 // iamProvider is shared by all IAM builders and their exported field sets, so
 // the manifest is parsed once.
-var iamProvider = resource.NewManifestBackedProvider(iamManifests)
+var iamProvider = resource.NewManifestBackedProvider(iam.LocalManifest().ManifestData)
 
 const (
 	USER_EMAIL                 = "email"

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -86,7 +86,7 @@ func NewSearchOptions(
 		// MergeManifestsByKind is the single point a future live-manifest source will
 		// be added to; the built-in manifests are the only source today.
 		manifests := resource.MergeManifestsByKind(resource.AppManifests())
-		selectableFields, searchFieldsHashes, searchFieldsProviders, err := resource.SearchFieldsForManifests(manifests)
+		selectableFields, searchFieldsHashes, searchFieldsProviders, err := resource.SearchFieldsForManifests(manifests...)
 		if err != nil {
 			return resource.SearchOptions{}, err
 		}

--- a/pkg/storage/unified/search/zz_dashboard_provider_test.go
+++ b/pkg/storage/unified/search/zz_dashboard_provider_test.go
@@ -1,8 +1,6 @@
 package search
 
 import (
-	"github.com/grafana/grafana-app-sdk/app"
-
 	dashboardapp "github.com/grafana/grafana/apps/dashboard/pkg/apis"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
@@ -11,5 +9,5 @@ import (
 // provider from its manifest, the way production does, for seeding a test
 // registry.
 func DashboardSearchFieldsProviderForTest() resource.SearchFieldsProvider {
-	return resource.NewManifestBackedProvider([]*app.ManifestData{dashboardapp.LocalManifest().ManifestData})
+	return resource.NewManifestBackedProvider(dashboardapp.LocalManifest().ManifestData)
 }

--- a/pkg/storage/unified/search/zz_dashboard_provider_test.go
+++ b/pkg/storage/unified/search/zz_dashboard_provider_test.go
@@ -11,5 +11,5 @@ import (
 // provider from its manifest, the way production does, for seeding a test
 // registry.
 func DashboardSearchFieldsProviderForTest() resource.SearchFieldsProvider {
-	return resource.NewManifestBackedProvider([]app.Manifest{dashboardapp.LocalManifest()})
+	return resource.NewManifestBackedProvider([]*app.ManifestData{dashboardapp.LocalManifest().ManifestData})
 }

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -413,7 +413,7 @@ func (s *service) registerServer(provider grpcserver.Provider) error {
 	// its initial poll completes before the index is built.
 	if registry := searchOptions.SearchFields; registry != nil {
 		if mwCfg := resource.NewManifestWatcherConfig(s.cfg); mwCfg != nil {
-			watcher, err := resource.NewManifestWatcher(*mwCfg, s.reg, func(live []appsdk.Manifest) {
+			watcher, err := resource.NewManifestWatcher(*mwCfg, s.reg, func(live []*appsdk.ManifestData) {
 				if err := resource.ApplyManifests(registry, resource.AppManifests(), live); err != nil {
 					s.log.Error("manifest reload failed, keeping current search fields", "error", err)
 					return


### PR DESCRIPTION
An `app.Manifest` carries two things: the manifest *data*, and where that data is loaded from (`Location`). Only the data is relevant to search, so this drops the search wiring's dependency on the raw `Manifest`, which may or may not exist for some deployments.

## What changed

**`[]app.Manifest` → `[]*app.ManifestData` throughout `pkg/storage/unified/resource`.** The unwrap used to happen in the middle of the call chain: `ManifestBackedProvider` took `[]app.Manifest`, pulled `.ManifestData` off each one, and handed the result to `NewSearchFieldsProvider`. Now the package speaks `*app.ManifestData` end to end and the unwrap happens once at the edge, in `AppManifests()`.

That also collapses the two constructors into one. `NewSearchFieldsProvider` existed only as the `*app.ManifestData`-taking half of `ManifestBackedProvider`; with the whole package on `ManifestData` there is nothing left for it to do, so it is **removed** — worth a look if anything out of tree calls it.

**The manifest-taking functions are now variadic**, which drops the `[]*app.ManifestData{...}` wrapper at the call sites that pass a single manifest:

```go
// before
resource.NewManifestBackedProvider([]app.Manifest{rulesmanifest.LocalManifest()})
// after
resource.NewManifestBackedProvider(rulesmanifest.LocalManifest().ManifestData)
```

Call sites that already hold a slice pass it with `...`. This is free: passing `s...` reuses the slice header, and the temp array for individual args is stack-allocated (the callee retains derived strings, never the slice itself), so neither form heap-allocates.

| Before | After |
| --- | --- |
| `AppManifests() []app.Manifest` | `AppManifests() []*app.ManifestData` |
| `NewManifestBackedProvider(manifests []app.Manifest)` | `NewManifestBackedProvider(manifests ...*app.ManifestData)` |
| `ManifestBackedProvider(manifests []app.Manifest)` | `ManifestBackedProvider(manifests ...*app.ManifestData)` |
| `NewSearchFieldsProvider(manifests []*app.ManifestData)` | *removed — merged into `ManifestBackedProvider`* |
| `SearchFieldProviders(manifests []app.Manifest)` | `SearchFieldProviders(manifests ...*app.ManifestData)` |
| `SearchFieldsForManifests(manifests []app.Manifest)` | `SearchFieldsForManifests(manifests ...*app.ManifestData)` |
| `SelectableFieldsForManifests(manifests []app.Manifest)` | `SelectableFieldsForManifests(manifests ...*app.ManifestData)` |
| `AppManifestsWithKinds(manifests []app.Manifest)` | `AppManifestsWithKinds(manifests ...*app.ManifestData)` |
| `ManifestFromUnstructured(...) (app.Manifest, error)` | `ManifestFromUnstructured(...) (*app.ManifestData, error)` |
| `ManifestWatcher.Manifests() []app.Manifest` | `ManifestWatcher.Manifests() []*app.ManifestData` |
| `NewManifestWatcher(..., onChange func([]app.Manifest))` | `NewManifestWatcher(..., onChange func([]*app.ManifestData))` |
| `ApplyManifests(registry, builtin, live []app.Manifest)` | `ApplyManifests(registry, builtin, live []*app.ManifestData)` |
| `MergeManifestsByKind(sources ...[]app.Manifest)` | `MergeManifestsByKind(sources ...[]*app.ManifestData)` |

Two stay list-shaped on purpose. `ApplyManifests` takes two lists (built-in and live), so only the last could be variadic and the symmetry reads better as-is. `MergeManifestsByKind` is variadic over *lists*, one per priority tier — it is now the only place in the package where `...` means something different from the rest, so it is worth reading carefully at the call site, though the types make a mix-up a compile error rather than a bug.

## Notes

- **`Location` is no longer carried through the search wiring.** Nothing read it — `pruneClaimedKinds` was the only code that preserved it across a merge — but if a future live-manifest source needs to know where a manifest came from, that is now dropped at `AppManifests()` / `ManifestFromUnstructured`.
- Added a nil guard in `SelectableFieldsForManifests`. `MergeManifestsByKind` deliberately passes manifests with no data through, and this path would previously have panicked on one (it dereferenced `m.ManifestData` unchecked); it is now skipped, like the other manifest walkers already do.
- `generate_manifests.sh` emits the new shape, so the generated `app_manifests.go` stays in sync.

## Testing

No behavior change intended — this is a type migration plus the call-shape change. `go vet ./...` is clean, and `pkg/storage/unified/{resource,search,search/builders,sql}`, `pkg/services/apiserver/searchroutes`, `pkg/registry/apis/search`, and `pkg/registry/apps/alerting/rules/search` all pass. Unit tests only; the integration suite was not run.



Added `no-check-unified-storage-compatibility` because the changes only effect how data is loaded inside each process, not what is communicated between them.