### PR TITLE
CodeEditor: Make space-triggered autocomplete opt-in

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/CodeEditor.test.tsx
+++ b/packages/grafana-ui/src/components/CodeMirror/CodeEditor.test.tsx
@@ -152,8 +152,14 @@ describe('CodeMirror CodeEditor', () => {
     expect(tabBinding).toEqual(expect.objectContaining({ key: 'Tab', run: acceptCompletion }));
   });
 
-  it('binds Space to insert a space and start completions when completion sources are configured', () => {
-    render(<CodeEditor value="SELECT" onChange={jest.fn()} completionSources={[jest.fn()]} />);
+  it('leaves Space unbound by default, so a space cannot open the popup as an explicit request', () => {
+    render(<CodeEditor value="a sentence" onChange={jest.fn()} completionSources={[jest.fn()]} />);
+
+    expect(getKeyBindings().find((binding) => binding.key === 'Space')).toBeUndefined();
+  });
+
+  it('binds Space to insert a space and start completions when completeOnSpace is set', () => {
+    render(<CodeEditor value="SELECT" onChange={jest.fn()} completionSources={[jest.fn()]} completeOnSpace />);
 
     const spaceBinding = getKeyBindings().find((binding) => binding.key === 'Space');
     const replaceSelection = jest.fn(() => ({ changes: { from: 6, insert: ' ' } }));

--- a/packages/grafana-ui/src/components/CodeMirror/CodeEditor.tsx
+++ b/packages/grafana-ui/src/components/CodeMirror/CodeEditor.tsx
@@ -21,21 +21,24 @@ import { useShallowStable, useStableCallback } from './useStableProps';
 
 const getCompletionExtensions = (
   sources: readonly CodeMirrorCompletionSource[] | undefined,
-  mode: CodeMirrorCompletionMode
+  mode: CodeMirrorCompletionMode,
+  completeOnSpace: boolean
 ): CodeMirrorExtension[] => {
   if (!sources || sources.length === 0) {
     return [];
   }
 
+  const spaceKeymap = completeOnSpace ? [autocompleteSpaceKeymap] : [];
+
   if (mode === 'override') {
-    return [autocompletion({ override: [...sources] }), autocompleteSpaceKeymap];
+    return [autocompletion({ override: [...sources] }), ...spaceKeymap];
   }
 
   // Merge: enable autocompletion and contribute the sources via language data
   // so they're combined with whatever the active language registers.
   return [
     autocompletion(),
-    autocompleteSpaceKeymap,
+    ...spaceKeymap,
     ...sources.map((source) => EditorState.languageData.of(() => [{ autocomplete: source }])),
   ];
 };
@@ -93,6 +96,7 @@ export const CodeEditor = memo(function CodeEditor({
   'aria-labelledby': ariaLabelledby,
   completionSources,
   completionMode = 'merge',
+  completeOnSpace = false,
   extensions: additionalExtensionsProp,
   theme: themeOverride,
   basicSetup: basicSetupProp,
@@ -115,11 +119,20 @@ export const CodeEditor = memo(function CodeEditor({
       autocompleteTabKeymap,
       ...getAccessibilityExtensions(ariaLabel, ariaLabelledby),
       ...(languageExtension ? [languageExtension] : []),
-      ...getCompletionExtensions(sources, completionMode),
+      ...getCompletionExtensions(sources, completionMode, completeOnSpace),
       ...(lineWrapping ? [EditorView.lineWrapping] : []),
       ...(additionalExtensions ?? []),
     ],
-    [ariaLabel, ariaLabelledby, languageExtension, sources, completionMode, lineWrapping, additionalExtensions]
+    [
+      ariaLabel,
+      ariaLabelledby,
+      languageExtension,
+      sources,
+      completionMode,
+      completeOnSpace,
+      lineWrapping,
+      additionalExtensions,
+    ]
   );
   return (
     <>

--- a/packages/grafana-ui/src/components/CodeMirror/types.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/types.ts
@@ -137,6 +137,17 @@ export interface CodeMirrorEditorProps {
    */
   completionMode?: CodeMirrorCompletionMode;
   /**
+   * When `true`, a typed space opens the completion popup as an explicit
+   * request. Suits a language where a space starts a new clause and the
+   * suggestions are keywords or identifiers, as after `SELECT ` in SQL.
+   *
+   * Leave it off (the default) for prose. A source is free to answer an explicit
+   * request with its whole list — the variable source does, so that Ctrl+Space
+   * offers every variable — and binding that to the space bar would open the
+   * popup on every word.
+   */
+  completeOnSpace?: boolean;
+  /**
    * Additional CodeMirror extensions to layer on top of the defaults.
    * Use this for linting, custom keymaps, themes, etc.
    */

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.test.tsx
@@ -2,12 +2,27 @@ import { render } from '@testing-library/react';
 
 import { SqlEditor } from './SqlEditor';
 
+let editorProps: Record<string, unknown> | undefined;
+
 jest.mock('@grafana/ui/unstable', () => ({
-  CodeMirrorEditor: () => <div className="cm-scroller" />,
+  CodeMirrorEditor: (props: Record<string, unknown>) => {
+    editorProps = props;
+    return <div className="cm-scroller" />;
+  },
   signatureHelp: jest.fn(),
 }));
 
 describe('SqlEditor', () => {
+  beforeEach(() => {
+    editorProps = undefined;
+  });
+
+  it('completes on space, so suggestions still open after FROM and in the SELECT list', () => {
+    render(<SqlEditor value="SELECT * FROM " onChange={jest.fn()} completionProvider={{ tables: () => [] }} />);
+
+    expect(editorProps?.completeOnSpace).toBe(true);
+  });
+
   it('contains horizontal overscroll within the editor', () => {
     render(<SqlEditor value="SELECT * FROM A" onChange={jest.fn()} />);
 

--- a/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlEditor/SqlEditor.tsx
@@ -78,6 +78,7 @@ export const SqlEditor = ({
           height={typeof height === 'number' ? `${height}px` : height}
           aria-label={ariaLabel}
           completionSources={completionSources}
+          completeOnSpace
           extensions={extensions}
         />
       </div>


### PR DESCRIPTION
Typing a space in the Text panel editor opened the full variable list.

`Space` was bound to insert a space and then call `startCompletion`, which is an *explicit* request - and the shared variable source answers those with every variable (added in #130078), so every word popped the menu.                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                   
Adds `completeOnSpace` to `CodeMirrorEditor`, default `false`. SQL Expressions opts in: its table and SELECT-list completions are only reachable via an explicit request at a whitespace position (`completionSituation.ts`).


Before

https://github.com/user-attachments/assets/6278818d-9f21-452f-9d8d-9e71adc9aa97



After

https://github.com/user-attachments/assets/56408e56-3657-4058-8d88-21f0fdadafb5




**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
