### PR TITLE
Auth: resolve externally-synced check once per auth module in org users list

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -432,6 +432,22 @@ func getFirstPublicErrorMessage(err *errutil.Error) string {
 	return errPublic.Message
 }
 
+// newExternallySyncedResolver returns an isExternallySynced function that caches
+// the result per auth module. Each OAuth lookup reads SSO settings twice (client
+// enabled and client config), so caching avoids those reads per user on list
+// endpoints. Not safe for concurrent use.
+func (hs *HTTPServer) newExternallySyncedResolver(ctx context.Context, cfg *setting.Cfg) func(authModule string) bool {
+	cache := make(map[string]bool)
+	return func(authModule string) bool {
+		if synced, ok := cache[authModule]; ok {
+			return synced
+		}
+		synced := hs.isExternallySynced(ctx, cfg, authModule)
+		cache[authModule] = synced
+		return synced
+	}
+}
+
 // isExternalySynced is used to tell if the user roles are externally synced
 // true means that the org role sync is handled by Grafana
 // Note: currently the users authinfo is overridden each time the user logs in

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -887,6 +887,31 @@ func TestIsProviderEnabled(t *testing.T) {
 	}
 }
 
+// countingAuthnService counts calls per client name to the two methods that
+// trigger an SSO settings read, so tests can assert the resolver caches per
+// module and keys the cache correctly.
+type countingAuthnService struct {
+	*authntest.FakeService
+	enabledCalls map[string]int
+	configCalls  map[string]int
+}
+
+func (s *countingAuthnService) IsClientEnabled(ctx context.Context, name string) bool {
+	if s.enabledCalls == nil {
+		s.enabledCalls = map[string]int{}
+	}
+	s.enabledCalls[name]++
+	return s.FakeService.IsClientEnabled(ctx, name)
+}
+
+func (s *countingAuthnService) GetClientConfig(ctx context.Context, name string) (authn.SSOClientConfig, bool) {
+	if s.configCalls == nil {
+		s.configCalls = map[string]int{}
+	}
+	s.configCalls[name]++
+	return s.FakeService.GetClientConfig(ctx, name)
+}
+
 type mockSocialService struct {
 	oAuthInfo       *social.OAuthInfo
 	oAuthInfos      map[string]*social.OAuthInfo

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -384,11 +384,12 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 		accessControlMetadata = accesscontrol.GetResourcesMetadata(c.Req.Context(), permissions, "users:id:", userIDs)
 	}
 
+	externallySynced := hs.newExternallySyncedResolver(c.Req.Context(), hs.Cfg)
 	for i := range filteredUsers {
 		filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
 		if module, ok := modules[filteredUsers[i].UserID]; ok {
 			filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
-			filteredUsers[i].IsExternallySynced = hs.isExternallySynced(c.Req.Context(), hs.Cfg, module)
+			filteredUsers[i].IsExternallySynced = externallySynced(module)
 		}
 	}
 
@@ -399,8 +400,12 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 }
 
 func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+	// Shared across pages so the externally-synced check is resolved once per
+	// auth module for the whole request, not once per page.
+	externallySynced := hs.newExternallySyncedResolver(c.Req.Context(), hs.Cfg)
+
 	if query.Limit > 0 || query.UserID != 0 {
-		return hs.searchOrgUsersPageUsingK8s(c, query)
+		return hs.searchOrgUsersPageUsingK8s(c, query, externallySynced)
 	}
 
 	const pageSize = 1000
@@ -410,7 +415,7 @@ func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *
 		pageQuery.Limit = pageSize
 		pageQuery.Page = page
 
-		pageResult, err := hs.searchOrgUsersPageUsingK8s(c, &pageQuery)
+		pageResult, err := hs.searchOrgUsersPageUsingK8s(c, &pageQuery, externallySynced)
 		if err != nil {
 			return nil, err
 		}
@@ -425,7 +430,7 @@ func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *
 	}
 }
 
-func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery, externallySynced func(authModule string) bool) (*org.SearchOrgUsersQueryResult, error) {
 	searchResult, err := hs.userService.Search(c.Req.Context(), &user.SearchUsersQuery{
 		SignedInUser:         query.User,
 		OrgID:                query.OrgID,
@@ -449,7 +454,7 @@ func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, que
 		isExternallySynced := false
 		for _, module := range u.AuthModule {
 			authLabels = append(authLabels, login.GetAuthProviderLabel(module))
-			if hs.isExternallySynced(c.Req.Context(), hs.Cfg, module) {
+			if externallySynced(module) {
 				isExternallySynced = true
 			}
 		}

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -789,6 +789,16 @@ func searchHits(n int, startID int64) []*user.UserSearchHitDTO {
 	return out
 }
 
+// searchHitsWithModules builds n hits, assigning auth modules round-robin so
+// each module appears across the whole range (and across pages).
+func searchHitsWithModules(n int, startID int64, modules ...string) []*user.UserSearchHitDTO {
+	out := searchHits(n, startID)
+	for i, h := range out {
+		h.AuthModule = user.AuthModuleConversion{modules[i%len(modules)]}
+	}
+	return out
+}
+
 func TestSearchOrgUsersUsingK8s(t *testing.T) {
 	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	lastSeen := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -917,6 +927,80 @@ func TestSearchOrgUsersUsingK8s(t *testing.T) {
 		assert.Equal(t, 1, svc.calls, "explicit limit must fetch exactly one page")
 		require.Len(t, res.OrgUsers, 50)
 	})
+}
+
+// The externally-synced check depends only on the auth module, so it is
+// resolved once per module per request, not once per user or per page.
+func TestSearchOrgUsersUsingK8s_ResolvesExternallySyncedPerModule(t *testing.T) {
+	githubModule := login.GithubAuthModule
+	gitlabModule := login.GitLabAuthModule
+
+	svc := &countingAuthnService{
+		FakeService: &authntest.FakeService{ExpectedClientConfig: &authntest.FakeSSOClientConfig{}},
+	}
+	// Two pages force the resolver to span more than one page; both modules
+	// appear on each page.
+	userSvc := &pagedUserService{
+		FakeUserService: &usertest.FakeUserService{},
+		pages: []user.SearchUserQueryResult{
+			{Users: searchHitsWithModules(1000, 1, githubModule, gitlabModule), TotalCount: 1500, Page: 1, PerPage: 1000},
+			{Users: searchHitsWithModules(500, 1001, githubModule, gitlabModule), TotalCount: 1500, Page: 2, PerPage: 1000},
+		},
+	}
+	hs := &HTTPServer{Cfg: setting.NewCfg(), authnService: svc, userService: userSvc}
+	reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)}}
+
+	res, err := hs.searchOrgUsersUsingK8s(reqCtx, &org.SearchOrgUsersQuery{OrgID: 1})
+	require.NoError(t, err)
+	require.Equal(t, 2, userSvc.calls, "both pages must be fetched")
+	require.Len(t, res.OrgUsers, 1500)
+	for _, u := range res.OrgUsers {
+		assert.True(t, u.IsExternallySynced)
+	}
+
+	// Each module is resolved exactly once, regardless of user or page count.
+	want := map[string]int{authn.ClientWithPrefix("github"): 1, authn.ClientWithPrefix("gitlab"): 1}
+	assert.Equal(t, want, svc.enabledCalls)
+	assert.Equal(t, want, svc.configCalls)
+}
+
+// Same invariant as the K8s path, for the legacy searchOrgUsersHelper loop.
+func TestSearchOrgUsersHelper_ResolvesExternallySyncedPerModule(t *testing.T) {
+	const userCount = 50
+	modules := []string{login.GithubAuthModule, login.GitLabAuthModule}
+
+	users := make([]*org.OrgUserDTO, userCount)
+	labels := make(map[int64]string, userCount)
+	for i := range users {
+		id := int64(i + 1)
+		users[i] = &org.OrgUserDTO{UserID: id, Login: fmt.Sprintf("user-%d", id)}
+		labels[id] = modules[i%len(modules)]
+	}
+
+	svc := &countingAuthnService{
+		FakeService: &authntest.FakeService{ExpectedClientConfig: &authntest.FakeSSOClientConfig{}},
+	}
+	hs := &HTTPServer{
+		Cfg:          setting.NewCfg(),
+		authnService: svc,
+		orgService: &orgtest.FakeOrgService{
+			ExpectedSearchOrgUsersResult: &org.SearchOrgUsersQueryResult{OrgUsers: users, TotalCount: userCount},
+		},
+		authInfoService: &authinfotest.FakeService{ExpectedRecentlyUsedLabel: labels},
+	}
+	reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)}}
+
+	res, err := hs.searchOrgUsersHelper(reqCtx, &org.SearchOrgUsersQuery{OrgID: 1})
+	require.NoError(t, err)
+	require.Len(t, res.OrgUsers, userCount)
+	for _, u := range res.OrgUsers {
+		assert.True(t, u.IsExternallySynced)
+	}
+
+	// Each module is resolved exactly once, regardless of user count.
+	want := map[string]int{authn.ClientWithPrefix("github"): 1, authn.ClientWithPrefix("gitlab"): 1}
+	assert.Equal(t, want, svc.enabledCalls)
+	assert.Equal(t, want, svc.configCalls)
 }
 
 func TestGetOrgUsersForCurrentOrg_KubernetesUsersRedirect(t *testing.T) {


### PR DESCRIPTION
## What

The org users list endpoints (`/api/org/users` and the current-org variant) set `IsExternallySynced` for each returned user. This change resolves that value once per distinct auth module per request, instead of once per user.

A small helper, `newExternallySyncedResolver`, caches the result per module for the duration of one request. Both list paths (the legacy `searchOrgUsersHelper` and the Kubernetes `searchOrgUsersPageUsingK8s`) now use it.

## Why

`isExternallySynced` depends only on the auth module, not on the user. After #130512, the OAuth provider lookup reads SSO settings on each call (a settings store read plus secret decryption), where before it was an in-memory lookup. Because the list endpoints called the check once per user, a large organization performed one settings read per user, which added significant latency.

Caching per module removes this per-user cost. For a typical organization, where users share one provider, the endpoint now does one resolution instead of one per user.

## Behavior

No change in output. The check depends only on the module, so caching per module returns the same result as before. The cache lives only for one request and is not shared across goroutines.

## Tests

- `TestSearchOrgUsersHelper_ResolvesExternallySyncedPerModule`
- `TestSearchOrgUsersUsingK8s_ResolvesExternallySyncedPerModule`

Both run the handler path with many users sharing one module and assert the provider is resolved once, not once per user.

Follow-up to #130512.

Made with [Cursor](https://cursor.com)