### PR TITLE
Org: Avoid repeated SSO settings queries when listing users

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -384,11 +384,17 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 		accessControlMetadata = accesscontrol.GetResourcesMetadata(c.Req.Context(), permissions, "users:id:", userIDs)
 	}
 
+	externallySyncedByAuthModule := make(map[string]bool)
 	for i := range filteredUsers {
 		filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
 		if module, ok := modules[filteredUsers[i].UserID]; ok {
 			filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
-			filteredUsers[i].IsExternallySynced = hs.isExternallySynced(c.Req.Context(), hs.Cfg, module)
+			isExternallySynced, ok := externallySyncedByAuthModule[module]
+			if !ok {
+				isExternallySynced = hs.isExternallySynced(c.Req.Context(), hs.Cfg, module)
+				externallySyncedByAuthModule[module] = isExternallySynced
+			}
+			filteredUsers[i].IsExternallySynced = isExternallySynced
 		}
 	}
 

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -48,6 +48,22 @@ import (
 	"github.com/grafana/grafana/pkg/web/webtest"
 )
 
+type countingAuthnService struct {
+	*authntest.FakeService
+	enabledCalls map[string]int
+	configCalls  map[string]int
+}
+
+func (s *countingAuthnService) IsClientEnabled(ctx context.Context, name string) bool {
+	s.enabledCalls[name]++
+	return s.FakeService.IsClientEnabled(ctx, name)
+}
+
+func (s *countingAuthnService) GetClientConfig(ctx context.Context, name string) (authn.SSOClientConfig, bool) {
+	s.configCalls[name]++
+	return s.FakeService.GetClientConfig(ctx, name)
+}
+
 func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 	cfg.AutoAssignOrg = true
 	cfg.AutoAssignOrgId = int(testOrgID)
@@ -228,6 +244,39 @@ func TestIntegrationOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 				assert.Equal(t, "user2", resp[1].Login)
 			}, mock)
 	})
+}
+
+func TestSearchOrgUsersCachesExternalSyncStatusByAuthModule(t *testing.T) {
+	authnService := &countingAuthnService{
+		FakeService: &authntest.FakeService{
+			ExpectedClientConfig: &authntest.FakeSSOClientConfig{},
+		},
+		enabledCalls: map[string]int{},
+		configCalls:  map[string]int{},
+	}
+	hs := setupSimpleHTTPServer(featuremgmt.WithFeatures())
+	hs.authnService = authnService
+	hs.orgService = &orgtest.FakeOrgService{ExpectedSearchOrgUsersResult: &org.SearchOrgUsersQueryResult{
+		OrgUsers: []*org.OrgUserDTO{{UserID: 1}, {UserID: 2}, {UserID: 3}, {UserID: 4}},
+	}}
+	hs.authInfoService = &authinfotest.FakeService{ExpectedRecentlyUsedLabel: map[int64]string{
+		1: login.GoogleAuthModule,
+		2: login.GoogleAuthModule,
+		3: login.GoogleAuthModule,
+		4: login.GithubAuthModule,
+	}}
+	reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)}}
+
+	_, err := hs.searchOrgUsersHelper(reqCtx, &org.SearchOrgUsersQuery{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int{
+		authn.ClientWithPrefix("google"): 1,
+		authn.ClientWithPrefix("github"): 1,
+	}, authnService.enabledCalls)
+	assert.Equal(t, map[string]int{
+		authn.ClientWithPrefix("google"): 1,
+		authn.ClientWithPrefix("github"): 1,
+	}, authnService.configCalls)
 }
 
 func TestOrgUsersAPIEndpoint_updateOrgRole(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Caches the externally-synced status for each authentication module while building an organization user response. Users backed by the same OAuth provider now share one configuration lookup per request.

Adds a regression test covering multiple users backed by the same provider and a second distinct provider.

**Why do we need this feature?**

OAuth provider configuration is dynamically resolved by both `IsClientEnabled` and `GetClientConfig`. Calling `isExternallySynced` once per user therefore performs two SSO settings reads per OAuth-backed user.

In a large hosted organization this caused `/api/org/users` requests to make about 2,395 database calls and take 26-30 seconds. The previous release made 5-9 calls and completed in roughly 150-200 ms.

Keeping the cache request-local preserves dynamic configuration behavior while reducing the work to once per distinct authentication module.

**Who is this feature for?**

Organization administrators and API clients listing users, particularly in organizations with many OAuth-backed users.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Tests:

- `go test ./pkg/api -run '^TestSearchOrgUsersCachesExternalSyncStatusByAuthModule$' -count=1`
- `go test ./pkg/api -run 'SearchOrgUsers' -count=1`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] This is not a pre-GA feature and does not require a feature toggle.
- [x] No documentation update is required for this internal performance fix.
