### PR TITLE
DashboardScene: recover variable display text after URL restore (#131682)

### DIFF
--- a/public/app/features/dashboard-scene/utils/utils.test.ts
+++ b/public/app/features/dashboard-scene/utils/utils.test.ts
@@ -1,3 +1,4 @@
+import { type VariableRefresh } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import {
@@ -9,6 +10,7 @@ import {
   SceneQueryRunner,
   SceneTimeRange,
   SceneVariableSet,
+  TestVariable,
 } from '@grafana/scenes';
 import { type Dashboard, type Panel, type RowPanel } from '@grafana/schema';
 
@@ -28,6 +30,7 @@ import {
   hasLibraryPanelsInV1Dashboard,
   getLayoutForObject,
   forceRenderChildren,
+  getMultiVariableValues,
 } from './utils';
 
 setPluginImportUtils({
@@ -570,3 +573,103 @@ const getAutoGrid = () => {
     panel,
   };
 };
+
+describe('getMultiVariableValues (#131682)', () => {
+  function buildVariable(state: {
+    value: string | string[];
+    text: string | string[];
+    options: Array<{ label: string; value: string }>;
+    isMulti: boolean;
+    includeAll: boolean;
+  }) {
+    const variable = new TestVariable({
+      name: 'eq',
+      query: 'A.*',
+      value: state.value,
+      text: state.text,
+      isMulti: state.isMulti,
+      includeAll: state.includeAll,
+      optionsToReturn: state.options,
+      delayMs: 0,
+      refresh: 0 as VariableRefresh,
+    });
+    // TestVariable is async; the options only land in `state.options` after
+    // `signalUpdateCompleted` runs. We don't need to subscribe — just settle
+    // the load and then mutate `state.options` to match the requested shape
+    // (the units under test read `state.options` directly, not the observable).
+    variable.signalUpdateCompleted();
+    variable.setState({ options: state.options });
+    return variable;
+  }
+
+  it('preserves the recorded text when it differs from the value (interactive selection)', () => {
+    const variable = buildVariable({
+      value: ['100202'],
+      text: ['HLB01 (15000014)'],
+      options: [{ label: 'HLB01 (15000014)', value: '100202' }],
+      isMulti: true,
+      includeAll: false,
+    });
+
+    expect(getMultiVariableValues(variable)).toEqual({
+      values: ['100202'],
+      texts: ['HLB01 (15000014)'],
+    });
+  });
+
+  it('recovers the display label from options when the recorded text mirrors the value (URL restore)', () => {
+    // Simulates the bug: a variable restored from a URL has `value` set from the
+    // query string and `text` left as the raw value because the URL only encodes
+    // the value, not the label. `${var:text}` should still resolve to the
+    // human-readable label.
+    const variable = buildVariable({
+      value: ['100202'],
+      text: ['100202'],
+      options: [{ label: 'HLB01 (15000014)', value: '100202' }],
+      isMulti: true,
+      includeAll: false,
+    });
+
+    expect(getMultiVariableValues(variable)).toEqual({
+      values: ['100202'],
+      texts: ['HLB01 (15000014)'],
+    });
+  });
+
+  it('recovers labels for every value when the recorded text array is too short', () => {
+    // Defensive: even if the recorded text array is shorter than the value
+    // array (shouldn't normally happen, but guards against partial URL
+    // restores), every value still gets a label.
+    const variable = buildVariable({
+      value: ['A1', 'B1', 'C1'],
+      text: ['A'],
+      options: [
+        { label: 'A', value: 'A1' },
+        { label: 'B', value: 'B1' },
+        { label: 'C', value: 'C1' },
+      ],
+      isMulti: true,
+      includeAll: false,
+    });
+
+    expect(getMultiVariableValues(variable)).toEqual({
+      values: ['A1', 'B1', 'C1'],
+      texts: ['A', 'B', 'C'],
+    });
+  });
+
+  it('falls back to the value itself when no matching option is found', () => {
+    const variable = buildVariable({
+      value: ['ghost'],
+      text: ['ghost'],
+      options: [{ label: 'Real', value: 'real' }],
+      isMulti: true,
+      includeAll: false,
+    });
+
+    expect(getMultiVariableValues(variable)).toEqual({
+      values: ['ghost'],
+      texts: ['ghost'],
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -170,10 +170,25 @@ export function getMultiVariableValues(variable: MultiValueVariable | CustomVari
     };
   }
 
-  return {
-    values: Array.isArray(value) ? value : [value],
-    texts: Array.isArray(text) ? text : [text],
-  };
+  const values = Array.isArray(value) ? value : [value];
+  const stateTexts = Array.isArray(text) ? text : [text];
+
+  // When the variable is restored from a URL, scenes populates `value` from the
+  // query string but may leave `text` mirroring the raw value. Using `text` as-is
+  // would then make `${var:text}` render the raw value inside repeated rows
+  // (see issue #131682). Recover the human-readable label from the option list
+  // whenever the recorded text equals the value (the "no display text" signal),
+  // or whenever the recorded text array is too short to cover every value.
+  const optionByValue = new Map(options.map((o) => [o.value, o.label] as const));
+  const texts = values.map((v, i) => {
+    const recorded = stateTexts[i];
+    if (recorded != null && recorded !== v) {
+      return recorded;
+    }
+    return optionByValue.get(v) ?? v;
+  });
+
+  return { values, texts };
 }
 
 // used to transform old interval model to new interval model from scenes


### PR DESCRIPTION
### What does this PR do?

Inside a repeating row or repeating tab, `${var:text}` collapses to the
raw value (e.g. `100202`) instead of the display label (e.g.
`HLB01 (15000014)`) after a page reload or when opening a bookmarked
URL that encodes the variable selection.

### Why?

The reported regression only affects dashboards that are opened from a
URL or reloaded: the variable's `value` is restored from the query
string, but `text` is left mirroring the raw value because the URL
only encodes the value, not the label. `getMultiVariableValues` used
to forward `state.text` as-is, so the per-repeat cloning carried the
wrong text into the local `LocalValueVariable` and the `${var:text}`
macro resolved to the raw value.

### How?

`getMultiVariableValues` now backfills the display text from
`state.options` whenever the recorded text equals the value (the
"no display text" signal) or the recorded text array is too short to
cover every value, and falls back to the value itself when no option
matches. Interactive selection (where `state.text` differs from the
value) is unchanged.

### Anything else a reviewer should know?

- Tests: 4 new unit cases in
  `public/app/features/dashboard-scene/utils/utils.test.ts` covering
  the interactive path, the URL-restore path, the defensive short-text
  path, and the no-matching-option fallback. Full utils suite
  (32/32) plus the row/tab repeater suites (10/10 + 8/8) all pass.
- Out of scope: the root cause lives in the `@grafana/scenes` URL
  restore logic that leaves `state.text` raw; the proper fix would be
  in scenes. This is a defensive fallback so the monorepo behaves
  correctly regardless of the scenes behaviour. A follow-up on
  `grafana/scenes` would be the right place to address the upstream
  bug.

Fixes #131682.
