### PR TITLE
Plugins: Log the outcome of scanning plugin directories

### DIFF
--- a/pkg/plugins/manager/sources/source_local_disk.go
+++ b/pkg/plugins/manager/sources/source_local_disk.go
@@ -259,6 +259,7 @@ func DirAsLocalSources(cfg *config.PluginManagementCfg, pluginsPaths []string, c
 	for _, pluginsPath := range pluginsPaths {
 		if _, err := os.Stat(pluginsPath); errors.Is(err, os.ErrNotExist) {
 			// If the directory does not exist, skip it
+			logger.Info("Skipping plugins directory as it does not exist", "path", pluginsPath)
 			continue
 		}
 		d, err := os.ReadDir(pluginsPath)
@@ -274,6 +275,7 @@ func DirAsLocalSources(cfg *config.PluginManagementCfg, pluginsPaths []string, c
 			}
 		}
 		slices.Sort(pluginDirs)
+		logger.Info("Scanned plugins directory", "path", pluginsPath, "found", len(pluginDirs))
 
 		for _, dir := range pluginDirs {
 			if cfg.DevMode {
@@ -282,6 +284,13 @@ func DirAsLocalSources(cfg *config.PluginManagementCfg, pluginsPaths []string, c
 				sources = append(sources, NewLocalSource(class, []string{dir}))
 			}
 		}
+	}
+
+	// A missing or empty plugins directory silently disables every plugin that ships with the
+	// distribution, including the Prometheus and SQL data sources, so report the outcome instead
+	// of returning nothing. Core plugins load from a separate source and are unaffected.
+	if len(pluginsPaths) > 0 && len(sources) == 0 {
+		logger.Warn("No external or bundled plugins found in any configured plugins directory", "paths", pluginsPaths)
 	}
 
 	return sources

--- a/pkg/plugins/manager/sources/source_local_disk_test.go
+++ b/pkg/plugins/manager/sources/source_local_disk_test.go
@@ -177,6 +177,76 @@ func TestDirAsLocalSourcesSkipsUnreadableDirectory(t *testing.T) {
 	}
 }
 
+// lastCtx unwraps the key/value pairs of the most recent call recorded by log.TestLogger, which
+// stores the variadic context as a single nested element.
+func lastCtx(t *testing.T, l *log.Logs) []any {
+	t.Helper()
+
+	require.Len(t, l.Ctx, 1)
+	inner, ok := l.Ctx[0].([]any)
+	require.True(t, ok)
+	return inner
+}
+
+func TestDirAsLocalSourcesLogsScanOutcome(t *testing.T) {
+	pluginRoot := filepath.Join("..", "testdata", "pluginRootWithDist")
+
+	t.Run("Logs how many plugin directories a path yielded", func(t *testing.T) {
+		logger := log.NewTestLogger()
+
+		got := DirAsLocalSources(&config.PluginManagementCfg{}, []string{pluginRoot}, plugins.ClassExternal, logger)
+
+		require.Len(t, got, 3)
+		require.Equal(t, 1, logger.InfoLogs.Calls)
+		require.Equal(t, "Scanned plugins directory", logger.InfoLogs.Message)
+		require.Equal(t, []any{"path", pluginRoot, "found", 3}, lastCtx(t, &logger.InfoLogs))
+		require.Equal(t, 0, logger.WarnLogs.Calls)
+	})
+
+	t.Run("Logs a missing directory instead of skipping it silently", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope")
+		logger := log.NewTestLogger()
+
+		got := DirAsLocalSources(&config.PluginManagementCfg{}, []string{missing}, plugins.ClassExternal, logger)
+
+		require.Empty(t, got)
+		require.Equal(t, 1, logger.InfoLogs.Calls)
+		require.Equal(t, "Skipping plugins directory as it does not exist", logger.InfoLogs.Message)
+		require.Equal(t, []any{"path", missing}, lastCtx(t, &logger.InfoLogs))
+	})
+
+	t.Run("Warns when no configured path yields a plugin", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "nope")
+		empty := t.TempDir()
+		logger := log.NewTestLogger()
+
+		got := DirAsLocalSources(&config.PluginManagementCfg{}, []string{missing, empty}, plugins.ClassExternal, logger)
+
+		require.Empty(t, got)
+		require.Equal(t, 1, logger.WarnLogs.Calls)
+		require.Equal(t, "No external or bundled plugins found in any configured plugins directory", logger.WarnLogs.Message)
+		require.Equal(t, []any{"paths", []string{missing, empty}}, lastCtx(t, &logger.WarnLogs))
+	})
+
+	t.Run("Does not warn when another path yields a plugin", func(t *testing.T) {
+		logger := log.NewTestLogger()
+		paths := []string{filepath.Join(t.TempDir(), "nope"), pluginRoot}
+
+		got := DirAsLocalSources(&config.PluginManagementCfg{}, paths, plugins.ClassExternal, logger)
+
+		require.Len(t, got, 3)
+		require.Equal(t, 0, logger.WarnLogs.Calls)
+	})
+
+	t.Run("Stays silent when no paths are configured", func(t *testing.T) {
+		logger := log.NewTestLogger()
+
+		require.Empty(t, DirAsLocalSources(&config.PluginManagementCfg{}, nil, plugins.ClassExternal, logger))
+		require.Equal(t, 0, logger.InfoLogs.Calls)
+		require.Equal(t, 0, logger.WarnLogs.Calls)
+	})
+}
+
 func TestLocalSource(t *testing.T) {
 	t.Run("NewLocalSource should always return plugins with StaticFS", func(t *testing.T) {
 		tmpDir := t.TempDir()


### PR DESCRIPTION
## What is this feature?

`DirAsLocalSources` returns silently when a configured plugins directory is missing, and says nothing when a directory exists but holds no plugins. This adds an `info` line per configured path reporting the outcome, plus a single `warn` when no configured path yields a plugin at all.

## Why do we need this feature?

This is a hardening follow-up to #131490, not the fix for it. The packaging bug itself is already fixed by #131033.

In 13.2.0 the deb/rpm post-install script moved the bundled plugins to a directory that no unit file pointed Grafana at, so all 13 bundled plugins became invisible and the Prometheus, PostgreSQL, MS SQL, InfluxDB and Elasticsearch data sources stopped working. The reporter's log contained no hint at all — the only symptom was `Plugins loaded count=39` being lower than it should be, and later `Could not find plugin definition for data source`.

Note that the sibling `LocalSource.Discover` in the same file already warns in the equivalent situation. Because `DirAsLocalSources` skips the path first, that warn never fires. This makes the two consistent.

With the change, the same scenario is self-diagnosing:

```
level=info msg="Skipping plugins directory as it does not exist" path=/usr/share/grafana/data/plugins-bundled
level=warn msg="No external or bundled plugins found in any configured plugins directory" paths="[...]"
```

## Known tradeoff

The warn fires whenever neither the external nor the bundled plugins directory yields anything, which includes two legitimate cases:

- A plain `make run` dev environment, which has no `data/plugins` and no `data/plugins-bundled` (the latter only exists after `make build-catalog-plugins-data`).
- SLIM Docker images, which ship an intentionally empty `data/plugins-bundled`.

Both statements are accurate and core plugins are unaffected (they load from a separate source), but flagging it since it means an extra warn line on every dev start. Happy to drop it to `info` if reviewers prefer.

## Which issue(s) does this PR fix?

Related to #131490
