### PR TITLE
Docs: Document the paths.bundled_plugins setting

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -216,6 +216,14 @@ Directory where Grafana automatically scans and looks for plugins. For informati
 
 **macOS:** By default, the Mac plugin location is: `/usr/local/var/lib/grafana/plugins`.
 
+#### `bundled_plugins`
+
+Directory where Grafana looks for the plugins that ship with the Grafana distribution, such as the Prometheus and PostgreSQL data sources. Defaults to `data/plugins-bundled`, relative to the Grafana home path.
+
+The Debian and RPM packages install these plugins under `/var/lib/grafana/plugins-bundled` so that Grafana can update them, and the `grafana-server` systemd unit passes a matching `cfg:default.paths.bundled_plugins` argument. If you override this option, or you edit the systemd unit, keep the two values in step. When they disagree, Grafana finds no bundled plugins and the data sources they provide stop working.
+
+Grafana downloads any missing bundled plugin from `grafana.com` on startup, so a mismatch is easy to miss on a host with internet access. On an air-gapped host, this directory decides whether the bundled data sources work at all. For information about installing plugins yourself, refer to [Install Grafana plugins](../../administration/plugin-management/#install-grafana-plugins).
+
 #### `provisioning`
 
 Directory that contains [provisioning](../../administration/provisioning/) configuration files that Grafana applies on startup.


### PR DESCRIPTION
## What is this feature?

Documents `paths.bundled_plugins` in the `[paths]` section of the configuration reference, next to the existing `plugins` entry.

## Why do we need this feature?

The setting had no coverage anywhere in `docs/` — zero hits for `bundled_plugins` across `docs/sources/` — even though it now decides whether the bundled data sources work on a host without internet access.

The new entry covers what the directory is, the `data/plugins-bundled` default relative to the home path, that the Debian and RPM packages install the plugins under `/var/lib/grafana/plugins-bundled` with a matching `cfg:default.paths.bundled_plugins` argument in the systemd unit, and why the two values have to stay in step.

It also notes that Grafana downloads missing bundled plugins from `grafana.com` on startup, which is why a mismatch is easy to miss on a connected host and breaks data sources outright on an air-gapped one. That is precisely what happened in #131490.

No change to `conf/defaults.ini` or `conf/sample.ini` — #131033 already added the key and an inline comment to both.

## Which issue(s) does this PR fix?

Related to #131490
