### PR TITLE
Dashboard: Support moving the sidebar

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
@@ -57,6 +57,23 @@ describe('Sidebar', () => {
     expect(screen.getByLabelText('Undock')).toBeInTheDocument();
   });
 
+  it('defaults to the right and persists a move to the left', () => {
+    const { unmount } = render(<TestSetup persistenceKey="position-persist" />);
+
+    const wrapper = screen.getByTestId('sidebar-test-wrapper');
+    expect(wrapper).toHaveStyle('padding-right: 72px');
+
+    act(() => screen.getByLabelText('Settings').click());
+    act(() => screen.getByLabelText('Move sidebar left').click());
+    expect(wrapper).toHaveStyle('padding-left: 312px');
+    expect(screen.getByLabelText('Undock')).toBeInTheDocument();
+
+    unmount();
+    render(<TestSetup persistenceKey="position-persist" />);
+
+    expect(screen.getByTestId('sidebar-test-wrapper')).toHaveStyle('padding-left: 72px');
+  });
+
   describe('hidden state', () => {
     it('renders show button instead of the sidebar container when defaultIsHidden is true', () => {
       render(<TestSetup defaultIsHidden />);
@@ -72,6 +89,18 @@ describe('Sidebar', () => {
 
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
       expect(screen.queryByTestId(selectors.components.Sidebar.showHideToggle)).not.toBeInTheDocument();
+    });
+
+    it('anchors the show button to the sidebar container after moving left', () => {
+      render(<TestSetup />);
+
+      act(() => screen.getByLabelText('Move sidebar left').click());
+      act(() => screen.getByLabelText('Hide').click());
+
+      expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toHaveStyle({
+        position: 'absolute',
+        left: '4px',
+      });
     });
 
     it('does not reserve space on the outer wrapper when hidden', () => {
@@ -199,6 +228,11 @@ function TestSetup({ persistenceKey, defaultIsHidden, hiddenPersistenceKey }: Te
           <Sidebar.Button icon="cog" title="Settings" onClick={() => setOpenPane('settings')} />
           <Sidebar.Button icon="process" title="Data" tooltip="Data transformations" />
           <Sidebar.Button icon="bell" title="Alerts" />
+          <Sidebar.Button
+            icon="exchange-alt"
+            title={`Move sidebar ${contextValue.position === 'right' ? 'left' : 'right'}`}
+            onClick={contextValue.onTogglePosition}
+          />
           <Sidebar.Button icon="arrow-to-right" title="Hide" onClick={() => contextValue.setIsHidden(true)} />
         </Sidebar.Toolbar>
       </Sidebar>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -209,7 +209,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       borderLeft: `1px solid ${theme.colors.border.weak}`,
     }),
     showButton: css({
-      position: 'fixed',
+      position: 'absolute',
       bottom: theme.spacing(2),
       zIndex: theme.zIndex.navbarFixed,
       padding: theme.spacing(1),

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -23,6 +23,7 @@ export interface SidebarContextValue {
   isHiddenPreference: boolean;
   canGoBack?: boolean;
   onToggleDock?: () => void;
+  onTogglePosition?: () => void;
   onResize: (diff: number) => void;
   /** Called when pane is closed or clicked outside of (in undocked mode) */
   onClosePane?: () => void;
@@ -59,8 +60,8 @@ export interface UseSideBarOptions {
   /** Open previous pane */
   onGoBack?: () => void;
   /**
-   * Optional key to use for persisting sidebar state (docked / compact / size)
-   * Can only be app name as the final local storag key will be `grafana.ui.sidebar.{persistenceKey}.{docked|compact|size}`
+   * Optional key to use for persisting sidebar state (docked / compact / size / position)
+   * Can only be app name as the final local storage key will be `grafana.ui.sidebar.{persistenceKey}.{docked|compact|size|position}`
    */
   persistenceKey?: string;
   /** Whether the sidebar is hidden by default */
@@ -71,6 +72,8 @@ export interface UseSideBarOptions {
    * persistenceKeys (e.g. dashboard view vs edit mode share a single hide preference).
    */
   hiddenPersistenceKey?: string;
+  /** Optional override for sharing the position preference across consumers. */
+  positionPersistenceKey?: string;
 }
 
 export const SIDE_BAR_WIDTH_ICON_ONLY = 5;
@@ -78,7 +81,7 @@ export const SIDE_BAR_WIDTH_WITH_TEXT = 8;
 
 export function useSidebar({
   hasOpenPane,
-  position = 'right',
+  position: defaultPosition = 'right',
   tabsMode,
   defaultToCompact = true,
   defaultToDocked = false,
@@ -91,8 +94,14 @@ export function useSidebar({
   canGoBack,
   defaultIsHidden = false,
   hiddenPersistenceKey,
+  positionPersistenceKey,
 }: UseSideBarOptions): SidebarContextValue {
   const theme = useTheme2();
+  const [position, setPosition] = useSidebarSavedState<SidebarPosition>(
+    positionPersistenceKey ?? persistenceKey,
+    'position',
+    defaultPosition
+  );
   const [isDocked, setIsDocked] = useSidebarSavedState(persistenceKey, 'docked', defaultToDocked);
   const [compact, setCompact] = useSidebarSavedState(persistenceKey, 'compact', defaultToCompact);
   const [paneWidth, setPaneWidth] = useSidebarSavedState(persistenceKey, 'size', 240);
@@ -114,6 +123,11 @@ export function useSidebar({
   const onToggleDock = useCallback(() => {
     setIsDocked((prev) => !prev);
   }, [setIsDocked]);
+
+  const onTogglePosition = useCallback(() => {
+    setIsDocked(() => true);
+    setPosition((prev) => (prev === 'right' ? 'left' : 'right'));
+  }, [setIsDocked, setPosition]);
 
   // Calculate how much space the outer wrapper needs to reserve for the sidebar toolbar + pane (if docked)
   const prop = position === 'right' ? 'paddingRight' : 'paddingLeft';
@@ -164,6 +178,7 @@ export function useSidebar({
   return {
     isDocked: effectiveIsDocked,
     onToggleDock: isMobile || isTemporarilyShown ? undefined : onToggleDock,
+    onTogglePosition: isMobile ? undefined : onTogglePosition,
     onResize,
     outerWrapperProps,
     position,
@@ -200,10 +215,19 @@ function readFromStore<T>(persistenceKey: string | undefined, subKey: string, de
     return Number.isNaN(value) ? defaultValue : (value as T);
   }
 
+  if (typeof defaultValue === 'string') {
+    const value = store.get(`grafana.ui.sidebar.${persistenceKey}.${subKey}`);
+    if ((defaultValue === 'left' || defaultValue === 'right') && value !== 'left' && value !== 'right') {
+      return defaultValue;
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return (value || defaultValue) as T;
+  }
+
   return defaultValue;
 }
 
-export function useSidebarSavedState<T = number | boolean>(
+export function useSidebarSavedState<T = number | boolean | string>(
   persistenceKey: string | undefined,
   subKey: string,
   defaultValue: T

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsLayoutContext.test.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsLayoutContext.test.tsx
@@ -31,13 +31,13 @@ describe('measureSidebarShiftPadding()', () => {
   test('when the container is missing, padding is 0', () => {
     const sidebar = document.createElement('div');
 
-    expect(measureSidebarShiftPadding(undefined, sidebar)).toBe(0);
+    expect(measureSidebarShiftPadding(undefined, sidebar, 'right')).toBe(0);
   });
 
   test('when the sidebar is missing, padding is 0', () => {
     const container = document.createElement('div');
 
-    expect(measureSidebarShiftPadding(container, undefined)).toBe(0);
+    expect(measureSidebarShiftPadding(container, undefined, 'right')).toBe(0);
   });
 
   test('when the container right edge is 1000 and the sidebar left edge is 680, right padding is 320', () => {
@@ -46,7 +46,7 @@ describe('measureSidebarShiftPadding()', () => {
     stubClientRect(container, 0, 1000);
     stubClientRect(sidebar, 680, 1000);
 
-    expect(measureSidebarShiftPadding(container, sidebar)).toEqual({ right: 320 });
+    expect(measureSidebarShiftPadding(container, sidebar, 'right')).toEqual({ right: 320 });
   });
 
   test('when the sidebar left edge is past the container right edge, right padding is 0', () => {
@@ -55,7 +55,16 @@ describe('measureSidebarShiftPadding()', () => {
     stubClientRect(container, 0, 1000);
     stubClientRect(sidebar, 1100, 1420);
 
-    expect(measureSidebarShiftPadding(container, sidebar)).toEqual({ right: 0 });
+    expect(measureSidebarShiftPadding(container, sidebar, 'right')).toEqual({ right: 0 });
+  });
+
+  test('when the sidebar is on the left, left padding is its overlap with the container', () => {
+    const container = document.createElement('div');
+    const sidebar = document.createElement('div');
+    stubClientRect(container, 100, 1100);
+    stubClientRect(sidebar, 100, 420);
+
+    expect(measureSidebarShiftPadding(container, sidebar, 'left')).toEqual({ left: 320 });
   });
 });
 
@@ -63,16 +72,23 @@ function renderUseEditActionsLayout({
   container = null,
   isDocked = false,
   isHidden = false,
+  sidebarPosition = 'right',
 }: {
   container?: HTMLDivElement | null;
   isDocked?: boolean;
   isHidden?: boolean;
+  sidebarPosition?: 'left' | 'right';
 } = {}) {
   const containerRef: RefObject<HTMLDivElement | null> = { current: container };
 
   return renderHook(() => useEditActionsLayout(), {
     wrapper: ({ children }) => (
-      <EditActionsLayoutProvider containerRef={containerRef} isDocked={isDocked} isHidden={isHidden}>
+      <EditActionsLayoutProvider
+        containerRef={containerRef}
+        isDocked={isDocked}
+        isHidden={isHidden}
+        sidebarPosition={sidebarPosition}
+      >
         {children}
       </EditActionsLayoutProvider>
     ),
@@ -150,5 +166,23 @@ describe('useEditActionsLayout()', () => {
     const { result } = renderUseEditActionsLayout({ container, isDocked: false, isHidden: false });
 
     expect(result.current.getSidebarShiftPadding()).toEqual({ right: 320 });
+  });
+
+  test('when the provider is undocked and the sidebar is on the left, left padding is 320', () => {
+    const container = document.createElement('div');
+    const sidebar = document.createElement('div');
+    sidebar.id = 'sidebar-container';
+    document.body.appendChild(sidebar);
+    stubClientRect(container, 100, 1100);
+    stubClientRect(sidebar, 100, 420);
+
+    const { result } = renderUseEditActionsLayout({
+      container,
+      isDocked: false,
+      isHidden: false,
+      sidebarPosition: 'left',
+    });
+
+    expect(result.current.getSidebarShiftPadding()).toEqual({ left: 320 });
   });
 });

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsLayoutContext.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsLayoutContext.tsx
@@ -1,8 +1,12 @@
 import { createContext, useContext, useMemo, useRef, type ReactNode, type RefObject } from 'react';
 
+import { type SidebarPosition } from '@grafana/ui';
+
+export type SidebarShiftPadding = number | { left: number } | { right: number };
+
 export type EditActionsLayout = {
   getPortalRoot: () => HTMLElement | undefined;
-  getSidebarShiftPadding: () => number | { right: number };
+  getSidebarShiftPadding: () => SidebarShiftPadding;
 };
 
 const defaultLayout: EditActionsLayout = {
@@ -16,39 +20,47 @@ export const useEditActionsLayout = () => useContext(EditActionsLayoutContext);
 
 export function measureSidebarShiftPadding(
   container: HTMLElement | null | undefined,
-  sidebar: HTMLElement | null | undefined
+  sidebar: HTMLElement | null | undefined,
+  position: SidebarPosition
 ) {
   if (!container || !sidebar) {
     return 0;
   }
-  return { right: Math.max(0, container.getBoundingClientRect().right - sidebar.getBoundingClientRect().left) };
+
+  const containerRect = container.getBoundingClientRect();
+  const sidebarRect = sidebar.getBoundingClientRect();
+  return position === 'left'
+    ? { left: Math.max(0, sidebarRect.right - containerRect.left) }
+    : { right: Math.max(0, containerRect.right - sidebarRect.left) };
 }
 
 export function EditActionsLayoutProvider({
   containerRef,
   isDocked,
   isHidden,
+  sidebarPosition,
   children,
 }: {
   containerRef: RefObject<HTMLDivElement | null>;
   isDocked: boolean;
   isHidden: boolean;
+  sidebarPosition: SidebarPosition;
   children: ReactNode;
 }) {
   // Keep the context value identity stable so panels do not re-render on dock or resize.
-  const sidebarLayoutRef = useRef({ isDocked, isHidden });
-  sidebarLayoutRef.current = { isDocked, isHidden };
+  const sidebarLayoutRef = useRef({ isDocked, isHidden, sidebarPosition });
+  sidebarLayoutRef.current = { isDocked, isHidden, sidebarPosition };
 
   const layout = useMemo<EditActionsLayout>(
     () => ({
       getPortalRoot: () => containerRef.current ?? undefined,
       getSidebarShiftPadding: () => {
-        const { isDocked: docked, isHidden: hidden } = sidebarLayoutRef.current;
+        const { isDocked: docked, isHidden: hidden, sidebarPosition: position } = sidebarLayoutRef.current;
         if (docked || hidden) {
           return 0;
         }
 
-        return measureSidebarShiftPadding(containerRef.current, document.getElementById('sidebar-container'));
+        return measureSidebarShiftPadding(containerRef.current, document.getElementById('sidebar-container'), position);
       },
     }),
     [containerRef]

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsPopover.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActionsPopover.tsx
@@ -17,6 +17,8 @@ import { useMedia } from 'react-use';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { ElementSelectionContext, Portal, useStyles2, useTheme2 } from '@grafana/ui';
 
+import { type SidebarShiftPadding } from './EditActionsLayoutContext';
+
 export const WAIT_FOR_MOUSE_REST_DURATION_MS = 225;
 
 /**
@@ -41,7 +43,7 @@ type EditActionsPopoverProps = {
   placement?: Placement;
   portalRoot?: () => HTMLElement | undefined;
   zIndex?: number;
-  shiftPadding?: () => number | { right: number };
+  shiftPadding?: () => SidebarShiftPadding;
 };
 
 /**

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.test.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.test.tsx
@@ -373,7 +373,12 @@ describe('<PanelEditActionsWrapper />', () => {
       });
 
       render(
-        <EditActionsLayoutProvider containerRef={{ current: portalRoot }} isDocked={false} isHidden={false}>
+        <EditActionsLayoutProvider
+          containerRef={{ current: portalRoot }}
+          isDocked={false}
+          isHidden={false}
+          sidebarPosition="right"
+        >
           <ElementSelectionContext.Provider
             value={{ enabled: true, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
           >

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.tsx
@@ -180,6 +180,17 @@ export function DashboardSidebarRenderer({ dashboard }: Props) {
             />
           )}
           <Sidebar.Divider />
+          {sidebarContext?.onTogglePosition && (
+            <Sidebar.Button
+              icon="exchange-alt"
+              onClick={sidebarContext.onTogglePosition}
+              title={
+                sidebarContext.position === 'right'
+                  ? t('dashboard.sidebar.move-left', 'Move sidebar left')
+                  : t('dashboard.sidebar.move-right', 'Move sidebar right')
+              }
+            />
+          )}
           <Sidebar.Button
             icon={'arrow-to-right'}
             onClick={onClickHideSidebar}

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
@@ -72,6 +72,22 @@ describe('DashboardSidebarSplitter', () => {
     const scrollContainer = screen.getByTestId(selectors.components.DashboardSidebarSplitter.bodyContainer);
     expect(scrollContainer).toHaveAttribute('tabindex', '0');
   });
+
+  it('moves the tighter canvas padding to the side containing the sidebar', async () => {
+    const user = userEvent.setup();
+    const scene = buildTestScene();
+
+    render(<DashboardSidebarSplitter dashboard={scene} />);
+
+    const scrollContainer = screen.getByTestId(selectors.components.DashboardSidebarSplitter.bodyContainer);
+    expect(getComputedStyle(scrollContainer).paddingLeft).toBe('16px');
+    expect(getComputedStyle(scrollContainer).paddingRight).toBe('8px');
+
+    await user.click(screen.getByRole('button', { name: 'Move sidebar left' }));
+
+    expect(getComputedStyle(scrollContainer).paddingLeft).toBe('8px');
+    expect(getComputedStyle(scrollContainer).paddingRight).toBe('16px');
+  });
 });
 
 export function buildTestScene() {

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -95,6 +95,7 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
     position: 'right',
     persistenceKey: isEditing ? 'dashboard' : 'dashboard-view',
     hiddenPersistenceKey: 'dashboard',
+    positionPersistenceKey: 'dashboard',
     defaultToDocked: isEditing ? true : false,
     onClosePane: () => sidebar.closePane(),
     onGoBack: () => sidebar.goBackToPrevious(),
@@ -173,6 +174,7 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
         containerRef={containerRef}
         isDocked={sidebarContext.isDocked}
         isHidden={sidebarContext.isHidden}
+        sidebarPosition={sidebarContext.position}
       >
         <ElementSelectionContext.Provider value={selectionContext}>
           <DashboardControlsChrome onPointerDown={onClearSelection}>{controls}</DashboardControlsChrome>

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -148,7 +148,11 @@ function DashboardSidebarSplitterNewLayouts({ dashboard, isEditing, body, contro
         {...sidebarContext.outerWrapperProps}
       >
         <div
-          className={cx(styles.scrollContainer, sidebarContext.isHiddenPreference && styles.scrollContainerNoSidebar)}
+          className={cx(
+            styles.scrollContainer,
+            sidebarContext.position === 'left' && styles.scrollContainerLeftSidebar,
+            sidebarContext.isHiddenPreference && styles.scrollContainerNoSidebar
+          )}
           ref={onBodyRef}
           onPointerDown={onClearSelection}
           data-testid={selectors.components.DashboardSidebarSplitter.bodyContainer}
@@ -298,8 +302,13 @@ function getStyles(theme: GrafanaTheme2) {
       padding: theme.spacing(1.125, 1, 2, 2),
       marginTop: theme.spacing(-1),
     }),
+    scrollContainerLeftSidebar: css({
+      paddingRight: theme.spacing(2),
+      paddingLeft: theme.spacing(1),
+    }),
     scrollContainerNoSidebar: css({
       paddingRight: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
     }),
     body: css({
       label: 'body',


### PR DESCRIPTION
What is this feature?

Adds a control to move the dashboard sidebar between the left and right sides of the dashboard. The selected position persists across page reloads and between dashboard view and edit modes. Moving the sidebar also docks it automatically.

Why do we need this feature?

Users may prefer the dashboard sidebar on a particular side based on their workflow, screen layout, or the content they are editing. Persisting the selected position provides a consistent experience across sessions.

Who is this feature for?

Dashboard authors and viewers who use the dashboard sidebar.

Which issue(s) does this PR fix?

No linked issue.

Tests added or updated:

- Sidebar defaults to the right.
- Moving left docks the sidebar.
- Position persists after remounting.
- The hidden sidebar restore control remains correctly positioned.
-  It works as expected from a user's perspective.
-  A new feature toggle is not required because this extends the existing sidebar component.
-  No documentation update is required for this small UI enhancement.