### PR TITLE
Chore: Use maps.Copy

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -188,9 +189,7 @@ func TestGetHomeDashboard(t *testing.T) {
 				t.Helper()
 				// Copy so we don't mutate the shared doc.
 				resp := map[string]any{}
-				for k, v := range k8sV1Doc {
-					resp[k] = v
-				}
+				maps.Copy(resp, k8sV1Doc)
 				resp["access"] = readOnlyAccess
 				out, err := json.Marshal(resp)
 				require.NoError(t, err)
@@ -203,9 +202,7 @@ func TestGetHomeDashboard(t *testing.T) {
 			expectedResponse: func(t *testing.T) []byte {
 				t.Helper()
 				resp := map[string]any{}
-				for k, v := range k8sV2Doc {
-					resp[k] = v
-				}
+				maps.Copy(resp, k8sV2Doc)
 				resp["access"] = readOnlyAccess
 				out, err := json.Marshal(resp)
 				require.NoError(t, err)

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"reflect"
 
@@ -97,9 +98,7 @@ func (r *NormalResponse) WriteTo(ctx *contextmodel.ReqContext) {
 	}
 
 	header := ctx.Resp.Header()
-	for k, v := range r.header {
-		header[k] = v
-	}
+	maps.Copy(header, r.header)
 	ctx.Resp.WriteHeader(r.status)
 	if _, err := ctx.Resp.Write(r.body.Bytes()); err != nil {
 		ctx.Logger.Error("Error writing to response", "err", err)
@@ -152,9 +151,7 @@ func (r StreamingResponse) Body() []byte {
 // Required to implement api.Response.
 func (r StreamingResponse) WriteTo(ctx *contextmodel.ReqContext) {
 	header := ctx.Resp.Header()
-	for k, v := range r.header {
-		header[k] = v
-	}
+	maps.Copy(header, r.header)
 	ctx.Resp.WriteHeader(r.status)
 
 	// Use a configuration that's compatible with the standard library

--- a/pkg/infra/filestorage/cdk_blob_filestorage.go
+++ b/pkg/infra/filestorage/cdk_blob_filestorage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"gocloud.dev/blob"
@@ -113,9 +114,7 @@ func (c cdkBlobStorage) Upsert(ctx context.Context, command *UpsertFileCommand) 
 
 		metadata = make(map[string]string)
 		if command.Properties != nil {
-			for k, v := range command.Properties {
-				metadata[k] = v
-			}
+			maps.Copy(metadata, command.Properties)
 		}
 		metadata[originalPathAttributeKey] = command.Path
 		return c.bucket.WriteAll(ctx, strings.ToLower(command.Path), contents, &blob.WriterOptions{
@@ -130,9 +129,7 @@ func (c cdkBlobStorage) Upsert(ctx context.Context, command *UpsertFileCommand) 
 
 	if command.Properties != nil {
 		metadata = make(map[string]string)
-		for k, v := range command.Properties {
-			metadata[k] = v
-		}
+		maps.Copy(metadata, command.Properties)
 	} else {
 		metadata = existing.Properties
 	}

--- a/pkg/infra/leaderelection/kvlease/elector_test.go
+++ b/pkg/infra/leaderelection/kvlease/elector_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -236,9 +237,7 @@ func (m *mapKV) Batch(_ context.Context, _ string, ops []kv.BatchOp) error {
 	defer m.mu.Unlock()
 
 	snapshot := make(map[string][]byte, len(m.data))
-	for k, v := range m.data {
-		snapshot[k] = v
-	}
+	maps.Copy(snapshot, m.data)
 
 	for i, op := range ops {
 		switch op.Mode {

--- a/pkg/infra/metrics/metricutil/utils.go
+++ b/pkg/infra/metrics/metricutil/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -82,9 +83,7 @@ func buildLabelSets(labels []string, labelValues map[string][]string) []promethe
 
 func copyLabelSet(ls prometheus.Labels) prometheus.Labels {
 	newLs := make(prometheus.Labels, len(ls))
-	for l, v := range ls {
-		newLs[l] = v
-	}
+	maps.Copy(newLs, ls)
 	return newLs
 }
 

--- a/pkg/infra/usagestats/mock.go
+++ b/pkg/infra/usagestats/mock.go
@@ -2,6 +2,7 @@ package usagestats
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,9 +23,7 @@ func (usm *UsageStatsMock) GetUsageReport(ctx context.Context) (Report, error) {
 		fnMetrics, err := fn(ctx)
 		require.NoError(usm.T, err)
 
-		for name, value := range fnMetrics {
-			all[name] = value
-		}
+		maps.Copy(all, fnMetrics)
 	}
 	return Report{Metrics: all}, nil
 }

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -2,6 +2,7 @@ package statscollector
 
 import (
 	"context"
+	"maps"
 	"math/rand"
 	"strings"
 	"time"
@@ -228,9 +229,7 @@ func (s *Service) collectSystemStats(ctx context.Context) (map[string]any, error
 	}
 
 	featureUsageStats := s.features.GetUsageStats(ctx)
-	for k, v := range featureUsageStats {
-		m[k] = v
-	}
+	maps.Copy(m, featureUsageStats)
 
 	return m, nil
 }

--- a/pkg/login/social/connectors/org_role_mapper.go
+++ b/pkg/login/social/connectors/org_role_mapper.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/configprovider"
@@ -288,9 +289,7 @@ func getMappedOrgRoles(externalOrgs []string, orgMapping map[string]map[int64]or
 	}
 
 	if orgRoles, ok := orgMapping["*"]; ok {
-		for orgID, role := range orgRoles {
-			userOrgRoles[orgID] = role
-		}
+		maps.Copy(userOrgRoles, orgRoles)
 	}
 
 	for _, org := range externalOrgs {

--- a/pkg/registry/apis/provisioning/jobs/loki_history.go
+++ b/pkg/registry/apis/provisioning/jobs/loki_history.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -142,9 +143,7 @@ func (h *LokiJobHistory) jobToStream(ctx context.Context, job *provisioning.Job)
 	labels := make(map[string]string)
 
 	// Add external labels
-	for k, v := range h.externalLabels {
-		labels[k] = v
-	}
+	maps.Copy(labels, h.externalLabels)
 
 	// Add system labels
 	labels[JobHistoryLabelKey] = JobHistoryLabelValue

--- a/pkg/registry/apis/provisioning/resources/ownership.go
+++ b/pkg/registry/apis/provisioning/resources/ownership.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -28,9 +29,7 @@ type TakeoverAllowlist struct {
 // The map is defensively copied so the caller is free to mutate ids afterwards.
 func NewTakeoverAllowlist(ids map[ResourceIdentifier]struct{}) *TakeoverAllowlist {
 	cp := make(map[ResourceIdentifier]struct{}, len(ids))
-	for k, v := range ids {
-		cp[k] = v
-	}
+	maps.Copy(cp, ids)
 	return &TakeoverAllowlist{ids: cp}
 }
 

--- a/pkg/registry/apis/provisioning/resources/resources_remove_test.go
+++ b/pkg/registry/apis/provisioning/resources/resources_remove_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -31,9 +32,7 @@ func managedGrafanaObj(name, namespace string, extraAnnotations map[string]any) 
 		utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
 		utils.AnnoKeyManagerIdentity: testRepoName,
 	}
-	for k, v := range extraAnnotations {
-		annotations[k] = v
-	}
+	maps.Copy(annotations, extraAnnotations)
 	return &unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{
 			"name":        name,

--- a/pkg/registry/apis/search/openapi_schemas.go
+++ b/pkg/registry/apis/search/openapi_schemas.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"maps"
 	"strings"
 
 	"k8s.io/kube-openapi/pkg/spec3"
@@ -46,9 +47,7 @@ func schemaRef(goName string) spec.Ref {
 // owns, and through them metav1.LabelSelector.
 func envelopeSchemas(roots ...string) map[string]spec.Schema {
 	defs := searchv0.GetOpenAPIDefinitions(schemaRef)
-	for name, def := range commonv0.GetOpenAPIDefinitions(schemaRef) {
-		defs[name] = def
-	}
+	maps.Copy(defs, commonv0.GetOpenAPIDefinitions(schemaRef))
 
 	out := map[string]spec.Schema{}
 	queue := append([]string{}, roots...)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -255,9 +256,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 		return
 	}
 
-	for k, v := range rec.header {
-		w.Header()[k] = v
-	}
+	maps.Copy(w.Header(), rec.header)
 	if rec.statusCode == http.StatusOK {
 		cr.openapiDocs.Store(cacheKey, openapiCacheEntry{rv: entry.rv, etag: etag, body: rec.body.Bytes()})
 		w.Header().Set("ETag", etag)

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -3,17 +3,17 @@ package acimpl
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	claims "github.com/grafana/authlib/types"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
-
-	claims "github.com/grafana/authlib/types"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -997,9 +997,7 @@ func (s *Service) GetStaticRoles(ctx context.Context) map[string]*accesscontrol.
 
 	// Return a copy to avoid external modifications
 	rolesCopy := make(map[string]*accesscontrol.RoleDTO, len(s.roles))
-	for k, v := range s.roles {
-		rolesCopy[k] = v
-	}
+	maps.Copy(rolesCopy, s.roles)
 	return rolesCopy
 }
 

--- a/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
+++ b/pkg/services/accesscontrol/acimpl/zanzana_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -479,9 +480,7 @@ func MergePermissions(a, b map[int64][]ac.Permission) map[int64][]ac.Permission 
 
 	result := make(map[int64][]ac.Permission, len(a)+len(b))
 	// Users only in a: alias the slice. No copy until we know we'll mutate it.
-	for userID, perms := range a {
-		result[userID] = perms
-	}
+	maps.Copy(result, a)
 
 	for userID, perms := range b {
 		existing, ok := result[userID]

--- a/pkg/services/annotations/annotationstest/fake.go
+++ b/pkg/services/annotations/annotationstest/fake.go
@@ -2,6 +2,7 @@ package annotationstest
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/grafana/grafana/pkg/services/annotations"
@@ -94,8 +95,6 @@ func (repo *fakeAnnotationsRepo) Items() map[int64]annotations.Item {
 	repo.mtx.Lock()
 	defer repo.mtx.Unlock()
 	ret := make(map[int64]annotations.Item)
-	for k, v := range repo.annotations {
-		ret[k] = v
-	}
+	maps.Copy(ret, repo.annotations)
 	return ret
 }

--- a/pkg/services/apiserver/builder/request_handler.go
+++ b/pkg/services/apiserver/builder/request_handler.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 
@@ -30,9 +31,7 @@ func convertHandlerToRouteFunction(handler http.HandlerFunc) restful.RouteFuncti
 		// Get all path parameters from the restful.Request
 		// The restful.Request has PathParameters() method that returns a map
 		pathParams := req.PathParameters()
-		for key, value := range pathParams {
-			vars[key] = value
-		}
+		maps.Copy(vars, pathParams)
 
 		// Set the vars in the request context using mux.SetURLVars
 		// This makes mux.Vars(r) work correctly

--- a/pkg/services/authn/authnimpl/usage_stats.go
+++ b/pkg/services/authn/authnimpl/usage_stats.go
@@ -2,6 +2,7 @@ package authnimpl
 
 import (
 	"context"
+	"maps"
 
 	"github.com/grafana/grafana/pkg/services/authn"
 )
@@ -43,9 +44,7 @@ func (s *Service) getUsageStats(ctx context.Context) (map[string]any, error) {
 				s.log.Warn("Failed to get usage stats from client", "client", client.Name(), "error", err)
 			}
 
-			for k, v := range clientStats {
-				m[k] = v
-			}
+			maps.Copy(m, clientStats)
 		}
 	}
 

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
@@ -878,9 +879,7 @@ func (s *Server) doOpenFGABatchCheck(
 		if err != nil {
 			return nil, err
 		}
-		for k, v := range results {
-			allResults[k] = v
-		}
+		maps.Copy(allResults, results)
 	}
 
 	return allResults, nil

--- a/pkg/services/cloudmigration/resource_dependency.go
+++ b/pkg/services/cloudmigration/resource_dependency.go
@@ -1,6 +1,8 @@
 package cloudmigration
 
 import (
+	"maps"
+
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 )
 
@@ -40,13 +42,9 @@ var alertingResourceDependency = DependencyMap{
 // by snapshot creation on instances where alerting is disabled.
 func ResourceDependency(alertingEnabled bool) DependencyMap {
 	depMap := make(DependencyMap, len(baseResourceDependency)+len(alertingResourceDependency))
-	for resourceType, dependencies := range baseResourceDependency {
-		depMap[resourceType] = dependencies
-	}
+	maps.Copy(depMap, baseResourceDependency)
 	if alertingEnabled {
-		for resourceType, dependencies := range alertingResourceDependency {
-			depMap[resourceType] = dependencies
-		}
+		maps.Copy(depMap, alertingResourceDependency)
 	}
 	return depMap
 }

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"slices"
 	"strconv"
@@ -869,9 +870,7 @@ func (s *Service) httpClientOptions(ctx context.Context, ds *datasources.DataSou
 		opts.CustomOptions = ds.JsonDataMap()
 		// allow the plugin sdk to get the json data in JSONDataFromHTTPClientOptions
 		deepJsonDataCopy := make(map[string]any, len(opts.CustomOptions))
-		for k, v := range opts.CustomOptions {
-			deepJsonDataCopy[k] = v
-		}
+		maps.Copy(deepJsonDataCopy, opts.CustomOptions)
 		opts.CustomOptions["grafanaData"] = deepJsonDataCopy
 	}
 	if ds.BasicAuth {

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -3,6 +3,7 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
@@ -161,9 +162,7 @@ func CollectEnvironment(ctx context.Context, cfg *setting.Cfg, store PluginVersi
 
 	if len(refs.DatasourcesByUID) > 0 {
 		env.Datasources = make(map[string]string, len(refs.DatasourcesByUID))
-		for uid, pluginID := range refs.DatasourcesByUID {
-			env.Datasources[uid] = pluginID
-		}
+		maps.Copy(env.Datasources, refs.DatasourcesByUID)
 	}
 
 	pluginIDs := refs.PluginIDs()

--- a/pkg/services/libraryelements/conversions.go
+++ b/pkg/services/libraryelements/conversions.go
@@ -3,6 +3,7 @@ package libraryelements
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -79,9 +80,7 @@ func toRawMessage(raw runtime.Object) (json.RawMessage, error) {
 func LibraryPanelToLegacyModel(panel *v0alpha1.LibraryPanel) (json.RawMessage, error) {
 	legacyModel := map[string]any{}
 	if panel.Status != nil {
-		for k, v := range panel.Status.Missing.Object {
-			legacyModel[k] = v
-		}
+		maps.Copy(legacyModel, panel.Status.Missing.Object)
 	}
 
 	spec := panel.Spec

--- a/pkg/services/ngalert/accesscontrol/silences_test.go
+++ b/pkg/services/ngalert/accesscontrol/silences_test.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"context"
+	"maps"
 	"math/rand"
 	"testing"
 
@@ -822,9 +823,7 @@ func TestSilenceAccess(t *testing.T) {
 			for _, silence := range silences {
 				expectedPermissions := tc.expectedPermissions.Clone()
 				if s, ok := tc.overrides[silence]; ok {
-					for k, v := range s.expectedPermissions {
-						expectedPermissions[k] = v
-					}
+					maps.Copy(expectedPermissions, s.expectedPermissions)
 				}
 				for _, permission := range models.SilencePermissions() {
 					assert.Equalf(t, expectedPermissions.Has(permission), perms[silence].Has(permission), "expected %s=%t permission for silence %s but got %t", permission, expectedPermissions.Has(permission), *silence.ID, perms[silence].Has(permission))

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -326,9 +327,7 @@ func withNoDataState() forEachState {
 
 func withLabels(labels data.Labels) forEachState {
 	return func(s *state.State) *state.State {
-		for k, v := range labels {
-			s.Labels[k] = v
-		}
+		maps.Copy(s.Labels, labels)
 		return s
 	}
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -962,16 +962,12 @@ func (alertRule *AlertRule) Copy() *AlertRule {
 
 	if alertRule.Annotations != nil {
 		result.Annotations = make(map[string]string, len(alertRule.Annotations))
-		for s, s2 := range alertRule.Annotations {
-			result.Annotations[s] = s2
-		}
+		maps.Copy(result.Annotations, alertRule.Annotations)
 	}
 
 	if alertRule.Labels != nil {
 		result.Labels = make(map[string]string, len(alertRule.Labels))
-		for s, s2 := range alertRule.Labels {
-			result.Labels[s] = s2
-		}
+		maps.Copy(result.Labels, alertRule.Labels)
 	}
 
 	if alertRule.Record != nil {

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"testing"
 	"time"
 
@@ -656,9 +657,7 @@ func NewTestMultiOrgAlertmanager(t *testing.T, opts ...TestMultiOrgAlertmanagerO
 	require.NoError(t, err)
 
 	if options.alertmanagers != nil {
-		for orgID, am := range options.alertmanagers {
-			moa.alertmanagers[orgID] = am
-		}
+		maps.Copy(moa.alertmanagers, options.alertmanagers)
 	}
 
 	if !options.skipLoad {

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
 	"runtime"
@@ -1507,9 +1508,7 @@ func stateForRule(rule *models.AlertRule, ts time.Time, evalState eval.State) *s
 		LastSentAt:         &ts,
 		LastEvaluationTime: ts,
 	}
-	for k, v := range rule.Labels {
-		s.Labels[k] = v
-	}
+	maps.Copy(s.Labels, rule.Labels)
 	for k, v := range state.GetRuleExtraLabels(&logtest.Fake{}, rule, "", true, featuremgmt.WithFeatures()) {
 		if _, ok := s.Labels[k]; !ok {
 			s.Labels[k] = v

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"errors"
+	"maps"
 	"net/url"
 	"strings"
 	"sync"
@@ -173,12 +174,8 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 
 	lbs := make(data.Labels, len(extraLabels)+len(labels)+len(resultLabels)+len(errorLabels))
 	dupes := make(data.Labels)
-	for key, val := range extraLabels {
-		lbs[key] = val
-	}
-	for key, val := range errorLabels {
-		lbs[key] = val
-	}
+	maps.Copy(lbs, extraLabels)
+	maps.Copy(lbs, errorLabels)
 	for key, val := range labels {
 		ruleVal, ok := lbs[key]
 		// if duplicate labels exist, reserved label will take precedence
@@ -393,9 +390,7 @@ func (c *cache) GetAlertInstances() []ngModels.AlertInstance {
 // if duplicate labels exist, keep the value from the first set
 func mergeLabels(a, b data.Labels) data.Labels {
 	newLbs := make(data.Labels, len(a)+len(b))
-	for k, v := range a {
-		newLbs[k] = v
-	}
+	maps.Copy(newLbs, a)
 	for k, v := range b {
 		if _, ok := newLbs[k]; !ok {
 			newLbs[k] = v

--- a/pkg/services/ngalert/state/compat_test.go
+++ b/pkg/services/ngalert/state/compat_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"maps"
 	"math/rand"
 	"net/url"
 	"testing"
@@ -119,9 +120,7 @@ func Test_StateToPostableAlert(t *testing.T) {
 					result := StateToPostableAlert(alertState, appURL)
 
 					expected := make(models.LabelSet, len(alertState.Annotations)+1)
-					for k, v := range alertState.Annotations {
-						expected[k] = v
-					}
+					maps.Copy(expected, alertState.Annotations)
 					expected["__value_string__"] = expectedValueString
 
 					require.Equal(t, expected, result.Annotations)
@@ -140,9 +139,7 @@ func Test_StateToPostableAlert(t *testing.T) {
 					result := StateToPostableAlert(alertState, appURL)
 
 					expected := make(models.LabelSet, len(alertState.Annotations)+1)
-					for k, v := range alertState.Annotations {
-						expected[k] = v
-					}
+					maps.Copy(expected, alertState.Annotations)
 					expected[alertingModels.ImageTokenAnnotation] = alertState.Image.Token
 					expected[alertingModels.ImageURLAnnotation] = alertState.Image.URL
 
@@ -161,9 +158,7 @@ func Test_StateToPostableAlert(t *testing.T) {
 					result := StateToPostableAlert(alertState, appURL)
 
 					expected := make(models.LabelSet, len(alertState.Annotations)+1)
-					for k, v := range alertState.Annotations {
-						expected[k] = v
-					}
+					maps.Copy(expected, alertState.Annotations)
 
 					require.Equal(t, expected, result.Annotations)
 				})
@@ -224,9 +219,7 @@ func Test_StateToPostableAlert(t *testing.T) {
 					result := StateToPostableAlert(alertState, appURL)
 
 					expected := make(models.LabelSet, len(alertState.Labels)+1)
-					for k, v := range alertState.Labels {
-						expected[k] = v
-					}
+					maps.Copy(expected, alertState.Labels)
 					expected[model.AlertNameLabel] = NoDataAlertName
 					expected[Rulename] = alertName
 
@@ -253,9 +246,7 @@ func Test_StateToPostableAlert(t *testing.T) {
 					result := StateToPostableAlert(alertState, appURL)
 
 					expected := make(models.LabelSet, len(alertState.Labels)+1)
-					for k, v := range alertState.Labels {
-						expected[k] = v
-					}
+					maps.Copy(expected, alertState.Labels)
 					expected[model.AlertNameLabel] = ErrorAlertName
 					expected[Rulename] = alertName
 

--- a/pkg/services/ngalert/state/historian/core.go
+++ b/pkg/services/ngalert/state/historian/core.go
@@ -2,6 +2,7 @@ package historian
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -111,8 +112,6 @@ func (p PanelKey) PanelID() int64 {
 }
 
 func mergeLabels(base, into data.Labels) data.Labels {
-	for k, v := range into {
-		base[k] = v
-	}
+	maps.Copy(base, into)
 	return base
 }

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
 	"slices"
@@ -2118,12 +2119,8 @@ func TestStaleResults(t *testing.T) {
 	getCacheID := func(t *testing.T, rule *models.AlertRule, result eval.Result) data.Fingerprint {
 		t.Helper()
 		labels := data.Labels{}
-		for key, value := range rule.Labels {
-			labels[key] = value
-		}
-		for key, value := range result.Instance {
-			labels[key] = value
-		}
+		maps.Copy(labels, rule.Labels)
+		maps.Copy(labels, result.Instance)
 		lbls := models.InstanceLabels(labels)
 		return lbls.Fingerprint()
 	}
@@ -2594,12 +2591,8 @@ func stateSliceToMap(states []*state.State) map[data.Fingerprint]*state.State {
 
 func mergeLabels(a, b data.Labels) data.Labels {
 	result := make(data.Labels, len(a)+len(b))
-	for k, v := range a {
-		result[k] = v
-	}
-	for k, v := range b {
-		result[k] = v
-	}
+	maps.Copy(result, a)
+	maps.Copy(result, b)
 	return result
 }
 

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -789,9 +789,7 @@ func GetRuleExtraLabels(l log.Logger, rule *models.AlertRule, folderTitle string
 	}
 
 	if rule.NotificationSettings != nil {
-		for k, v := range rule.NotificationSettings.ToLabels(features) {
-			extraLabels[k] = v
-		}
+		maps.Copy(extraLabels, rule.NotificationSettings.ToLabels(features))
 	}
 	return extraLabels
 }
@@ -887,9 +885,7 @@ func (a *State) transition(alertRule *models.AlertRule, result eval.Result, extr
 		}
 	}
 
-	for key, val := range extraAnnotations {
-		a.Annotations[key] = val
-	}
+	maps.Copy(a.Annotations, extraAnnotations)
 
 	nextState := StateTransition{
 		State:               a,

--- a/pkg/services/ngalert/tests/fakes/kvstore.go
+++ b/pkg/services/ngalert/tests/fakes/kvstore.go
@@ -2,6 +2,7 @@ package fakes
 
 import (
 	"context"
+	"maps"
 	"strings"
 	"sync"
 	"testing"
@@ -115,8 +116,6 @@ func (fkv *FakeKVStore) GetAll(ctx context.Context, orgId int64, namespace strin
 		return all, nil
 	}
 
-	for k, v := range values {
-		all[orgId][k] = v
-	}
+	maps.Copy(all[orgId], values)
 	return all, nil
 }

--- a/pkg/services/ngalert/writer/prom.go
+++ b/pkg/services/ngalert/writer/prom.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"time"
@@ -223,9 +224,7 @@ func PointsFromFrames(name string, t time.Time, frames data.Frames, extraLabels 
 			labels = data.Labels{}
 		}
 		delete(labels, "__name__")
-		for k, v := range extraLabels {
-			labels[k] = v
-		}
+		maps.Copy(labels, extraLabels)
 
 		points = append(points, Point{
 			Name:   name,

--- a/pkg/services/ngalert/writer/prom_test.go
+++ b/pkg/services/ngalert/writer/prom_test.go
@@ -2,6 +2,7 @@ package writer
 
 import (
 	"context"
+	"maps"
 	"math"
 	"math/rand/v2"
 	"net"
@@ -65,9 +66,7 @@ func TestPointsFromFrames(t *testing.T) {
 				for i, point := range points {
 					v := extractValue(t, frames, series[i], tc.frameType)
 					expectedLabels := map[string]string{"extra": "label"}
-					for k, v := range series[i] {
-						expectedLabels[k] = v
-					}
+					maps.Copy(expectedLabels, series[i])
 					require.Equal(t, expectedLabels, point.Labels)
 					require.Equal(t, "test", point.Name)
 					require.Equal(t, now, point.Metric.T)

--- a/pkg/services/notifications/email.go
+++ b/pkg/services/notifications/email.go
@@ -1,6 +1,8 @@
 package notifications
 
 import (
+	"maps"
+
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -41,8 +43,6 @@ func setDefaultTemplateData(cfg *setting.Cfg, data map[string]any, u *user.User)
 		data["Name"] = u.NameOrFallback()
 	}
 	dataCopy := map[string]any{}
-	for k, v := range data {
-		dataCopy[k] = v
-	}
+	maps.Copy(dataCopy, data)
 	data["TemplateData"] = dataCopy
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -524,13 +525,9 @@ func checkHistogram(promRegistry *prometheus.Registry, expMetricName string, exp
 // The additionalLabels are merged into the initial ones, and will overwrite a value if already set in initialLabels.
 func newLabels(initialLabels prometheus.Labels, additional ...prometheus.Labels) prometheus.Labels {
 	r := make(prometheus.Labels, len(initialLabels)+len(additional)/2)
-	for k, v := range initialLabels {
-		r[k] = v
-	}
+	maps.Copy(r, initialLabels)
 	for _, l := range additional {
-		for k, v := range l {
-			r[k] = v
-		}
+		maps.Copy(r, l)
 	}
 	return r
 }

--- a/pkg/services/pluginsintegration/pluginsettings/service/service.go
+++ b/pkg/services/pluginsintegration/pluginsettings/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -204,9 +205,7 @@ func (s *Service) updatePluginSetting(ctx context.Context, cmd *pluginsettings.U
 			return err
 		}
 
-		for key, encryptedData := range cmd.EncryptedSecureJsonData {
-			pluginSetting.SecureJsonData[key] = encryptedData
-		}
+		maps.Copy(pluginSetting.SecureJsonData, cmd.EncryptedSecureJsonData)
 
 		// add state change event on commit success
 		if pluginSetting.Enabled != cmd.Enabled {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"runtime"
 	"slices"
@@ -198,9 +199,7 @@ func (s *ServiceImpl) executeConcurrentQueries(ctx context.Context, user identit
 	resp := backend.NewQueryDataResponse()
 	reqCtx := contexthandler.FromContext(ctx)
 	for result := range rchan {
-		for refId, dataResponse := range result.responses {
-			resp.Responses[refId] = dataResponse
-		}
+		maps.Copy(resp.Responses, result.responses)
 		if reqCtx != nil {
 			for k, v := range result.header {
 				for _, val := range v {

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"mime"
 	"net/http"
 	"net/url"
@@ -148,9 +149,7 @@ func (rs *RenderingService) doRequest(ctx context.Context, u *url.URL, headers m
 	req.Header.Set(authTokenHeader, rs.Cfg.RendererAuthToken)
 	req.Header.Set(rateLimiterHeader, rs.domain)
 	req.Header.Set("User-Agent", fmt.Sprintf("Grafana/%s", rs.Cfg.BuildVersion))
-	for k, v := range headers {
-		req.Header[k] = v
-	}
+	maps.Copy(req.Header, headers)
 
 	logger.Debug("calling remote rendering service", "url", u)
 

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -914,9 +915,7 @@ func generateSettingsJSON(settings []Setting, continueToken string) string {
 		}
 		// Generate labels - always include section/key, merge with any custom labels
 		labels := map[string]string{"section": s.Section, "key": s.Key}
-		for k, v := range s.Labels {
-			labels[k] = v
-		}
+		maps.Copy(labels, s.Labels)
 		labelsJSON, _ := json.Marshal(labels)
 		sb.WriteString(fmt.Sprintf(
 			`{"apiVersion":"setting.grafana.app/v1beta1","kind":"Setting","metadata":{"name":"%s--%s","namespace":"test-namespace","labels":%s},"spec":{"section":"%s","key":"%s","value":"%s"}}`,

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	maps0 "maps"
 	"slices"
 	"strings"
 	"sync"
@@ -790,10 +789,10 @@ func mergeSecrets(settings map[string]any, storedSettings map[string]any) (map[s
 	return settingsWithSecrets, nil
 }
 
-func overrideMaps(maps ...map[string]any) map[string]any {
+func overrideMaps(input ...map[string]any) map[string]any {
 	result := make(map[string]any)
-	for _, m := range maps {
-		maps0.Copy(result, m)
+	for _, m := range input {
+		maps.Copy(result, m)
 	}
 	return result
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
+	maps0 "maps"
 	"slices"
 	"strings"
 	"sync"
@@ -105,9 +107,7 @@ func ProvideService(cfg *setting.Cfg, cfgProvider configprovider.ConfigProvider,
 	}
 
 	configurableProviders := make(map[string]bool)
-	for provider, enabled := range cfg.SSOSettingsConfigurableProviders {
-		configurableProviders[provider] = enabled
-	}
+	maps.Copy(configurableProviders, cfg.SSOSettingsConfigurableProviders)
 
 	providersList := ssosettings.AllOAuthProviders
 	providersList = append(providersList, social.LDAPProviderName)
@@ -382,12 +382,8 @@ func (s *Service) Patch(ctx context.Context, provider string, data map[string]an
 	}
 
 	newSettingsMap := make(map[string]any)
-	for k, v := range storedSettings.Settings {
-		newSettingsMap[k] = v
-	}
-	for k, v := range data {
-		newSettingsMap[k] = v
-	}
+	maps.Copy(newSettingsMap, storedSettings.Settings)
+	maps.Copy(newSettingsMap, data)
 
 	newSettings := &models.SSOSettings{
 		Provider: provider,
@@ -642,9 +638,7 @@ func (s *Service) mergeSSOSettingsMTAuthoritative(dbSettings, systemSettings *mo
 	s.logger.Debug("Merging SSO Settings, MT-Settings authoritative", "systemSettings", removeSecrets(systemSettings.Settings), "dbSettings", removeSecrets(dbSettings.Settings))
 
 	settings := make(map[string]any, len(systemSettings.Settings))
-	for k, v := range systemSettings.Settings {
-		settings[k] = v
-	}
+	maps.Copy(settings, systemSettings.Settings)
 	for k, v := range dbSettings.Settings {
 		if existing, ok := settings[k]; !ok || isEmptyString(existing) {
 			settings[k] = v
@@ -739,9 +733,7 @@ func getConfigMaps(settings map[string]any) []map[string]any {
 func mergeSettings(storedSettings, systemSettings map[string]any) map[string]any {
 	settings := make(map[string]any)
 
-	for k, v := range storedSettings {
-		settings[k] = v
-	}
+	maps.Copy(settings, storedSettings)
 
 	for k, v := range systemSettings {
 		if _, ok := settings[k]; !ok {
@@ -801,9 +793,7 @@ func mergeSecrets(settings map[string]any, storedSettings map[string]any) (map[s
 func overrideMaps(maps ...map[string]any) map[string]any {
 	result := make(map[string]any)
 	for _, m := range maps {
-		for k, v := range m {
-			result[k] = v
-		}
+		maps0.Copy(result, m)
 	}
 	return result
 }

--- a/pkg/services/ssosettings/ssosettingsimpl/service_test.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/service_test.go
@@ -1742,9 +1742,7 @@ func TestService_Upsert(t *testing.T) {
 
 		expected := settings
 		expected.Settings = make(map[string]any)
-		for key, value := range settings.Settings {
-			expected.Settings[key] = value
-		}
+		maps.Copy(expected.Settings, settings.Settings)
 		expected.Settings["client_secret"] = "encrypted-client-secret"
 
 		reloadable := ssosettingstests.NewMockReloadable(t)
@@ -1788,9 +1786,7 @@ func TestService_Upsert(t *testing.T) {
 
 		expected := settings
 		expected.Settings = make(map[string]any)
-		for key, value := range settings.Settings {
-			expected.Settings[key] = value
-		}
+		maps.Copy(expected.Settings, settings.Settings)
 		expected.Settings["client_secret"] = "current-client-secret"
 		expected.Settings["private_key"] = "current-private-key"
 

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -3,6 +3,7 @@ package dualwrite
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -555,9 +556,7 @@ func (w *wrappedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime.Ob
 		if existingLabels == nil {
 			existingLabels = make(map[string]string)
 		}
-		for key, value := range w.legacyLabels {
-			existingLabels[key] = value
-		}
+		maps.Copy(existingLabels, w.legacyLabels)
 		meta.SetLabels(existingLabels)
 	}
 	if len(w.legacyAnnotations) > 0 {
@@ -565,9 +564,7 @@ func (w *wrappedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime.Ob
 		if existingAnnotations == nil {
 			existingAnnotations = make(map[string]string)
 		}
-		for key, value := range w.legacyAnnotations {
-			existingAnnotations[key] = value
-		}
+		maps.Copy(existingAnnotations, w.legacyAnnotations)
 		meta.SetAnnotations(existingAnnotations)
 	}
 

--- a/pkg/storage/unified/client_test.go
+++ b/pkg/storage/unified/client_test.go
@@ -2,6 +2,7 @@ package unified
 
 import (
 	"context"
+	"maps"
 	"net"
 	"strings"
 	"sync"
@@ -264,9 +265,7 @@ func (s *testServer) getCalls() map[string]int {
 	defer s.mu.Unlock()
 
 	calls := make(map[string]int, len(s.Calls))
-	for method, count := range s.Calls {
-		calls[method] = count
-	}
+	maps.Copy(calls, s.Calls)
 
 	return calls
 }

--- a/pkg/storage/unified/informer/store.go
+++ b/pkg/storage/unified/informer/store.go
@@ -2,6 +2,7 @@ package informer
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -169,9 +170,7 @@ func (s *store) Replace(objs []runtime.Object, listRV int64) (added, updated, re
 	// result is the snapshot we install: objs, minus resurrections we suppress,
 	// plus live writes newer than the snapshot we carry forward.
 	result := make(map[string]entry, len(next))
-	for key, e := range next {
-		result[key] = e
-	}
+	maps.Copy(result, next)
 
 	// Classify snapshot objects in objs order (not map order) so added/updated
 	// are deterministic. A LIST carries no duplicate keys, but guard anyway.

--- a/pkg/storage/unified/migrations/migrator_test.go
+++ b/pkg/storage/unified/migrations/migrator_test.go
@@ -3,6 +3,7 @@ package migrations_test
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"testing"
 	"time"
@@ -378,12 +379,8 @@ func verifyRegisteredMigrations(t *testing.T, helper *apis.K8sTestHelper, onlyDe
 	expectedMigrationIDs := []string{createTableMigrationID}
 
 	allMigrationIDs := make(map[string]bool)
-	for id, enabled := range migrationIDsToDefault {
-		allMigrationIDs[id] = enabled
-	}
-	for id, enabled := range extraMigrationIDs {
-		allMigrationIDs[id] = enabled
-	}
+	maps.Copy(allMigrationIDs, migrationIDsToDefault)
+	maps.Copy(allMigrationIDs, extraMigrationIDs)
 
 	for id, enabled := range allMigrationIDs {
 		if onlyDefault && !enabled {

--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -285,9 +286,7 @@ func (c authzLimitedClient) BatchCheck(ctx context.Context, id claims.AuthInfo, 
 	}
 
 	// Merge results from underlying client
-	for correlationID, result := range resp.Results {
-		results[correlationID] = result
-	}
+	maps.Copy(results, resp.Results)
 
 	c.metrics.batchCheckDuration.WithLabelValues(fmt.Sprintf("%d", len(req.Checks))).Observe(time.Since(t).Seconds())
 	return claims.BatchCheckResponse{Results: results}, nil

--- a/pkg/storage/unified/resource/lease/lease_test.go
+++ b/pkg/storage/unified/resource/lease/lease_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"slices"
 	"sync"
 	"testing"
@@ -174,9 +175,7 @@ func (m *mapKV) Batch(ctx context.Context, sec string, ops []kv.BatchOp) error {
 
 	// Snapshot for atomic rollback on failure.
 	snapshot := make(map[string][]byte, len(m.data))
-	for k, v := range m.data {
-		snapshot[k] = v
-	}
+	maps.Copy(snapshot, m.data)
 
 	for i, op := range ops {
 		switch op.Mode {

--- a/pkg/storage/unified/resource/selectable_fields.go
+++ b/pkg/storage/unified/resource/selectable_fields.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"maps"
 	"slices"
 
 	"github.com/grafana/grafana-app-sdk/app"
@@ -39,9 +40,7 @@ func AppManifestsWithKinds(manifiests []app.Manifest) []app.Manifest {
 func SelectableFieldsForManifests(manifests []app.Manifest) map[LowerGroupResource][]string {
 	fields := map[LowerGroupResource][]string{}
 	for _, m := range manifests {
-		for k, v := range selectableFieldsForManifest(m) {
-			fields[k] = v
-		}
+		maps.Copy(fields, selectableFieldsForManifest(m))
 	}
 	return fields
 }

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"math/rand/v2"
 	"net/http"
 	"slices"
@@ -2798,9 +2799,7 @@ func (b *kvStorageBackend) ProcessBulk(ctx context.Context, setting BulkSettings
 		batchLastMicroRV := lastMicroRV
 		if rvManagerDB != nil {
 			batchLastMicroRV = make(map[string]int64, len(lastMicroRV)+len(batch))
-			for key, value := range lastMicroRV {
-				batchLastMicroRV[key] = value
-			}
+			maps.Copy(batchLastMicroRV, lastMicroRV)
 		}
 
 		for _, req := range batch {

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"iter"
+	"maps"
 	"net/http"
 	"sync"
 	"time"
@@ -348,9 +349,7 @@ func (f *fakeVector) GetSubresourceContent(_ context.Context, ns, model, res, ui
 	defer f.mu.Unlock()
 	key := subsKey(ns, model, res, uid)
 	out := map[string]string{}
-	for k, v := range f.storedSubs[key] {
-		out[k] = v
-	}
+	maps.Copy(out, f.storedSubs[key])
 	if len(out) == 0 {
 		return nil, "", nil
 	}

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -3452,9 +3453,7 @@ func (h *GitTestHelper) createRepo(
 		"Token":         user.Password,
 		"WorkflowsJSON": string(workflowsJSON),
 	}
-	for k, v := range opts.templateVariables {
-		templateValues[k] = v
-	}
+	maps.Copy(templateValues, opts.templateVariables)
 
 	tmpl := TestdataPath(repoType + ".json.tmpl")
 	repoObj := h.RenderObject(t, tmpl, templateValues)

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -279,7 +278,9 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			maps.Copy(tt.azureMonitorVariedProperties, commonAzureModelProps)
+			for k, v := range commonAzureModelProps {
+				tt.azureMonitorVariedProperties[k] = v
+			}
 			azureMonitorJSON, _ := json.Marshal(tt.azureMonitorVariedProperties)
 			tsdbQuery := []backend.DataQuery{
 				{

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -278,9 +279,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range commonAzureModelProps {
-				tt.azureMonitorVariedProperties[k] = v
-			}
+			maps.Copy(tt.azureMonitorVariedProperties, commonAzureModelProps)
 			azureMonitorJSON, _ := json.Marshal(tt.azureMonitorVariedProperties)
 			tsdbQuery := []backend.DataQuery{
 				{

--- a/pkg/tsdb/azuremonitor/sql.go
+++ b/pkg/tsdb/azuremonitor/sql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"regexp"
 	"strings"
 
@@ -164,7 +163,9 @@ func (s *Service) normalizeGrafanaSQLRequest(ctx context.Context, req *backend.Q
 // mergeTableParams combines explicit TableParameterValues with suffix segments from the table name.
 func mergeTableParams(table string, explicit map[string]any) map[string]any {
 	out := make(map[string]any)
-	maps.Copy(out, explicit)
+	for k, v := range explicit {
+		out[k] = v
+	}
 	parts := strings.SplitN(table, "_", 2)
 	if len(parts) < 2 {
 		return out

--- a/pkg/tsdb/azuremonitor/sql.go
+++ b/pkg/tsdb/azuremonitor/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 
@@ -163,9 +164,7 @@ func (s *Service) normalizeGrafanaSQLRequest(ctx context.Context, req *backend.Q
 // mergeTableParams combines explicit TableParameterValues with suffix segments from the table name.
 func mergeTableParams(table string, explicit map[string]any) map[string]any {
 	out := make(map[string]any)
-	for k, v := range explicit {
-		out[k] = v
-	}
+	maps.Copy(out, explicit)
 	parts := strings.SplitN(table, "_", 2)
 	if len(parts) < 2 {
 		return out

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/url"
 	"sort"
@@ -103,7 +102,9 @@ func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Value
 	var responseHeaders http.Header
 	if nextToken != nil {
 		nextParams := url.Values{}
-		maps.Copy(nextParams, parameters)
+		for k, v := range parameters {
+			nextParams[k] = v
+		}
 		nextParams.Set("nextToken", *nextToken)
 		responseHeaders = http.Header{
 			"Link": []string{fmt.Sprintf("<?%s>; rel=\"next\"", nextParams.Encode())},

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"sort"
@@ -102,9 +103,7 @@ func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Value
 	var responseHeaders http.Header
 	if nextToken != nil {
 		nextParams := url.Values{}
-		for k, v := range parameters {
-			nextParams[k] = v
-		}
+		maps.Copy(nextParams, parameters)
 		nextParams.Set("nextToken", *nextToken)
 		responseHeaders = http.Header{
 			"Link": []string{fmt.Sprintf("<?%s>; rel=\"next\"", nextParams.Encode())},

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
-	"maps"
 	"math"
 	"math/rand"
 	"sort"
@@ -321,7 +320,9 @@ func (s *Service) handleFallbackScenario(ctx context.Context, req *backend.Query
 			if sResp, err := handler(ctx, sReq); err != nil {
 				ctxLogger.Error("Failed to handle scenario", "scenarioId", scenarioID, "error", err)
 			} else {
-				maps.Copy(resp.Responses, sResp.Responses)
+				for refID, dr := range sResp.Responses {
+					resp.Responses[refID] = dr
+				}
 			}
 		}
 	}

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"math"
 	"math/rand"
 	"sort"
@@ -320,9 +321,7 @@ func (s *Service) handleFallbackScenario(ctx context.Context, req *backend.Query
 			if sResp, err := handler(ctx, sReq); err != nil {
 				ctxLogger.Error("Failed to handle scenario", "scenarioId", scenarioID, "error", err)
 			} else {
-				for refID, dr := range sResp.Responses {
-					resp.Responses[refID] = dr
-				}
+				maps.Copy(resp.Responses, sResp.Responses)
 			}
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

Replaces manual map-copy loops with the standard library `maps.Copy` helper across the Go backend. These changes were generated with the `mapsloop` Go modernizer and are intended to preserve existing behavior.

**Why do we need this feature?**

This removes repetitive map-copy boilerplate and keeps the codebase aligned with modern, idiomatic Go.

**Who is this feature for?**

Grafana maintainers. There is no user-facing behavior change.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This is a mechanical modernization limited to replacing equivalent map-copy loops with `maps.Copy`.

Validation:
- `git diff --check`
- Compile-only tests for every affected package with `go test -run "^$"`

Please check that:
- [x] It works as expected from a user perspective (no behavior change).
- [x] Feature toggle is not applicable.
- [x] Documentation and What’s New updates are not applicable.