### PR TITLE
Chore: modernize slices.contains

### DIFF
--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -329,11 +330,8 @@ func TestLoginViewRedirect(t *testing.T) {
 					expCookieMaxAge = 0
 				}
 				expCookie := fmt.Sprintf("redirect_to=%v; Path=%v; Max-Age=%v; HttpOnly; Secure", expCookieValue, expCookiePath, expCookieMaxAge)
-				for _, cookieValue := range setCookie {
-					if cookieValue == expCookie {
-						redirectToCookieFound = true
-						break
-					}
+				if slices.Contains(setCookie, expCookie) {
+					redirectToCookieFound = true
 				}
 				assert.True(t, redirectToCookieFound)
 			}
@@ -486,11 +484,8 @@ func TestLoginPostRedirect(t *testing.T) {
 			assert.Greater(t, len(setCookie), 0)
 			var redirectToCookieFound bool
 			expCookieValue := fmt.Sprintf("redirect_to=; Path=%v; Max-Age=0; HttpOnly; Secure", expCookiePath)
-			for _, cookieValue := range setCookie {
-				if cookieValue == expCookieValue {
-					redirectToCookieFound = true
-					break
-				}
+			if slices.Contains(setCookie, expCookieValue) {
+				redirectToCookieFound = true
 			}
 			assert.True(t, redirectToCookieFound)
 		})

--- a/pkg/api/static/static.go
+++ b/pkg/api/static/static.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 
@@ -123,10 +124,8 @@ func staticHandler(ctx *web.Context, log log.Logger, opt StaticOptions) bool {
 	}
 
 	file := ctx.Req.URL.Path
-	for _, p := range opt.Exclude {
-		if file == p {
-			return false
-		}
+	if slices.Contains(opt.Exclude, file) {
+		return false
 	}
 
 	// if we have a prefix, filter requests by stripping the prefix

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -544,10 +545,8 @@ func validateFederatedCredentialAudience(info *social.OAuthInfo, requester ident
 	if info.ClientAuthentication != social.ManagedIdentity {
 		return nil
 	}
-	for _, supportedFederatedCredentialAudience := range supportedFederatedCredentialAudiences {
-		if info.FederatedCredentialAudience == supportedFederatedCredentialAudience {
-			return nil
-		}
+	if slices.Contains(supportedFederatedCredentialAudiences, info.FederatedCredentialAudience) {
+		return nil
 	}
 	return ssosettings.ErrInvalidOAuthConfig("FIC audience is not a supported audience.")
 }
@@ -750,10 +749,5 @@ func (s *SocialAzureAD) isAllowedTenant(logger log.Logger, tenantID string) bool
 		return true
 	}
 
-	for _, t := range s.allowedOrganizations {
-		if t == tenantID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.allowedOrganizations, tenantID)
 }

--- a/pkg/login/social/connectors/generic_oauth.go
+++ b/pkg/login/social/connectors/generic_oauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/mail"
+	"slices"
 	"strconv"
 
 	"golang.org/x/oauth2"
@@ -183,10 +184,8 @@ func (s *SocialGenericOAuth) isTeamMember(ctx context.Context, client *http.Clie
 	}
 
 	for _, teamId := range s.teamIds {
-		for _, membershipId := range teamMemberships {
-			if teamId == membershipId {
-				return true
-			}
+		if slices.Contains(teamMemberships, teamId) {
+			return true
 		}
 	}
 
@@ -204,10 +203,8 @@ func (s *SocialGenericOAuth) isOrganizationMember(ctx context.Context, client *h
 	}
 
 	for _, allowedOrganization := range s.allowedOrganizations {
-		for _, organization := range organizations {
-			if organization == allowedOrganization {
-				return true
-			}
+		if slices.Contains(organizations, allowedOrganization) {
+			return true
 		}
 	}
 

--- a/pkg/login/social/connectors/google_oauth.go
+++ b/pkg/login/social/connectors/google_oauth.go
@@ -372,10 +372,8 @@ func (s *SocialGoogle) isHDAllowed(hd string) error {
 		return nil
 	}
 
-	for _, allowedDomain := range s.info.AllowedDomains {
-		if hd == allowedDomain {
-			return nil
-		}
+	if slices.Contains(s.info.AllowedDomains, hd) {
+		return nil
 	}
 
 	return errutil.Forbidden("the hd claim found in the ID token is not present in the allowed domains", errutil.WithPublicMessage("Invalid domain"))

--- a/pkg/login/social/connectors/social_base.go
+++ b/pkg/login/social/connectors/social_base.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -247,10 +248,8 @@ func (s *SocialBase) isGroupMember(groups []string) bool {
 	}
 
 	for _, allowedGroup := range s.info.AllowedGroups {
-		for _, group := range groups {
-			if group == allowedGroup {
-				return true
-			}
+		if slices.Contains(groups, allowedGroup) {
+			return true
 		}
 	}
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -186,13 +187,7 @@ func normalizeIncludePath(p string) string {
 
 func RoleAuth(roles ...org.RoleType) web.Handler {
 	return func(c *contextmodel.ReqContext) {
-		ok := false
-		for _, role := range roles {
-			if role == c.OrgRole {
-				ok = true
-				break
-			}
-		}
+		ok := slices.Contains(roles, c.OrgRole)
 		if !ok {
 			accessForbidden(c)
 		}

--- a/pkg/middleware/csrf/csrf.go
+++ b/pkg/middleware/csrf/csrf.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -82,10 +83,8 @@ func (c *CSRF) check(r *http.Request) error {
 	}
 
 	// Skip CSRF checks for "safe" methods
-	for _, method := range safeMethods {
-		if r.Method == method {
-			return nil
-		}
+	if slices.Contains(safeMethods, r.Method) {
+		return nil
 	}
 	// Skip CSRF checks for "safe" endpoints
 	for safeEndpoint := range c.safeEndpoints {

--- a/pkg/modules/util.go
+++ b/pkg/modules/util.go
@@ -1,11 +1,7 @@
 package modules
 
-func stringsContain(values []string, search string) bool {
-	for _, v := range values {
-		if search == v {
-			return true
-		}
-	}
+import "slices"
 
-	return false
+func stringsContain(values []string, search string) bool {
+	return slices.Contains(values, search)
 }

--- a/pkg/registry/apis/secret/decrypt/authorizer.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer.go
@@ -2,6 +2,7 @@ package decrypt
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -87,10 +88,8 @@ func (a *decryptAuthorizer) Authorize(
 	}
 
 	// Check whether the service identity is allowed to decrypt this secure value.
-	for _, decrypter := range secureValueDecrypters {
-		if decrypter == serviceIdentity {
-			return serviceIdentity, true, ""
-		}
+	if slices.Contains(secureValueDecrypters, serviceIdentity) {
+		return serviceIdentity, true, ""
 	}
 
 	// finally check if the owner matches any hardcoded service identities

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -126,23 +126,15 @@ func sortByEndTime(items []annotationV0.Annotation) {
 func matchTags(annoTags []string, filterTags []string, matchAny bool) bool {
 	if matchAny {
 		for _, filterTag := range filterTags {
-			for _, annoTag := range annoTags {
-				if annoTag == filterTag {
-					return true
-				}
+			if slices.Contains(annoTags, filterTag) {
+				return true
 			}
 		}
 		return false
 	}
 
 	for _, filterTag := range filterTags {
-		found := false
-		for _, annoTag := range annoTags {
-			if annoTag == filterTag {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(annoTags, filterTag)
 		if !found {
 			return false
 		}
@@ -153,23 +145,15 @@ func matchTags(annoTags []string, filterTags []string, matchAny bool) bool {
 func matchScopes(annoScopes []string, filterScopes []string, matchAny bool) bool {
 	if matchAny {
 		for _, filterScope := range filterScopes {
-			for _, annoScope := range annoScopes {
-				if annoScope == filterScope {
-					return true
-				}
+			if slices.Contains(annoScopes, filterScope) {
+				return true
 			}
 		}
 		return false
 	}
 
 	for _, filterScope := range filterScopes {
-		found := false
-		for _, annoScope := range annoScopes {
-			if annoScope == filterScope {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(annoScopes, filterScope)
 		if !found {
 			return false
 		}

--- a/pkg/server/bootstrap/buildinfo.go
+++ b/pkg/server/bootstrap/buildinfo.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"slices"
 	"strconv"
 	"time"
 
@@ -23,10 +24,8 @@ func getBuildstamp(opts BuildInfo) int64 {
 
 func validPackaging(packaging string) string {
 	validTypes := []string{"dev", "deb", "rpm", "docker", "brew", "hosted", "unknown"}
-	for _, vt := range validTypes {
-		if packaging == vt {
-			return packaging
-		}
+	if slices.Contains(validTypes, packaging) {
+		return packaging
 	}
 	return "unknown"
 }

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -273,12 +274,7 @@ func (p *ResourcePermission) Contains(targetActions []string) bool {
 	}
 
 	var contain = func(arr []string, s string) bool {
-		for _, item := range arr {
-			if item == s {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(arr, s)
 	}
 
 	for _, a := range targetActions {

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -187,12 +188,7 @@ type Wildcards []string
 
 // Contains check if wildcards contains scope
 func (wildcards Wildcards) Contains(scope string) bool {
-	for _, w := range wildcards {
-		if scope == w {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(wildcards, scope)
 }
 
 func isWildcard(scope string) bool {

--- a/pkg/services/apiserver/preferred_version.go
+++ b/pkg/services/apiserver/preferred_version.go
@@ -83,13 +83,7 @@ func ApplyPreferredForGroup(logger log.Logger, scheme *runtime.Scheme, apiResour
 		return nil
 	}
 
-	found := false
-	for _, gv := range pvs {
-		if gv == preferred {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(pvs, preferred)
 	if !found {
 		logger.Info("preferred_api_version: version not registered for group, skipping",
 			"group", group, "version", preferred.Version)

--- a/pkg/services/apiserver/versionpolicy/resolver.go
+++ b/pkg/services/apiserver/versionpolicy/resolver.go
@@ -2,6 +2,7 @@ package versionpolicy
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -107,12 +108,7 @@ func (r *Resolver) naturalPreferred(group string) string {
 }
 
 func (r *Resolver) isRegistered(group, version string) bool {
-	for _, v := range r.order[group] {
-		if v == version {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(r.order[group], version)
 }
 
 // Outranks reports whether version a is strictly above b for a persist ceiling (major, then maturity,

--- a/pkg/services/authn/authntest/fake.go
+++ b/pkg/services/authn/authntest/fake.go
@@ -2,6 +2,7 @@ package authntest
 
 import (
 	"context"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/models/usertoken"
@@ -81,12 +82,7 @@ func (f *FakeService) IsClientEnabled(_ context.Context, name string) bool {
 		return true
 	}
 	// Check if client is in the list of enabled clients
-	for _, s := range f.EnabledClients {
-		if s == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(f.EnabledClients, name)
 }
 
 func (f *FakeService) GetClientConfig(_ context.Context, name string) (authn.SSOClientConfig, bool) {

--- a/pkg/services/authn/identity.go
+++ b/pkg/services/authn/identity.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -282,12 +283,7 @@ func (i *Identity) HasUniqueId() bool {
 }
 
 func (i *Identity) IsAuthenticatedBy(providers ...string) bool {
-	for _, p := range providers {
-		if i.AuthenticatedBy == p {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(providers, i.AuthenticatedBy)
 }
 
 func (i *Identity) IsNil() bool {

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -245,12 +246,7 @@ func IsSubresourceRelation(relation string) bool {
 }
 
 func isValidRelation(relation string, valid []string) bool {
-	for _, r := range valid {
-		if r == relation {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(valid, relation)
 }
 
 func IsFolderResourceTuple(t *openfgav1.TupleKey) bool {

--- a/pkg/services/diagnostics/environment.go
+++ b/pkg/services/diagnostics/environment.go
@@ -3,6 +3,7 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sort"
 
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
@@ -64,10 +65,8 @@ func (r *EnvironmentRefs) AddPanelPluginID(id string) {
 	if id == "" {
 		return
 	}
-	for _, existing := range r.PanelPluginIDs {
-		if existing == id {
-			return
-		}
+	if slices.Contains(r.PanelPluginIDs, id) {
+		return
 	}
 	r.PanelPluginIDs = append(r.PanelPluginIDs, id)
 }

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"slices"
 )
 
 //go:generate mockery --name FeatureToggles --structname MockFeatureToggles --inpackage --filename feature_toggles_mock.go --with-expecter
@@ -32,12 +33,7 @@ type FeatureToggles interface {
 }
 
 func AnyEnabled(f FeatureToggles, flags ...string) bool {
-	for _, flag := range flags {
-		if f.IsEnabledGlobally(flag) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(flags, f.IsEnabledGlobally)
 }
 
 // FeatureFlagStage indicates the quality level

--- a/pkg/services/libraryelements/writers.go
+++ b/pkg/services/libraryelements/writers.go
@@ -3,6 +3,7 @@ package libraryelements
 import (
 	"bytes"
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -141,11 +142,8 @@ func parseFolderFilter(query model.SearchLibraryElementsQuery) FolderFilter {
 		folderUIDs = strings.Split(query.FolderFilterUIDs, ",")
 		result.folderUIDs = folderUIDs
 
-		for _, folderUID := range folderUIDs {
-			if isUIDGeneralFolder(folderUID) {
-				result.includeGeneralFolder = true
-				break
-			}
+		if slices.ContainsFunc(folderUIDs, isUIDGeneralFolder) {
+			result.includeGeneralFolder = true
 		}
 	}
 

--- a/pkg/services/live/pipeline/frame_processor_keep_field.go
+++ b/pkg/services/live/pipeline/frame_processor_keep_field.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"slices"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
@@ -15,15 +16,6 @@ func NewKeepFieldsFrameProcessor(config KeepFieldsFrameProcessorConfig) *KeepFie
 	return &KeepFieldsFrameProcessor{config: config}
 }
 
-func stringInSlice(str string, slice []string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}
-
 const FrameProcessorTypeKeepFields = "keepFields"
 
 func (p *KeepFieldsFrameProcessor) Type() string {
@@ -33,7 +25,7 @@ func (p *KeepFieldsFrameProcessor) Type() string {
 func (p *KeepFieldsFrameProcessor) ProcessFrame(_ context.Context, _ Vars, frame *data.Frame) (*data.Frame, error) {
 	var fieldsToKeep []*data.Field
 	for _, field := range frame.Fields {
-		if stringInSlice(field.Name, p.config.FieldNames) {
+		if slices.Contains(p.config.FieldNames, field.Name) {
 			fieldsToKeep = append(fieldsToKeep, field)
 		}
 	}

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,12 +43,7 @@ var (
 )
 
 func isPrometheusCompatible(dsType string) bool {
-	for _, t := range prometheusCompatibleDsTypes {
-		if dsType == t {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(prometheusCompatibleDsTypes, dsType)
 }
 
 func isLotexRulerCompatible(dsType string) bool {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -9,21 +9,21 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	alertingInstrument "github.com/grafana/alerting/http/instrument"
+	"github.com/grafana/alerting/http/instrument/instrumenttest"
 	"github.com/grafana/alerting/notify/historian/lokiclient"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	alertingInstrument "github.com/grafana/alerting/http/instrument"
-	"github.com/grafana/alerting/http/instrument/instrumenttest"
-
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -1058,10 +1058,8 @@ func TestGetFolderUIDsForFilterWithHistoricalFolders(t *testing.T) {
 	// Helper to create simple folder access override functions.
 	canReadRulesInFolders := func(folderUids ...string) func(folderUID string) (bool, error) {
 		return func(folderUID string) (bool, error) {
-			for _, f := range folderUids {
-				if folderUID == f {
-					return true, nil
-				}
+			if slices.Contains(folderUids, folderUID) {
+				return true, nil
 			}
 			return false, nil
 		}

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -130,13 +130,7 @@ func (f *RuleStore) DeleteAlertRulesByUID(ctx context.Context, orgID int64, user
 	var result = make([]*models.AlertRule, 0, len(rules))
 
 	for _, rule := range rules {
-		add := true
-		for _, UID := range UIDs {
-			if rule.UID == UID {
-				add = false
-				break
-			}
-		}
+		add := !slices.Contains(UIDs, rule.UID)
 		if add {
 			result = append(result, rule)
 		}

--- a/pkg/services/pluginsintegration/pluginchecker/service.go
+++ b/pkg/services/pluginsintegration/pluginchecker/service.go
@@ -42,12 +42,7 @@ func ProvideService(
 }
 
 func (s *Service) isManaged(ctx context.Context, pluginID string) bool {
-	for _, managedPlugin := range s.managedPluginsManager.ManagedPlugins(ctx) {
-		if managedPlugin == pluginID {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.managedPluginsManager.ManagedPlugins(ctx), pluginID)
 }
 
 func (s *Service) isProvisioned(ctx context.Context, pluginID string) bool {

--- a/pkg/services/pluginsintegration/plugininstaller/service_test.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service_test.go
@@ -3,6 +3,7 @@ package plugininstaller
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -191,10 +192,8 @@ func TestService_Run(t *testing.T) {
 				store,
 				&pluginfakes.FakePluginInstaller{
 					AddFunc: func(ctx context.Context, pluginID string, version string, opts plugins.AddOpts) error {
-						for _, plugin := range tt.pluginsToFail {
-							if plugin == pluginID {
-								return errors.New("Failed to install plugin")
-							}
+						if slices.Contains(tt.pluginsToFail, pluginID) {
+							return errors.New("Failed to install plugin")
 						}
 						if !tt.shouldInstall {
 							t.Fatal("Should not install plugin")
@@ -255,13 +254,7 @@ func TestService_Run(t *testing.T) {
 				expectedInstalledFromURL := 0
 				allPluginsToInstall := append(tt.pluginsToInstallSync, tt.pluginsToInstall...)
 				for _, plugin := range allPluginsToInstall {
-					expectedFailed := false
-					for _, pluginFail := range tt.pluginsToFail {
-						if plugin.ID == pluginFail {
-							expectedFailed = true
-							break
-						}
-					}
+					expectedFailed := slices.Contains(tt.pluginsToFail, plugin.ID)
 					if expectedFailed {
 						continue
 					}

--- a/pkg/services/publicdashboards/internal/validation/validation.go
+++ b/pkg/services/publicdashboards/internal/validation/validation.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"slices"
+
 	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/internal/models"
@@ -54,10 +56,5 @@ func IsValidShortUID(uid string) bool {
 }
 
 func IsValidShareType(shareType models.ShareType) bool {
-	for _, t := range models.ValidShareTypes {
-		if t == shareType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(models.ValidShareTypes, shareType)
 }

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -413,10 +414,8 @@ var logger = log.New("services.store.kind.dashboard")
 // If the type matches, it returns true, otherwise it skips the element, logs an error, and returns false.
 func checkAndSkipUnexpectedElement(iter *jsoniter.Iterator, jsonPath string, logContext map[string]any, allowedValues ...jsoniter.ValueType) bool {
 	next := iter.WhatIsNext()
-	for _, a := range allowedValues {
-		if next == a {
-			return true
-		}
+	if slices.Contains(allowedValues, next) {
+		return true
 	}
 
 	// Skip unexpected element.

--- a/pkg/services/user/identity.go
+++ b/pkg/services/user/identity.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -315,12 +316,7 @@ func (u *SignedInUser) GetAuthenticatedBy() string {
 }
 
 func (u *SignedInUser) IsAuthenticatedBy(providers ...string) bool {
-	for _, p := range providers {
-		if u.AuthenticatedBy == p {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(providers, u.AuthenticatedBy)
 }
 
 // FIXME: remove this method once all services are using an interface

--- a/pkg/storage/unified/resource/usagestats/declaration.go
+++ b/pkg/storage/unified/resource/usagestats/declaration.go
@@ -9,6 +9,7 @@ package usagestats
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
@@ -33,12 +34,7 @@ func (d StatsDeclaration) GroupResource() string {
 }
 
 func (d StatsDeclaration) HasMetric(name string) bool {
-	for _, m := range d.Metrics {
-		if m == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(d.Metrics, name)
 }
 
 var dashboardsDeclaration = StatsDeclaration{

--- a/pkg/storage/unified/search/builders/alertingrules.go
+++ b/pkg/storage/unified/search/builders/alertingrules.go
@@ -3,6 +3,7 @@ package builders
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sort"
 
 	rulesv0alpha1 "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
@@ -162,10 +163,8 @@ func appendSourceUID(uids []string, uid string) []string {
 	if expr.NodeTypeFromDatasourceUID(uid) != expr.TypeDatasourceNode {
 		return uids
 	}
-	for _, existing := range uids {
-		if existing == uid {
-			return uids
-		}
+	if slices.Contains(uids, uid) {
+		return uids
 	}
 	return append(uids, uid)
 }

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -18,23 +19,21 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana-app-sdk/resource"
-
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
-	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/routingtree"
-	policy_exports "github.com/grafana/grafana/pkg/services/ngalert/api/test-data/policy-exports"
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
-	v1model "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
-
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/fakes"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/routingtree"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	policy_exports "github.com/grafana/grafana/pkg/services/ngalert/api/test-data/policy-exports"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	v1model "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/api/alerting"
@@ -1306,11 +1305,8 @@ func TestIntegrationResourcePermissions(t *testing.T) {
 				for _, k := range allACMetadata {
 					key := v1beta1.AccessControlAnnotation(k)
 					var expected bool
-					for _, exp := range tc.expACMetadata {
-						if exp == k {
-							expected = true
-							break
-						}
+					if slices.Contains(tc.expACMetadata, k) {
+						expected = true
 					}
 					if expected {
 						assert.Equalf(t, "true", annotations[key], "expected annotation %s to be set", key)

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -2573,13 +2574,7 @@ func runDashboardListTests(t *testing.T, ctx TestContext) {
 
 				// Verify all expected items are found
 				for _, expected := range expectedTitles {
-					found := false
-					for _, title := range dashTitles {
-						if title == expected {
-							found = true
-							break
-						}
-					}
+					found := slices.Contains(dashTitles, expected)
 					require.True(t, found, "%s should see dashboard '%s' but didn't", identity.Name, expected)
 				}
 			})


### PR DESCRIPTION
**What is this feature?**

Replaces manual slice-membership loops with the standard library `slices.Contains` and `slices.ContainsFunc` helpers across the Go backend. These changes were generated with the `slicescontains` Go modernizer and are intended to preserve existing behavior.

**Why do we need this feature?**

This removes repetitive slice-membership boilerplate and keeps the codebase aligned with modern, idiomatic Go.

**Who is this feature for?**

Grafana maintainers. There is no user-facing behavior change.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

This is a mechanical modernization limited to replacing equivalent slice-membership loops with `slices.Contains` or `slices.ContainsFunc`.

Validation:
- `git diff --check`
- Compile-only tests for every affected package with `go test -run "^$"`

Please check that:
- [x] It works as expected from a user perspective (no behavior change).
- [x] Feature toggle is not applicable.
- [x] Documentation and What’s New updates are not applicable.