### PR TITLE
fix(time-range): keep describeTextRange invalid flag in sync with the parser

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -6,6 +6,7 @@ import {
   describeInterval,
   describeTimeRange,
   isRelativeTimeRange,
+  isValidTimeSpan,
   relativeToTimeRange,
   roundInterval,
   timeRangeToRelative,
@@ -461,5 +462,23 @@ describe('describeTextRange', () => {
   it('should handle now/y', () => {
     const info = describeTextRange('now/y');
     expect(info.display).toBe('This year so far');
+  });
+
+  it('should mark unparsable values as invalid even when the regex matches (#131339)', () => {
+    // The regex at line 414 is intentionally loose (unbounded digit
+    // group, not anchored at the end) so the user can type partial
+    // inputs. The parser, however, enforces a tighter grammar.
+    // Without the cross-check, a value like '604800s' matches the
+    // regex and gets a `display` string, but `isValidTimeSpan` reads
+    // `invalid` as `undefined` rather than `true`, so the value
+    // passes validation and a downstream caller ends up with
+    // `range.from === undefined`, which throws a `valueOf` TypeError
+    // at render time.
+    const info = describeTextRange('604800s');
+    expect(info.invalid).toBe(true);
+  });
+
+  it('isValidTimeSpan should reject values the parser rejects', () => {
+    expect(isValidTimeSpan('604800s')).toBe(false);
   });
 });

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -424,6 +424,17 @@ export function describeTextRange(expr: string): TimeOption {
         opt.display += 's';
       }
     }
+    // The regex is intentionally loose (unbounded digit count, not
+    // anchored at the end) so the user can type partial inputs. Cross-
+    // check with the parser: if the parser rejects what the regex
+    // accepted, the value is invalid. Without this, the validator
+    // (`isValidTimeSpan`) reads `invalid` as `undefined`, treats the
+    // value as accepted, and a downstream caller ends up with
+    // `range.from === undefined`, which throws a `valueOf` TypeError
+    // at render time.
+    if (!dateMath.parse(expr, false, 'utc')) {
+      opt.invalid = true;
+    }
   } else {
     opt.display = opt.from + ' to ' + opt.to;
     opt.invalid = true;

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -184,11 +184,13 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
       // Only evaluate if the timeFrom if parent time is relative
       if (rangeUtil.isRelativeTimeRange(parentTimeRange.raw)) {
         const timezone = this.getTimeZone();
-        newTimeData.timeRange = {
-          from: dateMath.toDateTime(timeFromInfo.from, { timezone })!,
-          to: dateMath.toDateTime(timeFromInfo.to, { timezone })!,
-          raw: { from: timeFromInfo.from, to: timeFromInfo.to },
-        };
+        const from = dateMath.toDateTime(timeFromInfo.from, { timezone });
+        const to = dateMath.toDateTime(timeFromInfo.to, { timezone });
+        if (!from || !to) {
+          newTimeData.timeInfo = 'invalid time override';
+          return newTimeData;
+        }
+        newTimeData.timeRange = { from, to, raw: { from: timeFromInfo.from, to: timeFromInfo.to } };
         infoBlocks.push(timeFromInfo.display);
       }
     }


### PR DESCRIPTION
## What

Two small fixes in the Grafana time-range code:

1. `describeTextRange` in `packages/grafana-data/src/datetime/rangeutil.ts` now cross-checks its result against `dateMath.parse` and sets `invalid: true` when the parser rejects the expression. `isValidTimeSpan` now agrees with the parser.
2. `PanelTimeRange.getTimeOverride` in `public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx` no longer asserts the `dateMath.toDateTime(...)` result as non-null in the `timeFrom` branch; it uses the same `if (!from || !to)` guard that the `timeShift` branch already had.

## Why

When a panel **Relative time** value fails to parse, the panel time range used to be set with `from: undefined`. A downstream caller (`calculateInterval`) then read `range.from.valueOf` and threw a `TypeError: Cannot read properties of undefined (reading 'valueOf')`. The panel showed an error badge and the console held the error; the rest of the dashboard kept working, but the message gave a reader nothing to act on — it named neither the field, nor the panel, nor the value that failed.

The first root cause is that `describeTextRange`'s regex (`rangeutil.ts:414`) is intentionally loose so the user can type partial inputs, but the parser is stricter. For a value like `604800s` the regex matches and the function builds a `display` string, but `isValidTimeSpan` reads `invalid` as `undefined` rather than `true`, so the value passes validation. The fix cross-checks with `dateMath.parse` and sets `invalid: true` when the parser rejects the expression.

The second root cause is at `PanelTimeRange.getTimeOverride`, where `dateMath.toDateTime`'s return value was asserted as non-null with `!` in the `timeFrom` branch. The `timeShift` branch a few lines below already had the correct guard; this change applies the same guard to the `timeFrom` branch so a null parse result becomes an `invalid time override` message instead of a downstream `TypeError`.

The third root cause is the unvalidated `PanelTimeRangeDrawer` entry point (it takes `timeFrom` from a `Combobox` with `createCustomValue` and never calls `isValidTimeSpan`). That change is out of scope here and noted as a follow-up.

## How to Test

- `packages/grafana-data/src/datetime/rangeutil.test.ts` gains two regression tests:
  - `describeTextRange('604800s')` returns `invalid: true`.
  - `isValidTimeSpan('604800s')` returns `false`.
- The pre-existing `describeTextRange` tests (`'5m'`, `'1h'`, `'13h'`, `'+3h'`, `'now/d'`, `'now/w'`, `'now/M'`, `'now/y'`) continue to pass: the cross-check is a no-op for values the parser accepts.
- Manual repro from the issue: open a panel in edit mode, set **Query options → Relative time** to `604800s`, turn off **Hide time info**. With the fix, the field rejects the value, the panel header no longer shows "Last 604800 seconds" as understood, and the `valueOf` `TypeError` is gone.

## Out of scope

- The unvalidated `PanelTimeRangeDrawer` entry point. The fix there is a one-line `isValidTimeSpan` call on the `timeFrom` value, but the change touches the query-options drawer component and wants its own focused PR with a screenshot.
- Tightening the loose regex at `rangeutil.ts:414` directly would reject every partial input the user might type while editing the field. The cross-check is the smaller and more correct fix.

Fixes #131339
