### PR TITLE
Unified storage: bucket batch size label on authz batch check metric

### DIFF
--- a/pkg/storage/unified/resource/access.go
+++ b/pkg/storage/unified/resource/access.go
@@ -55,12 +55,31 @@ func newMetrics(reg prometheus.Registerer) *accessMetrics {
 				NativeHistogramBucketFactor:     1.1,
 				NativeHistogramMaxBucketNumber:  160,
 				NativeHistogramMinResetDuration: time.Hour,
-			}, []string{"check_count"}),
+			}, []string{"check_count_bucket"}),
 		errorsTotal: promauto.With(reg).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "grafana_grpc_authz_limited_client_errors_total",
 				Help: "Number of errors",
 			}, []string{"group", "resource", "verb"}),
+	}
+}
+
+// batchSizeBucket keeps the batch size out of the label value, which would
+// otherwise add a series per size. Ranges cover 1 to batchCheckChunkSize (50),
+// the sizes search produces, and are spelled out so changing that constant
+// cannot reshape existing series unnoticed.
+func batchSizeBucket(n int) string {
+	switch {
+	case n <= 1:
+		return "1"
+	case n <= 10:
+		return "2-10"
+	case n <= 25:
+		return "11-25"
+	case n <= 50:
+		return "26-50"
+	default:
+		return "51+"
 	}
 }
 
@@ -288,7 +307,7 @@ func (c authzLimitedClient) BatchCheck(ctx context.Context, id claims.AuthInfo, 
 	// Merge results from underlying client
 	maps.Copy(results, resp.Results)
 
-	c.metrics.batchCheckDuration.WithLabelValues(fmt.Sprintf("%d", len(req.Checks))).Observe(time.Since(t).Seconds())
+	c.metrics.batchCheckDuration.WithLabelValues(batchSizeBucket(len(req.Checks))).Observe(time.Since(t).Seconds())
 	return claims.BatchCheckResponse{Results: results}, nil
 }
 

--- a/pkg/storage/unified/resource/access_test.go
+++ b/pkg/storage/unified/resource/access_test.go
@@ -321,3 +321,26 @@ func TestAuthzLimitedClientExemptionGate(t *testing.T) {
 		})
 	}
 }
+
+func TestBatchSizeBucket(t *testing.T) {
+	// Ranges below assume this chunk size; revisit them before changing it.
+	require.Equal(t, 50, batchCheckChunkSize)
+
+	for _, tt := range []struct {
+		size int
+		want string
+	}{
+		{0, "1"},
+		{1, "1"},
+		{2, "2-10"},
+		{10, "2-10"},
+		{11, "11-25"},
+		{25, "11-25"},
+		{26, "26-50"},
+		{50, "26-50"},
+		{51, "51+"},
+		{500, "51+"},
+	} {
+		require.Equal(t, tt.want, batchSizeBucket(tt.size), "size %d", tt.size)
+	}
+}


### PR DESCRIPTION
`grafana_grpc_authz_limited_client_batch_check_duration_seconds` used the batch size as its label value, so every distinct size produced another time series, each with a full set of histogram buckets. Nothing bounded it — the size comes from the caller.

Sizes now map to five ranges: `1`, `2-10`, `11-25`, `26-50`, `51+`. Label renamed `check_count` → `check_count_bucket` so the change is visible in queries.

The ranges match reality: the one caller in tree chunks at `batchCheckChunkSize = 50`. They are spelled out rather than derived from that constant, and a test pins the constant at 50 so the two cannot drift apart.