### PR TITLE
Unified storage: drop unused index_server_index_latency_seconds metric

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -3,13 +3,11 @@ package resource
 import (
 	"time"
 
-	"github.com/grafana/dskit/instrument"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type BleveIndexMetrics struct {
-	IndexLatency         *prometheus.HistogramVec
 	IndexSize            prometheus.Gauge
 	IndexedKinds         *prometheus.GaugeVec
 	IndexCreationTime    *prometheus.HistogramVec
@@ -41,14 +39,6 @@ var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 5
 
 func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 	m := &BleveIndexMetrics{
-		IndexLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "index_server_index_latency_seconds",
-			Help:                            "Time (in seconds) until index is updated with new event",
-			Buckets:                         instrument.DefBuckets,
-			NativeHistogramBucketFactor:     1.1, // enable native histograms
-			NativeHistogramMaxBucketNumber:  160,
-			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"resource"}),
 		IndexSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "index_server_index_size",
 			Help: "Size of the index in bytes - only for file-based indices",


### PR DESCRIPTION
The last code observing this metric was removed in #110861, along with the old search path it measured. It has been registered but never observed since, so it exports no series at all — a `HistogramVec` with no children emits nothing.

Nothing replaces it. `index_server_update_latency_seconds` times an index update, and `index_server_search_update_wait_time_seconds` times a query waiting on one. Neither covers end-to-end freshness from write to searchable, which is what this measured. If we want that back it is a new metric wired into the current indexing path, not this one.