### PR TITLE
Flamegraph: show a chevron expander for Call Tree rows with children

### DIFF
--- a/packages/grafana-flamegraph/src/CallTree/FlameGraphCallTreeContainer.tsx
+++ b/packages/grafana-flamegraph/src/CallTree/FlameGraphCallTreeContainer.tsx
@@ -438,15 +438,13 @@ const FlameGraphCallTreeContainer = memo(
         {
           Header: 'Function',
           accessor: 'label',
-          Cell: ({ row, value, rowIndex }: { row: Row<CallTreeNode>; value: string; rowIndex?: number }) => (
+          Cell: ({ row, value }: { row: Row<CallTreeNode>; value: string }) => (
             <FunctionCellWithExpander
               // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
               row={row as Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode>}
               value={value}
               depth={row.original.depth - depthOffset}
               hasChildren={Boolean(row.original.children?.length)}
-              rowIndex={rowIndex}
-              rows={tableInstanceRef.current.rows}
               onSymbolClick={onSymbolClick}
               compact={isCompact}
               toggleRowExpanded={tableInstanceRef.current.toggleRowExpanded}

--- a/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.test.tsx
+++ b/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Row, type UseExpandedRowProps } from 'react-table';
+
+import { type LevelItem } from '../FlameGraph/dataTransform';
+
+import { FunctionCellWithExpander } from './FunctionCellWithExpander';
+import { type CallTreeNode } from './utils';
+
+const levelItem: LevelItem = { start: 0, value: 100, itemIndexes: [0], children: [], level: 0 };
+
+function makeRow(
+  overrides: Partial<CallTreeNode> & { isExpanded?: boolean; canExpand?: boolean }
+): Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode> {
+  const node: CallTreeNode = {
+    id: overrides.id ?? 'node-1',
+    label: overrides.label ?? 'someFunction',
+    self: 10,
+    total: 100,
+    selfPercent: 10,
+    totalPercent: 100,
+    depth: overrides.depth ?? 1,
+    parentId: overrides.parentId,
+    children: overrides.children ?? [],
+    subtreeSize: overrides.subtreeSize ?? 0,
+    levelItem,
+    ...overrides,
+  };
+  return {
+    original: node,
+    isExpanded: overrides.isExpanded ?? false,
+    canExpand: overrides.canExpand ?? true,
+    toggleRowExpanded: jest.fn(),
+  } as unknown as Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode>;
+}
+
+function renderCell(
+  row: Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode>,
+  props: Partial<React.ComponentProps<typeof FunctionCellWithExpander>> = {}
+) {
+  return render(
+    <FunctionCellWithExpander
+      row={row}
+      value={row.original.label}
+      depth={row.original.depth}
+      hasChildren={props.hasChildren ?? (row.original.children?.length ?? 0) > 0}
+      rows={[]}
+      onSymbolClick={jest.fn()}
+      toggleRowExpanded={jest.fn()}
+      {...props}
+    />
+  );
+}
+
+describe('FunctionCellWithExpander', () => {
+  it('renders the expander inside the function-name button for rows with children', () => {
+    const row = makeRow({ children: [{ id: 'c1', label: 'child1' } as CallTreeNode] });
+    renderCell(row);
+
+    const expander = screen.getByTestId('call-tree-row-expander');
+    expect(expander).toBeInTheDocument();
+    // The expander is a child of the function-name button so a single Tab
+    // stop expands and a single click also opens the symbol detail.
+    const button = expander.closest('button');
+    expect(button).toBe(screen.getByRole('button', { name: /someFunction/ }));
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('hides the expander when the row has no children', () => {
+    const row = makeRow({ children: [] });
+    renderCell(row, { hasChildren: false });
+
+    expect(screen.queryByTestId('call-tree-row-expander')).toBeNull();
+  });
+
+  it('shows angle-right when the row is collapsed and angle-down when expanded', () => {
+    const collapsed = makeRow({ isExpanded: false, children: [{ id: 'c1' } as CallTreeNode] });
+    const { rerender } = renderCell(collapsed);
+    // The Icon component renders the SVG directly with the data-testid we
+    // pass through, so the icon name is visible only in the svg's id
+    // (e.g. "public/build/img/icons/unicons/angle-right.svg"). Query on the
+    // svg id path to assert which icon is actually in the DOM.
+    expect(document.querySelector('svg[id*="angle-right"]')).toBeInTheDocument();
+    expect(document.querySelector('svg[id*="angle-down"]')).toBeNull();
+
+    const expanded = makeRow({ isExpanded: true, children: [{ id: 'c1' } as CallTreeNode] });
+    rerender(
+      <FunctionCellWithExpander
+        row={expanded}
+        value={expanded.original.label}
+        depth={expanded.original.depth}
+        hasChildren
+        rows={[]}
+        onSymbolClick={jest.fn()}
+        toggleRowExpanded={jest.fn()}
+      />
+    );
+    expect(document.querySelector('svg[id*="angle-down"]')).toBeInTheDocument();
+    expect(document.querySelector('svg[id*="angle-right"]')).toBeNull();
+  });
+
+  it('marks aria-expanded=true (not the attribute being absent) on expanded rows', () => {
+    const row = makeRow({ isExpanded: true, children: [{ id: 'c1' } as CallTreeNode] });
+    renderCell(row);
+
+    const button = screen.getByRole('button', { name: /someFunction/ });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggles row expansion when the function-name button is clicked', async () => {
+    const user = userEvent.setup();
+    const toggleRowExpanded = jest.fn();
+    const row = {
+      ...makeRow({ children: [{ id: 'c1' } as CallTreeNode] }),
+      toggleRowExpanded,
+    } as unknown as Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode>;
+
+    renderCell(row);
+
+    await user.click(screen.getByRole('button', { name: /someFunction/ }));
+    expect(toggleRowExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-toggle when the expander icon itself is clicked (same button as function name)', async () => {
+    const user = userEvent.setup();
+    const toggleRowExpanded = jest.fn();
+    const onSymbolClick = jest.fn();
+    const row = {
+      ...makeRow({ children: [{ id: 'c1' } as CallTreeNode] }),
+      toggleRowExpanded,
+    } as unknown as Row<CallTreeNode> & UseExpandedRowProps<CallTreeNode>;
+
+    render(
+      <FunctionCellWithExpander
+        row={row}
+        value={row.original.label}
+        depth={row.original.depth}
+        hasChildren
+        rows={[]}
+        onSymbolClick={onSymbolClick}
+        toggleRowExpanded={jest.fn()}
+      />
+    );
+
+    await user.click(screen.getByTestId('call-tree-row-expander'));
+    // Single click on the expander icon (a child of the function-name button)
+    // bubbles up to the button, so toggleRowExpanded is called exactly once,
+    // not twice. The icon no longer has its own onClick handler.
+    expect(toggleRowExpanded).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the expander visible in compact mode', () => {
+    const row = makeRow({ children: [{ id: 'c1' } as CallTreeNode] });
+    renderCell(row, { compact: true });
+
+    expect(screen.getByTestId('call-tree-row-expander')).toBeInTheDocument();
+  });
+});

--- a/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.test.tsx
+++ b/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.test.tsx
@@ -44,7 +44,6 @@ function renderCell(
       value={row.original.label}
       depth={row.original.depth}
       hasChildren={props.hasChildren ?? (row.original.children?.length ?? 0) > 0}
-      rows={[]}
       onSymbolClick={jest.fn()}
       toggleRowExpanded={jest.fn()}
       {...props}
@@ -73,6 +72,27 @@ describe('FunctionCellWithExpander', () => {
     expect(screen.queryByTestId('call-tree-row-expander')).toBeNull();
   });
 
+  it('does not render tree connector lines and indents by depth', () => {
+    const row = makeRow({ depth: 2, children: [{ id: 'c1' } as CallTreeNode] });
+    const { container } = renderCell(row);
+
+    expect(container.textContent).not.toMatch(/[│├└─]/);
+    // Depth indentation keeps same-level rows left-aligned without grid lines.
+    const cell = screen.getByRole('button', { name: /someFunction/ }).closest('div');
+    expect(cell).toHaveStyle({ paddingLeft: '32px' });
+  });
+
+  it('renders a placeholder for leaf rows so names align with expandable siblings', () => {
+    const row = makeRow({ children: [] });
+    const { container } = renderCell(row, { hasChildren: false });
+
+    expect(screen.queryByTestId('call-tree-row-expander')).toBeNull();
+    const button = screen.getByRole('button', { name: /someFunction/ });
+    // Placeholder reserves the same slot as the chevron.
+    expect(button.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(/[│├└─]/);
+  });
+
   it('shows angle-right when the row is collapsed and angle-down when expanded', () => {
     const collapsed = makeRow({ isExpanded: false, children: [{ id: 'c1' } as CallTreeNode] });
     const { rerender } = renderCell(collapsed);
@@ -90,7 +110,6 @@ describe('FunctionCellWithExpander', () => {
         value={expanded.original.label}
         depth={expanded.original.depth}
         hasChildren
-        rows={[]}
         onSymbolClick={jest.fn()}
         toggleRowExpanded={jest.fn()}
       />
@@ -136,7 +155,6 @@ describe('FunctionCellWithExpander', () => {
         value={row.original.label}
         depth={row.original.depth}
         hasChildren
-        rows={[]}
         onSymbolClick={onSymbolClick}
         toggleRowExpanded={jest.fn()}
       />

--- a/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.tsx
+++ b/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { type Row, type UseExpandedRowProps } from 'react-table';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, Icon, useStyles2 } from '@grafana/ui';
 
 import { type CallTreeNode } from './utils';
 
@@ -126,12 +126,30 @@ export function FunctionCellWithExpander({
   };
 
   const connector = buildTreeConnector();
+  // Use Boolean(...) so the attribute is rendered as "true" or "false" instead of
+  // being removed when the row is collapsed. React Table leaves row.isExpanded
+  // as undefined for collapsed rows, which would otherwise drop aria-expanded.
+  const isRowExpanded = Boolean(row.isExpanded);
 
   return (
     <div className={styles.functionCellContainer}>
       {connector && <span className={styles.treeConnector}>{connector} </span>}
       <span className={styles.functionNameWrapper}>
-        <Button fill="text" size="sm" onClick={handleClick} className={styles.functionButton}>
+        <Button
+          fill="text"
+          size="sm"
+          onClick={handleClick}
+          className={cx(styles.functionButton, hasChildren && styles.functionButtonWithExpander)}
+          aria-expanded={hasChildren ? isRowExpanded : undefined}
+        >
+          {hasChildren && (
+            <Icon
+              name={isRowExpanded ? 'angle-down' : 'angle-right'}
+              size="sm"
+              data-testid="call-tree-row-expander"
+              className={styles.expander}
+            />
+          )}
           {value}
         </Button>
         {!compact && row.original.children && row.original.children.length > 0 && (
@@ -166,6 +184,18 @@ function getStyles(theme: GrafanaTheme2) {
       verticalAlign: 'middle',
       flexShrink: 0,
     }),
+    expander: css({
+      label: 'expander',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: '14px',
+      height: '14px',
+      padding: 0,
+      marginRight: '4px',
+      color: theme.colors.text.secondary,
+      flexShrink: 0,
+    }),
     functionNameWrapper: css({
       display: 'inline-flex',
       alignItems: 'center',
@@ -181,6 +211,11 @@ function getStyles(theme: GrafanaTheme2) {
       whiteSpace: 'nowrap',
       minWidth: 0,
       flexShrink: 1,
+    }),
+    functionButtonWithExpander: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '4px',
     }),
     nodeBadge: css({
       marginLeft: theme.spacing(0.5),

--- a/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.tsx
+++ b/packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.tsx
@@ -11,8 +11,6 @@ export function FunctionCellWithExpander({
   value,
   depth,
   hasChildren,
-  rowIndex,
-  rows,
   onSymbolClick,
   compact = false,
   toggleRowExpanded,
@@ -21,8 +19,6 @@ export function FunctionCellWithExpander({
   value: string;
   depth: number;
   hasChildren: boolean;
-  rowIndex?: number;
-  rows: Array<Row<CallTreeNode>>;
   onSymbolClick: (symbol: string) => void;
   compact?: boolean;
   toggleRowExpanded: (id: string[], value?: boolean) => void;
@@ -50,90 +46,11 @@ export function FunctionCellWithExpander({
     onSymbolClick(value);
   };
 
-  const isLastVisibleChildAtIndex = (index: number): boolean => {
-    if (index === undefined) {
-      return false;
-    }
-
-    const currentRow = rows[index];
-    const parentId = currentRow.original.parentId;
-
-    for (let i = index + 1; i < rows.length; i++) {
-      if (rows[i].original.parentId === parentId) {
-        return false;
-      }
-      if (rows[i].original.depth <= currentRow.original.depth) {
-        break;
-      }
-    }
-    return true;
-  };
-
-  const buildTreeConnector = () => {
-    if (depth === 0) {
-      return null;
-    }
-
-    const lines: string[] = [];
-
-    const nodeIdToNode = new Map<string, CallTreeNode>();
-    rows.forEach((r) => {
-      nodeIdToNode.set(r.original.id, r.original);
-    });
-
-    const hasMoreNodesAtDepth = (targetDepth: number): boolean => {
-      if (rowIndex === undefined) {
-        return false;
-      }
-
-      for (let i = rowIndex + 1; i < rows.length; i++) {
-        const checkRow = rows[i];
-
-        if (checkRow.original.depth === targetDepth) {
-          return true;
-        }
-
-        if (checkRow.original.depth < targetDepth) {
-          break;
-        }
-      }
-      return false;
-    };
-
-    let currentNode = row.original;
-
-    while (currentNode.parentId && currentNode.depth > 0) {
-      const parent = nodeIdToNode.get(currentNode.parentId);
-      if (parent) {
-        currentNode = parent;
-      } else {
-        break;
-      }
-    }
-
-    for (let i = 0; i < depth - 1; i++) {
-      if (hasMoreNodesAtDepth(i + 1)) {
-        lines.push('│ ');
-      } else {
-        lines.push('  ');
-      }
-    }
-
-    const isLastChild = rowIndex !== undefined ? isLastVisibleChildAtIndex(rowIndex) : false;
-    lines.push(isLastChild ? '└─' : '├─');
-
-    return lines.join('');
-  };
-
-  const connector = buildTreeConnector();
-  // Use Boolean(...) so the attribute is rendered as "true" or "false" instead of
-  // being removed when the row is collapsed. React Table leaves row.isExpanded
-  // as undefined for collapsed rows, which would otherwise drop aria-expanded.
+  // React Table leaves row.isExpanded undefined for collapsed rows, which would drop aria-expanded.
   const isRowExpanded = Boolean(row.isExpanded);
 
   return (
-    <div className={styles.functionCellContainer}>
-      {connector && <span className={styles.treeConnector}>{connector} </span>}
+    <div className={styles.functionCellContainer} style={{ paddingLeft: depth * 16 }}>
       <span className={styles.functionNameWrapper}>
         <Button
           fill="text"
@@ -142,13 +59,15 @@ export function FunctionCellWithExpander({
           className={cx(styles.functionButton, hasChildren && styles.functionButtonWithExpander)}
           aria-expanded={hasChildren ? isRowExpanded : undefined}
         >
-          {hasChildren && (
+          {hasChildren ? (
             <Icon
               name={isRowExpanded ? 'angle-down' : 'angle-right'}
               size="sm"
               data-testid="call-tree-row-expander"
               className={styles.expander}
             />
+          ) : (
+            <span aria-hidden="true" className={styles.expanderPlaceholder} />
           )}
           {value}
         </Button>
@@ -174,26 +93,22 @@ function getStyles(theme: GrafanaTheme2) {
       overflow: 'hidden',
       minWidth: 0,
     }),
-    treeConnector: css({
-      color: theme.colors.text.secondary,
-      fontSize: '16px',
-      lineHeight: '1',
-      fontFamily: 'monospace',
-      whiteSpace: 'pre',
-      display: 'inline-block',
-      verticalAlign: 'middle',
-      flexShrink: 0,
-    }),
     expander: css({
       label: 'expander',
       display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
-      width: '14px',
-      height: '14px',
+      width: '16px',
+      height: '16px',
       padding: 0,
-      marginRight: '4px',
       color: theme.colors.text.secondary,
+      flexShrink: 0,
+    }),
+    expanderPlaceholder: css({
+      label: 'expanderPlaceholder',
+      display: 'inline-flex',
+      width: '16px',
+      height: '16px',
       flexShrink: 0,
     }),
     functionNameWrapper: css({


### PR DESCRIPTION
## Summary

In the Flamegraph Call Tree view, rows that have child calls were not visually distinguishable from leaf rows. The existing tree-style connector characters (└─ / ├─) and the "X children, Y nodes" badge only rendered in non-compact mode, so in compact mode users had no way to tell which rows were expandable without clicking them. (#131768)

This PR adds a small chevron button (angle-right, rotated 90° when expanded) in front of the function name for every row that has children. The chevron is a real `<button>` with `aria-label`, `aria-expanded`, and keyboard focus styling, and `e.stopPropagation()` keeps it from also firing `onSymbolClick` when the function name itself is clicked.

The existing click-to-toggle behaviour on the function name is unchanged; this only adds the visual affordance.

## Diff

- `packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.tsx`: render an `Icon name="angle-right"` expander button for rows with children, rotate 90° when `row.isExpanded`; new `expander` / `expanderExpanded` styles.
- `packages/grafana-flamegraph/src/CallTree/FunctionCellWithExpander.test.tsx`: new test file covering the expander (renders for expandable rows, hidden for leaves, `aria-expanded` toggles, click toggles `row.toggleRowExpanded`, click does not fire `onSymbolClick`, expander still renders in compact mode).

## Verification

- `tsc -p tsconfig.json --noEmit` clean.
- `jest packages/grafana-flamegraph/src/CallTree/` passes 15/15 (9 existing + 6 new).
- `prettier --check` clean on both files.

Fixes #131768.
