### PR TITLE
Alerting: Migrate rule-editor query components to async
  DataSource API

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,15 +11,6 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
-jest.mock('app/features/datasources/hooks', () => ({
-  ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
-  // getDataSourceSrv (configured via the alerting test factories) so the current data source
-  // resolves synchronously and no post-render state update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
-}));
-
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 
@@ -64,11 +55,15 @@ describe('ImportToGMARules', () => {
   grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleCreate]);
   testWithFeatureToggles({ enable: ['alertingImportYAMLUI', 'alertingMigrationUI'] });
 
-  it('should render the import source options', () => {
+  it('should render the import source options', async () => {
     render(<ImportToGMARules />);
 
     expect(ui.importSource.existingDatasource.get()).toBeInTheDocument();
     expect(ui.importSource.yaml.get()).toBeInTheDocument();
+
+    // The data source picker resolves its current data source asynchronously; wait for it to
+    // settle so the state update doesn't escape act().
+    await waitFor(() => expect(ui.dsImport.dsPicker.get()).toBeEnabled());
   });
 
   describe('existing datasource', () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,6 +11,15 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
+  // getDataSourceSrv (configured via the alerting test factories) so the current data source
+  // resolves synchronously and no post-render state update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
@@ -1,0 +1,77 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+
+import { getDefaultFormValues } from '../../rule-editor/formDefaults';
+import { type RuleFormValues } from '../../types/rule-form';
+
+import { ExpressionEditor, type ExpressionEditorProps } from './ExpressionEditor';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstance: jest.fn(),
+  useDataSourceInstanceSettings: jest.fn(),
+}));
+
+const mockUseDataSourceInstance = jest.mocked(useDataSourceInstance);
+const mockUseDataSourceInstanceSettings = jest.mocked(useDataSourceInstanceSettings);
+
+function renderExpressionEditor(props: Partial<ExpressionEditorProps> = {}) {
+  function Wrapper() {
+    const formApi = useForm<RuleFormValues>({ defaultValues: getDefaultFormValues() });
+    return (
+      <FormProvider {...formApi}>
+        <ExpressionEditor dataSourceName="loki" onChange={jest.fn()} showPreviewAlertsButton={false} {...props} />
+      </FormProvider>
+    );
+  }
+  return render(<Wrapper />);
+}
+
+describe('ExpressionEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing while the data source is resolving', () => {
+    mockUseDataSourceInstance.mockReturnValue({ isLoading: true });
+    mockUseDataSourceInstanceSettings.mockReturnValue({ isLoading: true });
+
+    const { container } = renderExpressionEditor();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows an error message when the data source has no query editor', () => {
+    mockUseDataSourceInstance.mockReturnValue({
+      isLoading: false,
+      dataSource: { name: 'loki', components: {} } as DataSourceApi,
+    });
+    mockUseDataSourceInstanceSettings.mockReturnValue({
+      isLoading: false,
+      settings: { type: 'loki' } as DataSourceInstanceSettings,
+    });
+
+    renderExpressionEditor();
+
+    expect(screen.getByText(/could not load query editor/i)).toBeInTheDocument();
+  });
+
+  it('renders the plugin query editor once the data source has resolved', () => {
+    const QueryEditor = () => <div data-testid="plugin-query-editor" />;
+    mockUseDataSourceInstance.mockReturnValue({
+      isLoading: false,
+      dataSource: { name: 'loki', components: { QueryEditor } } as unknown as DataSourceApi,
+    });
+    mockUseDataSourceInstanceSettings.mockReturnValue({
+      isLoading: false,
+      settings: { type: 'loki' } as DataSourceInstanceSettings,
+    });
+
+    renderExpressionEditor();
+
+    expect(screen.getByTestId('plugin-query-editor')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
@@ -1,12 +1,17 @@
 import { css } from '@emotion/css';
 import { noop } from 'lodash';
 import { useCallback, useMemo } from 'react';
-import { useAsync } from 'react-use';
 
-import { CoreApp, DataSourcePluginContextProvider, type GrafanaTheme2, LoadingState } from '@grafana/data';
+import {
+  CoreApp,
+  type DataSourceInstanceSettings,
+  DataSourcePluginContextProvider,
+  type GrafanaTheme2,
+  LoadingState,
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { type PromQuery } from '@grafana/prometheus';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
 
@@ -31,17 +36,17 @@ export const ExpressionEditor = ({
 }: ExpressionEditorProps) => {
   const styles = useStyles2(getStyles);
 
-  const { mapToValue, mapToQuery } = useQueryMappers(dataSourceName);
+  const {
+    mapToValue,
+    mapToQuery,
+    isLoading: isLoadingSettings,
+    error: settingsError,
+    settings: dsi,
+  } = useQueryMappers(dataSourceName);
 
   const dataQuery = mapToQuery({ refId: 'A', hide: false }, value);
 
-  const {
-    error,
-    loading,
-    value: dataSource,
-  } = useAsync(() => {
-    return getDataSourceSrv().get(dataSourceName);
-  }, [dataSourceName]);
+  const { error: dataSourceError, isLoading: isLoadingDataSource, dataSource } = useDataSourceInstance(dataSourceName);
 
   const onChangeQuery = useCallback(
     (query: DataQuery) => {
@@ -56,15 +61,14 @@ export const ExpressionEditor = ({
     onPreview();
   };
 
-  if (loading || dataSource?.name !== dataSourceName) {
+  if (isLoadingSettings || isLoadingDataSource || dataSource?.name !== dataSourceName) {
     return null;
   }
 
-  const dsi = getDataSourceSrv().getInstanceSettings(dataSourceName);
-
-  if (error || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
+  if (dataSourceError || settingsError || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
     const errorMessage =
-      error?.message ||
+      dataSourceError?.message ||
+      settingsError?.message ||
       t(
         'alerting.expression-editor.error-no-component',
         'Data source plugin does not export any Query Editor component'
@@ -141,20 +145,29 @@ type QueryMappers<T extends DataQuery = DataQuery> = {
   mapToQuery: (existing: T, value: string | undefined) => T;
 };
 
-function useQueryMappers(dataSourceName: string): QueryMappers {
+interface UseQueryMappersResult extends QueryMappers {
+  isLoading: boolean;
+  error?: Error;
+  settings?: DataSourceInstanceSettings;
+}
+
+function useQueryMappers(dataSourceName: string): UseQueryMappersResult {
+  const { settings, isLoading, error } = useDataSourceInstanceSettings(dataSourceName);
+
   return useMemo(() => {
-    const settings = getDataSourceSrv().getInstanceSettings(dataSourceName);
-    if (!settings) {
-      throw new Error(`Datasource ${dataSourceName} not found`);
+    const mappers: QueryMappers = {
+      mapToValue: (query: DataQuery) => (query as PromQuery | LokiQuery).expr,
+      mapToQuery: (existing: DataQuery, value: string | undefined) => ({ ...existing, expr: value }),
+    };
+
+    if (isLoading || error || !settings) {
+      return { ...mappers, isLoading, error, settings };
     }
 
     if (!isSupportedExternalRulesSourceType(settings.type)) {
       throw new Error(`${settings.type} is not supported as an expression editor`);
     }
 
-    return {
-      mapToValue: (query: DataQuery) => (query as PromQuery | LokiQuery).expr,
-      mapToQuery: (existing: DataQuery, value: string | undefined) => ({ ...existing, expr: value }),
-    };
-  }, [dataSourceName]);
+    return { ...mappers, isLoading: false, settings };
+  }, [settings, isLoading, error]);
 }

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRule.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRule.test.tsx
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { of } from 'rxjs';
+
+import { type DataSourceInstanceSettings, LoadingState } from '@grafana/data';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+
+import { previewAlertRule } from '../../api/preview';
+import { getDefaultFormValues } from '../../rule-editor/formDefaults';
+import { type PreviewRuleResponse } from '../../types/preview';
+import { RuleFormType, type RuleFormValues } from '../../types/rule-form';
+
+import { usePreview } from './PreviewRule';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+jest.mock('../../api/preview', () => ({
+  previewAlertRule: jest.fn(),
+}));
+
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
+const mockPreviewAlertRule = jest.mocked(previewAlertRule);
+
+function renderUsePreview(formValues: Partial<RuleFormValues>) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    const formApi = useForm<RuleFormValues>({ defaultValues: { ...getDefaultFormValues(), ...formValues } });
+    return <FormProvider {...formApi}>{children}</FormProvider>;
+  }
+  return renderHook(() => usePreview(), { wrapper: Wrapper });
+}
+
+describe('usePreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves the data source before building the cloud preview request', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue({ uid: 'mimir-uid' } as DataSourceInstanceSettings);
+    mockPreviewAlertRule.mockReturnValue(
+      of({ data: { state: LoadingState.Done, series: [] } } as unknown as PreviewRuleResponse)
+    );
+
+    const { result } = renderUsePreview({
+      type: RuleFormType.cloudAlerting,
+      dataSourceName: 'Mimir',
+      condition: 'A',
+      expression: 'up == 1',
+    });
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(mockGetDataSourceInstanceSettings).toHaveBeenCalledWith('Mimir');
+    expect(mockPreviewAlertRule).toHaveBeenCalledWith(
+      expect.objectContaining({ dataSourceUid: 'mimir-uid', dataSourceName: 'Mimir', expr: 'up == 1' })
+    );
+  });
+
+  it('rejects when the data source cannot be resolved', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+
+    const { result } = renderUsePreview({ type: RuleFormType.cloudAlerting, dataSourceName: 'unknown' });
+
+    await expect(result.current[1]()).rejects.toThrow(/Cannot find data source settings/);
+    expect(mockPreviewAlertRule).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
@@ -7,7 +7,7 @@ import { takeWhile } from 'rxjs/operators';
 
 import { type GrafanaTheme2, LoadingState, dateTimeFormatISO } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Alert, Button, Stack, useStyles2 } from '@grafana/ui';
 
 import { previewAlertRule } from '../../api/preview';
@@ -57,14 +57,14 @@ export function PreviewRule(): React.ReactElement | null {
   );
 }
 
-export function usePreview(): [PreviewRuleResponse | undefined, () => void] {
+export function usePreview(): [PreviewRuleResponse | undefined, () => Promise<void>] {
   const [preview, setPreview] = useState<PreviewRuleResponse | undefined>();
   const { getValues } = useFormContext<RuleFormValues>();
   const isMounted = useMountedState();
 
-  const onPreview = useCallback(() => {
+  const onPreview = useCallback(async () => {
     const values = getValues(fields);
-    const request = createPreviewRequest(values);
+    const request = await createPreviewRequest(values);
 
     previewAlertRule(request)
       .pipe(takeWhile((response) => !isCompleted(response), true))
@@ -79,9 +79,9 @@ export function usePreview(): [PreviewRuleResponse | undefined, () => void] {
   return [preview, onPreview];
 }
 
-function createPreviewRequest(values: any[]): PreviewRuleRequest {
+async function createPreviewRequest(values: any[]): Promise<PreviewRuleRequest> {
   const [type, dataSourceName, condition, queries, expression] = values;
-  const dsSettings = getDataSourceSrv().getInstanceSettings(dataSourceName);
+  const dsSettings = await getDataSourceInstanceSettings(dataSourceName);
   if (!dsSettings) {
     throw new Error(`Cannot find data source settings for ${dataSourceName}`);
   }

--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceInstanceSettings, LoadingState } from '@grafana/data';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { TestDataSettings } from 'app/features/query/state/mocks/mockDataSource';
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { QueryEditor } from './QueryEditor';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+// Stub QueryWrapper — this suite only exercises settings-resolution, not plugin rendering.
+jest.mock('./QueryWrapper', () => ({
+  ...jest.requireActual('./QueryWrapper'),
+  // eslint-disable-next-line react/display-name
+  QueryWrapper: () => <div data-testid="query-wrapper" />,
+}));
+
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
+
+const query: AlertQuery = {
+  refId: 'A',
+  datasourceUid: 'test-uid',
+  model: { refId: 'A' },
+  relativeTimeRange: { from: 600, to: 0 },
+};
+
+const defaultProps = {
+  panelData: { A: { series: [], state: LoadingState.Done } },
+  queries: [query],
+  expressions: [],
+  onRunQueries: jest.fn(),
+  onChangeQueries: jest.fn(),
+  onDuplicateQuery: jest.fn(),
+  condition: null,
+  onSetCondition: jest.fn(),
+};
+
+describe('QueryEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows a loading placeholder while data source settings are resolving', () => {
+    mockGetDataSourceInstanceSettings.mockReturnValue(new Promise(() => {}));
+
+    render(<QueryEditor {...defaultProps} />);
+
+    expect(screen.getByText(/loading data source/i)).toBeInTheDocument();
+    expect(screen.queryByText(/this datasource has been removed/i)).not.toBeInTheDocument();
+  });
+
+  it('shows "datasource has been removed" once resolved and the data source is missing', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+
+    render(<QueryEditor {...defaultProps} />);
+
+    expect(await screen.findByText(/this datasource has been removed/i)).toBeInTheDocument();
+  });
+
+  it('renders the resolved query once data source settings are available', async () => {
+    const settings: DataSourceInstanceSettings = { ...TestDataSettings, uid: 'test-uid' };
+    mockGetDataSourceInstanceSettings.mockResolvedValue(settings);
+
+    render(<QueryEditor {...defaultProps} />);
+
+    expect(await screen.findByTestId('query-wrapper')).toBeInTheDocument();
+    expect(screen.queryByText(/this datasource has been removed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/loading data source/i)).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
@@ -1,6 +1,8 @@
 import { css } from '@emotion/css';
+import { useAsync } from 'react-use';
 
-import { type GrafanaTheme2, type PanelData } from '@grafana/data';
+import { type DataSourceInstanceSettings, type GrafanaTheme2, type PanelData } from '@grafana/data';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { useStyles2 } from '@grafana/ui';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -28,6 +30,7 @@ export const QueryEditor = ({
   onSetCondition,
 }: Props) => {
   const styles = useStyles2(getStyles);
+  const { settingsByUid, isLoading } = useDataSourceSettingsByUid(queries.map((query) => query.datasourceUid));
 
   return (
     <div className={styles.container}>
@@ -40,6 +43,8 @@ export const QueryEditor = ({
         onDuplicateQuery={onDuplicateQuery}
         condition={condition}
         onSetCondition={onSetCondition}
+        dataSourceSettingsByUid={settingsByUid}
+        isLoadingDataSourceSettings={isLoading}
       />
     </div>
   );
@@ -51,3 +56,25 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
   }),
 });
+
+interface UseDataSourceSettingsByUidResult {
+  settingsByUid: Record<string, DataSourceInstanceSettings>;
+  isLoading: boolean;
+}
+
+// QueryRows is a class component and can't use hooks, so settings are resolved here instead.
+function useDataSourceSettingsByUid(uids: string[]): UseDataSourceSettingsByUidResult {
+  const uniqueUids = Array.from(new Set(uids)).sort();
+  const uidsKey = uniqueUids.join(',');
+
+  const { value, loading } = useAsync(async () => {
+    const settingsList = await Promise.all(uniqueUids.map((uid) => getDataSourceInstanceSettings(uid)));
+    const entries = uniqueUids
+      .map((uid, index): [string, DataSourceInstanceSettings | undefined] => [uid, settingsList[index]])
+      .filter((entry): entry is [string, DataSourceInstanceSettings] => entry[1] !== undefined);
+    return Object.fromEntries(entries);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uidsKey]);
+
+  return { settingsByUid: value ?? {}, isLoading: loading };
+}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -10,10 +10,9 @@ import {
   getDataSourceRef,
   rangeUtil,
 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { Trans, t } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
-import { Button, Card, Icon, Stack } from '@grafana/ui';
+import { Button, Card, Icon, LoadingPlaceholder, Stack } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -36,6 +35,10 @@ interface Props {
   onDuplicateQuery: (query: AlertQuery) => void;
   condition: string | null;
   onSetCondition: (refId: string) => void;
+
+  // Data source settings, resolved by the parent (see QueryEditor.tsx)
+  dataSourceSettingsByUid: Record<string, DataSourceInstanceSettings>;
+  isLoadingDataSourceSettings: boolean;
 }
 
 export class QueryRows extends PureComponent<Props> {
@@ -145,7 +148,7 @@ export class QueryRows extends PureComponent<Props> {
   };
 
   getDataSourceSettings = (query: AlertQuery): DataSourceInstanceSettings | undefined => {
-    return getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+    return this.props.dataSourceSettingsByUid[query.datasourceUid];
   };
 
   render() {
@@ -174,6 +177,15 @@ export class QueryRows extends PureComponent<Props> {
                     }
 
                     if (!dsSettings) {
+                      if (this.props.isLoadingDataSourceSettings) {
+                        return (
+                          <LoadingPlaceholder
+                            key={`${query.refId}-${index}`}
+                            text={t('alerting.query-rows.loading-data-source', 'Loading data source...')}
+                          />
+                        );
+                      }
+
                       return (
                         <DatasourceNotFound
                           key={`${query.refId}-${index}`}

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceApi, type DataSourceInstanceSettings, LoadingState } from '@grafana/data';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+
+import { RecordingRuleEditor, type RecordingRuleEditorProps } from './RecordingRuleEditor';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  useDataSourceInstance: jest.fn(),
+  useDataSourceInstanceSettings: jest.fn(),
+}));
+
+const mockUseDataSourceInstance = jest.mocked(useDataSourceInstance);
+const mockUseDataSourceInstanceSettings = jest.mocked(useDataSourceInstanceSettings);
+
+const defaultProps: RecordingRuleEditorProps = {
+  queries: [
+    {
+      refId: 'A',
+      datasourceUid: 'loki',
+      model: { refId: 'A', expr: 'count_over_time({job="test"}[5m])' },
+      relativeTimeRange: { from: 600, to: 0 },
+    },
+  ],
+  onChangeQuery: jest.fn(),
+  runQueries: jest.fn(),
+  panelData: { A: { series: [], state: LoadingState.Done } },
+  dataSourceName: 'loki',
+};
+
+describe('RecordingRuleEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing while the data source is resolving', () => {
+    mockUseDataSourceInstance.mockReturnValue({ isLoading: true });
+    mockUseDataSourceInstanceSettings.mockReturnValue({ isLoading: true });
+
+    const { container } = render(<RecordingRuleEditor {...defaultProps} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows an error message when the data source has no query editor', () => {
+    mockUseDataSourceInstance.mockReturnValue({
+      isLoading: false,
+      dataSource: { name: 'loki', components: {} } as DataSourceApi,
+    });
+    mockUseDataSourceInstanceSettings.mockReturnValue({
+      isLoading: false,
+      settings: { type: 'loki' } as DataSourceInstanceSettings,
+    });
+
+    render(<RecordingRuleEditor {...defaultProps} />);
+
+    expect(screen.getByText(/could not load query editor/i)).toBeInTheDocument();
+  });
+
+  it('renders the plugin query editor once the data source has resolved', () => {
+    const QueryEditor = () => <div data-testid="plugin-query-editor" />;
+    mockUseDataSourceInstance.mockReturnValue({
+      isLoading: false,
+      dataSource: { name: 'loki', uid: 'loki', type: 'loki', components: { QueryEditor } } as unknown as DataSourceApi,
+    });
+    mockUseDataSourceInstanceSettings.mockReturnValue({
+      isLoading: false,
+      settings: { type: 'loki' } as DataSourceInstanceSettings,
+    });
+
+    render(<RecordingRuleEditor {...defaultProps} />);
+
+    expect(screen.getByTestId('plugin-query-editor')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/css';
 import { type FC, useCallback, useEffect, useState } from 'react';
-import { useAsync } from 'react-use';
 
 import { CoreApp, type GrafanaTheme2, LoadingState, type PanelData } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
@@ -44,13 +43,12 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     setData(panelData?.[queries[0]?.refId]);
   }, [panelData, queries]);
 
+  const { error: dataSourceError, isLoading: isLoadingDataSource, dataSource } = useDataSourceInstance(dataSourceName);
   const {
-    error,
-    loading,
-    value: dataSource,
-  } = useAsync(() => {
-    return getDataSourceSrv().get(dataSourceName);
-  }, [dataSourceName]);
+    settings: dsi,
+    isLoading: isLoadingSettings,
+    error: settingsError,
+  } = useDataSourceInstanceSettings(dataSourceName);
 
   const handleChangedQuery = useCallback(
     (changedQuery: DataQuery) => {
@@ -89,14 +87,15 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     [dataSource, queries, onChangeQuery]
   );
 
-  if (loading || dataSource?.name !== dataSourceName) {
+  if (isLoadingDataSource || isLoadingSettings || dataSource?.name !== dataSourceName) {
     return null;
   }
 
-  const dsi = getDataSourceSrv().getInstanceSettings(dataSourceName);
-
-  if (error || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
-    const errorMessage = error?.message || 'Data source plugin does not export any Query Editor component';
+  if (dataSourceError || settingsError || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
+    const errorMessage =
+      dataSourceError?.message ||
+      settingsError?.message ||
+      'Data source plugin does not export any Query Editor component';
     return (
       <div>
         <Trans i18nKey="alerting.recording-rule-editor.error-no-query-editor">

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -7,7 +7,8 @@ import { useEffectOnce } from 'react-use';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   Alert,
   Button,
@@ -382,7 +383,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     addExpressionsInQueries(prevExpressions);
   }, [prevExpressions, addExpressionsInQueries]);
 
-  const onClickSwitch = useCallback(() => {
+  const onClickSwitch = useCallback(async () => {
     const typeInForm = getValues('type');
     if (typeInForm === RuleFormType.cloudAlerting) {
       setValue('type', RuleFormType.grafana);
@@ -394,7 +395,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       setValue('type', RuleFormType.cloudAlerting);
       // dataSourceName is used only by Mimir/Loki alerting and recording rules
       // It should be empty for Grafana managed alert rules
-      const newDsName = getDataSourceSrv().getInstanceSettings(queries[0].datasourceUid)?.name;
+      const newDsName = (await getDataSourceInstanceSettings(queries[0].datasourceUid))?.name;
       if (newDsName) {
         setValue('dataSourceName', newDsName);
       }
@@ -731,14 +732,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
 const useSetExpressionAndDataSource = () => {
   const { setValue } = useFormContext<RuleFormValues>();
 
-  return (updatedQueries: AlertQuery[]) => {
+  return async (updatedQueries: AlertQuery[]) => {
     // update data source name and expression if it's been changed in the queries from the reducer when prom or loki query
     const query = updatedQueries[0];
     if (!query) {
       return;
     }
 
-    const dataSourceSettings = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+    const dataSourceSettings = await getDataSourceInstanceSettings(query.datasourceUid);
     if (!dataSourceSettings) {
       throw new Error('The Data source has not been defined.');
     }

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
@@ -11,6 +11,13 @@ import { setupDataSources } from '../../testSetup/datasources';
 import { RECEIVER_NAME, listContactPointsScenario } from './ContactPointLink.scenario';
 import { Details } from './Details';
 
+// useDatasource wraps the async settings API. Stub it so the (synchronous) tests below
+// don't trigger a post-mount state update for a datasource none of them assert on.
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  useDatasource: jest.fn(),
+}));
+
 const server = setupMockServer();
 
 beforeAll(() => {

--- a/public/app/features/alerting/unified/testSetup/datasources.ts
+++ b/public/app/features/alerting/unified/testSetup/datasources.ts
@@ -2,11 +2,13 @@ import { keyBy } from 'lodash';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { config, setDataSourceSrv } from '@grafana/runtime';
+import { initDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 /**
  * Sets up the data sources for the tests.
- * Sets up both config object from grafana/runtime and the data source server
+ * Sets up the config object from grafana/runtime, the legacy data source service and the
+ * settings cache backing the async getDataSourceInstanceSettings API
  * @param configs data source instance settings. Use **mockDataSource** to create mock settings
  */
 export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
@@ -14,9 +16,11 @@ export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
   const datasourceSettings = keyBy(configs, (c) => c.name);
 
   const defaultDatasource = configs.find((c) => c.isDefault);
+  const defaultDatasourceName = defaultDatasource?.name || config.defaultDatasource;
   config.datasources = datasourceSettings;
-  dataSourceSrv.init(config.datasources, defaultDatasource?.name || config.defaultDatasource);
+  dataSourceSrv.init(config.datasources, defaultDatasourceName);
   setDataSourceSrv(dataSourceSrv);
+  initDataSourceInstanceSettings(datasourceSettings, defaultDatasourceName);
 
   return dataSourceSrv;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { type DataQuery } from '@grafana/schema';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { dashboardDsSettingsMock, ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
 import { type Transformation } from '../types';
@@ -16,12 +17,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ds1SettingsMock);
 
 describe('QueryEditorSidebar', () => {
   afterAll(() => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -14,6 +14,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorSidebar', () => {
   afterAll(() => {
     jest.clearAllMocks();

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { AdHocVariableForm, type AdHocVariableFormProps } from './AdHocVariableForm';
 
@@ -31,12 +32,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('AdHocVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -29,6 +29,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('AdHocVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -6,6 +6,7 @@ import { VariableSupportType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { GroupByVariableForm, type GroupByVariableFormProps } from './GroupByVariableForm';
@@ -38,12 +39,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -36,6 +36,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -17,6 +17,7 @@ import { setRunRequest } from '@grafana/runtime';
 import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 import { getVariableQueryEditor } from 'app/features/variables/editor/getVariableQueryEditor';
 
@@ -50,12 +51,16 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation((ref) => {
+  const uid = typeof ref === 'string' ? ref : ref?.uid;
+  return uid === promDatasource.uid ? promDatasource : defaultDatasource;
+});
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -48,6 +48,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { AdHocFiltersVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { type AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
@@ -79,6 +80,16 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
+}));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -45,6 +45,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -7,6 +7,7 @@ import { GroupByVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { getGroupByVariableOptions, GroupByVariableEditor } from './GroupByVariableEditor';
@@ -47,12 +48,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -55,6 +55,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { QueryVariableEditor, Editor } from './QueryVariableEditor';
@@ -57,12 +58,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -81,6 +81,9 @@ jest.mock('../../hooks', () => {
     ...actual,
     useRecentlyUsedDataSources: () => [[mockDS2.name], pushRecentlyUsedDataSourceMock],
     useDatasources: () => mockDSList,
+    // useDatasource now wraps the async settings API; resolve it synchronously in tests
+    // via the same mock that stands in for the legacy getInstanceSettings lookup.
+    useDatasource: (ref: unknown) => getInstanceSettingsMock(ref),
   };
 });
 

--- a/public/app/features/datasources/hooks.test.ts
+++ b/public/app/features/datasources/hooks.test.ts
@@ -1,15 +1,23 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { TestDataSettings } from '../query/state/mocks/mockDataSource';
 
-import { useRecentlyUsedDataSources } from './hooks';
+import { useDatasource, useRecentlyUsedDataSources } from './hooks';
 
-// Mock react-use's useLocalStorage
+// Mock react-use's useLocalStorage while keeping the rest (e.g. useAsync) intact
 jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
   useLocalStorage: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
 const mockUseLocalStorage = jest.requireMock('react-use').useLocalStorage;
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 describe('useRecentlyUsedDataSources', () => {
   let mockSetStorage: jest.Mock;
@@ -110,5 +118,38 @@ describe('useRecentlyUsedDataSources', () => {
       // Should remove the first item and add new one at the end
       expect(mockSetStorage).toHaveBeenCalledWith(['uid2', 'uid3', 'uid4', 'uid5', 'test-uid']);
     });
+  });
+});
+
+describe('useDatasource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve to the settings returned by getDataSourceInstanceSettings', async () => {
+    const settings = { ...TestDataSettings, uid: 'test-uid' };
+    mockGetDataSourceInstanceSettings.mockResolvedValue(settings);
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    await waitFor(() => expect(result.current).toBe(settings));
+  });
+
+  it('should forward the ref and scopedVars to getDataSourceInstanceSettings', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+    const scopedVars = { ds: { text: 'prometheus', value: 'prometheus' } };
+
+    renderHook(() => useDatasource('$ds', scopedVars));
+
+    await waitFor(() => expect(mockGetDataSourceInstanceSettings).toHaveBeenCalledWith('$ds', scopedVars));
+  });
+
+  it('should return undefined while the lookup is pending', () => {
+    // Never resolves so the hook stays in its loading state.
+    mockGetDataSourceInstanceSettings.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    expect(result.current).toBeUndefined();
   });
 });

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
-import { useLocalStorage } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 import { type GetDataSourceListFilters, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 const LOCAL_STORAGE_KEY = 'grafana.features.datasources.components.picker.DataSourceDropDown.history';
 
@@ -55,14 +56,18 @@ export function useDatasources(filters: GetDataSourceListFilters, datasources?: 
 export function useDatasource(
   dataSource: string | DataSourceRef | DataSourceInstanceSettings | null | undefined,
   scopedVars?: ScopedVars
-) {
-  const dataSourceSrv = getDataSourceSrv();
+): DataSourceInstanceSettings | undefined {
+  // Compare `dataSource` and `scopedVars` by value so inline objects don't re-trigger the lookup.
+  const refKey = JSON.stringify(dataSource ?? null);
+  const scopedVarsKey = JSON.stringify(scopedVars ?? null);
 
-  if (typeof dataSource === 'string') {
-    return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
-  }
+  const { value } = useAsync(
+    () => getDataSourceInstanceSettings(dataSource, scopedVars),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refKey, scopedVarsKey]
+  );
 
-  return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
+  return value;
 }
 
 export interface KeyboardNavigatableListProps {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -138,11 +138,9 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it so the tests
+  // below don't trigger a post-render state update for a datasource none of them assert on.
+  useDatasource: jest.fn(),
 }));
 
 jest.mock('app/core/services/context_srv', () => ({

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -136,6 +136,15 @@ jest.mock('@grafana/runtime', () => ({
   usePluginLinks: jest.fn(() => ({ links: [] })),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -28,6 +28,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { type Props, QueryEditorRowHeader } from './QueryEditorRowHeader';
 
@@ -30,12 +31,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => mockDS);
 
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2701,6 +2701,9 @@
       "max-data-points": "MD = {{maxDataPoints}}",
       "min-interval": "Min. Interval = {{minInterval}}"
     },
+    "query-rows": {
+      "loading-data-source": "Loading data source..."
+    },
     "query-viewer": {
       "no-eval-data": "No data — query results could not be loaded.",
       "no-query": "No data source query to run for this rule."


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

###
  What changed?
Replaces the deprecated getDataSourceSrv() calls in PreviewRule, ExpressionEditor, RecordingRuleEditor, and QueryRows, plus two call sites in QueryAndExpressionsStep,
  with the async getDataSourceInstance(Settings) APIs and hooks from @grafana/runtime/unstable. Since QueryRows is a class component, its data source settings are now resolved by its
  functional parent (QueryEditor) and passed down as a prop, with a loading placeholder shown while resolution is pending.