### PR TITLE
Unified storage: register rvmanager metrics on the injected registry

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -223,6 +223,7 @@ func NewStorageBackend(
 			Dialect:                 dialect,
 			DB:                      dbConn,
 			BatchTransactionTimeout: cfg.ResourceVersionBatchTransactionTimeout,
+			Reg:                     reg,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create resource version manager: %w", err)
@@ -519,6 +520,7 @@ func (b *backend) initLocked(ctx context.Context) error {
 		Dialect:                 b.dialect,
 		DB:                      b.db,
 		BatchTransactionTimeout: b.batchTxnTimeout,
+		Reg:                     b.reg,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create resource version manager: %w", err)

--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -25,36 +25,46 @@ import (
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager")
 
-var (
-	rvmWriteDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "grafana_rvmanager_write_duration_seconds",
-		Help:                        "Duration of ResourceVersionManager write operations",
-		NativeHistogramBucketFactor: 1.1,
-	}, []string{"group", "resource", "status"})
+type metrics struct {
+	writeDuration          *prometheus.HistogramVec
+	execBatchDuration      *prometheus.HistogramVec
+	execBatchPhaseDuration *prometheus.HistogramVec
+	inflightWrites         *prometheus.GaugeVec
+	batchSize              *prometheus.HistogramVec
+}
 
-	rvmExecBatchDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "grafana_rvmanager_exec_batch_duration_seconds",
-		Help:                        "Duration of ResourceVersionManager batch operations",
-		NativeHistogramBucketFactor: 1.1,
-	}, []string{"group", "resource", "status"})
+func newMetrics(reg prometheus.Registerer) *metrics {
+	return &metrics{
+		writeDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "grafana_rvmanager_write_duration_seconds",
+			Help:                        "Duration of ResourceVersionManager write operations",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"group", "resource", "status"}),
 
-	rvmExecBatchPhaseDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "grafana_rvmanager_exec_batch_phase_duration_seconds",
-		Help:                        "Duration of batch operation phases",
-		NativeHistogramBucketFactor: 1.1,
-	}, []string{"group", "resource", "phase"})
+		execBatchDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "grafana_rvmanager_exec_batch_duration_seconds",
+			Help:                        "Duration of ResourceVersionManager batch operations",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"group", "resource", "status"}),
 
-	rvmInflightWrites = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "grafana_rvmanager_inflight_writes",
-		Help: "Number of concurrent write operations",
-	}, []string{"group", "resource"})
+		execBatchPhaseDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "grafana_rvmanager_exec_batch_phase_duration_seconds",
+			Help:                        "Duration of batch operation phases",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"group", "resource", "phase"}),
 
-	rvmBatchSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:                        "grafana_rvmanager_batch_size",
-		Help:                        "Number of write operations per batch",
-		NativeHistogramBucketFactor: 1.1,
-	}, []string{"group", "resource"})
-)
+		inflightWrites: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
+			Name: "grafana_rvmanager_inflight_writes",
+			Help: "Number of concurrent write operations",
+		}, []string{"group", "resource"}),
+
+		batchSize: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Name:                        "grafana_rvmanager_batch_size",
+			Help:                        "Number of write operations per batch",
+			NativeHistogramBucketFactor: 1.1,
+		}, []string{"group", "resource"}),
+	}
+}
 
 const (
 	defaultMaxBatchSize     = 25
@@ -83,6 +93,8 @@ type ResourceVersionManager struct {
 	maxBatchSize     int           // The maximum number of operations to batch together
 	maxBatchWaitTime time.Duration // The maximum time to wait for a batch to be ready
 	batchTxnTimeout  time.Duration // 0 = use defaultBatchTimeout for each batched WithTx
+
+	metrics *metrics
 }
 
 type writeOpResult struct {
@@ -116,6 +128,9 @@ type ResourceManagerOptions struct {
 	// BatchTransactionTimeout is the maximum duration for one batched transaction
 	// (all writes, lock, RV updates). Zero selects defaultBatchTimeout.
 	BatchTransactionTimeout time.Duration
+	// Reg is where the manager's metrics are registered. A nil Reg leaves them
+	// unregistered.
+	Reg prometheus.Registerer
 }
 
 // NewResourceVersionManager creates a new ResourceVersionManager
@@ -139,6 +154,7 @@ func NewResourceVersionManager(opts ResourceManagerOptions) (*ResourceVersionMan
 		maxBatchSize:     opts.MaxBatchSize,
 		maxBatchWaitTime: opts.MaxBatchWaitTime,
 		batchTxnTimeout:  opts.BatchTransactionTimeout,
+		metrics:          newMetrics(opts.Reg),
 	}, nil
 }
 
@@ -157,8 +173,8 @@ func (m *ResourceVersionManager) DB() db.DB {
 
 // ExecWithRV executes the given function with an incremented resource version
 func (m *ResourceVersionManager) ExecWithRV(ctx context.Context, key *resourcepb.ResourceKey, fn WriteEventFunc) (rv int64, err error) {
-	rvmInflightWrites.WithLabelValues(key.Group, key.Resource).Inc()
-	defer rvmInflightWrites.WithLabelValues(key.Group, key.Resource).Dec()
+	m.metrics.inflightWrites.WithLabelValues(key.Group, key.Resource).Inc()
+	defer m.metrics.inflightWrites.WithLabelValues(key.Group, key.Resource).Dec()
 
 	var status string
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
@@ -166,7 +182,7 @@ func (m *ResourceVersionManager) ExecWithRV(ctx context.Context, key *resourcepb
 		if err != nil {
 			status = "error"
 		}
-		rvmWriteDuration.WithLabelValues(key.Group, key.Resource, status).Observe(v)
+		m.metrics.writeDuration.WithLabelValues(key.Group, key.Resource, status).Observe(v)
 	}))
 	defer timer.ObserveDuration()
 
@@ -244,7 +260,7 @@ func (m *ResourceVersionManager) startBatchProcessor(group, resource string) {
 			}
 		}
 
-		rvmBatchSize.WithLabelValues(group, resource).Observe(float64(len(batch)))
+		m.metrics.batchSize.WithLabelValues(group, resource).Observe(float64(len(batch)))
 		m.execBatch(ctx, group, resource, batch)
 	}
 }
@@ -270,7 +286,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 		if err != nil {
 			status = "error"
 		}
-		rvmExecBatchDuration.WithLabelValues(group, resource, status).Observe(v)
+		m.metrics.execBatchDuration.WithLabelValues(group, resource, status).Observe(v)
 	}))
 	defer timer.ObserveDuration()
 
@@ -296,7 +312,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 			span.AddEvent("starting_batch_transaction")
 
 			writeTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "write_ops").Observe(v)
+				m.metrics.execBatchPhaseDuration.WithLabelValues(group, resource, "write_ops").Observe(v)
 			}))
 			for i := range batch {
 				guid, err := batch[i].fn(ctx, tx)
@@ -313,7 +329,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 			span.AddEvent("batch_operations_completed")
 
 			lockTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "waiting_for_lock").Observe(v)
+				m.metrics.execBatchPhaseDuration.WithLabelValues(group, resource, "waiting_for_lock").Observe(v)
 			}))
 			rv, err := m.Lock(ctx, tx, group, resource)
 			lockTimer.ObserveDuration()
@@ -328,7 +344,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 			))
 
 			rvUpdateTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "update_resource_versions").Observe(v)
+				m.metrics.execBatchPhaseDuration.WithLabelValues(group, resource, "update_resource_versions").Observe(v)
 			}))
 			defer rvUpdateTimer.ObserveDuration()
 			// Allocate the RVs

--- a/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bwmarrin/snowflake"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -267,4 +268,35 @@ func TestBulkSnowflakeRoundtrip(t *testing.T) {
 				counter, snowflakeID, microRV, roundtripped)
 		}
 	})
+}
+
+func TestNewMetricsRegistersOnGivenRegistry(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	m := newMetrics(reg)
+
+	// Touch every collector so the registry has series to gather.
+	m.writeDuration.WithLabelValues("g", "r", "ok").Observe(1)
+	m.execBatchDuration.WithLabelValues("g", "r", "ok").Observe(1)
+	m.execBatchPhaseDuration.WithLabelValues("g", "r", "write_ops").Observe(1)
+	m.inflightWrites.WithLabelValues("g", "r").Inc()
+	m.batchSize.WithLabelValues("g", "r").Observe(1)
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(mfs))
+	for _, mf := range mfs {
+		names = append(names, mf.GetName())
+	}
+	require.ElementsMatch(t, []string{
+		"grafana_rvmanager_write_duration_seconds",
+		"grafana_rvmanager_exec_batch_duration_seconds",
+		"grafana_rvmanager_exec_batch_phase_duration_seconds",
+		"grafana_rvmanager_inflight_writes",
+		"grafana_rvmanager_batch_size",
+	}, names)
+}
+
+func TestNewMetricsWithNilRegistry(t *testing.T) {
+	require.NotNil(t, newMetrics(nil))
 }


### PR DESCRIPTION
The five `grafana_rvmanager_*` metrics were package-level `promauto.New*` variables, so they registered on the global default registry at init instead of the registry passed through the wiring. No per-instance isolation, and they leak between tests. Everything else in unified storage uses `promauto.With(reg)`.

They now live on the manager, built from a `Reg` field on `ResourceManagerOptions` and passed at both call sites in `sql/backend.go`. A nil registry leaves them unregistered.

Metric names are unchanged — verified by running Grafana, creating a folder, and checking all five still appear on `/metrics`. New unit test covers the names. No `rvmanager` references in grafana-enterprise.