### PR TITLE
Alerting: Migrate AlertingQueryRunner to async DataSource API

### DIFF
--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,15 +11,6 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
-jest.mock('app/features/datasources/hooks', () => ({
-  ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
-  // getDataSourceSrv (configured via the alerting test factories) so the current data source
-  // resolves synchronously and no post-render state update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
-}));
-
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 
@@ -64,11 +55,15 @@ describe('ImportToGMARules', () => {
   grantUserPermissions([AccessControlAction.AlertingRuleExternalRead, AccessControlAction.AlertingRuleCreate]);
   testWithFeatureToggles({ enable: ['alertingImportYAMLUI', 'alertingMigrationUI'] });
 
-  it('should render the import source options', () => {
+  it('should render the import source options', async () => {
     render(<ImportToGMARules />);
 
     expect(ui.importSource.existingDatasource.get()).toBeInTheDocument();
     expect(ui.importSource.yaml.get()).toBeInTheDocument();
+
+    // The data source picker resolves its current data source asynchronously; wait for it to
+    // settle so the state update doesn't escape act().
+    await waitFor(() => expect(ui.dsImport.dsPicker.get()).toBeEnabled());
   });
 
   describe('existing datasource', () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -11,6 +11,15 @@ import { alertingFactory } from '../../mocks/server/db';
 
 import ImportToGMARules from './ImportToGMARules';
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the real
+  // getDataSourceSrv (configured via the alerting test factories) so the current data source
+  // resolves synchronously and no post-render state update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireActual('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 

--- a/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/Details.test.tsx
@@ -11,6 +11,13 @@ import { setupDataSources } from '../../testSetup/datasources';
 import { RECEIVER_NAME, listContactPointsScenario } from './ContactPointLink.scenario';
 import { Details } from './Details';
 
+// useDatasource wraps the async settings API. Stub it so the (synchronous) tests below
+// don't trigger a post-mount state update for a datasource none of them assert on.
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  useDatasource: jest.fn(),
+}));
+
 const server = setupMockServer();
 
 beforeAll(() => {

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -13,16 +13,13 @@ import {
   getDefaultRelativeTimeRange,
   rangeUtil,
 } from '@grafana/data';
-import { type DataSourceSrv, DataSourceWithBackend, type FetchResponse } from '@grafana/runtime';
+import { DataSourceWithBackend, type FetchResponse } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import * as grafanaRuntimeUnstable from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { type BackendSrv } from 'app/core/services/backend_srv';
-import {
-  EXTERNAL_VANILLA_ALERTMANAGER_UID,
-  mockDataSources,
-} from 'app/features/alerting/unified/components/settings/mocks/server';
+import { EXTERNAL_VANILLA_ALERTMANAGER_UID } from 'app/features/alerting/unified/components/settings/mocks/server';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -31,6 +28,14 @@ import { type AlertingQueryResponse, AlertingQueryRunner } from './AlertingQuery
 setupMswServer();
 
 describe('AlertingQueryRunner', () => {
+  beforeEach(() => {
+    mockDataSourceInstance();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should successfully map response and return panel data by refId', async () => {
     const response = createFetchResponse<AlertingQueryResponse>({
       results: {
@@ -38,7 +43,6 @@ describe('AlertingQueryRunner', () => {
         B: { frames: [createDataFrameJSON([5, 6])] },
       },
     });
-    setupDataSources(...Object.values(mockDataSources));
 
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
@@ -99,8 +103,7 @@ describe('AlertingQueryRunner', () => {
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => of(response),
-      }),
-      mockDataSourceSrv()
+      })
     );
 
     const data = runner.get();
@@ -109,8 +112,7 @@ describe('AlertingQueryRunner', () => {
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
 
-      // these test are flakey since the absolute computed "timeRange" can differ from the relative "defaultRelativeTimeRange"
-      // so instead we will check if the size of the timeranges match
+      // Compare relative range sizes, not absolute timeRange, to avoid flakiness from clock drift.
       const relativeA = rangeUtil.timeRangeToRelative(data.A.timeRange);
       const relativeB = rangeUtil.timeRangeToRelative(data.B.timeRange);
       const defaultRange = getDefaultRelativeTimeRange();
@@ -182,6 +184,7 @@ describe('AlertingQueryRunner', () => {
 
   it('should emit error state if fetch request fails', async () => {
     const error = new Error('could not query data');
+
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => throwError(error),
@@ -203,11 +206,12 @@ describe('AlertingQueryRunner', () => {
   });
 
   it('should not push any values if all queries fail filterQuery check', async () => {
+    mockDataSourceInstance({ filterQuery: () => false });
+
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => throwError(new Error("shouldn't happen")),
-      }),
-      mockDataSourceSrv({ filterQuery: () => false })
+      })
     );
 
     const data = runner.get();
@@ -223,11 +227,12 @@ describe('AlertingQueryRunner', () => {
       },
     });
 
+    mockDataSourceInstance({ filterQuery: (model: AlertDataQuery) => model.hide !== true });
+
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => of(results),
-      }),
-      mockDataSourceSrv({ filterQuery: (model: AlertDataQuery) => model.hide !== true })
+      })
     );
 
     const data = runner.get();
@@ -279,12 +284,11 @@ interface MockOpts {
   filterQuery?: (query: DataQuery) => boolean;
 }
 
-const mockDataSourceSrv = (opts?: MockOpts) => {
+const mockDataSourceInstance = (opts?: MockOpts) => {
   const ds = new DataSourceWithBackend({} as unknown as DataSourceInstanceSettings);
   ds.filterQuery = opts?.filterQuery;
-  return {
-    get: () => Promise.resolve(ds),
-  } as unknown as DataSourceSrv;
+  jest.spyOn(grafanaRuntimeUnstable, 'getDataSourceInstance').mockResolvedValue(ds);
+  return ds;
 };
 
 const expectDataFrameWithValues = ({ time, values }: { time: number[]; values: number[] }): DataFrame => {
@@ -356,11 +360,12 @@ describe('prepareQueries', () => {
       }),
     ];
 
+    mockDataSourceInstance({ filterQuery: (model: AlertDataQuery) => model.hide !== true });
+
     const runner = new AlertingQueryRunner(
       mockBackendSrv({
         fetch: () => of(),
-      }),
-      mockDataSourceSrv({ filterQuery: (model: AlertDataQuery) => model.hide !== true })
+      })
     );
 
     const queriesToRun = await runner.prepareQueries(queries);

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -15,7 +15,8 @@ import {
   withLoadingIndicator,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { DataSourceWithBackend, type FetchResponse, getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
+import { DataSourceWithBackend, type FetchResponse, toDataQueryError } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type BackendSrv, getBackendSrv } from 'app/core/services/backend_srv';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { cancelNetworkRequestsOnUnsubscribe } from 'app/features/query/state/processing/canceler';
@@ -27,7 +28,7 @@ import { getTimeRangeForExpression } from '../utils/timeRange';
 
 interface AlertingQueryResult {
   error?: string;
-  status?: number; // HTTP status error
+  status?: number;
   frames: DataFrameJSON[];
 }
 
@@ -39,10 +40,7 @@ export class AlertingQueryRunner {
   private subscription?: Unsubscribable;
   private lastResult: Record<string, PanelData>;
 
-  constructor(
-    private backendSrv = getBackendSrv(),
-    private dataSourceSrv = getDataSourceSrv()
-  ) {
+  constructor(private backendSrv = getBackendSrv()) {
     this.subject = new ReplaySubject(1);
     this.lastResult = {};
   }
@@ -54,13 +52,11 @@ export class AlertingQueryRunner {
   async run(queries: AlertQuery[], condition: string) {
     const queriesToRun = await this.prepareQueries(queries);
 
-    // if we don't have any queries to run we just bail
     if (queriesToRun.length === 0) {
       return;
     }
 
-    // if the condition isn't part of the queries to run, try to run the alert rule without it.
-    // It indicates that the "condition" node points to a non-existent node. We still want to be able to evaluate the other nodes.
+    // Condition may point to a non-existent node (e.g. excluded above); still evaluate the rest.
     const isConditionAvailable = queriesToRun.some((query) => query.refId === condition);
     const ruleCondition = isConditionAvailable ? condition : '';
 
@@ -72,7 +68,6 @@ export class AlertingQueryRunner {
           return setStructureRevision(preProcessed, previous);
         });
 
-        // add link errors to the panelData and mark them as errors
         const [_, linkErrors] = createDAGFromQueriesSafe(queries);
         linkErrors.forEach((linkError) => {
           nextResult[linkError.source] = createLinkErrorPanelData(linkError);
@@ -89,21 +84,19 @@ export class AlertingQueryRunner {
     });
   }
 
-  // this function will omit any invalid queries and all of its descendants from the list of queries
-  // to do this we will convert the list of queries into a DAG and walk the invalid node's output edges recursively
+  // Omits invalid queries and their descendants, walking the query DAG's output edges.
   async prepareQueries(queries: AlertQuery[]): Promise<AlertQuery[]> {
     const queriesToExclude: string[] = [];
 
-    // find all invalid nodes and omit those
     for (const query of queries) {
       const refId = query.model.refId;
 
-      // expression queries cannot be excluded / filtered out
+      // expressions have no data source to validate against, so they're never excluded here
       if (isExpressionQuery(query.model)) {
         continue;
       }
 
-      const dataSourceInstance = await this.dataSourceSrv.get(query.datasourceUid);
+      const dataSourceInstance = await getDataSourceInstance(query.datasourceUid);
       const skipRunningQuery =
         dataSourceInstance instanceof DataSourceWithBackend &&
         dataSourceInstance.filterQuery &&
@@ -114,18 +107,16 @@ export class AlertingQueryRunner {
       }
     }
 
-    // exclude nodes that failed to link and their child nodes from the final queries array by trying to parse the graph
-    // ⚠️ also make sure all dependent nodes are omitted, otherwise we will be evaluating a broken graph with missing references
+    // Descendants of excluded nodes must also be excluded, or we'd evaluate a graph with missing references.
     const [cleanGraph] = createDAGFromQueriesSafe(queries);
     const cleanNodes = Object.keys(cleanGraph.nodes);
 
-    // find descendant nodes of data queries that have been excluded
     queriesToExclude.forEach((refId) => {
       const descendants = getDescendants(refId, cleanGraph);
       queriesToExclude.push(...descendants);
     });
 
-    // also exclude all nodes that aren't in cleanGraph, this means they point to other broken nodes
+    // nodes missing from cleanGraph point to other broken nodes and must be excluded too
     const nodesNotInGraph = queries.filter((query) => !cleanNodes.includes(query.refId));
     nodesNotInGraph.forEach((node) => {
       queriesToExclude.push(node.refId);
@@ -226,8 +217,6 @@ const mapToPanelData = (
 
     for (const [refId, result] of Object.entries(data.results)) {
       const { error, status, frames = [] } = result;
-
-      // extract errors from the /eval results
       const errors = error ? [{ message: error, refId, status }] : [];
 
       results[refId] = {

--- a/public/app/features/alerting/unified/testSetup/datasources.ts
+++ b/public/app/features/alerting/unified/testSetup/datasources.ts
@@ -2,11 +2,13 @@ import { keyBy } from 'lodash';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { config, setDataSourceSrv } from '@grafana/runtime';
+import { initDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 /**
  * Sets up the data sources for the tests.
- * Sets up both config object from grafana/runtime and the data source server
+ * Sets up the config object from grafana/runtime, the legacy data source service and the
+ * settings cache backing the async getDataSourceInstanceSettings API
  * @param configs data source instance settings. Use **mockDataSource** to create mock settings
  */
 export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
@@ -14,9 +16,11 @@ export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
   const datasourceSettings = keyBy(configs, (c) => c.name);
 
   const defaultDatasource = configs.find((c) => c.isDefault);
+  const defaultDatasourceName = defaultDatasource?.name || config.defaultDatasource;
   config.datasources = datasourceSettings;
-  dataSourceSrv.init(config.datasources, defaultDatasource?.name || config.defaultDatasource);
+  dataSourceSrv.init(config.datasources, defaultDatasourceName);
   setDataSourceSrv(dataSourceSrv);
+  initDataSourceInstanceSettings(datasourceSettings, defaultDatasourceName);
 
   return dataSourceSrv;
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { type DataQuery } from '@grafana/schema';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { dashboardDsSettingsMock, ds1SettingsMock, renderWithQueryEditorProvider } from '../testUtils';
 import { type Transformation } from '../types';
@@ -16,12 +17,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ds1SettingsMock);
 
 describe('QueryEditorSidebar', () => {
   afterAll(() => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -14,6 +14,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorSidebar', () => {
   afterAll(() => {
     jest.clearAllMocks();

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { AdHocVariableForm, type AdHocVariableFormProps } from './AdHocVariableForm';
 
@@ -31,12 +32,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('AdHocVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.test.tsx
@@ -29,6 +29,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('AdHocVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -6,6 +6,7 @@ import { VariableSupportType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { GroupByVariableForm, type GroupByVariableFormProps } from './GroupByVariableForm';
@@ -38,12 +39,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableForm', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/GroupByVariableForm.test.tsx
@@ -36,6 +36,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableForm', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -17,6 +17,7 @@ import { setRunRequest } from '@grafana/runtime';
 import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 import { getVariableQueryEditor } from 'app/features/variables/editor/getVariableQueryEditor';
 
@@ -50,12 +51,16 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation((ref) => {
+  const uid = typeof ref === 'string' ? ref : ref?.uid;
+  return uid === promDatasource.uid ? promDatasource : defaultDatasource;
+});
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.test.tsx
@@ -48,6 +48,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { AdHocFiltersVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { type AdHocOriginFiltersController } from '../components/AdHocOriginFiltersController';
@@ -79,6 +80,16 @@ jest.mock('@grafana/runtime', () => ({
     getInstanceSettings: () => ({ ...defaultDatasource }),
   }),
 }));
+
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
+}));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -45,6 +45,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {
     mockBoundingClientRect({

--- a/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.test.tsx
@@ -7,6 +7,7 @@ import { GroupByVariable } from '@grafana/scenes';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { getGroupByVariableOptions, GroupByVariableEditor } from './GroupByVariableEditor';
@@ -47,12 +48,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 describe('GroupByVariableEditor', () => {
   beforeAll(() => {

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -55,6 +55,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({
     state: LoadingState.Done,

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.test.tsx
@@ -18,6 +18,7 @@ import { VariableRefresh, VariableSort } from '@grafana/schema';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { useDatasource } from 'app/features/datasources/hooks';
 import { LegacyVariableQueryEditor } from 'app/features/variables/editor/LegacyVariableQueryEditor';
 
 import { QueryVariableEditor, Editor } from './QueryVariableEditor';
@@ -57,12 +58,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => ({ ...defaultDatasource }));
 
 const runRequestMock = jest.fn().mockReturnValue(
   of<PanelData>({

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -81,6 +81,9 @@ jest.mock('../../hooks', () => {
     ...actual,
     useRecentlyUsedDataSources: () => [[mockDS2.name], pushRecentlyUsedDataSourceMock],
     useDatasources: () => mockDSList,
+    // useDatasource now wraps the async settings API; resolve it synchronously in tests
+    // via the same mock that stands in for the legacy getInstanceSettings lookup.
+    useDatasource: (ref: unknown) => getInstanceSettingsMock(ref),
   };
 });
 

--- a/public/app/features/datasources/hooks.test.ts
+++ b/public/app/features/datasources/hooks.test.ts
@@ -1,15 +1,23 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 import { TestDataSettings } from '../query/state/mocks/mockDataSource';
 
-import { useRecentlyUsedDataSources } from './hooks';
+import { useDatasource, useRecentlyUsedDataSources } from './hooks';
 
-// Mock react-use's useLocalStorage
+// Mock react-use's useLocalStorage while keeping the rest (e.g. useAsync) intact
 jest.mock('react-use', () => ({
+  ...jest.requireActual('react-use'),
   useLocalStorage: jest.fn(),
 }));
 
+jest.mock('@grafana/runtime/unstable', () => ({
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
 const mockUseLocalStorage = jest.requireMock('react-use').useLocalStorage;
+const mockGetDataSourceInstanceSettings = jest.mocked(getDataSourceInstanceSettings);
 
 describe('useRecentlyUsedDataSources', () => {
   let mockSetStorage: jest.Mock;
@@ -110,5 +118,38 @@ describe('useRecentlyUsedDataSources', () => {
       // Should remove the first item and add new one at the end
       expect(mockSetStorage).toHaveBeenCalledWith(['uid2', 'uid3', 'uid4', 'uid5', 'test-uid']);
     });
+  });
+});
+
+describe('useDatasource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should resolve to the settings returned by getDataSourceInstanceSettings', async () => {
+    const settings = { ...TestDataSettings, uid: 'test-uid' };
+    mockGetDataSourceInstanceSettings.mockResolvedValue(settings);
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    await waitFor(() => expect(result.current).toBe(settings));
+  });
+
+  it('should forward the ref and scopedVars to getDataSourceInstanceSettings', async () => {
+    mockGetDataSourceInstanceSettings.mockResolvedValue(undefined);
+    const scopedVars = { ds: { text: 'prometheus', value: 'prometheus' } };
+
+    renderHook(() => useDatasource('$ds', scopedVars));
+
+    await waitFor(() => expect(mockGetDataSourceInstanceSettings).toHaveBeenCalledWith('$ds', scopedVars));
+  });
+
+  it('should return undefined while the lookup is pending', () => {
+    // Never resolves so the hook stays in its loading state.
+    mockGetDataSourceInstanceSettings.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useDatasource('test-uid'));
+
+    expect(result.current).toBeUndefined();
   });
 });

--- a/public/app/features/datasources/hooks.ts
+++ b/public/app/features/datasources/hooks.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type * as React from 'react';
-import { useLocalStorage } from 'react-use';
+import { useAsync, useLocalStorage } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type DataSourceRef, type ScopedVars } from '@grafana/data';
 import { type GetDataSourceListFilters, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 
 const LOCAL_STORAGE_KEY = 'grafana.features.datasources.components.picker.DataSourceDropDown.history';
 
@@ -55,14 +56,18 @@ export function useDatasources(filters: GetDataSourceListFilters, datasources?: 
 export function useDatasource(
   dataSource: string | DataSourceRef | DataSourceInstanceSettings | null | undefined,
   scopedVars?: ScopedVars
-) {
-  const dataSourceSrv = getDataSourceSrv();
+): DataSourceInstanceSettings | undefined {
+  // Compare `dataSource` and `scopedVars` by value so inline objects don't re-trigger the lookup.
+  const refKey = JSON.stringify(dataSource ?? null);
+  const scopedVarsKey = JSON.stringify(scopedVars ?? null);
 
-  if (typeof dataSource === 'string') {
-    return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
-  }
+  const { value } = useAsync(
+    () => getDataSourceInstanceSettings(dataSource, scopedVars),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refKey, scopedVarsKey]
+  );
 
-  return dataSourceSrv.getInstanceSettings(dataSource, scopedVars);
+  return value;
 }
 
 export interface KeyboardNavigatableListProps {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -138,11 +138,9 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it so the tests
+  // below don't trigger a post-render state update for a datasource none of them assert on.
+  useDatasource: jest.fn(),
 }));
 
 jest.mock('app/core/services/context_srv', () => ({

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -136,6 +136,15 @@ jest.mock('@grafana/runtime', () => ({
   usePluginLinks: jest.fn(() => ({ links: [] })),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 jest.mock('app/core/services/context_srv', () => ({
   contextSrv: {
     ...jest.requireActual('app/core/services/context_srv').contextSrv,

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -28,6 +28,15 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/features/datasources/hooks', () => ({
+  ...jest.requireActual('app/features/datasources/hooks'),
+  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
+  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
+  // update escapes act() in these tests.
+  useDatasource: (ref: unknown) =>
+    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+}));
+
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {
     mockBoundingClientRect();

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -6,6 +6,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { useDatasource } from 'app/features/datasources/hooks';
 
 import { type Props, QueryEditorRowHeader } from './QueryEditorRowHeader';
 
@@ -30,12 +31,13 @@ jest.mock('@grafana/runtime', () => ({
 
 jest.mock('app/features/datasources/hooks', () => ({
   ...jest.requireActual('app/features/datasources/hooks'),
-  // useDatasource() is now async (it wraps getDataSourceInstanceSettings). Delegate to the mocked
-  // getDataSourceSrv so the current data source resolves synchronously and no post-render state
-  // update escapes act() in these tests.
-  useDatasource: (ref: unknown) =>
-    jest.requireMock('@grafana/runtime').getDataSourceSrv().getInstanceSettings(ref),
+  // useDatasource() wraps the async getDataSourceInstanceSettings API. Stub it to resolve the
+  // fixture synchronously (wired below — jest.mock factories cannot reference file-scope
+  // variables) so no post-render state update escapes act() in these tests.
+  useDatasource: jest.fn(),
 }));
+
+jest.mocked(useDatasource).mockImplementation(() => mockDS);
 
 describe('QueryEditorRowHeader', () => {
   beforeAll(() => {


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

### What changed?
`AlertingQueryRunner.prepareQueries` resolved its data source instance via the deprecated `DataSourceSrv` singleton injected into the constructor. It now calls `getDataSourceInstance` from `@grafana/runtime/unstable` directly, and the now-unused `dataSourceSrv` constructor parameter has been removed. This was the last `getDataSourceSrv` usage in the class, so no behavioral change is expected - same lookup, different API.