### PR TITLE
Unified storage: fix metric names and swap a summary for a histogram

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -16,7 +16,7 @@ type BleveIndexMetrics struct {
 	IndexBuildFailures   prometheus.Counter
 	IndexBuildSkipped    prometheus.Counter
 	UpdateLatency        prometheus.Histogram
-	UpdatedDocuments     prometheus.Summary
+	UpdatedDocuments     prometheus.Histogram
 	SearchUpdateWaitTime *prometheus.HistogramVec
 	RebuildQueueLength   prometheus.Gauge
 
@@ -40,7 +40,7 @@ var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 5
 func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 	m := &BleveIndexMetrics{
 		IndexSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
-			Name: "index_server_index_size",
+			Name: "index_server_index_size_bytes",
 			Help: "Size of the index in bytes - only for file-based indices",
 		}),
 		IndexedKinds: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
@@ -78,9 +78,12 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		UpdatedDocuments: promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-			Name: "index_server_update_documents",
-			Help: "Number of documents indexed during index update",
+		UpdatedDocuments: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "index_server_update_documents",
+			Help:                            "Number of documents indexed during index update",
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
 		}),
 		SearchUpdateWaitTime: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "index_server_search_update_wait_time_seconds",

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -36,7 +36,7 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
 		ListWithFieldSelectors: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "storage_server_field_selector_search_count",
+			Name: "storage_server_field_selector_search_total",
 			Help: "number of times List was served by field selector search",
 		}, []string{"resource", "served_by"}),
 		RequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1753,7 +1753,7 @@ type bleveIndex struct {
 
 	indexMetrics     *resource.BleveIndexMetrics
 	updateLatency    prometheus.Histogram
-	updatedDocuments prometheus.Summary
+	updatedDocuments prometheus.Histogram
 
 	// Used to detect if the index can be safely closed, if it no longer belongs to this instance. UnixMilli.
 	lastFetchedFromCache atomic.Int64


### PR DESCRIPTION
Three metrics in unified storage did not follow the usual conventions:

1. `storage_server_field_selector_search_count` → `storage_server_field_selector_search_total` — it is a counter
2. `index_server_index_size` → `index_server_index_size_bytes` — its Help already said bytes
3. `index_server_update_documents` — was a summary, now a native histogram

The summary carried no objectives, so it only ever exported `_sum` and `_count`. As a native histogram it keeps both and adds the distribution, and unlike summary quantiles it can be aggregated across instances.

The two renames are breaking for anything querying the old names.