### PR TITLE
Alerting: Migrate triage and
  insights datasource lookups to async DataSource API

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1200,11 +1200,6 @@
       "count": 5
     }
   },
-  "public/app/features/alerting/unified/home/Insights.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/hooks/useAlertmanagerConfig.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -1266,21 +1261,6 @@
   "public/app/features/alerting/unified/testSetup/datasources.ts": {
     "@grafana/no-config-datasources": {
       "count": 2
-    }
-  },
-  "public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
     }
   },
   "public/app/features/alerting/unified/types/alerting.ts": {

--- a/public/app/features/alerting/unified/home/Home.tsx
+++ b/public/app/features/alerting/unified/home/Home.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
+import { useAsync } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Box, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { Box, LoadingPlaceholder, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
 
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { isLocalDevEnv } from '../utils/misc';
@@ -15,12 +16,18 @@ import { getInsightsScenes, insightsIsAvailable } from './Insights';
 import { PluginIntegrations } from './PluginIntegrations';
 import SyntheticMonitoringCard from './SyntheticMonitoringCard';
 
+type HomeTab = 'insights' | 'overview';
+
 function Home() {
   const styles = useStyles2(getStyles);
-  const insightsEnabled = insightsIsAvailable() || isLocalDevEnv();
+  const { value: insights, loading } = useAsync(async () => {
+    const enabled = (await insightsIsAvailable()) || isLocalDevEnv();
+    return { enabled, scene: await getInsightsScenes() };
+  }, []);
 
-  const [activeTab, setActiveTab] = useState<'insights' | 'overview'>(insightsEnabled ? 'insights' : 'overview');
-  const insightsScene = getInsightsScenes();
+  // Availability is only known after the async check, so the default tab cannot be useState's initial value.
+  const [selectedTab, setSelectedTab] = useState<HomeTab>();
+  const activeTab = selectedTab ?? (insights?.enabled ? 'insights' : 'overview');
 
   return (
     <AlertingPageWrapper subTitle="Learn about problems in your systems moments after they occur" navId="alerting">
@@ -34,26 +41,32 @@ function Home() {
         </div>
       </Stack>
       <Box marginTop={2}>
-        <TabsBar>
-          {insightsEnabled && (
-            <Tab
-              key="insights"
-              label={t('alerting.home.label-insights', 'Insights')}
-              active={activeTab === 'insights'}
-              onChangeTab={() => setActiveTab('insights')}
-            />
-          )}
-          <Tab
-            key="overview"
-            label={t('alerting.home.label-get-started', 'Get started')}
-            active={activeTab === 'overview'}
-            onChangeTab={() => setActiveTab('overview')}
-          />
-        </TabsBar>
-        <TabContent className={styles.tabContent}>
-          {activeTab === 'insights' && <insightsScene.Component model={insightsScene} />}
-          {activeTab === 'overview' && <GettingStarted />}
-        </TabContent>
+        {loading ? (
+          <LoadingPlaceholder text={t('alerting.home.text-loading', 'Loading...')} />
+        ) : (
+          <>
+            <TabsBar>
+              {insights?.enabled && (
+                <Tab
+                  key="insights"
+                  label={t('alerting.home.label-insights', 'Insights')}
+                  active={activeTab === 'insights'}
+                  onChangeTab={() => setSelectedTab('insights')}
+                />
+              )}
+              <Tab
+                key="overview"
+                label={t('alerting.home.label-get-started', 'Get started')}
+                active={activeTab === 'overview'}
+                onChangeTab={() => setSelectedTab('overview')}
+              />
+            </TabsBar>
+            <TabContent className={styles.tabContent}>
+              {activeTab === 'insights' && insights && <insights.scene.Component model={insights.scene} />}
+              {activeTab === 'overview' && <GettingStarted />}
+            </TabContent>
+          </>
+        )}
       </Box>
     </AlertingPageWrapper>
   );

--- a/public/app/features/alerting/unified/home/Insights.test.ts
+++ b/public/app/features/alerting/unified/home/Insights.test.ts
@@ -1,0 +1,78 @@
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { NestedScene, SceneFlexItem, SceneFlexLayout } from '@grafana/scenes';
+
+import { mockDataSource } from '../mocks';
+
+import { getInsightsScenes, insightsIsAvailable } from './Insights';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstanceSettings: jest.fn(),
+}));
+
+const getDataSourceInstanceSettingsMock = jest.mocked(getDataSourceInstanceSettings);
+
+const CLOUD_USAGE_UID = 'grafanacloud-usage';
+const ALERT_STATE_HISTORY_UID = 'grafanacloud-alert-state-history';
+const CLOUD_PROM_UID = 'grafanacloud-prom';
+
+function setupAvailableDataSources(...uids: string[]) {
+  getDataSourceInstanceSettingsMock.mockImplementation(async (ref) =>
+    typeof ref === 'string' && uids.includes(ref) ? mockDataSource({ uid: ref }) : undefined
+  );
+}
+
+async function getCategoryTitles() {
+  const body = (await getInsightsScenes()).state.body;
+  if (!(body instanceof SceneFlexLayout)) {
+    throw new Error('Expected the insights scene body to be a SceneFlexLayout');
+  }
+  return body.state.children.map((child) =>
+    child instanceof SceneFlexItem && child.state.body instanceof NestedScene ? child.state.body.state.title : undefined
+  );
+}
+
+describe('insightsIsAvailable', () => {
+  it('resolves to true when the cloud usage data source exists', async () => {
+    setupAvailableDataSources(CLOUD_USAGE_UID);
+
+    await expect(insightsIsAvailable()).resolves.toBe(true);
+    expect(getDataSourceInstanceSettingsMock).toHaveBeenCalledWith(CLOUD_USAGE_UID);
+  });
+
+  it('resolves to false when the cloud usage data source is missing', async () => {
+    setupAvailableDataSources(ALERT_STATE_HISTORY_UID, CLOUD_PROM_UID);
+
+    await expect(insightsIsAvailable()).resolves.toBe(false);
+  });
+});
+
+describe('getInsightsScenes', () => {
+  it('builds every category once all data sources resolve', async () => {
+    setupAvailableDataSources(CLOUD_USAGE_UID, ALERT_STATE_HISTORY_UID, CLOUD_PROM_UID);
+
+    await expect(getCategoryTitles()).resolves.toEqual([
+      'Grafana-managed alert rules',
+      'Grafana Alertmanager',
+      'Mimir-managed alert rules',
+      'Mimir-managed alert rules - per rule group',
+      'Mimir Alertmanager',
+    ]);
+  });
+
+  it('omits the categories whose data sources are missing', async () => {
+    setupAvailableDataSources(CLOUD_USAGE_UID);
+
+    await expect(getCategoryTitles()).resolves.toEqual([
+      'Grafana Alertmanager',
+      'Mimir-managed alert rules - per rule group',
+      'Mimir Alertmanager',
+    ]);
+  });
+
+  it('builds no categories when no data source resolves', async () => {
+    setupAvailableDataSources();
+
+    await expect(getCategoryTitles()).resolves.toEqual([]);
+  });
+});

--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -1,6 +1,7 @@
 import { type DataSourceInstanceSettings, type DataSourceJsonData } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   EmbeddedScene,
   NestedScene,
@@ -98,28 +99,23 @@ export function overrideToFixedColor(key: keyof typeof SERIES_COLOR_MAPPING) {
 
 export const PANEL_STYLES = { minHeight: 300 };
 
-const THIS_WEEK_TIME_RANGE = new SceneTimeRange({ from: 'now-1w', to: 'now' });
-
 const namespace = getAPINamespace();
 
 export const INSTANCE_ID = namespace.includes('stacks-') ? namespace.replace('stacks-', '') : undefined;
 
-const getInsightsDataSources = () => {
-  const dataSourceSrv = getDataSourceSrv();
+/** Resolves `settings` on the module-level descriptors that the scene builders below read. */
+async function loadInsightsDataSourceSettings() {
+  await Promise.all(
+    [ashDs, cloudUsageDs, grafanaCloudPromDs].map(async (ds) => {
+      ds.settings = await getDataSourceInstanceSettings(ds.uid);
+    })
+  );
+}
 
-  [ashDs, cloudUsageDs, grafanaCloudPromDs].forEach((ds) => {
-    ds.settings = dataSourceSrv.getInstanceSettings(ds.uid);
-  });
-  return [ashDs, cloudUsageDs, grafanaCloudPromDs];
-};
+export const insightsIsAvailable = async () => Boolean(await getDataSourceInstanceSettings(cloudUsageDs.uid));
 
-export const insightsIsAvailable = () => {
-  const [_, cloudUsageDs, __] = getInsightsDataSources();
-  return cloudUsageDs.settings;
-};
-
-export function getInsightsScenes() {
-  const [ashDs, cloudUsageDs, grafanaCloudPromDs] = getInsightsDataSources();
+export async function getInsightsScenes() {
+  await loadInsightsDataSourceSettings();
 
   const categories = [];
 
@@ -175,7 +171,7 @@ export function getInsightsScenes() {
   }
 
   return new EmbeddedScene({
-    $timeRange: THIS_WEEK_TIME_RANGE,
+    $timeRange: new SceneTimeRange({ from: 'now-1w', to: 'now' }),
     controls: [
       new SceneReactObject({
         component: SectionSubheader,

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -1,5 +1,5 @@
 import { type DataSourceApi, type MetricFindValue, getDefaultTimeRange } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { AdHocFiltersVariable, EmbeddedScene, SceneTimeRange, SceneVariableSet } from '@grafana/scenes';
 
 import {
@@ -11,18 +11,20 @@ import {
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
   // AdHocFiltersVariable constructor calls getTemplateSrv().getAdhocFilters to patch it.
   // Without this stub it logs "Failed to patch getAdhocFilters".
   getTemplateSrv: () => ({ getAdhocFilters: jest.fn().mockReturnValue([]) }),
 }));
 
-const getDataSourceSrvMock = jest.mocked(getDataSourceSrv);
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getDataSourceInstance: jest.fn(),
+}));
 
-function mockGetDataSourceSrv(dsOverrides: Partial<DataSourceApi> = {}) {
-  getDataSourceSrvMock.mockReturnValue({
-    get: async () => dsOverrides as DataSourceApi,
-  } as ReturnType<typeof getDataSourceSrv>);
+const getDataSourceInstanceMock = jest.mocked(getDataSourceInstance);
+
+function mockDataSourceInstance(dsOverrides: Partial<DataSourceApi> = {}) {
+  getDataSourceInstanceMock.mockResolvedValue(dsOverrides as DataSourceApi);
 }
 
 function activateWithScene(variable: AdHocFiltersVariable) {
@@ -37,7 +39,7 @@ function activateWithScene(variable: AdHocFiltersVariable) {
 describe('tagKeysProviders', () => {
   describe('getGroupByTagKeysProvider', () => {
     it('should show promoted labels first and remaining sorted under All', async () => {
-      mockGetDataSourceSrv({
+      mockDataSourceInstance({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'cluster_name', value: 'cluster_name' },
           { text: 'exported_namespace', value: 'exported_namespace' },
@@ -64,7 +66,7 @@ describe('tagKeysProviders', () => {
     });
 
     it('should return only promoted labels when DS returns no extra keys', async () => {
-      mockGetDataSourceSrv({
+      mockDataSourceInstance({
         getTagKeys: jest.fn().mockResolvedValue([] satisfies MetricFindValue[]),
       });
 
@@ -83,7 +85,7 @@ describe('tagKeysProviders', () => {
 
   describe('getAdHocTagKeysProvider', () => {
     it('should show promoted labels first under Common, then remaining sorted under All', async () => {
-      mockGetDataSourceSrv({
+      mockDataSourceInstance({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'alertstate', value: 'alertstate' },
           { text: 'alertname', value: 'alertname' },
@@ -131,7 +133,7 @@ describe('tagKeysProviders', () => {
   describe('fetchTagValues', () => {
     it('queries the datasource getTagValues with the key and no filters', async () => {
       const getTagValues = jest.fn().mockResolvedValue([{ text: 'platform-monitoring' }] satisfies MetricFindValue[]);
-      mockGetDataSourceSrv({ getTagValues });
+      mockDataSourceInstance({ getTagValues });
 
       const timeRange = getDefaultTimeRange();
       const result = await fetchTagValues(timeRange, 'team');
@@ -144,7 +146,7 @@ describe('tagKeysProviders', () => {
   describe('getAdHocTagValuesProvider', () => {
     it('should return values from datasource', async () => {
       const tagValues: MetricFindValue[] = [{ text: 'firing' }, { text: 'pending' }];
-      mockGetDataSourceSrv({
+      mockDataSourceInstance({
         getTagValues: jest.fn().mockResolvedValue(tagValues),
       });
 
@@ -174,7 +176,7 @@ describe('tagKeysProviders', () => {
         return [];
       });
 
-      mockGetDataSourceSrv({ getTagValues });
+      mockDataSourceInstance({ getTagValues });
 
       const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
       activateWithScene(variable);
@@ -210,7 +212,7 @@ describe('tagKeysProviders', () => {
         return [];
       });
 
-      mockGetDataSourceSrv({ getTagValues });
+      mockDataSourceInstance({ getTagValues });
 
       const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
       activateWithScene(variable);
@@ -252,7 +254,7 @@ describe('tagKeysProviders', () => {
         return [];
       });
 
-      mockGetDataSourceSrv({ getTagValues });
+      mockDataSourceInstance({ getTagValues });
 
       const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
       activateWithScene(variable);
@@ -286,7 +288,7 @@ describe('tagKeysProviders', () => {
         return [];
       });
 
-      mockGetDataSourceSrv({ getTagValues });
+      mockDataSourceInstance({ getTagValues });
 
       const variable = new AdHocFiltersVariable({ name: 'filters', datasource: { uid: 'test' } });
       activateWithScene(variable);
@@ -307,7 +309,7 @@ describe('tagKeysProviders', () => {
 
   describe('edge cases', () => {
     it('should return promoted labels only when DS lacks getTagKeys', async () => {
-      mockGetDataSourceSrv({});
+      mockDataSourceInstance({});
 
       const variable = new AdHocFiltersVariable({ name: 'groupBy', datasource: { uid: 'test' } });
       activateWithScene(variable);

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -1,6 +1,6 @@
 import { type MetricFindValue, type TimeRange } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { type AdHocFilterWithLabels, type AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
 
 import { COMBINED_FILTER_LABEL_KEYS, DATASOURCE_UID, METRIC_NAME } from '../constants';
@@ -42,7 +42,7 @@ const metricQuery: PromQuery = { refId: 'keys', expr: METRIC_NAME };
  * scoped to the GRAFANA_ALERTS metric.
  */
 async function fetchTagKeys(timeRange: TimeRange): Promise<MetricFindValue[]> {
-  const ds = await getDataSourceSrv().get({ uid: DATASOURCE_UID });
+  const ds = await getDataSourceInstance({ uid: DATASOURCE_UID });
 
   if (!ds.getTagKeys) {
     return [];
@@ -59,7 +59,7 @@ async function fetchTagKeys(timeRange: TimeRange): Promise<MetricFindValue[]> {
  * scoped to the GRAFANA_ALERTS metric.
  */
 export async function fetchTagValues(timeRange: TimeRange, key: string): Promise<MetricFindValue[]> {
-  const ds = await getDataSourceSrv().get({ uid: DATASOURCE_UID });
+  const ds = await getDataSourceInstance({ uid: DATASOURCE_UID });
 
   if (!ds.getTagValues) {
     return [];

--- a/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
+++ b/public/app/features/alerting/unified/triage/scene/useLabelsBreakdown.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { type DateTime } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstance } from '@grafana/runtime/unstable';
 import { useTimeRange } from '@grafana/scenes-react';
 
 import { useAsync } from '../../hooks/useAsync';
@@ -48,7 +48,7 @@ export function useLabelsBreakdown(): {
   const [timeRange] = useTimeRange();
 
   const [{ execute }, state] = useAsync(async (matchSelector: string, start: string, end: string) => {
-    const ds = await getDataSourceSrv().get({ uid: DATASOURCE_UID });
+    const ds = await getDataSourceInstance({ uid: DATASOURCE_UID });
     if (!isPrometheusDatasource(ds)) {
       throw new Error(`Expected a Prometheus datasource but got "${ds.type}"`);
     }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1600,7 +1600,8 @@
       "synthetic-monitoring-card-item-2": "Run ping, DNS, HTTP/S, and TCP checks at every network layer.",
       "synthetic-monitoring-card-item-3": "Use 20+ global probes or private probes behind your firewall.",
       "synthetic-monitoring-card-item-4": "Track SLOs with built-in Prometheus-style alerts — right from the UI.",
-      "synthetic-monitoring-card-title": "Synthetic Monitoring"
+      "synthetic-monitoring-card-title": "Synthetic Monitoring",
+      "text-loading": "Loading..."
     },
     "import-to-gma": {
       "action-button": "Import",


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

### What changed?

Migrating `getDataSourceSrv()` calls to the new async `getDataSourceInstance` / `getDataSourceInstanceSettings` APIs from `@grafana/runtime/unstable`.