### PR TITLE
Alerting: Migrate rule-editor query components to async DataSource API

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1074,9 +1074,6 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
@@ -1092,23 +1089,12 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    },
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
@@ -1134,11 +1120,6 @@
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/CloudDataSourceSelector.tsx": {
     "@grafana/require-no-margin": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx": {
-    "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
@@ -73,7 +73,7 @@ describe('ExpressionEditor', () => {
   });
 
   it('renders the query editor with the current expression once the data source resolves', () => {
-    const QueryEditor = jest.fn(() => <div data-testid="query-editor" />);
+    const QueryEditor = jest.fn((_props: Record<string, unknown>) => <div data-testid="query-editor" />);
     jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
       isLoading: false,
       dataSource: {

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.test.tsx
@@ -1,0 +1,101 @@
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
+import * as runtimeUnstable from '@grafana/runtime/unstable';
+
+import { getDefaultFormValues } from '../../rule-editor/formDefaults';
+import { type RuleFormValues } from '../../types/rule-form';
+
+import { ExpressionEditor, type ExpressionEditorProps } from './ExpressionEditor';
+
+const DATASOURCE_NAME = 'My Prometheus';
+const DATASOURCE_UID = 'prom-uid';
+
+function FormWrapper(props: ExpressionEditorProps) {
+  const formApi = useForm<RuleFormValues>({ defaultValues: getDefaultFormValues() });
+
+  return (
+    <FormProvider {...formApi}>
+      <ExpressionEditor {...props} />
+    </FormProvider>
+  );
+}
+
+function renderEditor(props: Partial<ExpressionEditorProps> = {}) {
+  return render(
+    <FormWrapper
+      value="up"
+      onChange={jest.fn()}
+      dataSourceName={DATASOURCE_NAME}
+      showPreviewAlertsButton={false}
+      {...props}
+    />
+  );
+}
+
+describe('ExpressionEditor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders nothing while the data source instance or its settings are loading', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({ isLoading: true });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({ isLoading: true });
+
+    const { container } = renderEditor();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows an error message when the data source type is not supported as an expression editor', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
+      isLoading: false,
+      dataSource: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'elasticsearch',
+        components: { QueryEditor: () => null },
+      } as unknown as DataSourceApi,
+    });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'elasticsearch',
+      } as unknown as DataSourceInstanceSettings,
+    });
+
+    const { container } = renderEditor();
+
+    expect(container).toHaveTextContent('elasticsearch is not supported as an expression editor');
+  });
+
+  it('renders the query editor with the current expression once the data source resolves', () => {
+    const QueryEditor = jest.fn(() => <div data-testid="query-editor" />);
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
+      isLoading: false,
+      dataSource: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'prometheus',
+        components: { QueryEditor },
+      } as unknown as DataSourceApi,
+    });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'prometheus',
+      } as unknown as DataSourceInstanceSettings,
+    });
+
+    renderEditor({ value: 'up == 1' });
+
+    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+    const [props] = QueryEditor.mock.calls[0];
+    expect(props).toMatchObject({ query: { refId: 'A', hide: false, expr: 'up == 1' } });
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
@@ -142,7 +142,7 @@ function mapToValue(query: DataQuery): string {
   return (query as PromQuery | LokiQuery).expr;
 }
 
-function mapToQuery(existing: DataQuery, value: string | undefined): DataQuery {
+function mapToQuery(existing: DataQuery, value: string | undefined) {
   return { ...existing, expr: value };
 }
 

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionEditor.tsx
@@ -1,12 +1,17 @@
 import { css } from '@emotion/css';
 import { noop } from 'lodash';
-import { useCallback, useMemo } from 'react';
-import { useAsync } from 'react-use';
+import { useCallback } from 'react';
 
-import { CoreApp, DataSourcePluginContextProvider, type GrafanaTheme2, LoadingState } from '@grafana/data';
+import {
+  CoreApp,
+  type DataSourceInstanceSettings,
+  DataSourcePluginContextProvider,
+  type GrafanaTheme2,
+  LoadingState,
+} from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { type PromQuery } from '@grafana/prometheus';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { Alert, Button, useStyles2 } from '@grafana/ui';
 
@@ -31,23 +36,21 @@ export const ExpressionEditor = ({
 }: ExpressionEditorProps) => {
   const styles = useStyles2(getStyles);
 
-  const { mapToValue, mapToQuery } = useQueryMappers(dataSourceName);
+  const {
+    settings: dsi,
+    isLoading: settingsLoading,
+    error: settingsError,
+  } = useExpressionDataSourceSettings(dataSourceName);
 
   const dataQuery = mapToQuery({ refId: 'A', hide: false }, value);
 
-  const {
-    error,
-    loading,
-    value: dataSource,
-  } = useAsync(() => {
-    return getDataSourceSrv().get(dataSourceName);
-  }, [dataSourceName]);
+  const { error: dsError, isLoading: dsLoading, dataSource } = useDataSourceInstance(dataSourceName);
 
   const onChangeQuery = useCallback(
     (query: DataQuery) => {
       onChange(mapToValue(query));
     },
-    [onChange, mapToValue]
+    [onChange]
   );
 
   const [alertPreview, onPreview] = usePreview();
@@ -56,15 +59,14 @@ export const ExpressionEditor = ({
     onPreview();
   };
 
-  if (loading || dataSource?.name !== dataSourceName) {
+  if (dsLoading || settingsLoading || dataSource?.name !== dataSourceName) {
     return null;
   }
 
-  const dsi = getDataSourceSrv().getInstanceSettings(dataSourceName);
-
-  if (error || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
+  if (dsError || settingsError || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
     const errorMessage =
-      error?.message ||
+      dsError?.message ||
+      settingsError?.message ||
       t(
         'alerting.expression-editor.error-no-component',
         'Data source plugin does not export any Query Editor component'
@@ -136,25 +138,29 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-type QueryMappers<T extends DataQuery = DataQuery> = {
-  mapToValue: (query: T) => string;
-  mapToQuery: (existing: T, value: string | undefined) => T;
-};
+function mapToValue(query: DataQuery): string {
+  return (query as PromQuery | LokiQuery).expr;
+}
 
-function useQueryMappers(dataSourceName: string): QueryMappers {
-  return useMemo(() => {
-    const settings = getDataSourceSrv().getInstanceSettings(dataSourceName);
-    if (!settings) {
-      throw new Error(`Datasource ${dataSourceName} not found`);
-    }
+function mapToQuery(existing: DataQuery, value: string | undefined): DataQuery {
+  return { ...existing, expr: value };
+}
 
-    if (!isSupportedExternalRulesSourceType(settings.type)) {
-      throw new Error(`${settings.type} is not supported as an expression editor`);
-    }
+interface ExpressionDataSourceSettings {
+  settings?: DataSourceInstanceSettings;
+  isLoading: boolean;
+  error?: Error;
+}
 
-    return {
-      mapToValue: (query: DataQuery) => (query as PromQuery | LokiQuery).expr,
-      mapToQuery: (existing: DataQuery, value: string | undefined) => ({ ...existing, expr: value }),
-    };
-  }, [dataSourceName]);
+// Only prometheus/loki-flavored data sources have an expression editor; surface anything else as an error.
+function useExpressionDataSourceSettings(dataSourceName: string): ExpressionDataSourceSettings {
+  const { settings, isLoading, error } = useDataSourceInstanceSettings(dataSourceName);
+
+  if (error || isLoading || !settings) {
+    return { settings, isLoading, error };
+  }
+  if (!isSupportedExternalRulesSourceType(settings.type)) {
+    return { settings, isLoading, error: new Error(`${settings.type} is not supported as an expression editor`) };
+  }
+  return { settings, isLoading };
 }

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
@@ -7,7 +7,7 @@ import { takeWhile } from 'rxjs/operators';
 
 import { type GrafanaTheme2, LoadingState, dateTimeFormatISO } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { Alert, Button, Stack, useStyles2 } from '@grafana/ui';
 
 import { previewAlertRule } from '../../api/preview';
@@ -68,9 +68,9 @@ export function usePreview(): [PreviewRuleResponse | undefined, () => void] {
   const { getValues } = useFormContext<RuleFormValues>();
   const isMounted = useMountedState();
 
-  const onPreview = useCallback(() => {
+  const onPreview = useCallback(async () => {
     const values = getValues(fields);
-    const request = createPreviewRequest(values);
+    const request = await createPreviewRequest(values);
 
     previewAlertRule(request)
       .pipe(takeWhile((response) => !isCompleted(response), true))
@@ -85,9 +85,9 @@ export function usePreview(): [PreviewRuleResponse | undefined, () => void] {
   return [preview, onPreview];
 }
 
-function createPreviewRequest(values: any[]): PreviewRuleRequest {
+async function createPreviewRequest(values: any[]): Promise<PreviewRuleRequest> {
   const [type, dataSourceName, condition, queries, expression] = values;
-  const dsSettings = getDataSourceSrv().getInstanceSettings(dataSourceName);
+  const dsSettings = await getDataSourceInstanceSettings(dataSourceName);
   if (!dsSettings) {
     throw new Error(`Cannot find data source settings for ${dataSourceName}`);
   }

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.test.tsx
@@ -1,5 +1,5 @@
 import { type PropsWithChildren } from 'react';
-import { render, screen } from 'test/test-utils';
+import { fireEvent, render, screen } from 'test/test-utils';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import * as runtimeUnstable from '@grafana/runtime/unstable';
@@ -7,8 +7,14 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { QueryRows } from './QueryRows';
 
+const NEW_DATASOURCE_SETTINGS = { uid: 'new-uid', type: 'prometheus' } as unknown as DataSourceInstanceSettings;
+
 jest.mock('./QueryWrapper', () => ({
-  QueryWrapper: () => <div data-testid="query-wrapper" />,
+  QueryWrapper: ({ onChangeDataSource }: { onChangeDataSource: (settings: DataSourceInstanceSettings) => void }) => (
+    <div data-testid="query-wrapper">
+      <button data-testid="change-datasource" onClick={() => onChangeDataSource(NEW_DATASOURCE_SETTINGS)} />
+    </div>
+  ),
   EmptyQueryWrapper: ({ children }: PropsWithChildren) => <div>{children}</div>,
 }));
 
@@ -68,5 +74,52 @@ describe('QueryRows', () => {
     renderQueryRows();
 
     expect(screen.getByTestId('query-wrapper')).toBeInTheDocument();
+  });
+
+  it('shows a retryable load error instead of the removed-datasource card when the settings lookup fails', async () => {
+    const reloadSpy = jest.spyOn(runtimeUnstable, 'reloadDataSourceInstanceSettings').mockResolvedValue();
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      error: new Error('backend unreachable'),
+    });
+
+    const { container, user } = renderQueryRows();
+
+    expect(container).toHaveTextContent('Could not load datasource');
+    expect(container).toHaveTextContent('backend unreachable');
+    expect(screen.queryByText('This datasource has been removed')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies a datasource change synchronously using the already-resolved previous settings', () => {
+    const onQueriesChange = jest.fn();
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: { uid: DATASOURCE_UID, type: 'prometheus' } as unknown as DataSourceInstanceSettings,
+    });
+
+    render(
+      <QueryRows
+        queries={[QUERY]}
+        expressions={[]}
+        data={{}}
+        onRunQueries={jest.fn()}
+        onQueriesChange={onQueriesChange}
+        onDuplicateQuery={jest.fn()}
+        condition={null}
+        onSetCondition={jest.fn()}
+      />
+    );
+
+    // fireEvent (unlike userEvent) does not await a microtask, so a callback that still needed to
+    // fetch the previous settings would not have updated onQueriesChange by this point.
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(screen.getByTestId('change-datasource'));
+
+    expect(onQueriesChange).toHaveBeenCalledTimes(1);
+    const [updatedQueries] = onQueriesChange.mock.calls[0];
+    expect(updatedQueries[0].datasourceUid).toBe(NEW_DATASOURCE_SETTINGS.uid);
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.test.tsx
@@ -1,0 +1,72 @@
+import { type PropsWithChildren } from 'react';
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceInstanceSettings } from '@grafana/data';
+import * as runtimeUnstable from '@grafana/runtime/unstable';
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { QueryRows } from './QueryRows';
+
+jest.mock('./QueryWrapper', () => ({
+  QueryWrapper: () => <div data-testid="query-wrapper" />,
+  EmptyQueryWrapper: ({ children }: PropsWithChildren) => <div>{children}</div>,
+}));
+
+const DATASOURCE_UID = 'ds-uid';
+
+const QUERY: AlertQuery = {
+  refId: 'A',
+  datasourceUid: DATASOURCE_UID,
+  queryType: '',
+  model: { refId: 'A' },
+};
+
+function renderQueryRows() {
+  return render(
+    <QueryRows
+      queries={[QUERY]}
+      expressions={[]}
+      data={{}}
+      onRunQueries={jest.fn()}
+      onQueriesChange={jest.fn()}
+      onDuplicateQuery={jest.fn()}
+      condition={null}
+      onSetCondition={jest.fn()}
+    />
+  );
+}
+
+describe('QueryRows', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders nothing for a row while its data source settings are loading', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({ isLoading: true });
+
+    renderQueryRows();
+
+    expect(screen.queryByTestId('query-wrapper')).not.toBeInTheDocument();
+    expect(screen.queryByText('This datasource has been removed')).not.toBeInTheDocument();
+  });
+
+  it('shows the datasource-not-found card once loading settles with no settings resolved', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({ isLoading: false });
+
+    renderQueryRows();
+
+    expect(screen.getByText('This datasource has been removed')).toBeInTheDocument();
+    expect(screen.queryByTestId('query-wrapper')).not.toBeInTheDocument();
+  });
+
+  it('renders the query editor once the data source settings resolve', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: { uid: DATASOURCE_UID, type: 'prometheus' } as unknown as DataSourceInstanceSettings,
+    });
+
+    renderQueryRows();
+
+    expect(screen.getByTestId('query-wrapper')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -11,7 +11,7 @@ import {
   rangeUtil,
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceInstanceSettings, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
+import { reloadDataSourceInstanceSettings, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { Button, Card, Icon, Stack } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
@@ -28,10 +28,6 @@ import {
   errorFromPreviewData,
   getThresholdsForQueries,
 } from './util';
-
-function getDataSourceSettings(query: AlertQuery): Promise<DataSourceInstanceSettings | undefined> {
-  return getDataSourceInstanceSettings(query.datasourceUid);
-}
 
 interface Props {
   queries: AlertQuery[];
@@ -90,9 +86,14 @@ export const QueryRows = ({
     );
   };
 
-  const onChangeDataSource = async (settings: DataSourceInstanceSettings, index: number) => {
-    const previousSettings = await getDataSourceSettings(queries[index]);
-
+  // previousSettings is the resolved settings QueryRowItem already has for this row (via its own
+  // useDataSourceInstanceSettings) — passed in rather than re-fetched, so this stays synchronous
+  // and cannot apply a stale result if the row's queries change before a fetch would resolve.
+  const onChangeDataSource = (
+    settings: DataSourceInstanceSettings,
+    index: number,
+    previousSettings?: DataSourceInstanceSettings
+  ) => {
     const updatedQueries = queries.map((item, itemIndex) => {
       if (itemIndex !== index) {
         return item;
@@ -193,7 +194,11 @@ interface QueryRowItemProps {
   threshold?: ThresholdDefinition;
   onChangeQuery: (query: DataQuery, index: number) => void;
   onRemoveQuery: (query: DataQuery) => void;
-  onChangeDataSource: (settings: DataSourceInstanceSettings, index: number) => void;
+  onChangeDataSource: (
+    settings: DataSourceInstanceSettings,
+    index: number,
+    previousSettings?: DataSourceInstanceSettings
+  ) => void;
   onDuplicateQuery: (query: AlertQuery) => void;
   onChangeTimeRange: (timeRange: RelativeTimeRange, index: number) => void;
   onChangeQueryOptions: (options: AlertQueryOptions, index: number) => void;
@@ -217,10 +222,26 @@ const QueryRowItem = ({
   onRunQueries,
   onSetCondition,
 }: QueryRowItemProps) => {
-  const { settings: dsSettings, isLoading: isDsSettingsLoading } = useDataSourceInstanceSettings(query.datasourceUid);
+  const {
+    settings: dsSettings,
+    isLoading: isDsSettingsLoading,
+    error: dsSettingsError,
+  } = useDataSourceInstanceSettings(query.datasourceUid);
 
   if (isDsSettingsLoading) {
     return null;
+  }
+
+  if (dsSettingsError) {
+    return (
+      <DataSourceLoadError
+        index={index}
+        model={query.model}
+        error={dsSettingsError}
+        onRetry={() => reloadDataSourceInstanceSettings()}
+        onRemoveQuery={() => onRemoveQuery(query)}
+      />
+    );
   }
 
   if (!dsSettings) {
@@ -252,7 +273,7 @@ const QueryRowItem = ({
       onChangeQuery={onChangeQuery}
       onRemoveQuery={onRemoveQuery}
       queries={queries}
-      onChangeDataSource={onChangeDataSource}
+      onChangeDataSource={(newSettings) => onChangeDataSource(newSettings, index, dsSettings)}
       onDuplicateQuery={onDuplicateQuery}
       onChangeTimeRange={onChangeTimeRange}
       onChangeQueryOptions={onChangeQueryOptions}
@@ -363,6 +384,42 @@ const DatasourceNotFound = ({ index, onUpdateDatasource, onRemoveQuery, model }:
             </pre>
           </div>
         )}
+      </QueryOperationRow>
+    </EmptyQueryWrapper>
+  );
+};
+
+interface DataSourceLoadErrorProps {
+  index: number;
+  model: AlertDataQuery;
+  error: Error;
+  onRetry: () => void;
+  onRemoveQuery: () => void;
+}
+
+const DataSourceLoadError = ({ index, model, error, onRetry, onRemoveQuery }: DataSourceLoadErrorProps) => {
+  const refId = model.refId;
+
+  return (
+    <EmptyQueryWrapper>
+      <QueryOperationRow title={refId} draggable index={index} id={refId} isOpen collapsable={false}>
+        <Card noMargin>
+          <Card.Heading>
+            <Trans i18nKey="alerting.data-source-load-error.title">Could not load datasource</Trans>
+          </Card.Heading>
+          <Card.Description>{error.message}</Card.Description>
+          <Card.Figure>
+            <Icon name="exclamation-triangle" />
+          </Card.Figure>
+          <Card.Actions>
+            <Button key="retry" variant="secondary" onClick={onRetry}>
+              <Trans i18nKey="alerting.data-source-load-error.retry">Retry</Trans>
+            </Button>
+            <Button key="remove" variant="destructive" onClick={onRemoveQuery}>
+              <Trans i18nKey="alerting.data-source-load-error.remove-query">Remove query</Trans>
+            </Button>
+          </Card.Actions>
+        </Card>
       </QueryOperationRow>
     </EmptyQueryWrapper>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -11,7 +11,7 @@ import {
   rangeUtil,
 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceInstanceSettings, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { Button, Card, Icon, Stack } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
@@ -29,18 +29,15 @@ import {
   getThresholdsForQueries,
 } from './util';
 
-function getDataSourceSettings(query: AlertQuery): DataSourceInstanceSettings | undefined {
-  return getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+function getDataSourceSettings(query: AlertQuery): Promise<DataSourceInstanceSettings | undefined> {
+  return getDataSourceInstanceSettings(query.datasourceUid);
 }
 
 interface Props {
-  // The query configuration
   queries: AlertQuery[];
   expressions: AlertQuery[];
   data: Record<string, PanelData>;
   onRunQueries: () => void;
-
-  // Query editing
   onQueriesChange: (queries: AlertQuery[]) => void;
   onDuplicateQuery: (query: AlertQuery) => void;
   condition: string | null;
@@ -93,13 +90,13 @@ export const QueryRows = ({
     );
   };
 
-  const onChangeDataSource = (settings: DataSourceInstanceSettings, index: number) => {
+  const onChangeDataSource = async (settings: DataSourceInstanceSettings, index: number) => {
+    const previousSettings = await getDataSourceSettings(queries[index]);
+
     const updatedQueries = queries.map((item, itemIndex) => {
       if (itemIndex !== index) {
         return item;
       }
-
-      const previousSettings = getDataSourceSettings(item);
 
       // Copy model if changing to a datasource of same type.
       if (settings.type === previousSettings?.type) {
@@ -220,7 +217,11 @@ const QueryRowItem = ({
   onRunQueries,
   onSetCondition,
 }: QueryRowItemProps) => {
-  const dsSettings = getDataSourceSettings(query);
+  const { settings: dsSettings, isLoading: isDsSettingsLoading } = useDataSourceInstanceSettings(query.datasourceUid);
+
+  if (isDsSettingsLoading) {
+    return null;
+  }
 
   if (!dsSettings) {
     return (

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
@@ -17,7 +17,7 @@ const QUERY: AlertQuery = {
   refId: 'A',
   datasourceUid: DATASOURCE_UID,
   queryType: '',
-  model: { refId: 'A', expr: 'up' },
+  model: { refId: 'A', expression: 'up' },
 };
 
 function renderEditor(props: Partial<RecordingRuleEditorProps> = {}) {
@@ -70,7 +70,7 @@ describe('RecordingRuleEditor', () => {
   });
 
   it('renders the query editor with the first query once the data source resolves', () => {
-    const QueryEditor = jest.fn(() => <div data-testid="query-editor" />);
+    const QueryEditor = jest.fn((_props: Record<string, unknown>) => <div data-testid="query-editor" />);
     jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
       isLoading: false,
       dataSource: {

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from 'test/test-utils';
+
+import { type DataSourceApi, type DataSourceInstanceSettings } from '@grafana/data';
+import * as runtimeUnstable from '@grafana/runtime/unstable';
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { RecordingRuleEditor, type RecordingRuleEditorProps } from './RecordingRuleEditor';
+
+jest.mock('./VizWrapper', () => ({
+  VizWrapper: () => <div data-testid="viz-wrapper" />,
+}));
+
+const DATASOURCE_NAME = 'My Loki';
+const DATASOURCE_UID = 'loki-uid';
+
+const QUERY: AlertQuery = {
+  refId: 'A',
+  datasourceUid: DATASOURCE_UID,
+  queryType: '',
+  model: { refId: 'A', expr: 'up' },
+};
+
+function renderEditor(props: Partial<RecordingRuleEditorProps> = {}) {
+  return render(
+    <RecordingRuleEditor
+      queries={[QUERY]}
+      onChangeQuery={jest.fn()}
+      runQueries={jest.fn()}
+      panelData={{}}
+      dataSourceName={DATASOURCE_NAME}
+      {...props}
+    />
+  );
+}
+
+describe('RecordingRuleEditor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders nothing while the data source instance is still loading', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({ isLoading: true });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({ isLoading: true });
+
+    const { container } = renderEditor();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows an error message when the resolved data source has no query editor component', () => {
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
+      isLoading: false,
+      dataSource: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'loki',
+        components: {},
+      } as unknown as DataSourceApi,
+    });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: { name: DATASOURCE_NAME, uid: DATASOURCE_UID, type: 'loki' } as unknown as DataSourceInstanceSettings,
+    });
+
+    const { container } = renderEditor();
+
+    expect(container).toHaveTextContent(
+      'Could not load query editor due to: Data source plugin does not export any Query Editor component'
+    );
+  });
+
+  it('renders the query editor with the first query once the data source resolves', () => {
+    const QueryEditor = jest.fn(() => <div data-testid="query-editor" />);
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstance').mockReturnValue({
+      isLoading: false,
+      dataSource: {
+        name: DATASOURCE_NAME,
+        uid: DATASOURCE_UID,
+        type: 'loki',
+        components: { QueryEditor },
+      } as unknown as DataSourceApi,
+    });
+    jest.spyOn(runtimeUnstable, 'useDataSourceInstanceSettings').mockReturnValue({
+      isLoading: false,
+      settings: { name: DATASOURCE_NAME, uid: DATASOURCE_UID, type: 'loki' } as unknown as DataSourceInstanceSettings,
+    });
+
+    renderEditor();
+
+    expect(screen.getByTestId('query-editor')).toBeInTheDocument();
+    const [props] = QueryEditor.mock.calls[0];
+    expect(props).toMatchObject({ query: QUERY, queries: [QUERY] });
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RecordingRuleEditor.tsx
@@ -1,10 +1,9 @@
 import { css } from '@emotion/css';
 import { type FC, useCallback, useEffect, useState } from 'react';
-import { useAsync } from 'react-use';
 
 import { CoreApp, type GrafanaTheme2, LoadingState, type PanelData } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { useDataSourceInstance, useDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type DataQuery } from '@grafana/schema';
 import { useStyles2 } from '@grafana/ui';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
@@ -44,13 +43,8 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     setData(panelData?.[queries[0]?.refId]);
   }, [panelData, queries]);
 
-  const {
-    error,
-    loading,
-    value: dataSource,
-  } = useAsync(() => {
-    return getDataSourceSrv().get(dataSourceName);
-  }, [dataSourceName]);
+  const { error: dsError, isLoading: dsLoading, dataSource } = useDataSourceInstance(dataSourceName);
+  const { settings: dsi, isLoading: dsiLoading } = useDataSourceInstanceSettings(dataSourceName);
 
   const handleChangedQuery = useCallback(
     (changedQuery: DataQuery) => {
@@ -73,13 +67,9 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
           datasource: changedQuery.datasource,
           refId: changedQuery.refId,
           editorMode: changedQuery.editorMode,
-          // Instant and range are used by Prometheus queries
           instant: changedQuery.instant,
           range: changedQuery.range,
-          // Query type is used by Loki queries
-          // On first render/when creating a recording rule, the query type is not set
-          // unless the user has changed it betwee range/instant. The cleanest way to handle this
-          // is to default to instant, or whatever the changed type is
+          // Loki queryType defaults to instant until the user picks range/instant explicitly.
           queryType: isLoki ? changedQuery.queryType || LokiQueryType.Instant : changedQuery.queryType,
           legendFormat: changedQuery.legendFormat,
         },
@@ -89,14 +79,12 @@ export const RecordingRuleEditor: FC<RecordingRuleEditorProps> = ({
     [dataSource, queries, onChangeQuery]
   );
 
-  if (loading || dataSource?.name !== dataSourceName) {
+  if (dsLoading || dsiLoading || dataSource?.name !== dataSourceName) {
     return null;
   }
 
-  const dsi = getDataSourceSrv().getInstanceSettings(dataSourceName);
-
-  if (error || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
-    const errorMessage = error?.message || 'Data source plugin does not export any Query Editor component';
+  if (dsError || !dataSource || !dataSource?.components?.QueryEditor || !dsi) {
+    const errorMessage = dsError?.message || 'Data source plugin does not export any Query Editor component';
     return (
       <div>
         <Trans i18nKey="alerting.recording-rule-editor.error-no-query-editor">

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -7,7 +7,8 @@ import { useEffectOnce } from 'react-use';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   Alert,
   Button,
@@ -251,18 +252,15 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   const updateExpressionAndDatasource = useSetExpressionAndDataSource();
 
   const onChangeQueries = useCallback(
-    (updatedQueries: AlertQuery[]) => {
-      // Most data sources triggers onChange and onRunQueries consecutively
-      // It means our reducer state is always one step behind when runQueries is invoked
-      // Invocation cycle => onChange -> dispatch(setDataQueries) -> onRunQueries -> setDataQueries Reducer
-      // As a workaround we update form values as soon as possible to avoid stale state
-      // This way we can access up to date queries in runQueriesPreview without waiting for re-render
+    async (updatedQueries: AlertQuery[]) => {
+      // onRunQueries fires right after onChange, before the reducer reflects updatedQueries —
+      // update form values now so runQueriesPreview reads fresh data instead of stale state.
       const previousQueries = getValues('queries');
 
       const expressionQueries = previousQueries.filter<AlertQuery<ExpressionQuery>>(isExpressionQueryInAlert);
 
       setValue('queries', [...updatedQueries, ...expressionQueries], { shouldValidate: false });
-      updateExpressionAndDatasource(updatedQueries);
+      await updateExpressionAndDatasource(updatedQueries);
 
       // we only remove or add the reducer(optimize reducer) expression when creating a new alert.
       // When editing an alert, we assume the user wants to manually adjust expressions and queries for more control and customization.
@@ -283,7 +281,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   );
 
   const onChangeRecordingRulesQueries = useCallback(
-    (updatedQueries: AlertQuery[]) => {
+    async (updatedQueries: AlertQuery[]) => {
       const query = updatedQueries[0];
 
       if (!isPromOrLokiQuery(query.model)) {
@@ -293,7 +291,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       const expression = query.model.expr;
 
       setValue('queries', updatedQueries, { shouldValidate: false });
-      updateExpressionAndDatasource(updatedQueries);
+      await updateExpressionAndDatasource(updatedQueries);
 
       dispatch(setRecordingRulesQueries({ recordingRuleQueries: updatedQueries, expression }));
       runQueriesPreview();
@@ -327,12 +325,12 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   //when data source is changed in the cloud selector we need to update the queries in the reducer
 
   const onChangeCloudDatasource = useCallback(
-    (datasourceUid: string) => {
+    async (datasourceUid: string) => {
       const newQueries = cloneDeep(queries);
       newQueries[0].datasourceUid = datasourceUid;
       setValue('queries', newQueries, { shouldValidate: false });
 
-      updateExpressionAndDatasource(newQueries);
+      await updateExpressionAndDatasource(newQueries);
 
       dispatch(setDataQueries(newQueries));
     },
@@ -342,7 +340,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   // ExpressionEditor for cloud query needs to update queries in the reducer and in the form
   // otherwise the value is not updated for Grafana managed alerts
 
-  const onChangeExpression = (value: string) => {
+  const onChangeExpression = async (value: string) => {
     const newQueries = cloneDeep(queries);
 
     if (newQueries[0].model) {
@@ -361,7 +359,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
 
     setValue('queries', newQueries, { shouldValidate: false });
 
-    updateExpressionAndDatasource(newQueries);
+    await updateExpressionAndDatasource(newQueries);
 
     dispatch(setDataQueries(newQueries));
     runQueriesPreview();
@@ -382,7 +380,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     addExpressionsInQueries(prevExpressions);
   }, [prevExpressions, addExpressionsInQueries]);
 
-  const onClickSwitch = useCallback(() => {
+  const onClickSwitch = useCallback(async () => {
     const typeInForm = getValues('type');
     if (typeInForm === RuleFormType.cloudAlerting) {
       setValue('type', RuleFormType.grafana);
@@ -392,14 +390,13 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       prevCondition && setValue('condition', prevCondition);
     } else {
       setValue('type', RuleFormType.cloudAlerting);
-      // dataSourceName is used only by Mimir/Loki alerting and recording rules
-      // It should be empty for Grafana managed alert rules
-      const newDsName = getDataSourceSrv().getInstanceSettings(queries[0].datasourceUid)?.name;
+      // dataSourceName only applies to Mimir/Loki rules — resolve it now, leave empty otherwise.
+      const newDsName = (await getDataSourceInstanceSettings(queries[0].datasourceUid))?.name;
       if (newDsName) {
         setValue('dataSourceName', newDsName);
       }
 
-      updateExpressionAndDatasource(queries);
+      await updateExpressionAndDatasource(queries);
 
       const expressions = queries.filter((query) => query.datasourceUid === ExpressionDatasourceUID);
       setPrevExpressions(expressions);
@@ -731,14 +728,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
 const useSetExpressionAndDataSource = () => {
   const { setValue } = useFormContext<RuleFormValues>();
 
-  return (updatedQueries: AlertQuery[]) => {
-    // update data source name and expression if it's been changed in the queries from the reducer when prom or loki query
+  return async (updatedQueries: AlertQuery[]) => {
+    // Sync the form's expression field from the reducer's prom/loki query, if one changed.
     const query = updatedQueries[0];
     if (!query) {
       return;
     }
 
-    const dataSourceSettings = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+    const dataSourceSettings = await getDataSourceInstanceSettings(query.datasourceUid);
     if (!dataSourceSettings) {
       throw new Error('The Data source has not been defined.');
     }

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -260,7 +260,6 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       const expressionQueries = previousQueries.filter<AlertQuery<ExpressionQuery>>(isExpressionQueryInAlert);
 
       setValue('queries', [...updatedQueries, ...expressionQueries], { shouldValidate: false });
-      await updateExpressionAndDatasource(updatedQueries);
 
       // we only remove or add the reducer(optimize reducer) expression when creating a new alert.
       // When editing an alert, we assume the user wants to manually adjust expressions and queries for more control and customization.
@@ -276,6 +275,10 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       if (oldRefId && newRefId) {
         dispatch(rewireExpressions({ oldRefId, newRefId }));
       }
+
+      // Runs after the reducer/form updates above so a slower-resolving call can't apply its
+      // (now stale) expression field after a faster, more recent call already has.
+      await updateExpressionAndDatasource(updatedQueries);
     },
     [queries, updateExpressionAndDatasource, getValues, setValue, editingExistingRule, isOptimizeReducerEnabled]
   );
@@ -291,10 +294,12 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       const expression = query.model.expr;
 
       setValue('queries', updatedQueries, { shouldValidate: false });
-      await updateExpressionAndDatasource(updatedQueries);
-
       dispatch(setRecordingRulesQueries({ recordingRuleQueries: updatedQueries, expression }));
       runQueriesPreview();
+
+      // Runs after the reducer/form updates above so a slower-resolving call can't apply its
+      // (now stale) expression field after a faster, more recent call already has.
+      await updateExpressionAndDatasource(updatedQueries);
     },
     [runQueriesPreview, setValue, updateExpressionAndDatasource]
   );
@@ -329,10 +334,11 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
       const newQueries = cloneDeep(queries);
       newQueries[0].datasourceUid = datasourceUid;
       setValue('queries', newQueries, { shouldValidate: false });
-
-      await updateExpressionAndDatasource(newQueries);
-
       dispatch(setDataQueries(newQueries));
+
+      // Runs after the reducer/form updates above so a slower-resolving call can't apply its
+      // (now stale) expression field after a faster, more recent call already has.
+      await updateExpressionAndDatasource(newQueries);
     },
     [queries, setValue, updateExpressionAndDatasource, dispatch]
   );
@@ -358,11 +364,12 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     }
 
     setValue('queries', newQueries, { shouldValidate: false });
-
-    await updateExpressionAndDatasource(newQueries);
-
     dispatch(setDataQueries(newQueries));
     runQueriesPreview();
+
+    // Runs after the reducer/form updates above so a slower-resolving call can't apply its
+    // (now stale) expression field after a faster, more recent call already has.
+    await updateExpressionAndDatasource(newQueries);
   };
 
   const removeExpressionsInQueries = useCallback(() => dispatch(removeExpressions()), [dispatch]);
@@ -396,12 +403,14 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
         setValue('dataSourceName', newDsName);
       }
 
-      await updateExpressionAndDatasource(queries);
-
       const expressions = queries.filter((query) => query.datasourceUid === ExpressionDatasourceUID);
       setPrevExpressions(expressions);
       removeExpressionsInQueries();
       setPrevCondition(condition);
+
+      // Runs after the reducer/form updates above so a slower-resolving call can't apply its
+      // (now stale) expression field after a faster, more recent call already has.
+      await updateExpressionAndDatasource(queries);
     }
   }, [
     getValues,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1050,6 +1050,11 @@
       "title-search-panel": "Search panel",
       "title-select-dashboard-and-panel": "Select dashboard and panel"
     },
+    "data-source-load-error": {
+      "remove-query": "Remove query",
+      "retry": "Retry",
+      "title": "Could not load datasource"
+    },
     "datasource-not-found": {
       "card-description": "The datasource for this query was not found, it was either removed or is not installed correctly.",
       "remove-query": "Remove query",


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

### What changed?
Migrating `getDataSourceSrv()` calls to the new async `getDataSourceInstance` and `getDataSourceInstanceSettings` APIs from @grafana/runtime/unstable.