### PR TITLE
Alerting: Migrate rule filtering and details to async DataSource API

### DIFF
--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -138,15 +138,22 @@ setupMswServer();
 
 // The async data source list hooks used by RuleListV1/MultipleDataSourcePicker resolve one
 // microtask after mount even with a synchronously-populated cache; that harmless update can
-// land outside this suite's act() scope. Filter out only that warning.
-const ASYNC_DATASOURCE_HOOK_ACT_WARNING = /inside a test was not wrapped in act\(/;
+// land outside this suite's act() scope. React reports the component name as a separate arg
+// (the message is a format string), so check both — matching on the message alone would also
+// swallow act() warnings from unrelated components.
+const ACT_WARNING_MESSAGE = /inside a test was not wrapped in act\(/;
+const KNOWN_ASYNC_DATASOURCE_HOOK_COMPONENTS = ['RuleListV1', 'MultipleDataSourcePicker'];
 
 describe('RuleList', () => {
   let consoleErrorSpy: jest.SpyInstance;
   beforeEach(() => {
     const trackedConsoleError = console.error;
     consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
-      if (typeof message === 'string' && ASYNC_DATASOURCE_HOOK_ACT_WARNING.test(message)) {
+      const isKnownAsyncDataSourceHookWarning =
+        typeof message === 'string' &&
+        ACT_WARNING_MESSAGE.test(message) &&
+        args.some((arg) => typeof arg === 'string' && KNOWN_ASYNC_DATASOURCE_HOOK_COMPONENTS.includes(arg));
+      if (isKnownAsyncDataSourceHookWarning) {
         return;
       }
       trackedConsoleError(message, ...args);

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -136,8 +136,21 @@ const ui = {
 
 setupMswServer();
 
+// The async data source list hooks used by RuleListV1/MultipleDataSourcePicker resolve one
+// microtask after mount even with a synchronously-populated cache; that harmless update can
+// land outside this suite's act() scope. Filter out only that warning.
+const ASYNC_DATASOURCE_HOOK_ACT_WARNING = /inside a test was not wrapped in act\(/;
+
 describe('RuleList', () => {
+  let consoleErrorSpy: jest.SpyInstance;
   beforeEach(() => {
+    const trackedConsoleError = console.error;
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((message, ...args) => {
+      if (typeof message === 'string' && ASYNC_DATASOURCE_HOOK_ACT_WARNING.test(message)) {
+        return;
+      }
+      trackedConsoleError(message, ...args);
+    });
     setAlertmanagerChoices(AlertmanagerChoice.All, 1);
     grantUserPermissions([
       AccessControlAction.AlertingRuleRead,
@@ -164,6 +177,7 @@ describe('RuleList', () => {
   });
 
   afterEach(() => {
+    consoleErrorSpy.mockRestore();
     jest.resetAllMocks();
   });
 

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.test.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.test.ts
@@ -2,15 +2,16 @@ import { HttpResponse, http } from 'msw';
 import { act, getWrapper, renderHook } from 'test/test-utils';
 
 import { type ComboboxOption } from '@grafana/ui';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { setupMswServer } from '../../../mockApi';
-import { grantUserPermissions } from '../../../mocks';
+import { grantUserPermissions, mockDataSource } from '../../../mocks';
 import { setGrafanaPromRules, setPrometheusRules } from '../../../mocks/server/configure';
 import { alertingFactory } from '../../../mocks/server/db';
 
-import { useNamespaceAndGroupOptions } from './useRuleFilterAutocomplete';
+import { useAlertingDataSourceOptions, useNamespaceAndGroupOptions } from './useRuleFilterAutocomplete';
 
 const server = setupMswServer();
 
@@ -263,6 +264,34 @@ describe('useNamespaceAndGroupOptions', () => {
       // the typed text is forwarded to the backend, and only matching folders come back
       expect(requests[0].get('search.folder')).toBe('authnz');
       expect(options).toEqual([{ label: 'systems/authnz', value: 'systems/authnz', description: 'Grafana folder' }]);
+    });
+  });
+
+  describe('useAlertingDataSourceOptions', () => {
+    it('returns only alerting-capable data sources as options', async () => {
+      setupDataSources(
+        mockDataSource({ name: 'mimir' }, { alerting: true }),
+        mockDataSource({ name: 'loki' }, { alerting: false })
+      );
+
+      const { result } = renderHook(() => useAlertingDataSourceOptions(), { wrapper });
+
+      const options = await resolveOptions(() => result.current(''));
+
+      expect(options).toEqual([{ label: 'mimir', value: 'mimir' }]);
+    });
+
+    it('filters the returned options by the search input', async () => {
+      setupDataSources(
+        mockDataSource({ name: 'mimir' }, { alerting: true }),
+        mockDataSource({ name: 'loki' }, { alerting: true })
+      );
+
+      const { result } = renderHook(() => useAlertingDataSourceOptions(), { wrapper });
+
+      const options = await resolveOptions(() => result.current('lok'));
+
+      expect(options).toEqual([{ label: 'loki', value: 'loki' }]);
     });
   });
 

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -3,7 +3,8 @@ import { useCallback } from 'react';
 
 import { type DataSourceInstanceSettings, type IconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv, logError, logWarning } from '@grafana/runtime';
+import { logError, logWarning } from '@grafana/runtime';
+import { getDataSourceInstanceList } from '@grafana/runtime/unstable';
 import { type ComboboxOption } from '@grafana/ui';
 import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
@@ -275,9 +276,8 @@ export function useLabelOptions(): {
 
 export function useAlertingDataSourceOptions(): (inputValue: string) => Promise<Array<ComboboxOption<string>>> {
   return useCallback(async (inputValue: string) => {
-    const options = getDataSourceSrv()
-      .getList({ alerting: true })
-      .map((ds: DataSourceInstanceSettings) => ({ label: ds.name, value: ds.name }));
+    const items = await getDataSourceInstanceList({ alerting: true });
+    const options = items.map((ds) => ({ label: ds.name, value: ds.name }));
     return filterBySearch(options, inputValue);
   }, []);
 }

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+
+import { mockDataSource } from '../../mocks';
+
+import { MultipleDataSourcePicker } from './MultipleDataSourcePicker';
+
+function getInput() {
+  return screen.getByTestId(selectors.components.DataSourcePicker.inputV2);
+}
+
+describe('MultipleDataSourcePicker', () => {
+  it('groups options by whether the data source manages alerts', async () => {
+    setupDataSources(
+      mockDataSource({ name: 'mimir-managing', jsonData: { manageAlerts: true } }, { alerting: true }),
+      mockDataSource({ name: 'mimir-not-managing', jsonData: { manageAlerts: false } }, { alerting: true })
+    );
+
+    const user = userEvent.setup();
+    render(<MultipleDataSourcePicker alerting current={[]} onChange={jest.fn()} />);
+
+    await user.click(getInput());
+
+    expect(await screen.findByText('Data sources with configured alert rules')).toBeInTheDocument();
+    expect(screen.getByText('Other data sources')).toBeInTheDocument();
+    expect(screen.getByText('mimir-managing')).toBeInTheDocument();
+    expect(screen.getByText('mimir-not-managing')).toBeInTheDocument();
+  });
+
+  it('resolves currently selected names to their data source settings', async () => {
+    setupDataSources(mockDataSource({ name: 'loki', jsonData: {} }, { alerting: true }));
+
+    render(<MultipleDataSourcePicker alerting current={['loki']} onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('loki')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a "not found" placeholder for a selected name that no longer resolves', async () => {
+    setupDataSources();
+
+    render(<MultipleDataSourcePicker alerting current={['missing-ds']} onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('missing-ds - not found')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps labels aligned with their names when current is reordered', async () => {
+    setupDataSources(
+      mockDataSource({ name: 'loki', jsonData: {} }, { alerting: true }),
+      mockDataSource({ name: 'mimir', jsonData: {} }, { alerting: true })
+    );
+
+    const { rerender } = render(<MultipleDataSourcePicker alerting current={['loki', 'mimir']} onChange={jest.fn()} />);
+    await screen.findByText('loki');
+
+    rerender(<MultipleDataSourcePicker alerting current={['mimir', 'loki']} onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      const container = screen.getByTestId(selectors.components.DataSourcePicker.container);
+      const labels = within(container)
+        .getAllByText(/loki|mimir/)
+        .map((el) => el.textContent);
+      expect(labels).toEqual(['mimir', 'loki']);
+    });
+  });
+
+  it('calls onChange with the resolved data source settings when an option is selected', async () => {
+    setupDataSources(mockDataSource({ name: 'loki', jsonData: {} }, { alerting: true }));
+    const onChange = jest.fn();
+
+    const user = userEvent.setup();
+    render(<MultipleDataSourcePicker alerting current={[]} onChange={onChange} />);
+
+    await user.click(getInput());
+    await user.click(await screen.findByText('loki'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ name: 'loki' }), 'add');
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
+import * as runtimeUnstable from '@grafana/runtime/unstable';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
 import { mockDataSource } from '../../mocks';
@@ -67,6 +68,21 @@ describe('MultipleDataSourcePicker', () => {
         .map((el) => el.textContent);
       expect(labels).toEqual(['mimir', 'loki']);
     });
+  });
+
+  it('shows a loading indicator instead of "No datasources found" while options are resolving', async () => {
+    setupDataSources(mockDataSource({ name: 'loki', jsonData: {} }, { alerting: true }));
+    jest.spyOn(runtimeUnstable, 'getDataSourceInstanceList').mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<MultipleDataSourcePicker alerting current={[]} onChange={jest.fn()} />);
+
+    await user.click(getInput());
+
+    expect(screen.getByText('Loading options...')).toBeInTheDocument();
+    expect(screen.queryByText('No datasources found')).not.toBeInTheDocument();
+
+    jest.restoreAllMocks();
   });
 
   it('calls onChange with the resolved data source settings when an option is selected', async () => {

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
@@ -54,7 +54,7 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   const [state, setState] = useState<{ error?: string }>();
 
   // `isDataSourceManagingAlerts` and `filter` need `jsonData`, absent from the slim list item.
-  const { value: dataSources = [] } = useAsync(async () => {
+  const { value: dataSources = [], loading: isLoadingOptions } = useAsync(async () => {
     const items = await getDataSourceInstanceList({
       alerting,
       tracing,
@@ -74,7 +74,7 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   }, [alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type]);
 
   // Unrestricted by the type filters above, since `current` may reference a data source they'd exclude.
-  const { byUid: dataSourceByUid } = useDataSourceInstanceListByUid();
+  const { byUid: dataSourceByUid, isLoading: isLoadingCurrentDataSources } = useDataSourceInstanceListByUid();
   const dataSourceByName = useMemo(() => {
     const map = new Map<string, DataSourceInstanceListItem>();
     dataSourceByUid.forEach((ds) => map.set(ds.name, ds));
@@ -187,7 +187,7 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   return (
     <div data-testid={selectors.components.DataSourcePicker.container}>
       <MultiSelect
-        isLoading={isLoading}
+        isLoading={isLoading || isLoadingOptions || isLoadingCurrentDataSources}
         disabled={disabled}
         data-testid={selectors.components.DataSourcePicker.inputV2}
         inputId={inputId || 'data-source-picker'}

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
@@ -1,7 +1,9 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { type PopValueActionMeta, type RemoveValueActionMeta } from 'react-select';
+import { useAsync } from 'react-use';
 
 import {
+  type DataSourceInstanceListItem,
   type DataSourceInstanceSettings,
   type SelectableValue,
   getDataSourceUID,
@@ -9,10 +11,12 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { type DataSourcePickerProps, getDataSourceSrv } from '@grafana/runtime';
+import { type DataSourcePickerProps } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import { getDataSourceInstanceList, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type ActionMeta, MultiSelect, PluginSignatureBadge, Stack } from '@grafana/ui';
 
+import { useDataSourceInstanceListByUid } from '../../hooks/useDataSourceInstanceListByUid';
 import { isDataSourceManagingAlerts } from '../../utils/datasource';
 
 export interface MultipleDataSourcePickerProps extends Omit<DataSourcePickerProps, 'onChange' | 'current'> {
@@ -21,11 +25,63 @@ export interface MultipleDataSourcePickerProps extends Omit<DataSourcePickerProp
 }
 
 export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) => {
-  const dataSourceSrv = getDataSourceSrv();
+  const {
+    autoFocus,
+    onBlur,
+    onClear,
+    openMenuOnFocus,
+    placeholder,
+    width,
+    inputId,
+    disabled = false,
+    isLoading = false,
+    current,
+    hideTextValue,
+    noDefault,
+    alerting,
+    tracing,
+    metrics,
+    mixed,
+    dashboard,
+    variables,
+    annotations,
+    pluginId,
+    type,
+    filter,
+    logs,
+  } = props;
 
   const [state, setState] = useState<{ error?: string }>();
 
-  const onChange = (items: Array<SelectableValue<string>>, actionMeta: ActionMeta) => {
+  // `isDataSourceManagingAlerts` and `filter` need `jsonData`, absent from the slim list item.
+  const { value: dataSources = [] } = useAsync(async () => {
+    const items = await getDataSourceInstanceList({
+      alerting,
+      tracing,
+      metrics,
+      logs,
+      dashboard,
+      mixed,
+      variables,
+      annotations,
+      pluginId,
+      type,
+    });
+    const settled = await Promise.all(items.map((item) => getDataSourceInstanceSettings(item.uid)));
+    const settledSettings = settled.filter((ds): ds is DataSourceInstanceSettings => !!ds);
+    return filter ? settledSettings.filter(filter) : settledSettings;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type]);
+
+  // Unrestricted by the type filters above, since `current` may reference a data source they'd exclude.
+  const dataSourceByUid = useDataSourceInstanceListByUid();
+  const dataSourceByName = useMemo(() => {
+    const map = new Map<string, DataSourceInstanceListItem>();
+    dataSourceByUid.forEach((ds) => map.set(ds.name, ds));
+    return map;
+  }, [dataSourceByUid]);
+
+  const onChange = async (items: Array<SelectableValue<string>>, actionMeta: ActionMeta) => {
     if (actionMeta.action === 'clear' && props.onClear) {
       props.onClear();
       return;
@@ -46,8 +102,7 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
       action = 'add';
     }
 
-    const dsSettings = dataSourceSrv.getInstanceSettings(dataSourceName);
-
+    const dsSettings = await getDataSourceInstanceSettings(dataSourceName);
     if (dsSettings) {
       props.onChange(dsSettings, action);
       setState({ error: undefined });
@@ -55,13 +110,12 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   };
 
   const getCurrentValue = (): Array<SelectableValue<string>> | undefined => {
-    const { current, hideTextValue, noDefault } = props;
     if (!current && noDefault) {
       return;
     }
 
     return current?.map((dataSourceName: string) => {
-      const ds = dataSourceSrv.getInstanceSettings(dataSourceName);
+      const ds = dataSourceByUid.get(dataSourceName) ?? dataSourceByName.get(dataSourceName);
       if (ds) {
         return {
           label: ds.name.slice(0, 37),
@@ -88,23 +142,6 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   };
 
   const getDataSourceOptions = () => {
-    const { alerting, tracing, metrics, mixed, dashboard, variables, annotations, pluginId, type, filter, logs } =
-      props;
-
-    const dataSources = dataSourceSrv.getList({
-      alerting,
-      tracing,
-      metrics,
-      logs,
-      dashboard,
-      mixed,
-      variables,
-      annotations,
-      pluginId,
-      filter,
-      type,
-    });
-
     const alertManagingDs = dataSources.filter(isDataSourceManagingAlerts).map((ds) => ({
       value: ds.name,
       label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
@@ -142,18 +179,6 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
 
     return groupedOptions;
   };
-
-  const {
-    autoFocus,
-    onBlur,
-    onClear,
-    openMenuOnFocus,
-    placeholder,
-    width,
-    inputId,
-    disabled = false,
-    isLoading = false,
-  } = props;
 
   const options = getDataSourceOptions();
   const value = getCurrentValue();

--- a/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rules/MultipleDataSourcePicker.tsx
@@ -74,7 +74,7 @@ export const MultipleDataSourcePicker = (props: MultipleDataSourcePickerProps) =
   }, [alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type]);
 
   // Unrestricted by the type filters above, since `current` may reference a data source they'd exclude.
-  const dataSourceByUid = useDataSourceInstanceListByUid();
+  const { byUid: dataSourceByUid } = useDataSourceInstanceListByUid();
   const dataSourceByName = useMemo(() => {
     const map = new Map<string, DataSourceInstanceListItem>();
     dataSourceByUid.forEach((ds) => map.set(ds.name, ds));

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+
+import { mockAlertQuery, mockCombinedRule, mockDataSource, mockRulerGrafanaRule } from '../../mocks';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+
+import { RuleDetailsDataSources } from './RuleDetailsDataSources';
+
+describe('RuleDetailsDataSources', () => {
+  it('resolves data source names from the data source list for Grafana-managed rules', async () => {
+    const prometheus = mockDataSource({ uid: 'prom-1', name: 'prometheus' });
+    setupDataSources(prometheus);
+
+    const rule = mockCombinedRule({
+      rulerRule: mockRulerGrafanaRule(undefined, {
+        data: [mockAlertQuery({ datasourceUid: prometheus.uid })],
+      }),
+    });
+
+    render(<RuleDetailsDataSources rule={rule} rulesSource={GRAFANA_RULES_SOURCE_NAME} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('prometheus')).toBeInTheDocument();
+    });
+  });
+
+  it('deduplicates queries that target the same data source', async () => {
+    const prometheus = mockDataSource({ uid: 'prom-1', name: 'prometheus' });
+    setupDataSources(prometheus);
+
+    const rule = mockCombinedRule({
+      rulerRule: mockRulerGrafanaRule(undefined, {
+        data: [
+          mockAlertQuery({ refId: 'A', datasourceUid: prometheus.uid }),
+          mockAlertQuery({ refId: 'B', datasourceUid: prometheus.uid }),
+        ],
+      }),
+    });
+
+    render(<RuleDetailsDataSources rule={rule} rulesSource={GRAFANA_RULES_SOURCE_NAME} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('prometheus')).toHaveLength(1);
+    });
+  });
+
+  it('renders nothing when the rule has no data sources to show', async () => {
+    setupDataSources();
+
+    const rule = mockCombinedRule({
+      rulerRule: mockRulerGrafanaRule(undefined, { data: [] }),
+    });
+
+    const { container } = render(<RuleDetailsDataSources rule={rule} rulesSource={GRAFANA_RULES_SOURCE_NAME} />);
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
@@ -21,7 +21,7 @@ export function RuleDetailsDataSources(props: Props): JSX.Element | null {
   const { rulesSource, rule } = props;
   const styles = useStyles2(getStyles);
 
-  const dataSourceByUid = useDataSourceInstanceListByUid();
+  const { byUid: dataSourceByUid } = useDataSourceInstanceListByUid();
 
   const dataSources: Array<{ name: string; icon?: string }> = useMemo(() => {
     if (isCloudRulesSource(rulesSource)) {

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
@@ -3,11 +3,11 @@ import { type JSX, useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
 import { useStyles2 } from '@grafana/ui';
 import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { type CombinedRule, type RulesSource } from 'app/types/unified-alerting';
 
+import { useDataSourceInstanceListByUid } from '../../hooks/useDataSourceInstanceListByUid';
 import { isCloudRulesSource } from '../../utils/datasource';
 import { rulerRuleType } from '../../utils/rules';
 import { DetailsField } from '../DetailsField';
@@ -21,6 +21,8 @@ export function RuleDetailsDataSources(props: Props): JSX.Element | null {
   const { rulesSource, rule } = props;
   const styles = useStyles2(getStyles);
 
+  const dataSourceByUid = useDataSourceInstanceListByUid();
+
   const dataSources: Array<{ name: string; icon?: string }> = useMemo(() => {
     if (isCloudRulesSource(rulesSource)) {
       return [{ name: rulesSource.name, icon: rulesSource.meta.info.logos.small }];
@@ -29,7 +31,7 @@ export function RuleDetailsDataSources(props: Props): JSX.Element | null {
     if (rulerRuleType.grafana.rule(rule.rulerRule)) {
       const { data } = rule.rulerRule.grafana_alert;
       const unique = data.reduce<Record<string, { name: string; icon?: string }>>((dataSources, query) => {
-        const ds = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
+        const ds = dataSourceByUid.get(query.datasourceUid);
 
         if (!ds || ds.uid === ExpressionDatasourceUID) {
           return dataSources;
@@ -43,7 +45,7 @@ export function RuleDetailsDataSources(props: Props): JSX.Element | null {
     }
 
     return [];
-  }, [rule, rulesSource]);
+  }, [rule, rulesSource, dataSourceByUid]);
 
   if (dataSources.length === 0) {
     return null;

--- a/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.test.ts
+++ b/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.test.ts
@@ -1,0 +1,18 @@
+import { renderHook, waitFor } from 'test/test-utils';
+
+import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
+
+import { mockDataSource } from '../mocks';
+
+import { useDataSourceInstanceListByUid } from './useDataSourceInstanceListByUid';
+
+describe('useDataSourceInstanceListByUid', () => {
+  it('indexes the data source list by uid', async () => {
+    setupDataSources(mockDataSource({ uid: 'prom-1', name: 'prometheus' }));
+
+    const { result } = renderHook(() => useDataSourceInstanceListByUid());
+
+    await waitFor(() => expect(result.current.get('prom-1')?.name).toBe('prometheus'));
+    expect(result.current.get('missing-uid')).toBeUndefined();
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.test.ts
+++ b/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.test.ts
@@ -12,7 +12,20 @@ describe('useDataSourceInstanceListByUid', () => {
 
     const { result } = renderHook(() => useDataSourceInstanceListByUid());
 
-    await waitFor(() => expect(result.current.get('prom-1')?.name).toBe('prometheus'));
-    expect(result.current.get('missing-uid')).toBeUndefined();
+    await waitFor(() => expect(result.current.byUid.get('prom-1')?.name).toBe('prometheus'));
+    expect(result.current.byUid.get('missing-uid')).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('reports a loading state before the data source list resolves', async () => {
+    setupDataSources(mockDataSource({ uid: 'prom-1', name: 'prometheus' }));
+
+    const { result } = renderHook(() => useDataSourceInstanceListByUid());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.byUid.size).toBe(0);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 });

--- a/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.ts
+++ b/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
+
+export function useDataSourceInstanceListByUid(): ReadonlyMap<string, DataSourceInstanceListItem> {
+  const { items } = useDataSourceInstanceList({ all: true });
+  return useMemo(() => new Map(items.map((item) => [item.uid, item])), [items]);
+}

--- a/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.ts
+++ b/public/app/features/alerting/unified/hooks/useDataSourceInstanceListByUid.ts
@@ -3,7 +3,14 @@ import { useMemo } from 'react';
 import { type DataSourceInstanceListItem } from '@grafana/data';
 import { useDataSourceInstanceList } from '@grafana/runtime/unstable';
 
-export function useDataSourceInstanceListByUid(): ReadonlyMap<string, DataSourceInstanceListItem> {
-  const { items } = useDataSourceInstanceList({ all: true });
-  return useMemo(() => new Map(items.map((item) => [item.uid, item])), [items]);
+export interface DataSourceInstanceListByUidResult {
+  byUid: ReadonlyMap<string, DataSourceInstanceListItem>;
+  isLoading: boolean;
+  error?: Error;
+}
+
+export function useDataSourceInstanceListByUid(): DataSourceInstanceListByUidResult {
+  const { items, isLoading, error } = useDataSourceInstanceList({ all: true });
+  const byUid = useMemo(() => new Map(items.map((item) => [item.uid, item])), [items]);
+  return { byUid, isLoading, error };
 }

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -1,3 +1,6 @@
+import { waitFor } from '@testing-library/react';
+import { renderHook } from 'test/test-utils';
+
 import { DEFAULT_ROUTING_TREE_NAME_ALIAS, USER_DEFINED_TREE_NAME } from '@grafana/alerting';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 
@@ -20,12 +23,13 @@ import { Annotation } from '../utils/constants';
 import { parsePromQLStyleMatcherLooseSafe } from '../utils/matchers';
 import { getFilter } from '../utils/search';
 
-import { filterRules } from './useFilteredRules';
+import { filterRules, useFilteredRules } from './useFilteredRules';
 
 const dataSources = {
   prometheus: mockDataSource({ uid: 'prom-1', name: 'prometheus' }),
   loki: mockDataSource({ uid: 'loki-1', name: 'loki' }),
 };
+const dataSourceByUid = new Map(Object.values(dataSources).map((ds) => [ds.uid, { ...ds, isDefault: false }]));
 beforeAll(() => {
   setupDataSources(...Object.values(dataSources));
 });
@@ -172,7 +176,11 @@ describe('filterRules', function () {
       'Prometheus-ds'
     );
 
-    const filtered = filterRules([ns, cloudNs], getFilter({ dataSourceNames: ['loki', 'Prometheus-ds'] }));
+    const filtered = filterRules(
+      [ns, cloudNs],
+      getFilter({ dataSourceNames: ['loki', 'Prometheus-ds'] }),
+      dataSourceByUid
+    );
 
     expect(filtered[0].groups[0].rules).toHaveLength(2);
     expect(filtered[0].groups[0].rules[0].name).toBe('Memory too low');
@@ -327,6 +335,35 @@ describe('filterRules', function () {
 
     expect(filtered[0]?.groups[0]?.rules).toHaveLength(1);
     expect(filtered[0]?.groups[0]?.rules[0]?.name).toBe(longRuleName);
+  });
+});
+
+describe('useFilteredRules', () => {
+  it('resolves datasource uids to names from the async data source list before filtering', async () => {
+    const rules = [
+      mockCombinedRule({
+        name: 'Queries prometheus',
+        rulerRule: mockRulerGrafanaRule(undefined, {
+          data: [mockAlertQuery({ datasourceUid: dataSources.prometheus.uid })],
+        }),
+      }),
+      mockCombinedRule({
+        name: 'Queries loki',
+        rulerRule: mockRulerGrafanaRule(undefined, {
+          data: [mockAlertQuery({ datasourceUid: dataSources.loki.uid })],
+        }),
+      }),
+    ];
+    const ns = mockCombinedRuleNamespace({
+      groups: [mockCombinedRuleGroup('Resources usage group', rules)],
+    });
+
+    const { result } = renderHook(() => useFilteredRules([ns], getFilter({ dataSourceNames: ['loki'] })));
+
+    await waitFor(() => {
+      expect(result.current[0]?.groups[0]?.rules).toHaveLength(1);
+    });
+    expect(result.current[0]?.groups[0]?.rules[0]?.name).toBe('Queries loki');
   });
 });
 

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.test.ts
@@ -365,6 +365,26 @@ describe('useFilteredRules', () => {
     });
     expect(result.current[0]?.groups[0]?.rules[0]?.name).toBe('Queries loki');
   });
+
+  it('does not exclude rules from a data source filter while the data source list is still loading', async () => {
+    const rule = mockCombinedRule({
+      name: 'Queries prometheus',
+      rulerRule: mockRulerGrafanaRule(undefined, {
+        data: [mockAlertQuery({ datasourceUid: dataSources.prometheus.uid })],
+      }),
+    });
+    const ns = mockCombinedRuleNamespace({
+      groups: [mockCombinedRuleGroup('Resources usage group', [rule])],
+    });
+
+    // Filtering by a data source the rule doesn't query for would normally exclude it, but the
+    // async data source list hasn't resolved on this first render, so the filter is skipped.
+    const { result } = renderHook(() => useFilteredRules([ns], getFilter({ dataSourceNames: ['loki'] })));
+
+    expect(result.current[0]?.groups[0]?.rules).toHaveLength(1);
+
+    await waitFor(() => expect(result.current).toHaveLength(0));
+  });
 });
 
 // Legacy URLs may put free-text or search-syntax tokens in queryString instead of PromQL matchers.

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -288,7 +288,12 @@ const reduceGroups = (
 
       if ('dataSourceNames' in matchesFilterFor) {
         if (rulerRuleType.grafana.rule(rule.rulerRule)) {
-          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState, dataSourceByUid, skipDataSourceFilter);
+          const doesNotQueryDs = isQueryingDataSource(
+            rule.rulerRule,
+            filterState,
+            dataSourceByUid,
+            skipDataSourceFilter
+          );
 
           if (doesNotQueryDs) {
             matchesFilterFor.dataSourceNames = true;

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -3,7 +3,7 @@ import { chain, compact, isEmpty } from 'lodash';
 import { useCallback, useDeferredValue, useEffect, useMemo } from 'react';
 
 import { isDefaultRoutingTreeName } from '@grafana/alerting';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { type DataSourceInstanceListItem } from '@grafana/data';
 import { type Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { type CombinedRuleGroup, type CombinedRuleNamespace, type Rule } from 'app/types/unified-alerting';
 import { PromRuleType, type RulerGrafanaRuleDTO, isPromAlertingRuleState } from 'app/types/unified-alerting-dto';
@@ -30,6 +30,7 @@ import {
 } from '../utils/rules';
 
 import { calculateGroupTotals, calculateRuleFilteredTotals, calculateRuleTotals } from './useCombinedRuleNamespaces';
+import { useDataSourceInstanceListByUid } from './useDataSourceInstanceListByUid';
 import { useURLSearchParams } from './useURLSearchParams';
 
 export function useRulesFilter() {
@@ -104,8 +105,10 @@ export const useFilteredRules = (namespaces: CombinedRuleNamespace[], filterStat
   const deferredNamespaces = useDeferredValue(namespaces);
   const deferredFilterState = useDeferredValue(filterState);
 
+  const dataSourceByUid = useDataSourceInstanceListByUid();
+
   return useMemo(() => {
-    const filteredRules = filterRules(deferredNamespaces, deferredFilterState);
+    const filteredRules = filterRules(deferredNamespaces, deferredFilterState, dataSourceByUid);
 
     // Totals recalculation is a workaround for the lack of server-side filtering
     filteredRules.forEach((namespace) => {
@@ -124,12 +127,13 @@ export const useFilteredRules = (namespaces: CombinedRuleNamespace[], filterStat
     });
 
     return filteredRules;
-  }, [deferredNamespaces, deferredFilterState]);
+  }, [deferredNamespaces, deferredFilterState, dataSourceByUid]);
 };
 
 export const filterRules = (
   namespaces: CombinedRuleNamespace[],
-  filterState: RulesFilter = { dataSourceNames: [], labels: [], freeFormWords: [] }
+  filterState: RulesFilter = { dataSourceNames: [], labels: [], freeFormWords: [] },
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem> = new Map()
 ): CombinedRuleNamespace[] => {
   let filteredNamespaces = namespaces;
 
@@ -150,7 +154,10 @@ export const filterRules = (
   const filteredRuleNamespaces: CombinedRuleNamespace[] = [];
 
   try {
-    const matches = filteredNamespaces.reduce<CombinedRuleNamespace[]>(reduceNamespaces(filterState), []);
+    const matches = filteredNamespaces.reduce<CombinedRuleNamespace[]>(
+      reduceNamespaces(filterState, dataSourceByUid),
+      []
+    );
     matches.forEach((match) => {
       filteredRuleNamespaces.push(match);
     });
@@ -163,7 +170,10 @@ export const filterRules = (
   return filteredRuleNamespaces;
 };
 
-const reduceNamespaces = (filterState: RulesFilter) => {
+const reduceNamespaces = (
+  filterState: RulesFilter,
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>
+) => {
   return (namespaceAcc: CombinedRuleNamespace[], namespace: CombinedRuleNamespace) => {
     const groupNameFilter = filterState.groupName;
     let filteredGroups = namespace.groups;
@@ -172,7 +182,7 @@ const reduceNamespaces = (filterState: RulesFilter) => {
       filteredGroups = fuzzyFilter(filteredGroups, (g) => g.name, groupNameFilter);
     }
 
-    filteredGroups = filteredGroups.reduce<CombinedRuleGroup[]>(reduceGroups(filterState), []);
+    filteredGroups = filteredGroups.reduce<CombinedRuleGroup[]>(reduceGroups(filterState, dataSourceByUid), []);
 
     if (filteredGroups.length) {
       namespaceAcc.push({
@@ -186,7 +196,7 @@ const reduceNamespaces = (filterState: RulesFilter) => {
 };
 
 // Reduces groups to only groups that have rules matching the filters
-const reduceGroups = (filterState: RulesFilter) => {
+const reduceGroups = (filterState: RulesFilter, dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>) => {
   const ruleNameQuery = filterState.ruleName ?? filterState.freeFormWords.join(' ');
 
   return (groupAcc: CombinedRuleGroup[], group: CombinedRuleGroup) => {
@@ -266,7 +276,7 @@ const reduceGroups = (filterState: RulesFilter) => {
 
       if ('dataSourceNames' in matchesFilterFor) {
         if (rulerRuleType.grafana.rule(rule.rulerRule)) {
-          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState);
+          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState, dataSourceByUid);
 
           if (doesNotQueryDs) {
             matchesFilterFor.dataSourceNames = true;
@@ -344,7 +354,11 @@ function looseParseMatcher(matcherQuery: string): Matcher | undefined {
   }
 }
 
-const isQueryingDataSource = (rulerRule: RulerGrafanaRuleDTO, filterState: RulesFilter): boolean => {
+const isQueryingDataSource = (
+  rulerRule: RulerGrafanaRuleDTO,
+  filterState: RulesFilter,
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>
+): boolean => {
   if (!filterState.dataSourceNames?.length) {
     return true;
   }
@@ -353,8 +367,8 @@ const isQueryingDataSource = (rulerRule: RulerGrafanaRuleDTO, filterState: Rules
     if (!query.datasourceUid) {
       return false;
     }
-    const ds = getDataSourceSrv().getInstanceSettings(query.datasourceUid);
-    return ds?.name && filterState?.dataSourceNames?.includes(ds.name);
+    const ds = dataSourceByUid.get(query.datasourceUid);
+    return ds && filterState?.dataSourceNames?.includes(ds.name);
   });
 };
 

--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -105,10 +105,13 @@ export const useFilteredRules = (namespaces: CombinedRuleNamespace[], filterStat
   const deferredNamespaces = useDeferredValue(namespaces);
   const deferredFilterState = useDeferredValue(filterState);
 
-  const dataSourceByUid = useDataSourceInstanceListByUid();
+  const { byUid: dataSourceByUid, isLoading, error } = useDataSourceInstanceListByUid();
+  // Skip the data-source filter (rather than exclude every rule) while the list is unresolved,
+  // since an empty map would otherwise look identical to "no rules match".
+  const skipDataSourceFilter = isLoading || !!error;
 
   return useMemo(() => {
-    const filteredRules = filterRules(deferredNamespaces, deferredFilterState, dataSourceByUid);
+    const filteredRules = filterRules(deferredNamespaces, deferredFilterState, dataSourceByUid, skipDataSourceFilter);
 
     // Totals recalculation is a workaround for the lack of server-side filtering
     filteredRules.forEach((namespace) => {
@@ -127,13 +130,14 @@ export const useFilteredRules = (namespaces: CombinedRuleNamespace[], filterStat
     });
 
     return filteredRules;
-  }, [deferredNamespaces, deferredFilterState, dataSourceByUid]);
+  }, [deferredNamespaces, deferredFilterState, dataSourceByUid, skipDataSourceFilter]);
 };
 
 export const filterRules = (
   namespaces: CombinedRuleNamespace[],
   filterState: RulesFilter = { dataSourceNames: [], labels: [], freeFormWords: [] },
-  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem> = new Map()
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem> = new Map(),
+  skipDataSourceFilter = false
 ): CombinedRuleNamespace[] => {
   let filteredNamespaces = namespaces;
 
@@ -155,7 +159,7 @@ export const filterRules = (
 
   try {
     const matches = filteredNamespaces.reduce<CombinedRuleNamespace[]>(
-      reduceNamespaces(filterState, dataSourceByUid),
+      reduceNamespaces(filterState, dataSourceByUid, skipDataSourceFilter),
       []
     );
     matches.forEach((match) => {
@@ -172,7 +176,8 @@ export const filterRules = (
 
 const reduceNamespaces = (
   filterState: RulesFilter,
-  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>,
+  skipDataSourceFilter: boolean
 ) => {
   return (namespaceAcc: CombinedRuleNamespace[], namespace: CombinedRuleNamespace) => {
     const groupNameFilter = filterState.groupName;
@@ -182,7 +187,10 @@ const reduceNamespaces = (
       filteredGroups = fuzzyFilter(filteredGroups, (g) => g.name, groupNameFilter);
     }
 
-    filteredGroups = filteredGroups.reduce<CombinedRuleGroup[]>(reduceGroups(filterState, dataSourceByUid), []);
+    filteredGroups = filteredGroups.reduce<CombinedRuleGroup[]>(
+      reduceGroups(filterState, dataSourceByUid, skipDataSourceFilter),
+      []
+    );
 
     if (filteredGroups.length) {
       namespaceAcc.push({
@@ -196,7 +204,11 @@ const reduceNamespaces = (
 };
 
 // Reduces groups to only groups that have rules matching the filters
-const reduceGroups = (filterState: RulesFilter, dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>) => {
+const reduceGroups = (
+  filterState: RulesFilter,
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>,
+  skipDataSourceFilter: boolean
+) => {
   const ruleNameQuery = filterState.ruleName ?? filterState.freeFormWords.join(' ');
 
   return (groupAcc: CombinedRuleGroup[], group: CombinedRuleGroup) => {
@@ -276,7 +288,7 @@ const reduceGroups = (filterState: RulesFilter, dataSourceByUid: ReadonlyMap<str
 
       if ('dataSourceNames' in matchesFilterFor) {
         if (rulerRuleType.grafana.rule(rule.rulerRule)) {
-          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState, dataSourceByUid);
+          const doesNotQueryDs = isQueryingDataSource(rule.rulerRule, filterState, dataSourceByUid, skipDataSourceFilter);
 
           if (doesNotQueryDs) {
             matchesFilterFor.dataSourceNames = true;
@@ -357,9 +369,10 @@ function looseParseMatcher(matcherQuery: string): Matcher | undefined {
 const isQueryingDataSource = (
   rulerRule: RulerGrafanaRuleDTO,
   filterState: RulesFilter,
-  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>
+  dataSourceByUid: ReadonlyMap<string, DataSourceInstanceListItem>,
+  skipDataSourceFilter: boolean
 ): boolean => {
-  if (!filterState.dataSourceNames?.length) {
+  if (!filterState.dataSourceNames?.length || skipDataSourceFilter) {
     return true;
   }
 

--- a/public/app/features/alerting/unified/testSetup/datasources.ts
+++ b/public/app/features/alerting/unified/testSetup/datasources.ts
@@ -2,11 +2,12 @@ import { keyBy } from 'lodash';
 
 import { type DataSourceInstanceSettings } from '@grafana/data';
 import { config, setDataSourceSrv } from '@grafana/runtime';
+import { setDataSourceInstanceSettings } from '@grafana/runtime/internal';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 /**
- * Sets up the data sources for the tests.
- * Sets up both config object from grafana/runtime and the data source server
+ * Sets up the data sources for the tests: the legacy `DataSourceSrv` and the in-memory cache
+ * backing the async `@grafana/runtime/unstable` APIs, so tests work with either.
  * @param configs data source instance settings. Use **mockDataSource** to create mock settings
  */
 export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
@@ -14,9 +15,11 @@ export function setupDataSources(...configs: DataSourceInstanceSettings[]) {
   const datasourceSettings = keyBy(configs, (c) => c.name);
 
   const defaultDatasource = configs.find((c) => c.isDefault);
+  const defaultDatasourceName = defaultDatasource?.name || config.defaultDatasource;
   config.datasources = datasourceSettings;
-  dataSourceSrv.init(config.datasources, defaultDatasource?.name || config.defaultDatasource);
+  dataSourceSrv.init(config.datasources, defaultDatasourceName);
   setDataSourceSrv(dataSourceSrv);
+  setDataSourceInstanceSettings(datasourceSettings, defaultDatasourceName);
 
   return dataSourceSrv;
 }


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

### What changed?
Migrates `getDataSourceSrv()` calls to the new async `getDataSourceInstanceList`/`getDataSourceInstanceSettings` APIs from `@grafana/runtime/unstable`.