### PR TITLE
Alerting: Migrate shared rule-form utilities to async DataSource API

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1248,16 +1248,6 @@
       "count": 2
     }
   },
-  "public/app/features/alerting/unified/rule-editor/formDefaults.test.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
-  "public/app/features/alerting/unified/rule-editor/formDefaults.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/state/AlertingQueryRunner.ts": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -1298,11 +1288,6 @@
       "count": 1
     }
   },
-  "public/app/features/alerting/unified/utils/datasource.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
-    }
-  },
   "public/app/features/alerting/unified/utils/misc.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
@@ -1322,11 +1307,6 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
-    }
-  },
-  "public/app/features/alerting/unified/utils/rule-form.ts": {
-    "@grafana/no-get-data-source-srv": {
-      "count": 1
     }
   },
   "public/app/features/alerting/unified/utils/rules.ts": {

--- a/public/app/features/alerting/unified/components/export/GrafanaModifyExport.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaModifyExport.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
+import { useAsync } from 'react-use';
 
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
@@ -38,8 +39,16 @@ function GrafanaModifyExport() {
 
 function RuleModifyExport({ ruleIdentifier }: { ruleIdentifier: RuleIdentifier }) {
   const { loading, error, result: rulerRule } = useRuleWithLocation({ ruleIdentifier: ruleIdentifier });
+  const isGrafanaManagedRule = Boolean(rulerRule && rulerRuleType.grafana.rule(rulerRule.rule));
 
-  if (loading) {
+  const { value: ruleForm, loading: loadingRuleForm } = useAsync(async () => {
+    if (!rulerRule || !isGrafanaManagedRule) {
+      return undefined;
+    }
+    return formValuesFromExistingRule(rulerRule);
+  }, [rulerRule, isGrafanaManagedRule]);
+
+  if (loading || loadingRuleForm) {
     return <LoadingPlaceholder text={t('alerting.rule-modify-export.text-loading-the-rule', 'Loading the rule...')} />;
   }
 
@@ -79,13 +88,8 @@ function RuleModifyExport({ ruleIdentifier }: { ruleIdentifier: RuleIdentifier }
     );
   }
 
-  if (rulerRule && rulerRuleType.grafana.rule(rulerRule.rule)) {
-    return (
-      <ModifyExportRuleForm
-        ruleForm={formValuesFromExistingRule(rulerRule)}
-        alertUid={rulerRule.rule.grafana_alert.uid}
-      />
-    );
+  if (rulerRule && rulerRuleType.grafana.rule(rulerRule.rule) && ruleForm) {
+    return <ModifyExportRuleForm ruleForm={ruleForm} alertUid={rulerRule.rule.grafana_alert.uid} />;
   }
 
   return <Alert title={t('alerting.rule-modify-export.title-unknown-error', 'Unknown error')} />;

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -93,20 +93,22 @@ export const QueryRows = ({
     );
   };
 
-  const onChangeDataSource = (settings: DataSourceInstanceSettings, index: number) => {
-    const updatedQueries = queries.map((item, itemIndex) => {
-      if (itemIndex !== index) {
-        return item;
-      }
+  const onChangeDataSource = async (settings: DataSourceInstanceSettings, index: number) => {
+    const updatedQueries = await Promise.all(
+      queries.map(async (item, itemIndex) => {
+        if (itemIndex !== index) {
+          return item;
+        }
 
-      const previousSettings = getDataSourceSettings(item);
+        const previousSettings = getDataSourceSettings(item);
 
-      // Copy model if changing to a datasource of same type.
-      if (settings.type === previousSettings?.type) {
-        return copyModel(item, settings);
-      }
-      return newModel(item, settings);
-    });
+        // Copy model if changing to a datasource of same type.
+        if (settings.type === previousSettings?.type) {
+          return copyModel(item, settings);
+        }
+        return newModel(item, settings);
+      })
+    );
 
     onQueriesChange(updatedQueries);
   };
@@ -275,9 +277,12 @@ function copyModel(item: AlertQuery, settings: DataSourceInstanceSettings): Omit
   };
 }
 
-function newModel(item: AlertQuery, settings: DataSourceInstanceSettings): Omit<AlertQuery, 'datasource'> {
+async function newModel(
+  item: AlertQuery,
+  settings: DataSourceInstanceSettings
+): Promise<Omit<AlertQuery, 'datasource'>> {
   const isExpression = isExpressionQuery(item);
-  const isInstant = isExpression ? false : getInstantFromDataQuery(item);
+  const isInstant = isExpression ? false : await getInstantFromDataQuery(item);
 
   const newQuery: Omit<AlertQuery, 'datasource'> = {
     refId: item.refId,

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FormProvider, type SubmitErrorHandler, type UseFormWatch, useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom-v5-compat';
 
@@ -7,7 +7,7 @@ import { type GrafanaTheme2, store } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
-import { Alert, Button, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Spinner, Stack, useStyles2 } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import InfoPausedRule from 'app/features/alerting/unified/components/InfoPausedRule';
@@ -103,11 +103,15 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
 
   const ruleType = translateRouteParamToRuleType(routeParams.type);
 
-  const defaultValues: RuleFormValues = useMemo(() => {
+  const getDefaultValues = useCallback(async (): Promise<RuleFormValues> => {
     // If we have an existing AND a prefill, then we're coming from the restore dialog
     // and we want to merge the two
     if (existing && prefill) {
-      return { ...formValuesFromExistingRule(existing), ...formValuesFromPrefill(prefill) };
+      const [existingValues, prefillValues] = await Promise.all([
+        formValuesFromExistingRule(existing),
+        formValuesFromPrefill(prefill),
+      ]);
+      return { ...existingValues, ...prefillValues };
     }
     if (existing) {
       return formValuesFromExistingRule(existing);
@@ -122,14 +126,14 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
 
   const formAPI = useForm<RuleFormValues>({
     mode: 'onSubmit',
-    defaultValues,
+    defaultValues: getDefaultValues,
     shouldFocusError: true,
   });
 
   const {
     handleSubmit,
     watch,
-    formState: { isSubmitting },
+    formState: { isSubmitting, isLoading: isLoadingDefaultValues },
     trigger,
   } = formAPI;
 
@@ -194,7 +198,10 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
             trackNewGrafanaAlertRuleFormSavedSuccess({
               simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
               simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
-              canBeTransformedToSimpleQuery: areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries),
+              canBeTransformedToSimpleQuery: await areQueriesTransformableToSimpleCondition(
+                dataQueries,
+                expressionQueries
+              ),
             });
           }
         } else {
@@ -240,7 +247,10 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
           trackNewGrafanaAlertRuleFormSavedSuccess({
             simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
             simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
-            canBeTransformedToSimpleQuery: areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries),
+            canBeTransformedToSimpleQuery: await areQueriesTransformableToSimpleCondition(
+              dataQueries,
+              expressionQueries
+            ),
           });
         }
 
@@ -259,7 +269,10 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
           trackNewGrafanaAlertRuleFormSavedSuccess({
             simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
             simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
-            canBeTransformedToSimpleQuery: areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries),
+            canBeTransformedToSimpleQuery: await areQueriesTransformableToSimpleCondition(
+              dataQueries,
+              expressionQueries
+            ),
           });
         }
       } else {
@@ -298,6 +311,10 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
     }
     locationService.getHistory().goBack();
   };
+
+  if (isLoadingDefaultValues) {
+    return <Spinner />;
+  }
 
   if (!type) {
     return null;

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/ModifyExportRuleForm.tsx
@@ -36,13 +36,13 @@ interface ModifyExportRuleFormProps {
 }
 
 export function ModifyExportRuleForm({ ruleForm, alertUid }: ModifyExportRuleFormProps) {
-  const defaultValuesForNewRule: RuleFormValues = useMemo(() => {
+  const getDefaultValuesForNewRule = useCallback(async (): Promise<RuleFormValues> => {
     const defaultRuleType = RuleFormType.grafana;
 
     return {
       ...getDefaultFormValues(),
       condition: 'C',
-      queries: getDefaultQueries(false),
+      queries: await getDefaultQueries(false),
       type: defaultRuleType,
       evaluateEvery: DEFAULT_GROUP_EVALUATION_INTERVAL,
     };
@@ -50,9 +50,13 @@ export function ModifyExportRuleForm({ ruleForm, alertUid }: ModifyExportRuleFor
 
   const formAPI = useForm<RuleFormValues>({
     mode: 'onSubmit',
-    defaultValues: ruleForm ?? defaultValuesForNewRule,
+    defaultValues: ruleForm ?? getDefaultValuesForNewRule,
     shouldFocusError: true,
   });
+
+  const {
+    formState: { isLoading: isLoadingDefaultValues },
+  } = formAPI;
 
   const existing = Boolean(ruleForm);
   const notifyApp = useAppNotification();
@@ -80,6 +84,10 @@ export function ModifyExportRuleForm({ ruleForm, alertUid }: ModifyExportRuleFor
   const onClose = useCallback(() => {
     setExportData(undefined);
   }, [setExportData]);
+
+  if (isLoadingDefaultValues) {
+    return <LoadingPlaceholder text={t('alerting.modify-export-rule-form.text-loading', 'Loading...')} />;
+  }
 
   return (
     <FormProvider {...formAPI}>

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/SimplifiedRuleEditor.test.tsx
@@ -46,7 +46,8 @@ const dataSources = {
 };
 
 const selectFolderAndGroup = async (user: UserEvent) => {
-  const folderPicker = ui.inputs.folder.get();
+  // Form mounts asynchronously now — .find() waits for it, unlike .get().
+  const folderPicker = await ui.inputs.folder.find();
   const folderButton = await within(folderPicker).findByRole('button', { name: /select folder/i });
   await user.click(folderButton);
 
@@ -251,9 +252,12 @@ describe('Can create a new grafana managed alert using simplified routing', () =
 
       const { user } = renderRuleEditor();
 
+      // Wait for the async form mount before the .get() calls below.
+      await ui.inputs.name.find();
+
       await user.click(ui.inputs.switchModeBasic(GrafanaRuleFormStep.Query).get()); // switch to query step advanced mode
       await user.click(ui.inputs.switchModeBasic(GrafanaRuleFormStep.Notification).get()); // switch to notifications step advanced mode
-      await user.type(await ui.inputs.name.find(), 'my great new rule');
+      await user.type(ui.inputs.name.get(), 'my great new rule');
 
       await selectFolderAndGroup(user);
 

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { useEffectOnce } from 'react-use';
+import { useAsync, useEffectOnce } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -41,7 +41,12 @@ import {
   getDefaultOrFirstCompatibleDataSource,
   getRulesDataSources,
 } from '../../../utils/datasource';
-import { type PromOrLokiQuery, isPromOrLokiQuery } from '../../../utils/rule-form';
+import {
+  type PromOrLokiQuery,
+  getDefaultQueries,
+  getInstantFromDataQuery,
+  isPromOrLokiQuery,
+} from '../../../utils/rule-form';
 import {
   isCloudAlertingRuleByType,
   isCloudRecordingRuleByType,
@@ -81,6 +86,15 @@ import {
 import { useAdvancedMode } from './useAdvancedMode';
 import { useAlertQueryRunner } from './useAlertQueryRunner';
 import { onlyOneDSInQueries } from './utils';
+
+async function resolveOptimizeReduceExpressionPayload(
+  updatedQueries: AlertQuery[],
+  expressionQueries: Array<AlertQuery<ExpressionQuery>>
+) {
+  const dataQuery = updatedQueries.length === 1 ? updatedQueries[0] : undefined;
+  const isInstantDataQuery = dataQuery ? ((await getInstantFromDataQuery(dataQuery)) ?? false) : false;
+  return { updatedQueries, expressionQueries, isInstantDataQuery };
+}
 
 interface Props {
   editingExistingRule: boolean;
@@ -126,7 +140,9 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     // When editing an alert, we assume the user wants to manually adjust expressions and queries for more control and customization.
 
     if (!editingExistingRule && isOptimizeReducerEnabled) {
-      dispatch(optimizeReduceExpression({ updatedQueries: dataQueries, expressionQueries }));
+      resolveOptimizeReduceExpressionPayload(dataQueries, expressionQueries).then((payload) =>
+        dispatch(optimizeReduceExpression(payload))
+      );
     }
   });
 
@@ -191,7 +207,8 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     setValue('queries', queries, { shouldValidate: false });
   }, [queries, runQueries, setValue]);
 
-  const noCompatibleDataSources = getDefaultOrFirstCompatibleDataSource() === undefined;
+  const { value: defaultOrFirstCompatibleDataSource } = useAsync(() => getDefaultOrFirstCompatibleDataSource(), []);
+  const noCompatibleDataSources = defaultOrFirstCompatibleDataSource === undefined;
 
   const emptyQueries = queries.length === 0;
 
@@ -251,7 +268,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   const updateExpressionAndDatasource = useSetExpressionAndDataSource();
 
   const onChangeQueries = useCallback(
-    (updatedQueries: AlertQuery[]) => {
+    async (updatedQueries: AlertQuery[]) => {
       // Most data sources triggers onChange and onRunQueries consecutively
       // It means our reducer state is always one step behind when runQueries is invoked
       // Invocation cycle => onChange -> dispatch(setDataQueries) -> onRunQueries -> setDataQueries Reducer
@@ -266,8 +283,10 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
 
       // we only remove or add the reducer(optimize reducer) expression when creating a new alert.
       // When editing an alert, we assume the user wants to manually adjust expressions and queries for more control and customization.
+      // Must dispatch before setDataQueries: it mutates state.queries, which setDataQueries then rebuilds from.
       if (!editingExistingRule && isOptimizeReducerEnabled) {
-        dispatch(optimizeReduceExpression({ updatedQueries, expressionQueries }));
+        const payload = await resolveOptimizeReduceExpressionPayload(updatedQueries, expressionQueries);
+        dispatch(optimizeReduceExpression(payload));
       }
 
       dispatch(setDataQueries(updatedQueries));
@@ -430,9 +449,9 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
   const switchMode = isGrafanaAlertingType
     ? {
         isAdvancedMode: !simplifiedQueryStep,
-        setAdvancedMode: (isAdvanced: boolean) => {
+        setAdvancedMode: async (isAdvanced: boolean) => {
           if (!getValues('editorSettings.simplifiedQueryEditor')) {
-            if (!areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
+            if (!(await areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries))) {
               setShowResetModal(true);
               return;
             }
@@ -546,8 +565,9 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
               >
                 <Button
                   type="button"
-                  onClick={() => {
-                    dispatch(addNewDataQuery());
+                  onClick={async () => {
+                    const datasource = await getDefaultOrFirstCompatibleDataSource();
+                    dispatch(addNewDataQuery(datasource));
                   }}
                   variant="secondary"
                   data-testid={selectors.components.QueryTab.addQuery}
@@ -670,10 +690,10 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
           </div>
         }
         confirmText={t('alerting.query-and-expressions-step.confirmText-deactivate', 'Deactivate')}
-        onConfirm={() => {
+        onConfirm={async () => {
           setValue('editorSettings.simplifiedQueryEditor', true);
           setShowResetModal(false);
-          dispatch(resetToSimpleCondition());
+          dispatch(resetToSimpleCondition(await getDefaultQueries()));
         }}
         onDismiss={() => setShowResetModal(false)}
       />

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
@@ -22,67 +22,69 @@ describe('areQueriesTransformableToSimpleCondition', () => {
   beforeEach(() => {
     setupDataSources(ds);
   });
-  it('should return false if dataQueries length is not 1', () => {
+  it('should return false if dataQueries length is not 1', async () => {
     // zero dataQueries
-    expect(areQueriesTransformableToSimpleCondition([], expressionQueries)).toBe(false);
+    expect(await areQueriesTransformableToSimpleCondition([], expressionQueries)).toBe(false);
     // more than one dataQueries
-    expect(areQueriesTransformableToSimpleCondition([mockDataQuery(), mockDataQuery()], expressionQueries)).toBe(false);
+    expect(await areQueriesTransformableToSimpleCondition([mockDataQuery(), mockDataQuery()], expressionQueries)).toBe(
+      false
+    );
   });
 
-  it('should return false if expressionQueries length is not 2', () => {
+  it('should return false if expressionQueries length is not 2', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery()];
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, []);
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, []);
     expect(result).toBe(false);
   });
 
   // notSimpleCondition
   // reducer:
-  it('should return false if the mockDataQuery() refId does not match SimpleConditionIdentifier.queryId', () => {
+  it('should return false if the mockDataQuery() refId does not match SimpleConditionIdentifier.queryId', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery({ refId: 'foo' })];
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries);
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries);
     expect(result).toBe(false);
   });
 
-  it('should return false if no reduce expression is found with correct type and refId', () => {
+  it('should return false if no reduce expression is found with correct type and refId', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery()];
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, [
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, [
       { ...reduceExpression, refId: 'hello' },
       thresholdExpression,
     ]);
     expect(result).toBe(false);
   });
 
-  it('should return false if no threshold expression is found that points to reducer', () => {
+  it('should return false if no threshold expression is found that points to reducer', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery()];
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, [
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, [
       reduceExpression,
       mockThresholdExpression({ expression: 'hello' }),
     ]);
     expect(result).toBe(false);
   });
 
-  it('should return false if no threshold expression is found that points to instant data query', () => {
+  it('should return false if no threshold expression is found that points to instant data query', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery({ instant: true })];
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, [
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, [
       mockThresholdExpression({ expression: 'hello' }),
     ]);
     expect(result).toBe(false);
   });
 
-  it('should return false if reduceExpression settings mode is not ReducerMode.Strict', () => {
+  it('should return false if reduceExpression settings mode is not ReducerMode.Strict', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery()];
     const transformedReduceExpression = produce(reduceExpression, (draft) => {
       draft.model.settings = { mode: ReducerMode.DropNonNumbers };
     });
 
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, [
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, [
       transformedReduceExpression,
       thresholdExpression,
     ]);
     expect(result).toBe(false);
   });
 
-  it('should return false if thresholdExpression unloadEvaluator has a value', () => {
+  it('should return false if thresholdExpression unloadEvaluator has a value', async () => {
     const dataQueries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>> = [mockDataQuery()];
 
     const transformedThresholdExpression = produce(thresholdExpression, (draft) => {
@@ -96,20 +98,20 @@ describe('areQueriesTransformableToSimpleCondition', () => {
         },
       ];
     });
-    const result = areQueriesTransformableToSimpleCondition(dataQueries, [
+    const result = await areQueriesTransformableToSimpleCondition(dataQueries, [
       reduceExpression,
       transformedThresholdExpression,
     ]);
     expect(result).toBe(false);
   });
 
-  it('should return true when data query is connected to valid reducer and threshold', () => {
-    const result = areQueriesTransformableToSimpleCondition([mockDataQuery({ refId: 'A' })], expressionQueries);
+  it('should return true when data query is connected to valid reducer and threshold', async () => {
+    const result = await areQueriesTransformableToSimpleCondition([mockDataQuery({ refId: 'A' })], expressionQueries);
     expect(result).toBe(true);
   });
 
-  it('should return true when all conditions are met for instant data query with threshold', () => {
-    const result = areQueriesTransformableToSimpleCondition(
+  it('should return true when all conditions are met for instant data query with threshold', async () => {
+    const result = await areQueriesTransformableToSimpleCondition(
       [mockDataQuery({ instant: true })],
       [mockThresholdExpression({ expression: 'A' })]
     );

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,4 +1,8 @@
-import { type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
+import {
+  type DataSourceInstanceListItem,
+  type RelativeTimeRange,
+  getDefaultRelativeTimeRange,
+} from '@grafana/data';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import {
   ExpressionDatasourceUID,
@@ -17,6 +21,7 @@ import {
   optimizeReduceExpression,
   queriesAndExpressionsReducer,
   removeExpression,
+  resetToSimpleCondition,
   rewireExpressions,
   setDataQueries,
   updateExpression,
@@ -45,8 +50,7 @@ const thresholdExpression: AlertQuery<ExpressionQuery> = {
   },
 };
 
-const ds1 = {
-  id: 1,
+const ds1: DataSourceInstanceListItem = {
   uid: 'c8eceabb-0275-4108-8f03-8f74faf4bf6d',
   type: 'prometheus',
   name: 'gdev-prometheus',
@@ -57,18 +61,10 @@ const ds1 = {
         small: 'http://example.com/logo.png',
       },
     },
-  },
-  jsonData: {},
-  access: 'proxy',
+  } as DataSourceInstanceListItem['meta'],
+  readOnly: false,
+  isDefault: false,
 };
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: () => ({
-    getList: () => [ds1],
-    getInstanceSettings: () => ds1,
-  }),
-}));
 
 const alertQuery: AlertQuery = {
   refId: 'A',
@@ -138,9 +134,28 @@ describe('Query and expressions reducer', () => {
       queries: [alertQuery],
     };
 
-    const newState = queriesAndExpressionsReducer(initialState, addNewDataQuery());
+    const newState = queriesAndExpressionsReducer(initialState, addNewDataQuery(ds1));
     expect(newState.queries).toHaveLength(2);
     expect(newState).toMatchSnapshot();
+  });
+
+  it('should not add a query when no compatible data source is available', () => {
+    const initialState: QueriesAndExpressionsState = {
+      queries: [alertQuery],
+    };
+
+    const newState = queriesAndExpressionsReducer(initialState, addNewDataQuery(undefined));
+    expect(newState).toEqual(initialState);
+  });
+
+  it('should reset to the simple condition default queries', () => {
+    const initialState: QueriesAndExpressionsState = {
+      queries: [alertQuery, expressionQuery],
+    };
+
+    const defaultQueries: AlertQuery[] = [alertQuery];
+    const newState = queriesAndExpressionsReducer(initialState, resetToSimpleCondition(defaultQueries));
+    expect(newState).toEqual({ queries: defaultQueries });
   });
 
   it('should set data queries', () => {
@@ -397,6 +412,7 @@ describe('Query and expressions reducer', () => {
       optimizeReduceExpression({
         updatedQueries: [alertQuery],
         expressionQueries: [reduceExpression, thresholdExpression],
+        isInstantDataQuery: true,
       })
     );
     expect(newState).toMatchSnapshot();
@@ -412,6 +428,7 @@ describe('Query and expressions reducer', () => {
       optimizeReduceExpression({
         updatedQueries: [alertQuery],
         expressionQueries: [thresholdExpression, reduceExpression],
+        isInstantDataQuery: true,
       })
     );
     expect(newState).toMatchSnapshot();
@@ -427,6 +444,7 @@ describe('Query and expressions reducer', () => {
       optimizeReduceExpression({
         updatedQueries: [alertQuery, alertQuery],
         expressionQueries: [reduceExpression, thresholdExpression],
+        isInstantDataQuery: true,
       })
     );
     expect(newState).toEqual(initialState);
@@ -449,7 +467,11 @@ describe('Query and expressions reducer', () => {
 
     const newState = queriesAndExpressionsReducer(
       initialState,
-      optimizeReduceExpression({ updatedQueries: [alertQuery], expressionQueries: [thresholdExpression] })
+      optimizeReduceExpression({
+        updatedQueries: [alertQuery],
+        expressionQueries: [thresholdExpression],
+        isInstantDataQuery: false,
+      })
     );
     expect(newState).toMatchSnapshot();
   });

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,8 +1,4 @@
-import {
-  type DataSourceInstanceListItem,
-  type RelativeTimeRange,
-  getDefaultRelativeTimeRange,
-} from '@grafana/data';
+import { type DataSourceInstanceListItem, type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import {
   ExpressionDatasourceUID,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -1,9 +1,9 @@
 import { createAction, createReducer, original } from '@reduxjs/toolkit';
 
 import {
+  type DataSourceInstanceListItem,
   ReducerID,
   type RelativeTimeRange,
-  getDataSourceRef,
   getDefaultRelativeTimeRange,
   getNextRefId,
   rangeUtil,
@@ -20,8 +20,6 @@ import {
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { logError } from '../../../Analytics';
-import { getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
-import { getDefaultQueries, getInstantFromDataQuery } from '../../../utils/rule-form';
 import { createDagFromQueries, getOriginOfRefId } from '../dag';
 import { queriesWithUpdatedReferences, refIdExists } from '../util';
 
@@ -52,7 +50,7 @@ const initialState: QueriesAndExpressionsState = {
 };
 
 export const duplicateQuery = createAction<AlertQuery>('duplicateQuery');
-export const addNewDataQuery = createAction('addNewDataQuery');
+export const addNewDataQuery = createAction<DataSourceInstanceListItem | undefined>('addNewDataQuery');
 export const setDataQueries = createAction<AlertQuery[]>('setDataQueries');
 
 export const addNewExpression = createAction<ExpressionQueryType>('addNewExpression');
@@ -66,10 +64,11 @@ export const updateExpressionTimeRange = createAction('updateExpressionTimeRange
 const updateMaxDataPoints = createAction<{ refId: string; maxDataPoints: number }>('updateMaxDataPoints');
 const updateMinInterval = createAction<{ refId: string; minInterval: string }>('updateMinInterval');
 
-export const resetToSimpleCondition = createAction('resetToSimpleCondition');
+export const resetToSimpleCondition = createAction<AlertQuery[]>('resetToSimpleCondition');
 export const optimizeReduceExpression = createAction<{
   updatedQueries: AlertQuery[];
   expressionQueries: Array<AlertQuery<ExpressionQuery>>;
+  isInstantDataQuery: boolean;
 }>('optimizeReduceExpression');
 export const setRecordingRulesQueries = createAction<{ recordingRuleQueries: AlertQuery[]; expression: string }>(
   'setRecordingRulesQueries'
@@ -79,14 +78,13 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
   // data queries actions
   builder
     // simple condition actions
-    .addCase(resetToSimpleCondition, (state) => {
-      state.queries = getDefaultQueries();
+    .addCase(resetToSimpleCondition, (state, { payload }) => {
+      state.queries = payload;
     })
     .addCase(duplicateQuery, (state, { payload }) => {
       state.queries = addQuery(state.queries, payload);
     })
-    .addCase(addNewDataQuery, (state) => {
-      const datasource = getDefaultOrFirstCompatibleDataSource();
+    .addCase(addNewDataQuery, (state, { payload: datasource }) => {
       if (!datasource) {
         return;
       }
@@ -95,7 +93,13 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
         datasourceUid: datasource.uid,
         model: {
           refId: '',
-          datasource: getDataSourceRef(datasource),
+          // Built by hand: datasource is a slim DataSourceInstanceListItem, and getDataSourceRef()
+          // requires the full DataSourceInstanceSettings.
+          datasource: {
+            uid: datasource.uid,
+            type: datasource.type,
+            ...(datasource.apiVersion ? { apiVersion: datasource.apiVersion } : {}),
+          },
         },
       });
     })
@@ -237,7 +241,7 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
     })
     // removes the reduce expression when we have a instant data query
     .addCase(optimizeReduceExpression, (state, { payload }) => {
-      const { updatedQueries, expressionQueries } = payload;
+      const { updatedQueries, expressionQueries, isInstantDataQuery } = payload;
 
       if (updatedQueries.length !== 1) {
         // we only optimize when we have one data query
@@ -245,7 +249,6 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
       }
 
       const dataQuery = updatedQueries.at(0);
-      const isInstantDataQuery = dataQuery ? getInstantFromDataQuery(dataQuery) : false;
       const hasReducer = expressionQueries.some((q) => isReducerExpression(q.model));
       const shouldRemoveReducer = isInstantDataQuery && expressionQueries.length === 2 && hasReducer;
 

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useEffectOnce } from 'react-use';
 
 import { ReducerID } from '@grafana/data';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
@@ -10,23 +11,16 @@ import { type SimpleCondition } from '../../../types/rule-form';
 
 import { getSimpleConditionFromExpressions } from './SimpleCondition';
 
-function initializeSimpleCondition(
-  isGrafanaAlertingType: boolean,
-  dataQueries: Array<AlertQuery<AlertDataQuery>>,
-  expressionQueries: Array<AlertQuery<ExpressionQuery>>
-) {
-  if (isGrafanaAlertingType && areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)) {
-    return getSimpleConditionFromExpressions(expressionQueries);
-  } else {
-    return {
-      whenField: ReducerID.last,
-      evaluator: {
-        params: [0],
-        type: EvalFunction.IsAbove,
-      },
-    };
-  }
+function defaultSimpleCondition(): SimpleCondition {
+  return {
+    whenField: ReducerID.last,
+    evaluator: {
+      params: [0],
+      type: EvalFunction.IsAbove,
+    },
+  };
 }
+
 export function determineAdvancedMode(simplifiedQueryEditor: boolean | undefined, isGrafanaAlertingType: boolean) {
   return simplifiedQueryEditor === false || !isGrafanaAlertingType;
 }
@@ -43,9 +37,19 @@ export const useAdvancedMode = (
 ) => {
   const isAdvancedMode = determineAdvancedMode(simplifiedQueryEditor, isGrafanaAlertingType);
 
-  const [simpleCondition, setSimpleCondition] = useState<SimpleCondition>(
-    initializeSimpleCondition(isGrafanaAlertingType, dataQueries, expressionQueries)
-  );
+  const [simpleCondition, setSimpleCondition] = useState<SimpleCondition>(defaultSimpleCondition());
+
+  useEffectOnce(() => {
+    // Resolves the real initial value once transformability's async datasource lookup settles.
+    async function resolveInitialSimpleCondition() {
+      const transformable =
+        isGrafanaAlertingType && (await areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries));
+      if (transformable) {
+        setSimpleCondition(getSimpleConditionFromExpressions(expressionQueries));
+      }
+    }
+    resolveInitialSimpleCondition();
+  });
 
   useEffect(() => {
     if (isGrafanaAlertingType && !isAdvancedMode) {

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/version-history/ConfirmVersionRestoreModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/version-history/ConfirmVersionRestoreModal.tsx
@@ -69,7 +69,7 @@ export const ConfirmVersionRestoreModal = ({
     if (!versionToRestore || !ruleWithLocation) {
       return;
     }
-    const payload = rulerRuleToFormValues({ ...ruleWithLocation, rule: versionToRestore });
+    const payload = await rulerRuleToFormValues({ ...ruleWithLocation, rule: versionToRestore });
     const ruleFormUrl = urlUtil.renderUrl(`/alerting/${ruleIdentifier.uid}/edit`, {
       isManualRestore: true,
       defaults: JSON.stringify(payload),

--- a/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
+++ b/public/app/features/alerting/unified/rule-editor/ExistingRuleEditor.tsx
@@ -1,6 +1,8 @@
+import { useAsync } from 'react-use';
+
 import { type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Stack } from '@grafana/ui';
+import { Alert, LoadingPlaceholder, Stack } from '@grafana/ui';
 import { type RuleIdentifier } from 'app/types/unified-alerting';
 
 import { AlertWarning } from '../AlertWarning';
@@ -47,6 +49,13 @@ export function ExistingRuleEditor({
     loading: loadingEditable,
     error: errorEditable,
   } = useIsRuleEditable(ruleSourceName, ruleWithLocation?.rule);
+
+  const { value: clonePrefill } = useAsync(async () => {
+    if (!clone || !ruleWithLocation) {
+      return undefined;
+    }
+    return rulerRuleToFormValues(cloneRuleDefinition(ruleWithLocation));
+  }, [clone, ruleWithLocation]);
 
   if (fetchRuleError || errorEditable) {
     return (
@@ -109,6 +118,12 @@ export function ExistingRuleEditor({
     ? t('alerting.editor.edit-recording-rule', 'Edit recording rule')
     : t('alerting.editor.edit-alert-rule', 'Edit alert rule');
 
+  const cloneContent = clonePrefill ? (
+    <AlertRuleForm prefill={clonePrefill} />
+  ) : (
+    <LoadingPlaceholder text={t('alerting.existing-rule-editor.loading-clone', 'Loading rule...')} />
+  );
+
   return (
     <AlertingPageWrapper
       navId={navId}
@@ -122,7 +137,7 @@ export function ExistingRuleEditor({
       pageNav={getPageNav({ text: pageTitle })}
     >
       {clone ? (
-        <AlertRuleForm prefill={rulerRuleToFormValues(cloneRuleDefinition(ruleWithLocation))} />
+        cloneContent
       ) : (
         <AlertRuleForm existing={ruleWithLocation} prefill={prefill} isManualRestore={isManualRestore} />
       )}

--- a/public/app/features/alerting/unified/rule-editor/RuleEditor.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditor.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom-v5-compat';
+import { useAsync } from 'react-use';
 
 import { type NavModelItem } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -77,7 +78,7 @@ export const RECORDING_TYPE = ['grafana-recording', 'recording'];
  * This one is used for creating new rules (both alerting and recording rules)
  */
 function NewRuleEditor() {
-  const prefill = useDefaultsFromQuery();
+  const { queryDefaults: prefill, loading: loadingPrefill } = useDefaultsFromQuery();
   const isManualRestore = useManualRestore();
   const { type = '', identifier = '' } = useRuleEditorPathParams();
 
@@ -101,8 +102,9 @@ function NewRuleEditor() {
         id: 'alert-rule-add',
         text: isExisting ? editText : newText,
       }}
+      isLoading={loadingPrefill}
     >
-      <AlertRuleForm prefill={prefill} isManualRestore={isManualRestore} />
+      {!loadingPrefill && <AlertRuleForm prefill={prefill} isManualRestore={isManualRestore} />}
     </AlertingPageWrapper>
   );
 }
@@ -132,12 +134,17 @@ function useDefaultsFromQuery() {
   const [searchParams] = useURLSearchParams();
 
   const ruleType = translateRouteParamToRuleType(type);
+  const defaultsParam = searchParams.get('defaults');
 
-  const queryDefaults = searchParams.has('defaults')
-    ? formValuesFromQueryParams(searchParams.get('defaults') ?? '', ruleType)
-    : undefined;
+  const { value: queryDefaults, loading } = useAsync(async () => {
+    if (!defaultsParam) {
+      return undefined;
+    }
+    return formValuesFromQueryParams(defaultsParam, ruleType);
+  }, [defaultsParam, ruleType]);
 
-  return queryDefaults;
+  // Only report loading when a `defaults` param exists, so the common new-rule flow never waits.
+  return { queryDefaults, loading: Boolean(defaultsParam) && loading };
 }
 
 function useManualRestore() {

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
@@ -1,15 +1,12 @@
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { type DataSourceInstanceListItem } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { mockAlertQuery, mockDataSource, mockReduceExpression, mockThresholdExpression } from '../mocks';
+import { setupDataSources } from '../testSetup/datasources';
 import { RuleFormType } from '../types/rule-form';
 import { Annotation } from '../utils/constants';
 import { DataSourceType, getDefaultOrFirstCompatibleDataSource } from '../utils/datasource';
 import { MANUAL_ROUTING_KEY, getDefaultQueries } from '../utils/rule-form';
-
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual('@grafana/runtime'),
-  getDataSourceSrv: jest.fn(),
-}));
 
 import {
   formValuesFromPrefill,
@@ -29,42 +26,44 @@ const mocks = {
 };
 
 // Setup mock implementation
-mocks.getDefaultOrFirstCompatibleDataSource.mockReturnValue(
+mocks.getDefaultOrFirstCompatibleDataSource.mockResolvedValue(
   mockDataSource({
     type: DataSourceType.Prometheus,
-  })
+  }) as DataSourceInstanceListItem
 );
 
 // TODO Not sure why queries are an empty array in the default form values
-const defaultFormValues = {
-  ...getDefaultFormValues(),
-  queries: getDefaultQueries(),
-};
+async function getExpectedDefaultFormValues() {
+  return {
+    ...getDefaultFormValues(),
+    queries: await getDefaultQueries(),
+  };
+}
 
 describe('formValuesFromQueryParams', () => {
-  it('should return default values when given invalid JSON', () => {
-    const result = formValuesFromQueryParams('invalid json', RuleFormType.grafana);
+  it('should return default values when given invalid JSON', async () => {
+    const result = await formValuesFromQueryParams('invalid json', RuleFormType.grafana);
 
-    expect(result).toEqual(defaultFormValues);
+    expect(result).toEqual(await getExpectedDefaultFormValues());
   });
 
-  it('should preserve evaluateEvery when provided', () => {
+  it('should preserve evaluateEvery when provided', async () => {
     // "Continue in Alerting" from the panel drawer passes the rule's interval through this param;
     // it must not be overwritten with the default.
     const ruleDefinition = JSON.stringify({ evaluateEvery: '5m' });
 
-    const result = formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
+    const result = await formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
 
     expect(result.evaluateEvery).toBe('5m');
   });
 
-  it('should fall back to the default evaluateEvery when not provided', () => {
-    const result = formValuesFromQueryParams(JSON.stringify({}), RuleFormType.grafana);
+  it('should fall back to the default evaluateEvery when not provided', async () => {
+    const result = await formValuesFromQueryParams(JSON.stringify({}), RuleFormType.grafana);
 
-    expect(result.evaluateEvery).toBe(defaultFormValues.evaluateEvery);
+    expect(result.evaluateEvery).toBe((await getExpectedDefaultFormValues()).evaluateEvery);
   });
 
-  it('should normalize annotations', () => {
+  it('should normalize annotations', async () => {
     const ruleDefinition = JSON.stringify({
       annotations: [
         { key: 'custom', value: 'my custom annotation' },
@@ -76,7 +75,7 @@ describe('formValuesFromQueryParams', () => {
       ],
     });
 
-    const result = formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
+    const result = await formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
 
     const [summary, description, runbookURL, ...rest] = result.annotations;
 
@@ -89,8 +88,8 @@ describe('formValuesFromQueryParams', () => {
   });
 
   describe('when simplified query editor is enabled', () => {
-    it('should enable simplified query editor if queries are transformable to simple condition', () => {
-      const result = formValuesFromQueryParams(
+    it('should enable simplified query editor if queries are transformable to simple condition', async () => {
+      const result = await formValuesFromQueryParams(
         JSON.stringify({
           queries: [
             mockAlertQuery(),
@@ -105,8 +104,8 @@ describe('formValuesFromQueryParams', () => {
       expect(result.editorSettings!.simplifiedQueryEditor).toBe(true);
     });
 
-    it('should disable simplified query editor if queries are not transformable to simple condition', () => {
-      const result = formValuesFromQueryParams(
+    it('should disable simplified query editor if queries are not transformable to simple condition', async () => {
+      const result = await formValuesFromQueryParams(
         JSON.stringify({
           queries: [mockAlertQuery(), mockAlertQuery(), mockThresholdExpression({ expression: 'B' })],
         }),
@@ -118,8 +117,8 @@ describe('formValuesFromQueryParams', () => {
     });
   });
 
-  it('should default to instant queries for loki and prometheus if not specified', () => {
-    const result = formValuesFromQueryParams(
+  it('should default to instant queries for loki and prometheus if not specified', async () => {
+    const result = await formValuesFromQueryParams(
       JSON.stringify({
         queries: [
           mockAlertQuery({ datasourceUid: 'loki', model: { refId: 'A', datasource: { type: DataSourceType.Loki } } }),
@@ -140,8 +139,8 @@ describe('formValuesFromQueryParams', () => {
     expect(prometheusQuery.model.range).toBe(false);
   });
 
-  it('should preserver instant and range values if specified', () => {
-    const result = formValuesFromQueryParams(
+  it('should preserver instant and range values if specified', async () => {
+    const result = await formValuesFromQueryParams(
       JSON.stringify({
         queries: [
           mockAlertQuery({
@@ -165,7 +164,7 @@ describe('formValuesFromQueryParams', () => {
     expect(prometheusQuery.model.instant).toBe(false);
   });
 
-  it('should reveal hidden queries', () => {
+  it('should reveal hidden queries', async () => {
     const ruleDefinition = JSON.stringify({
       queries: [
         { refId: 'A', model: { refId: 'A', hide: true } },
@@ -174,7 +173,7 @@ describe('formValuesFromQueryParams', () => {
       ],
     });
 
-    const result = formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
+    const result = await formValuesFromQueryParams(ruleDefinition, RuleFormType.grafana);
 
     expect(result.queries.length).toBe(3);
 
@@ -214,97 +213,88 @@ describe('getDefaultFormValues', () => {
   const grafanaConfig = config;
   const uaConfig = grafanaConfig.unifiedAlerting;
 
-  const mockGetInstanceSettings = jest.fn();
-
-  beforeEach(() => {
-    (getDataSourceSrv as jest.Mock).mockReturnValue({
-      getInstanceSettings: mockGetInstanceSettings,
-    });
-  });
-
   afterEach(() => {
     uaConfig.defaultRecordingRulesTargetDatasourceUID = undefined;
-    jest.clearAllMocks();
   });
 
   it('should set targetDatasourceUid from config when datasource is valid for recording rules', () => {
     const expectedDatasourceUid = 'test-datasource-uid';
     uaConfig.defaultRecordingRulesTargetDatasourceUID = expectedDatasourceUid;
 
-    const validDataSource = mockDataSource({
-      uid: expectedDatasourceUid,
-      type: DataSourceType.Prometheus,
-      jsonData: {
-        allowAsRecordingRulesTarget: true,
-      },
-    });
-    mockGetInstanceSettings.mockReturnValue(validDataSource);
+    setupDataSources(
+      mockDataSource({
+        uid: expectedDatasourceUid,
+        type: DataSourceType.Prometheus,
+        jsonData: {
+          allowAsRecordingRulesTarget: true,
+        },
+      })
+    );
 
     const result = getDefaultFormValues();
 
     expect(result.targetDatasourceUid).toBe(expectedDatasourceUid);
-    expect(mockGetInstanceSettings).toHaveBeenCalledWith(expectedDatasourceUid);
   });
 
   it('should set targetDatasourceUid to undefined when datasource has allowAsRecordingRulesTarget disabled', () => {
     const datasourceUid = 'test-datasource-uid';
     uaConfig.defaultRecordingRulesTargetDatasourceUID = datasourceUid;
 
-    const invalidDataSource = mockDataSource({
-      uid: datasourceUid,
-      type: DataSourceType.Prometheus,
-      jsonData: {
-        allowAsRecordingRulesTarget: false,
-      },
-    });
-    mockGetInstanceSettings.mockReturnValue(invalidDataSource);
+    setupDataSources(
+      mockDataSource({
+        uid: datasourceUid,
+        type: DataSourceType.Prometheus,
+        jsonData: {
+          allowAsRecordingRulesTarget: false,
+        },
+      })
+    );
 
     const result = getDefaultFormValues();
 
     expect(result.targetDatasourceUid).toBeUndefined();
-    expect(mockGetInstanceSettings).toHaveBeenCalledWith(datasourceUid);
   });
 
   it('should set targetDatasourceUid to undefined when datasource type is not supported', () => {
     const datasourceUid = 'test-datasource-uid';
     uaConfig.defaultRecordingRulesTargetDatasourceUID = datasourceUid;
 
-    const nonPrometheusDataSource = mockDataSource({
-      uid: datasourceUid,
-      type: DataSourceType.Loki,
-      jsonData: {
-        allowAsRecordingRulesTarget: true,
-      },
-    });
-    mockGetInstanceSettings.mockReturnValue(nonPrometheusDataSource);
+    setupDataSources(
+      mockDataSource({
+        uid: datasourceUid,
+        type: DataSourceType.Loki,
+        jsonData: {
+          allowAsRecordingRulesTarget: true,
+        },
+      })
+    );
 
     const result = getDefaultFormValues();
 
     expect(result.targetDatasourceUid).toBeUndefined();
-    expect(mockGetInstanceSettings).toHaveBeenCalledWith(datasourceUid);
   });
 
   it('should set targetDatasourceUid to undefined when datasource does not exist', () => {
     const datasourceUid = 'non-existent-datasource-uid';
     uaConfig.defaultRecordingRulesTargetDatasourceUID = datasourceUid;
 
-    mockGetInstanceSettings.mockReturnValue(null);
+    setupDataSources();
 
     const result = getDefaultFormValues();
 
     expect(result.targetDatasourceUid).toBeUndefined();
-    expect(mockGetInstanceSettings).toHaveBeenCalledWith(datasourceUid);
   });
 
   it('should set targetDatasourceUid to undefined when defaultRecordingRulesTargetDatasourceUID is not provided', () => {
+    setupDataSources();
+
     const result = getDefaultFormValues();
     expect(result.targetDatasourceUid).toBeUndefined();
-    expect(mockGetInstanceSettings).not.toHaveBeenCalled();
   });
 });
 
 describe('formValuesFromPrefill', () => {
-  it('should preserve threshold expression query structure', () => {
+  it('should preserve threshold expression query structure', async () => {
     const prefillData = {
       folder: { uid: 'test-folder', title: 'Test Folder' },
       group: 'test-group',
@@ -354,7 +344,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
 
     const queryC = result.queries.find((q) => q.refId === 'C');
     expect(queryC?.model).toHaveProperty('type', 'threshold');
@@ -367,7 +357,7 @@ describe('formValuesFromPrefill', () => {
     expect(queryC?.model).not.toHaveProperty('range');
   });
 
-  it('should preserve reduce expression query structure', () => {
+  it('should preserve reduce expression query structure', async () => {
     const prefillData = {
       queries: [
         {
@@ -387,7 +377,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const query = result.queries[0];
 
     expect(query.model).toHaveProperty('type', 'reduce');
@@ -397,7 +387,7 @@ describe('formValuesFromPrefill', () => {
     expect(query.model).not.toHaveProperty('range');
   });
 
-  it('should preserve math expression query structure', () => {
+  it('should preserve math expression query structure', async () => {
     const prefillData = {
       queries: [
         {
@@ -426,7 +416,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const query = result.queries[0];
 
     expect(query.model).toHaveProperty('type', 'math');
@@ -434,7 +424,7 @@ describe('formValuesFromPrefill', () => {
     expect(query.model).toHaveProperty('conditions');
   });
 
-  it('should preserve classic_conditions expression query structure', () => {
+  it('should preserve classic_conditions expression query structure', async () => {
     const prefillData = {
       queries: [
         {
@@ -470,7 +460,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const [query] = result.queries.filter(isExpressionQueryInAlert);
 
     expect(query.model).toHaveProperty('type', 'classic_conditions');
@@ -479,7 +469,7 @@ describe('formValuesFromPrefill', () => {
     expect(query.model.conditions?.[1].evaluator.type).toBe('within_range');
   });
 
-  it('should preserve resample expression query structure', () => {
+  it('should preserve resample expression query structure', async () => {
     const prefillData = {
       queries: [
         {
@@ -511,7 +501,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const query = result.queries[0];
 
     expect(query.model).toHaveProperty('type', 'resample');
@@ -520,7 +510,7 @@ describe('formValuesFromPrefill', () => {
     expect(query.model).toHaveProperty('window', '2m');
   });
 
-  it('should preserve Prometheus query fields', () => {
+  it('should preserve Prometheus query fields', async () => {
     const prefillData = {
       queries: [
         {
@@ -544,7 +534,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const [query] = result.queries.filter(isAlertQueryOfAlertData);
 
     expect(query.model).toHaveProperty('expr', 'rate(promhttp_metric_handler_requests_total{}[15m])');
@@ -555,7 +545,7 @@ describe('formValuesFromPrefill', () => {
     expect(query.model.range).toBe(false);
   });
 
-  it('should not add default values to query models', () => {
+  it('should not add default values to query models', async () => {
     const prefillData = {
       queries: [
         {
@@ -567,7 +557,7 @@ describe('formValuesFromPrefill', () => {
       ],
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
     const query = result.queries[0];
 
     // Should NOT have defaults added
@@ -577,13 +567,13 @@ describe('formValuesFromPrefill', () => {
     expect(query.model).not.toHaveProperty('queryType');
   });
 
-  it('should preserve missingSeriesEvalsToResolve when duplicating a rule', () => {
+  it('should preserve missingSeriesEvalsToResolve when duplicating a rule', async () => {
     const prefillData = {
       type: RuleFormType.grafana,
       missingSeriesEvalsToResolve: 5,
     };
 
-    const result = formValuesFromPrefill(prefillData);
+    const result = await formValuesFromPrefill(prefillData);
 
     expect(result.missingSeriesEvalsToResolve).toBe(5);
   });

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.ts
@@ -2,7 +2,7 @@ import { clamp } from 'lodash';
 import * as z from 'zod';
 
 import { store } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { alertingAlertRuleFormSchema } from 'app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema';
 import { type RuleWithLocation } from 'app/types/unified-alerting';
 import { GrafanaAlertStateDecision, type RulerRuleDTO } from 'app/types/unified-alerting-dto';
@@ -12,7 +12,7 @@ import { RuleFormType, type RuleFormValues } from '../types/rule-form';
 // TODO Ideally all of these should be moved here
 import { getRulesAccess } from '../utils/access-control';
 import { defaultAnnotations } from '../utils/constants';
-import { GRAFANA_RULES_SOURCE_NAME, isValidRecordingRulesTarget } from '../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDataSourceByUid, isValidRecordingRulesTarget } from '../utils/datasource';
 import {
   MANUAL_ROUTING_KEY,
   SIMPLIFIED_QUERY_EDITOR_KEY,
@@ -47,7 +47,9 @@ function getValidDefaultTargetDatasourceUid(): string | undefined {
   }
 
   try {
-    const datasource = getDataSourceSrv().getInstanceSettings(configuredDefaultUid);
+    // Sync on purpose, unlike other datasource lookups in this migration: getDefaultFormValues()
+    // is used as a synchronous useForm({ defaultValues }) elsewhere and must stay that way.
+    const datasource = getDataSourceByUid(configuredDefaultUid);
     if (datasource && isValidRecordingRulesTarget(datasource)) {
       return configuredDefaultUid;
     }
@@ -132,7 +134,7 @@ function getDefaultEditorSettings(ruleType?: RuleFormType) {
   };
 }
 
-export function formValuesFromQueryParams(ruleDefinition: string, type: RuleFormType): RuleFormValues {
+export async function formValuesFromQueryParams(ruleDefinition: string, type: RuleFormType): Promise<RuleFormValues> {
   let ruleFromQueryParams: Partial<RuleFormValues>;
 
   try {
@@ -140,7 +142,7 @@ export function formValuesFromQueryParams(ruleDefinition: string, type: RuleForm
   } catch (err) {
     return {
       ...getDefaultFormValues(type),
-      queries: getDefaultQueries(),
+      queries: await getDefaultQueries(),
     };
   }
 
@@ -150,7 +152,7 @@ export function formValuesFromQueryParams(ruleDefinition: string, type: RuleForm
         ...getDefaultFormValues(type),
         ...ruleFromQueryParams,
         annotations: normalizeDefaultAnnotations(ruleFromQueryParams.annotations ?? []),
-        queries: ruleFromQueryParams.queries ?? getDefaultQueries(),
+        queries: ruleFromQueryParams.queries ?? (await getDefaultQueries()),
         type: ruleFromQueryParams.type ?? type ?? RuleFormType.grafana,
         evaluateEvery: ruleFromQueryParams.evaluateEvery ?? DEFAULT_GROUP_EVALUATION_INTERVAL,
       })
@@ -239,7 +241,7 @@ const cloudRuleFormValuesSchema = z.looseObject({
   missingSeriesEvalsToResolve: z.number().optional(),
 });
 
-export function formValuesFromPrefill(rule: Partial<RuleFormValues>): RuleFormValues {
+export async function formValuesFromPrefill(rule: Partial<RuleFormValues>): Promise<RuleFormValues> {
   let parsedRule: z.infer<typeof alertingAlertRuleFormSchema> | z.infer<typeof cloudRuleFormValuesSchema>;
   // differencitate between cloud and grafana prefill
   if (rule.type === RuleFormType.cloudAlerting) {
@@ -259,15 +261,15 @@ export function formValuesFromPrefill(rule: Partial<RuleFormValues>): RuleFormVa
   );
 }
 
-export function formValuesFromExistingRule(rule: RuleWithLocation<RulerRuleDTO>) {
-  return revealHiddenQueries(rulerRuleToFormValues(rule));
+export async function formValuesFromExistingRule(rule: RuleWithLocation<RulerRuleDTO>): Promise<RuleFormValues> {
+  return revealHiddenQueries(await rulerRuleToFormValues(rule));
 }
 
-export function defaultFormValuesForRuleType(ruleType: RuleFormType): RuleFormValues {
+export async function defaultFormValuesForRuleType(ruleType: RuleFormType): Promise<RuleFormValues> {
   return {
     ...getDefaultFormValues(ruleType),
     condition: 'C',
-    queries: getDefaultQueries(isGrafanaRecordingRuleByType(ruleType)),
+    queries: await getDefaultQueries(isGrafanaRecordingRuleByType(ruleType)),
     type: ruleType,
     evaluateEvery: DEFAULT_GROUP_EVALUATION_INTERVAL,
   };

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
@@ -1,0 +1,75 @@
+import { mockAlertQuery, mockDataSource, mockReduceExpression, mockThresholdExpression } from '../mocks';
+import { setupDataSources } from '../testSetup/datasources';
+import { DataSourceType } from '../utils/datasource';
+
+import { getDefaultFormValues } from './formDefaults';
+import { areQueriesTransformableToSimpleCondition, setQueryEditorSettings } from './formProcessing';
+
+describe('areQueriesTransformableToSimpleCondition', () => {
+  it('should return false when there is not exactly one data query', async () => {
+    expect(await areQueriesTransformableToSimpleCondition([], [])).toBe(false);
+    expect(
+      await areQueriesTransformableToSimpleCondition([mockAlertQuery(), mockAlertQuery()], [mockThresholdExpression()])
+    ).toBe(false);
+  });
+
+  it('should return false when there are more than two expressions', async () => {
+    const result = await areQueriesTransformableToSimpleCondition(
+      [mockAlertQuery()],
+      [mockReduceExpression(), mockThresholdExpression(), mockThresholdExpression({ refId: 'D' })]
+    );
+    expect(result).toBe(false);
+  });
+
+  it('should return true for a strict reduce expression feeding a clean threshold expression', async () => {
+    const result = await areQueriesTransformableToSimpleCondition(
+      [mockAlertQuery()],
+      [mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })]
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return true for a single threshold expression pointing at an instant data query', async () => {
+    setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'prom', uid: 'prom-1' }));
+
+    const dataQuery = mockAlertQuery({ datasourceUid: 'prom-1', model: { refId: 'A', instant: true } });
+    const result = await areQueriesTransformableToSimpleCondition(
+      [dataQuery],
+      [mockThresholdExpression({ expression: 'A' })]
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('should return false for a single threshold expression pointing at a non-instant data query', async () => {
+    setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'prom', uid: 'prom-1' }));
+
+    const dataQuery = mockAlertQuery({ datasourceUid: 'prom-1', model: { refId: 'A', instant: false } });
+    const result = await areQueriesTransformableToSimpleCondition(
+      [dataQuery],
+      [mockThresholdExpression({ expression: 'A' })]
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('setQueryEditorSettings', () => {
+  it('should enable the simplified editor when queries are transformable', async () => {
+    const result = await setQueryEditorSettings({
+      ...getDefaultFormValues(),
+      queries: [mockAlertQuery(), mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })],
+    });
+
+    expect(result.editorSettings?.simplifiedQueryEditor).toBe(true);
+  });
+
+  it('should disable the simplified editor when queries are not transformable', async () => {
+    const result = await setQueryEditorSettings({
+      ...getDefaultFormValues(),
+      queries: [mockAlertQuery(), mockAlertQuery({ refId: 'B' }), mockThresholdExpression({ expression: 'C' })],
+    });
+
+    expect(result.editorSettings?.simplifiedQueryEditor).toBe(false);
+  });
+});

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
@@ -1,64 +1,17 @@
-import { mockAlertQuery, mockDataSource, mockReduceExpression, mockThresholdExpression } from '../mocks';
-import { setupDataSources } from '../testSetup/datasources';
-import { DataSourceType } from '../utils/datasource';
+import { mockAlertQuery, mockReduceExpression, mockThresholdExpression } from '../mocks';
 
 import { getDefaultFormValues } from './formDefaults';
-import { areQueriesTransformableToSimpleCondition, setQueryEditorSettings } from './formProcessing';
-
-describe('areQueriesTransformableToSimpleCondition', () => {
-  it('should return false when there is not exactly one data query', async () => {
-    expect(await areQueriesTransformableToSimpleCondition([], [])).toBe(false);
-    expect(
-      await areQueriesTransformableToSimpleCondition([mockAlertQuery(), mockAlertQuery()], [mockThresholdExpression()])
-    ).toBe(false);
-  });
-
-  it('should return false when there are more than two expressions', async () => {
-    const result = await areQueriesTransformableToSimpleCondition(
-      [mockAlertQuery()],
-      [mockReduceExpression(), mockThresholdExpression(), mockThresholdExpression({ refId: 'D' })]
-    );
-    expect(result).toBe(false);
-  });
-
-  it('should return true for a strict reduce expression feeding a clean threshold expression', async () => {
-    const result = await areQueriesTransformableToSimpleCondition(
-      [mockAlertQuery()],
-      [mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })]
-    );
-    expect(result).toBe(true);
-  });
-
-  it('should return true for a single threshold expression pointing at an instant data query', async () => {
-    setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'prom', uid: 'prom-1' }));
-
-    const dataQuery = mockAlertQuery({ datasourceUid: 'prom-1', model: { refId: 'A', instant: true } });
-    const result = await areQueriesTransformableToSimpleCondition(
-      [dataQuery],
-      [mockThresholdExpression({ expression: 'A' })]
-    );
-
-    expect(result).toBe(true);
-  });
-
-  it('should return false for a single threshold expression pointing at a non-instant data query', async () => {
-    setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'prom', uid: 'prom-1' }));
-
-    const dataQuery = mockAlertQuery({ datasourceUid: 'prom-1', model: { refId: 'A', instant: false } });
-    const result = await areQueriesTransformableToSimpleCondition(
-      [dataQuery],
-      [mockThresholdExpression({ expression: 'A' })]
-    );
-
-    expect(result).toBe(false);
-  });
-});
+import { setQueryEditorSettings } from './formProcessing';
 
 describe('setQueryEditorSettings', () => {
   it('should enable the simplified editor when queries are transformable', async () => {
     const result = await setQueryEditorSettings({
       ...getDefaultFormValues(),
-      queries: [mockAlertQuery(), mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })],
+      queries: [
+        mockAlertQuery(),
+        mockReduceExpression({ expression: 'A' }),
+        mockThresholdExpression({ expression: 'B' }),
+      ],
     });
 
     expect(result.editorSettings?.simplifiedQueryEditor).toBe(true);

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -11,7 +11,7 @@ import { defaultAnnotations } from '../utils/constants';
 import { isSupportedExternalRulesSourceType } from '../utils/datasource';
 import { getInstantFromDataQuery } from '../utils/rule-form';
 
-export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
+export async function setQueryEditorSettings(values: RuleFormValues): Promise<RuleFormValues> {
   // data queries only
   const dataQueries = values.queries.filter((query) => !isExpressionQuery(query.model));
 
@@ -42,7 +42,7 @@ export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
       condition: conditionRefStillValid ? values.condition : (expressionQueries[0]?.refId ?? ''),
       editorSettings: {
         simplifiedQueryEditor: hasValidExpressions
-          ? areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)
+          ? await areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)
           : true,
         simplifiedNotificationEditor: true,
       },
@@ -61,7 +61,7 @@ export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
     };
   }
 
-  const queryParamsAreTransformable = areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries);
+  const queryParamsAreTransformable = await areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries);
   return {
     ...values,
     editorSettings: {
@@ -104,10 +104,10 @@ export function setInstantOrRange(values: RuleFormValues): RuleFormValues {
  *   2.2 a threshold expression pointing to a (instant) data query
  * ⚠️ do not assert on refIds or indexes of the queries
  */
-export function areQueriesTransformableToSimpleCondition(
+export async function areQueriesTransformableToSimpleCondition(
   dataQueries: Array<AlertQuery<AlertDataQuery>>,
   expressionQueries: Array<AlertQuery<ExpressionQuery>>
-) {
+): Promise<boolean> {
   // 1. check if we only have a _single_ data query
   if (dataQueries.length !== 1) {
     return false;
@@ -144,7 +144,7 @@ export function areQueriesTransformableToSimpleCondition(
   }
 
   // 2.2 check for a single threshold expression pointing to an "instant" data query
-  const isInstantDataQuery = dataQuery ? getInstantFromDataQuery(dataQuery) : false;
+  const isInstantDataQuery = dataQuery ? await getInstantFromDataQuery(dataQuery) : false;
   const hasSingleThresholdExpression = expressionQueries.length === 1 && thresholdExpression;
   const thresholdPointingToDataQuery = thresholdExpression?.model.expression === dataQuery?.refId;
 

--- a/public/app/features/alerting/unified/utils/datasource.test.ts
+++ b/public/app/features/alerting/unified/utils/datasource.test.ts
@@ -1,9 +1,12 @@
 import { config } from '@grafana/runtime';
 
 import { mockDataSource } from '../mocks';
+import { setupDataSources } from '../testSetup/datasources';
 
 import {
   SUPPORTED_EXTERNAL_PROMETHEUS_FLAVORED_RULE_SOURCE_TYPES,
+  getDefaultOrFirstCompatibleDataSource,
+  getFirstCompatibleDataSource,
   isDataSourceManagingAlerts,
   isValidRecordingRulesTarget,
 } from './datasource';
@@ -102,5 +105,53 @@ describe('isValidRecordingRulesTarget', () => {
         })
       )
     ).toBe(false);
+  });
+});
+
+describe('getFirstCompatibleDataSource', () => {
+  it('should return the first alerting-capable data source', async () => {
+    setupDataSources(
+      mockDataSource({ name: 'not-alerting', uid: 'ds-1' }, { alerting: false }),
+      mockDataSource({ name: 'alerting-ds', uid: 'ds-2' }, { alerting: true })
+    );
+
+    const result = await getFirstCompatibleDataSource();
+    expect(result?.uid).toBe('ds-2');
+  });
+
+  it('should return undefined when no alerting-capable data source exists', async () => {
+    setupDataSources(mockDataSource({ name: 'not-alerting', uid: 'ds-1' }, { alerting: false }));
+
+    const result = await getFirstCompatibleDataSource();
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getDefaultOrFirstCompatibleDataSource', () => {
+  it('should return the default data source when it is alerting-capable', async () => {
+    setupDataSources(
+      mockDataSource({ name: 'default-ds', uid: 'ds-1', isDefault: true }, { alerting: true }),
+      mockDataSource({ name: 'other-ds', uid: 'ds-2' }, { alerting: true })
+    );
+
+    const result = await getDefaultOrFirstCompatibleDataSource();
+    expect(result?.uid).toBe('ds-1');
+  });
+
+  it('should fall back to the first alerting-capable data source when the default is not alerting-capable', async () => {
+    setupDataSources(
+      mockDataSource({ name: 'default-ds', uid: 'ds-1', isDefault: true }, { alerting: false }),
+      mockDataSource({ name: 'other-ds', uid: 'ds-2' }, { alerting: true })
+    );
+
+    const result = await getDefaultOrFirstCompatibleDataSource();
+    expect(result?.uid).toBe('ds-2');
+  });
+
+  it('should return undefined when no compatible data source exists', async () => {
+    setupDataSources(mockDataSource({ name: 'default-ds', uid: 'ds-1', isDefault: true }, { alerting: false }));
+
+    const result = await getDefaultOrFirstCompatibleDataSource();
+    expect(result).toBeUndefined();
   });
 });

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -1,5 +1,11 @@
-import { type DataSourceInstanceSettings, type DataSourceJsonData, type DataSourceSettings } from '@grafana/data';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import {
+  type DataSourceInstanceListItem,
+  type DataSourceInstanceSettings,
+  type DataSourceJsonData,
+  type DataSourceSettings,
+} from '@grafana/data';
+import { config } from '@grafana/runtime';
+import { getDataSourceInstanceList, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import {
   type AlertManagerDataSourceJsonData,
   AlertManagerImplementation,
@@ -322,15 +328,21 @@ export function getDataSourceUID(rulesSourceIdentifier: { rulesSourceName: strin
   return ds.uid;
 }
 
-export function getFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {
-  return getDataSourceSrv().getList({ alerting: true })[0];
+export async function getFirstCompatibleDataSource(): Promise<DataSourceInstanceListItem | undefined> {
+  const dataSources = await getDataSourceInstanceList({ alerting: true });
+  return dataSources[0];
 }
 
-export function getDefaultOrFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {
-  const defaultDataSource = getDataSourceSrv().getInstanceSettings('default');
+export async function getDefaultOrFirstCompatibleDataSource(): Promise<DataSourceInstanceListItem | undefined> {
+  const defaultDataSource = await getDataSourceInstanceSettings('default');
   const defaultIsCompatible = defaultDataSource?.meta.alerting ?? false;
 
-  return defaultIsCompatible ? defaultDataSource : getFirstCompatibleDataSource();
+  if (defaultDataSource && defaultIsCompatible) {
+    // isDefault isn't guaranteed here, but we resolved this via the 'default' ref, so it is one.
+    return { ...defaultDataSource, isDefault: true };
+  }
+
+  return getFirstCompatibleDataSource();
 }
 
 export function isDataSourceManagingAlerts(ds: DataSourceInstanceSettings<DataSourceJsonData>) {

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -179,7 +179,7 @@ describe('formValuesToRulerGrafanaRuleDTO', () => {
 });
 
 describe('rulerRuleToFormValues', () => {
-  it('should convert grafana recording rule to form values', () => {
+  it('should convert grafana recording rule to form values', async () => {
     const mockRecordingRule = mockRulerGrafanaRecordingRule({
       grafana_alert: {
         uid: 'recording-rule-uid',
@@ -222,7 +222,7 @@ describe('rulerRuleToFormValues', () => {
       },
     });
 
-    const result = rulerRuleToFormValues(ruleWithLocation);
+    const result = await rulerRuleToFormValues(ruleWithLocation);
 
     expect(result).toMatchObject({
       name: 'My Recording Rule',
@@ -445,7 +445,7 @@ describe('getNotificationSettingsForDTO with selectedPolicy', () => {
 });
 
 describe('rulerRuleToFormValues with policy routing', () => {
-  it('should set selectedPolicy and manualRouting=false when notification_settings.policy is defined', () => {
+  it('should set selectedPolicy and manualRouting=false when notification_settings.policy is defined', async () => {
     const rule: RulerGrafanaRuleDTO = {
       for: '1m',
       grafana_alert: {
@@ -469,7 +469,7 @@ describe('rulerRuleToFormValues with policy routing', () => {
       group: { name: 'group1', interval: '1m', rules: [rule] },
       rule,
     };
-    const result = rulerRuleToFormValues(ruleWithLocation);
+    const result = await rulerRuleToFormValues(ruleWithLocation);
     expect(result.selectedPolicy).toBe('TestPolicy');
     expect(result.manualRouting).toBe(false);
     expect(result.contactPoints).toBeUndefined();
@@ -502,23 +502,23 @@ describe('rulerRuleToFormValues with legacy label migration', () => {
     };
   };
 
-  it('should migrate legacy label to selectedPolicy when FF is ON', () => {
+  it('should migrate legacy label to selectedPolicy when FF is ON', async () => {
     jest.replaceProperty(config, 'featureToggles', {
       ...config.featureToggles,
       alertingPolicyRoutingSettings: true,
     });
-    const result = rulerRuleToFormValues(makeLegacyLabelRule('TestPolicy'));
+    const result = await rulerRuleToFormValues(makeLegacyLabelRule('TestPolicy'));
     expect(result.selectedPolicy).toBe('TestPolicy');
     expect(result.manualRouting).toBe(false);
     jest.restoreAllMocks();
   });
 
-  it('should NOT migrate legacy label when FF is OFF', () => {
+  it('should NOT migrate legacy label when FF is OFF', async () => {
     jest.replaceProperty(config, 'featureToggles', {
       ...config.featureToggles,
       alertingPolicyRoutingSettings: false,
     });
-    const result = rulerRuleToFormValues(makeLegacyLabelRule('TestPolicy'));
+    const result = await rulerRuleToFormValues(makeLegacyLabelRule('TestPolicy'));
     expect(result.selectedPolicy).toBeUndefined();
     jest.restoreAllMocks();
   });
@@ -621,40 +621,44 @@ describe('getInstantFromDataQuery', () => {
     },
   };
 
-  it('should return undefined if datasource UID is undefined', () => {
+  it('should return undefined if datasource UID is undefined', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'Mimir-cloud', uid: 'mimir-1' }));
-    const result = getInstantFromDataQuery({ ...query });
+    const result = await getInstantFromDataQuery({ ...query });
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined if datasource type is not Prometheus or Loki', () => {
+  it('should return undefined if datasource type is not Prometheus or Loki', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Alertmanager, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
+    const result = await getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
     expect(result).toBeUndefined();
   });
 
-  it('should return true if datasource is Prometheus and instant is not defined', () => {
+  it('should return true if datasource is Prometheus and instant is not defined', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
+    const result = await getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
 
     expect(result).toBe(true);
   });
 
-  it('should return the value of instant if datasource is Prometheus and instant is defined', () => {
+  it('should return the value of instant if datasource is Prometheus and instant is defined', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Prometheus, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({ ...query, datasourceUid: 'aa', model: { refId: 'f', instant: false } });
+    const result = await getInstantFromDataQuery({
+      ...query,
+      datasourceUid: 'aa',
+      model: { refId: 'f', instant: false },
+    });
     expect(result).toBe(false);
   });
 
-  it('should return true if datasource is Loki and queryType is not defined', () => {
+  it('should return true if datasource is Loki and queryType is not defined', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Loki, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
+    const result = await getInstantFromDataQuery({ ...query, datasourceUid: 'aa' });
     expect(result).toBe(true);
   });
 
-  it('should return true if datasource is Loki and queryType is instant', () => {
+  it('should return true if datasource is Loki and queryType is instant', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Loki, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({
+    const result = await getInstantFromDataQuery({
       ...query,
       datasourceUid: 'aa',
       model: { refId: 'f', queryType: 'instant' },
@@ -663,9 +667,9 @@ describe('getInstantFromDataQuery', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false if datasource is Loki and queryType is not instant', () => {
+  it('should return false if datasource is Loki and queryType is not instant', async () => {
     setupDataSources(mockDataSource({ type: DataSourceType.Loki, name: 'aa', uid: 'aa-1' }));
-    const result = getInstantFromDataQuery({
+    const result = await getInstantFromDataQuery({
       ...query,
       datasourceUid: 'aa',
       model: { refId: 'f', queryType: 'range' },

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -11,8 +11,9 @@ import {
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { type PromQuery } from '@grafana/prometheus';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
 import { type VizPanel, sceneGraph } from '@grafana/scenes';
 import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
@@ -339,7 +340,7 @@ function getEditorSettingsFromDTO(ga: GrafanaRuleDefinition) {
   };
 }
 
-export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleFormValues {
+export async function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): Promise<RuleFormValues> {
   const { ruleSourceName, namespace, group, rule } = ruleWithLocation;
   const normalizedRule = fixMissingRefIdsInExpressionModel(rule);
 
@@ -412,7 +413,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
   } else {
     // DATASOURCE-MANAGED RULES
     if (rulerRuleType.dataSource.alertingRule(normalizedRule)) {
-      const datasourceUid = getDataSourceSrv().getInstanceSettings(ruleSourceName)?.uid ?? '';
+      const datasourceUid = (await getDataSourceInstanceSettings(ruleSourceName))?.uid ?? '';
 
       const defaultQuery = {
         refId: 'A',
@@ -440,7 +441,7 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         group: group.name,
       };
     } else if (rulerRuleType.dataSource.recordingRule(normalizedRule)) {
-      const datasourceUid = getDataSourceSrv().getInstanceSettings(ruleSourceName)?.uid ?? '';
+      const datasourceUid = (await getDataSourceInstanceSettings(ruleSourceName))?.uid ?? '';
 
       const defaultQuery = {
         refId: 'A',
@@ -589,8 +590,8 @@ export function recordingRulerRuleToRuleForm(
   };
 }
 
-export const getDefaultQueries = (isRecordingRule = false): AlertQuery[] => {
-  const dataSource = getDefaultOrFirstCompatibleDataSource();
+export const getDefaultQueries = async (isRecordingRule = false): Promise<AlertQuery[]> => {
+  const dataSource = await getDefaultOrFirstCompatibleDataSource();
   if (!dataSource) {
     const expressions = isRecordingRule ? getDefaultExpressionsForRecording('A') : getDefaultExpressions('A', 'B');
     return [...expressions];
@@ -747,7 +748,7 @@ export const dataQueriesToGrafanaQueries = async (
   const result: AlertQuery[] = [];
 
   for (const target of queries) {
-    const datasource = await getDataSourceSrv().get(target.datasource?.uid ? target.datasource : panelDataSourceRef);
+    const datasource = await getDataSourceInstance(target.datasource?.uid ? target.datasource : panelDataSourceRef);
     const dsRef = { uid: datasource.uid, type: datasource.type };
 
     const range = rangeUtil.relativeToTimeRange(relativeTimeRange);
@@ -774,7 +775,7 @@ export const dataQueriesToGrafanaQueries = async (
       result.push(newQuery);
       // queries
     } else {
-      const datasourceSettings = getDataSourceSrv().getInstanceSettings(dsRef);
+      const datasourceSettings = await getDataSourceInstanceSettings(dsRef);
       if (datasourceSettings && datasourceSettings.meta.alerting) {
         const newQuery: AlertQuery = {
           refId: interpolatedTarget.refId,
@@ -975,14 +976,14 @@ export function isPromOrLokiQuery(model: AlertDataQuery): model is PromOrLokiQue
   return 'expr' in model;
 }
 
-export function getInstantFromDataQuery(query: AlertQuery<AlertDataQuery>): boolean | undefined {
+export async function getInstantFromDataQuery(query: AlertQuery<AlertDataQuery>): Promise<boolean | undefined> {
   const dataSourceUID = query.datasourceUid ?? query.model.datasource?.uid;
   if (!dataSourceUID) {
     return undefined;
   }
 
   // find the datasource type from the UID
-  const type = getDataSourceSrv().getInstanceSettings(dataSourceUID)?.type;
+  const type = (await getDataSourceInstanceSettings(dataSourceUID))?.type;
   if (!type) {
     return undefined;
   }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1184,6 +1184,7 @@
       "title-new-evaluation-group": "New evaluation group"
     },
     "existing-rule-editor": {
+      "loading-clone": "Loading rule...",
       "sorry-permission": "Sorry! You do not have permission to edit this rule.",
       "sorry-this-rule-does-not-exist": "Sorry! This rule does not exist.",
       "title-cannot-edit-rule": "Cannot edit rule",
@@ -2120,7 +2121,8 @@
     "modify-export-rule-form": {
       "action-buttons": {
         "export": "Export"
-      }
+      },
+      "text-loading": "Loading..."
     },
     "more-button": {
       "aria-label": "More",


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/127031

### What changed?

Migrates the shared rule-form and datasource utilities (`utils/datasource.ts`, `utils/rule-form.ts`, `formDefaults.ts`, `formProcessing.ts`) and the query/expression reducer from the deprecated `getDataSourceSrv()` to the new async `@grafana/runtime/unstable` APIs. Reducer actions (`addNewDataQuery`, `resetToSimpleCondition`, `optimizeReduceExpression`) now take pre-resolved payloads instead of calling these lookups from inside the reducer, since reducers cannot await. `AlertRuleForm` and `ModifyExportRuleForm` resolve their default values asynchronously using React Hook Form async `defaultValues` support, showing a loading state meanwhile. `QueryAndExpressionsStep.tsx` and `QueryRows.tsx` are touched only on the lines dispatching these actions or calling the now-async utilities — the remaining `getDataSourceSrv()` usage in those two files belongs to a sibling PR migrating the rest of the rule-editor query components, so expect a small rebase depending on merge order.