### PR TITLE
Unified storage: drop registerOrReuse from informer metrics

### DIFF
--- a/pkg/storage/unified/informer/processed.go
+++ b/pkg/storage/unified/informer/processed.go
@@ -1,11 +1,11 @@
 package informer
 
 import (
-	"errors"
 	"time"
 
 	"github.com/grafana/dskit/instrument"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // ProcessTrigger records how the work-queue key a consumer is now processing was
@@ -46,33 +46,37 @@ const (
 // every delivery has no such gate, so its source="relist" measures
 // resync-driven work volume rather than missed events.
 type ProcessedMetrics struct {
-	resource        string
 	natsBacked      bool
 	processed       *prometheus.CounterVec
 	deliveryLatency *prometheus.HistogramVec
 }
 
 // NewProcessedMetrics builds the metrics on reg for the given resource label
-// value and delivery backend, reusing collectors already registered on reg so
-// several consumers share one set of series. A nil reg leaves the collectors
-// unregistered (the recorder still classifies and its record calls are harmless
-// no-ops).
+// value and delivery backend. A nil reg leaves the collectors unregistered (the
+// recorder still classifies and its record calls are harmless no-ops).
+//
+// resource is a const label, so each consumer gets its own collector while the
+// scrape still shows one metric family with a resource dimension. Two consumers
+// built for the same resource on one registry is a wiring mistake, and registers
+// as a duplicate rather than passing unnoticed.
 func NewProcessedMetrics(reg prometheus.Registerer, resource string, natsBacked bool) *ProcessedMetrics {
+	constLabels := prometheus.Labels{"resource": resource}
 	return &ProcessedMetrics{
-		resource:   resource,
 		natsBacked: natsBacked,
-		processed: registerOrReuse(reg, prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "grafana_provisioning_events_processed_total",
-			Help: "Processing started for a work-queue key, by resource and source (live = a live event; relist = the periodic re-list; initial = the informer's initial list).",
-		}, []string{"resource", "source"})),
-		deliveryLatency: registerOrReuse(reg, prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		processed: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name:        "grafana_provisioning_events_processed_total",
+			Help:        "Processing started for a work-queue key, by resource and source (live = a live event; relist = the periodic re-list; initial = the informer's initial list).",
+			ConstLabels: constLabels,
+		}, []string{"source"}),
+		deliveryLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "grafana_provisioning_event_delivery_latency_seconds",
 			Help:                            "Time from an event being issued (its resource version, in the DB/NATS) to it entering the work queue, by resource and source, sampled only for events that lead to genuine processing. Excludes the time the key then waits in the queue to be picked up.",
 			Buckets:                         instrument.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
-		}, []string{"resource", "source"})),
+			ConstLabels:                     constLabels,
+		}, []string{"source"}),
 	}
 }
 
@@ -113,7 +117,7 @@ func (m *ProcessedMetrics) RecordProcessed(trigger ProcessTrigger) {
 	}
 	switch trigger {
 	case TriggerLive, TriggerRelist, TriggerInitial:
-		m.processed.WithLabelValues(m.resource, string(trigger)).Inc()
+		m.processed.WithLabelValues(string(trigger)).Inc()
 	}
 }
 
@@ -127,24 +131,6 @@ func (m *ProcessedMetrics) ObserveDeliveryLatency(trigger ProcessTrigger, second
 	}
 	switch trigger {
 	case TriggerLive, TriggerRelist, TriggerInitial:
-		m.deliveryLatency.WithLabelValues(m.resource, string(trigger)).Observe(seconds)
+		m.deliveryLatency.WithLabelValues(string(trigger)).Observe(seconds)
 	}
-}
-
-// registerOrReuse registers c on reg, returning the collector already registered
-// under the same descriptor when there is one — several consumers built against
-// the same registry share one set of collectors. A nil reg returns c
-// unregistered.
-func registerOrReuse[C prometheus.Collector](reg prometheus.Registerer, c C) C {
-	if reg == nil {
-		return c
-	}
-	if err := reg.Register(c); err != nil {
-		are := prometheus.AlreadyRegisteredError{}
-		if errors.As(err, &are) {
-			return are.ExistingCollector.(C)
-		}
-		panic(err)
-	}
-	return c
 }

--- a/pkg/storage/unified/informer/processed_test.go
+++ b/pkg/storage/unified/informer/processed_test.go
@@ -1,11 +1,13 @@
 package informer
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessedMetrics_ClassifyAdd(t *testing.T) {
@@ -61,14 +63,14 @@ func TestProcessedMetrics_RecordProcessed(t *testing.T) {
 	m.RecordProcessed(TriggerRelist)
 	m.RecordProcessed(TriggerInitial)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("jobs", "live")))
-	assert.Equal(t, 2.0, testutil.ToFloat64(m.processed.WithLabelValues("jobs", "relist")))
-	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("jobs", "initial")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("live")))
+	assert.Equal(t, 2.0, testutil.ToFloat64(m.processed.WithLabelValues("relist")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("initial")))
 
 	// An unknown source (e.g. the zero value carried by a non-classified queue
 	// item) records nothing.
 	m.RecordProcessed(ProcessTrigger(""))
-	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("jobs", "live")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(m.processed.WithLabelValues("live")))
 }
 
 func TestProcessedMetrics_NilSafe(t *testing.T) {
@@ -77,9 +79,9 @@ func TestProcessedMetrics_NilSafe(t *testing.T) {
 	assert.NotPanics(t, func() { m.ObserveDeliveryLatency(TriggerLive, 1.0) })
 }
 
-// TestProcessedMetrics_SharedAcrossResources verifies that several consumers on
-// one registry share the same collectors (via registerOrReuse) and emit
-// distinct series per resource label.
+// TestProcessedMetrics_SharedAcrossResources verifies that several consumers can
+// be built on one registry and that the scrape shows one metric family carrying
+// a series per resource.
 func TestProcessedMetrics_SharedAcrossResources(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	jobsM := NewProcessedMetrics(reg, "jobs", false)
@@ -89,6 +91,13 @@ func TestProcessedMetrics_SharedAcrossResources(t *testing.T) {
 	reposM.RecordProcessed(TriggerRelist)
 	reposM.RecordProcessed(TriggerRelist)
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(jobsM.processed.WithLabelValues("jobs", "relist")))
-	assert.Equal(t, 2.0, testutil.ToFloat64(reposM.processed.WithLabelValues("repositories", "relist")))
+	assert.Equal(t, 1.0, testutil.ToFloat64(jobsM.processed.WithLabelValues("relist")))
+	assert.Equal(t, 2.0, testutil.ToFloat64(reposM.processed.WithLabelValues("relist")))
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP grafana_provisioning_events_processed_total Processing started for a work-queue key, by resource and source (live = a live event; relist = the periodic re-list; initial = the informer's initial list).
+# TYPE grafana_provisioning_events_processed_total counter
+grafana_provisioning_events_processed_total{resource="jobs",source="relist"} 1
+grafana_provisioning_events_processed_total{resource="repositories",source="relist"} 2
+`), "grafana_provisioning_events_processed_total"))
 }


### PR DESCRIPTION
`registerOrReuse` swallows `AlreadyRegisteredError` and returns the existing collector. That is an antipattern: duplicate registration means something is wired twice, and absorbing it hides the mistake.

It existed because the three consumers — connections, repositories, jobs — each build their own `ProcessedMetrics` for the same family, differing only in the `resource` label value. Registration compares label *names*, not values, so all three collided.

Making `resource` a const label gives each consumer its own descriptor, so plain `promauto` works. Scrape output is unchanged — still one family with a `resource` dimension, now asserted directly via `GatherAndCompare`. Registering the same resource twice fails, as it should.

No provisioning code changes. A separate copy of the helper remains in `pkg/registry/apis/provisioning/informer/metrics.go`, which is provisioning-owned.