### PR TITLE
datasources: new feature-flag to control the query-api used

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -99,6 +99,7 @@ declare module "@openfeature/core" {
     | "grafana.unifiedDataSourcePicker"
     | "rawPrometheus.tableNg"
     | "datasources.queryGateway"
+    | "datasources.querier.newName"
     | "grafana.panelPluginTransformations"
     | "grafana.dashboardsAutoHeightPanels"
     | "grafana.dashboardAutoGridDefault";

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -43,6 +43,8 @@ export const FlagKeys = {
   DatasourcesAzureMonitorBatchAPI: "datasources.azureMonitorBatchAPI",
   /** Use the new datasource API groups for datasource CRUD requests, frontend flag */
   DatasourcesConfigUiUseNewDatasourceCRUDAPIs: "datasources.config.ui.useNewDatasourceCRUDAPIs",
+  /** Data source query service, use the new name */
+  DatasourcesQuerierNewName: "datasources.querier.newName",
   /** Data source query gateway */
   DatasourcesQueryGateway: "datasources.queryGateway",
   /** Send Datsource health requests to /apis/ API routes instead of the legacy /api/datasources/uid/{uid}/health route. */
@@ -362,6 +364,17 @@ export const useFlagDatasourcesAzureMonitorBatchAPI = (options?: ReactFlagEvalua
  */
 export const useFlagDatasourcesConfigUiUseNewDatasourceCRUDAPIs = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("datasources.config.ui.useNewDatasourceCRUDAPIs", false, options).value;
+};
+
+/**
+ * Data source query service, use the new name
+ *
+ * **Details:**
+ * - flag key: `datasources.querier.newName`
+ * - default value: `false`
+ */
+export const useFlagDatasourcesQuerierNewName = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("datasources.querier.newName", false, options).value;
 };
 
 /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -901,6 +901,7 @@ describe('DataSourceWithBackend', () => {
     });
     afterEach(() => {
       config.featureToggles.queryServiceFromUI = oldQsUI;
+      mockGetBooleanValue.mockReset().mockReturnValue(false);
       mockGetObjectValue.mockReset().mockReturnValue({ types: ['prometheus'] });
       mockIsQueryServiceCompatible.mockReset().mockReturnValue(false);
     });
@@ -920,6 +921,63 @@ describe('DataSourceWithBackend', () => {
       type: 'loki',
       jsonData: {},
     } as DataSourceInstanceSettings;
+
+    it('uses query.grafana.app when the new-name flag is disabled', async () => {
+      mockIsQueryServiceCompatible.mockReturnValue(true);
+      mockGetBooleanValue.mockReturnValue(false);
+
+      const { ds, mock } = createMockDatasource();
+
+      await firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A' }],
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      );
+
+      expect(mock.calls[0][0].url).toBe('/apis/query.grafana.app/v0alpha1/namespaces/default/query?ds_type=dummy');
+      expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.querier.newName', false);
+    });
+
+    it('uses datasource.grafana.app when the new-name flag is enabled', async () => {
+      mockIsQueryServiceCompatible.mockReturnValue(true);
+      mockGetBooleanValue.mockReturnValue(true);
+
+      const { ds, mock } = createMockDatasource();
+
+      await firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A' }],
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      );
+
+      expect(mock.calls[0][0].url).toBe('/apis/datasource.grafana.app/v0alpha1/namespaces/default/query?ds_type=dummy');
+      expect(mockGetBooleanValue).toHaveBeenCalledWith('datasources.querier.newName', false);
+    });
+
+    it('uses the legacy endpoint when the datasource is not query-service compatible', async () => {
+      mockIsQueryServiceCompatible.mockReturnValue(false);
+      mockGetBooleanValue.mockReturnValue(true);
+
+      const { ds, mock } = createMockDatasource();
+
+      await firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A' }],
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      );
+
+      expect(mock.calls[0][0].url).toBe('/api/ds/query?ds_type=dummy');
+      expect(mockGetBooleanValue).not.toHaveBeenCalledWith('datasources.querier.newName', false);
+    });
 
     it.each([
       [

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -252,7 +252,11 @@ class DataSourceWithBackend<
         types: [],
       });
       if (isQueryServiceCompatible(datasources, allowedTypes)) {
-        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
+        let apiGroup = 'query.grafana.app';
+        if (getFeatureFlagClient().getBooleanValue(FlagKeys.DatasourcesQuerierNewName, false)) {
+          apiGroup = 'datasource.grafana.app';
+        }
+        url = `/apis/${apiGroup}/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
       }
     }
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3288,6 +3288,15 @@ var (
 			Generate:     Generate{Go: true, React: true},
 		},
 		{
+			Name:         "datasources.querier.newName",
+			Description:  "Data source query service, use the new name",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDatasourcesCoreServicesSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
+		{
 			Name:        "grafana.panelPluginTransformations",
 			Description: "Let panel plugins register system transformations",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -382,6 +382,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-08-06,grafana.unifiedDataSourcePicker,GA,@grafana/grafana-datasources-core-services,false,false,true
 2026-08-20,rawPrometheus.tableNg,experimental,@grafana/data-sources-plugins,false,false,true
 2026-08-11,datasources.queryGateway,experimental,@grafana/data-sources-plugins,false,false,false
+2026-08-28,datasources.querier.newName,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-08-17,grafana.panelPluginTransformations,experimental,@grafana/dataviz-squad,false,false,true
 2026-08-18,grafana.dashboardsAutoHeightPanels,experimental,@grafana/dashboards-squad,false,false,true
 2026-08-13,grafana.dashboardAutoGridDefault,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2103,6 +2103,21 @@
     },
     {
       "metadata": {
+        "name": "datasources.querier.newName",
+        "resourceVersion": "1787908978150",
+        "creationTimestamp": "2026-08-28T09:22:58Z"
+      },
+      "spec": {
+        "description": "Data source query service, use the new name",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-datasources-core-services",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "datasources.queryGateway",
         "resourceVersion": "1786455922969",
         "creationTimestamp": "2026-08-11T13:45:22Z"


### PR DESCRIPTION
add a feature-flag to the javascript part, we use it to choose if datasource-queries go to `/apis/query.grafana.app/...` or to `/apis/datasource.grafana.app/...`

the backend part is already able to handle both paths.

(part of https://github.com/grafana/grafana-enterprise/issues/11837)