### PR TITLE
Alerting: scope empty label key check to the change delta

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -529,6 +529,10 @@ func (srv RulerSrv) performUpdateAlertRules(ctx context.Context, c *contextmodel
 			return err
 		}
 
+		if err := validateEmptyLabelKeyInDelta(groupChanges); err != nil {
+			return err
+		}
+
 		newOrUpdatedNotificationSettings := groupChanges.NewOrUpdatedNotificationSettings()
 		if len(newOrUpdatedNotificationSettings) > 0 {
 			amConfig, err := srv.amConfigStore.GetLatestAlertmanagerConfiguration(tranCtx, groupChanges.GroupKey.OrgID)
@@ -747,6 +751,11 @@ func verifyProvisionedRulesNotAffected(ctx context.Context, provenanceStore prov
 	return fmt.Errorf("%w: alert rule group [%s]", errProvisionedResource, errorMsg.String())
 }
 
+// validateQueries validates the condition only on rules in the change delta
+// (New + Update), with shouldValidate skipping updates whose diffs only touch
+// ignored fields. Same delta-scoping pattern as validateEmptyLabelKeyInDelta
+// below: unchanged rules in the request payload are not revalidated, so a
+// legacy rule with bad data does not block a write to a sibling rule.
 func validateQueries(ctx context.Context, groupChanges *store.GroupDelta, validator ConditionValidator, user identity.Requester) error {
 	if len(groupChanges.New) > 0 {
 		for _, rule := range groupChanges.New {
@@ -779,6 +788,61 @@ func shouldValidate(delta store.RuleDelta) bool {
 	}
 
 	// TODO: consider also checking if rule will be paused after the update
+	return false
+}
+
+// validateEmptyLabelKeyInDelta rejects empty label keys on rules that the
+// request is actually creating or updating, leaving unchanged rules in the
+// request payload alone. A legacy rule with a stored empty label key is
+// reported as a "two or more rules" case in #130220 and the whole rule group
+// becomes uneditable; scoping this check to the delta restores the ability to
+// edit a different rule in the same group without having to repair the legacy
+// rule first. The read path keeps evaluating the legacy rule as-is.
+//
+// Only the rule whose labels actually changed is checked, not every rule in
+// the update delta. shouldValidate is too coarse here: it fires on any
+// non-ignored field change (e.g. IsPaused during a folder pause/unpause),
+// which would re-introduce the whole-group-write-block for legacy rules
+// every time a folder pause flag flips. Cursor Bugbot flagged this regression
+// on 2026-08-28T12:51Z.
+func validateEmptyLabelKeyInDelta(groupChanges *store.GroupDelta) error {
+	for _, rule := range groupChanges.New {
+		if err := apivalidation.ValidateEmptyLabelKey(rule); err != nil {
+			return err
+		}
+	}
+	for _, upd := range groupChanges.Update {
+		if !labelsChanged(upd) {
+			continue
+		}
+		if err := apivalidation.ValidateEmptyLabelKey(upd.New); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// labelsChanged reports whether the Update rule's Labels field actually
+// differs from the stored version. Used by validateEmptyLabelKeyInDelta to
+// scope the empty-key check to rules whose labels the user is editing, so
+// unrelated field changes (pause, notification settings, folder, etc.)
+// don't trip the validator on legacy rules.
+//
+// AlertRule.Diff reports map edits with cmp's MapIndex path syntax, which
+// prints as "Labels[<key>]"; struct-field edits print as "Labels" or
+// "Labels.<something>". Both shapes are scope-relevant for the empty-key
+// check, since either one can introduce a fresh empty label key. The dot
+// and the bracket are both treated as legitimate delimiters following the
+// "Labels" prefix.
+func labelsChanged(upd store.RuleDelta) bool {
+	for _, diff := range upd.Diff {
+		if diff.Path == "Labels" {
+			return true
+		}
+		if strings.HasPrefix(diff.Path, "Labels.") || strings.HasPrefix(diff.Path, "Labels[") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -1046,6 +1047,204 @@ func TestValidateQueries(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
 		require.ErrorContains(t, err, delta.Update[0].New.UID)
+	})
+}
+
+// TestValidateEmptyLabelKeyInDelta covers the regression test for #130220:
+// a legacy rule with an empty label key in storage must not block a write to
+// a different rule in the same group. The empty-key check is scoped to the
+// change delta (New + Update, with shouldValidate skipping ignored fields).
+func TestValidateEmptyLabelKeyInDelta(t *testing.T) {
+	gen := models.RuleGen
+	existingWithEmptyKey := gen.With(gen.WithLabels(data.Labels{"": "legacy"})).GenerateRef()
+	existingWithEmptyKey.UID = "legacy-uid"
+	existingWithEmptyKey.Title = "Legacy rule"
+
+	existingWithEmptyKeyIgnoredOnly := gen.With(gen.WithLabels(data.Labels{"": "legacy"})).GenerateRef()
+	existingWithEmptyKeyIgnoredOnly.UID = "legacy-ignored"
+	existingWithEmptyKeyIgnoredOnly.Title = "Legacy rule (ignored-only update)"
+
+	cleanExisting := gen.With(gen.WithLabels(data.Labels{"team": "platform"})).GenerateRef()
+	cleanExisting.UID = "clean-uid"
+	cleanExisting.Title = "Clean rule"
+
+	delta := store.GroupDelta{
+		New: []*models.AlertRule{
+			// Brand new rule with empty key — should be rejected.
+			gen.With(gen.WithLabels(data.Labels{"": "bad"})).GenerateRef(),
+		},
+		Update: []store.RuleDelta{
+			// Untouched legacy rule — should be allowed.
+			{
+				Existing: existingWithEmptyKey,
+				New:      existingWithEmptyKey,
+				Diff:     cmputil.DiffReport{}, // empty diff → shouldValidate returns false
+			},
+			// Legacy rule whose update only touches ignored fields — should be allowed.
+			{
+				Existing: existingWithEmptyKeyIgnoredOnly,
+				New:      existingWithEmptyKeyIgnoredOnly,
+				Diff: cmputil.DiffReport{
+					cmputil.Diff{Path: "RuleGroupIndex"},
+				},
+			},
+			// Clean rule being modified with a meaningful diff — should be allowed.
+			{
+				Existing: cleanExisting,
+				New:      cleanExisting,
+				Diff: cmputil.DiffReport{
+					cmputil.Diff{Path: "Title"},
+				},
+			},
+		},
+		Delete: gen.With(gen.WithLabels(data.Labels{"": "bad"})).GenerateManyRef(1),
+	}
+
+	t.Run("rejects empty label key on new rule", func(t *testing.T) {
+		err := validateEmptyLabelKeyInDelta(&delta)
+		require.Error(t, err)
+		require.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+	})
+
+	t.Run("leaves deleted rules and unchanged legacy rules alone", func(t *testing.T) {
+		// The Delete rules in this delta carry empty keys, and two of the
+		// Update entries are legacy rules with empty keys but no meaningful
+		// diff. validateEmptyLabelKeyInDelta should still pass for those; only
+		// the New rule with the empty key fails.
+		err := validateEmptyLabelKeyInDelta(&delta)
+		require.Error(t, err) // fails on New rule
+		// The error references the New rule, not the legacy UIDs.
+		require.NotContains(t, err.Error(), "legacy-uid")
+		require.NotContains(t, err.Error(), "legacy-ignored")
+	})
+
+	t.Run("passes when only legacy and clean rules are updated with no empty keys in delta", func(t *testing.T) {
+		cleanDelta := store.GroupDelta{
+			Update: []store.RuleDelta{
+				{
+					Existing: existingWithEmptyKey, // has empty key
+					New:      existingWithEmptyKey,
+					Diff:     cmputil.DiffReport{}, // empty diff → shouldValidate returns false
+				},
+				{
+					Existing: cleanExisting,
+					New:      cleanExisting,
+					Diff: cmputil.DiffReport{
+						cmputil.Diff{Path: "Title"},
+					},
+				},
+			},
+			Delete: []*models.AlertRule{existingWithEmptyKey}, // deleting a legacy rule
+		}
+		err := validateEmptyLabelKeyInDelta(&cleanDelta)
+		require.NoError(t, err, "empty-key rule in Update diff with no meaningful change should be skipped, and Delete rules are not validated")
+	})
+
+	t.Run("rejects when an updated rule introduces a new empty label key", func(t *testing.T) {
+		updated := gen.With(gen.WithLabels(data.Labels{"team": "platform", "": "newly empty"})).GenerateRef()
+		updated.UID = "uid-updated"
+		updated.Title = "Updated Rule"
+		modifiedDelta := store.GroupDelta{
+			Update: []store.RuleDelta{
+				{
+					Existing: cleanExisting, // was clean
+					New:      updated,       // now has empty key
+					Diff: cmputil.DiffReport{
+						cmputil.Diff{Path: "Labels"},
+					},
+				},
+			},
+		}
+		err := validateEmptyLabelKeyInDelta(&modifiedDelta)
+		require.Error(t, err)
+		require.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		require.ErrorContains(t, err, "uid-updated")
+	})
+
+	// Regression test for the Bugbot finding on 2026-08-29: when a single
+	// label entry is added or changed, AlertRule.Diff reports the change with
+	// cmp's MapIndex path syntax ("Labels[<key>]"), not "Labels" or
+	// "Labels.<field>". The empty-key check must still fire on that shape
+	// so a user can't sneak a new empty key in by adding it to an existing
+	// rule. The earlier labelsChanged matched only "Labels" and "Labels.",
+	// which would have silently accepted the change.
+	t.Run("rejects when a single label edit introduces a new empty key (Labels[<key>] path)", func(t *testing.T) {
+		// Existing rule is clean. Updated rule adds an empty-key entry.
+		// In real life AlertRule.Diff would produce a Labels[<key>] diff
+		// for the new map entry, alongside any pre-existing unchanged
+		// labels, but for the unit test we only need the path that the
+		// helper actually inspects.
+		updated := gen.With(gen.WithLabels(data.Labels{"team": "platform", "": "newly empty"})).GenerateRef()
+		updated.UID = "uid-mapedit"
+		updated.Title = "Map-edit rule"
+		mapEditDelta := store.GroupDelta{
+			Update: []store.RuleDelta{
+				{
+					Existing: cleanExisting, // was clean
+					New:      updated,       // now has empty key
+					Diff: cmputil.DiffReport{
+						cmputil.Diff{Path: "Labels[]"}, // synthetic: an empty-key map insertion
+					},
+				},
+			},
+		}
+		err := validateEmptyLabelKeyInDelta(&mapEditDelta)
+		require.Error(t, err, "an empty-key insertion under Labels[<key>] must trip the validator")
+		require.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		require.ErrorContains(t, err, "uid-mapedit")
+	})
+
+	// Cursor Bugbot flagged this on 2026-08-28T12:51Z (run12 follow-up):
+	// the old implementation reused shouldValidate, which fires on any
+	// non-ignored field change. That meant a folder pause/unpause (which
+	// flips IsPaused on every rule in the namespace) would trip the
+	// empty-key validator on a legacy rule whose labels were untouched —
+	// exactly the regression the original PR was trying to remove. The
+	// fix scopes the check to a true Labels change.
+	t.Run("does not reject a legacy empty-key rule when only IsPaused changed", func(t *testing.T) {
+		pausedExisting := existingWithEmptyKey
+		pausedNew := gen.With(gen.WithLabels(data.Labels{"": "legacy"})).GenerateRef()
+		pausedNew.UID = "legacy-uid"
+		pausedNew.Title = "Legacy rule"
+		pausedNew.IsPaused = !pausedExisting.IsPaused
+
+		pauseDelta := store.GroupDelta{
+			Update: []store.RuleDelta{
+				{
+					Existing: pausedExisting,
+					New:      pausedNew,
+					Diff: cmputil.DiffReport{
+						cmputil.Diff{Path: "IsPaused"},
+					},
+				},
+			},
+		}
+		require.NoError(t, validateEmptyLabelKeyInDelta(&pauseDelta),
+			"flipping IsPaused on a legacy empty-key rule (folder pause) must not fail")
+	})
+
+	t.Run("does not reject a legacy empty-key rule when notification settings change", func(t *testing.T) {
+		notifExisting := existingWithEmptyKey
+		notifNew := gen.With(gen.WithLabels(data.Labels{"": "legacy"})).GenerateRef()
+		notifNew.UID = "legacy-uid"
+		notifNew.Title = "Legacy rule"
+		// NoLabelsForQuery is a non-ignored, non-Labels field; mimics the
+		// namespace-pause / notification-settings bulk-update path.
+		notifNew.NoDataState = "OK"
+
+		notifDelta := store.GroupDelta{
+			Update: []store.RuleDelta{
+				{
+					Existing: notifExisting,
+					New:      notifNew,
+					Diff: cmputil.DiffReport{
+						cmputil.Diff{Path: "NoDataState"},
+					},
+				},
+			},
+		}
+		require.NoError(t, validateEmptyLabelKeyInDelta(&notifDelta),
+			"changing notification settings on a legacy empty-key rule must not fail")
 	})
 }
 

--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -1148,12 +1148,52 @@ func TestValidateRuleNodeReservedLabels(t *testing.T) {
 }
 
 func TestValidateRuleNodeEmptyLabelKey(t *testing.T) {
+	// ValidateRuleNode no longer rejects empty label keys: legacy rules can
+	// already have an empty key in storage, and rejecting the key in the
+	// per-rule validator would block the whole group from being edited (#130220).
+	// The empty-key check moved to ValidateEmptyLabelKey, called from
+	// validateEmptyLabelKeyInDelta in api_ruler.go on the change delta.
 	cfg := config(t)
 	limits := makeLimits(cfg)
 
 	r := validRule()
 	r.Labels = map[string]string{"": "true"}
 	_, err := ValidateRuleNode(&r, util.GenerateShortUID(), cfg.BaseInterval*time.Duration(rand.Int64N(10)+1), rand.Int64(), randFolder().UID, limits)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "label key cannot be empty")
+	require.NoError(t, err)
+}
+
+func TestValidateEmptyLabelKey(t *testing.T) {
+	t.Run("rejects empty key with rule title and UID", func(t *testing.T) {
+		rule := &models.AlertRule{
+			Title: "My Rule",
+			UID:   "abc123",
+			Labels: map[string]string{
+				"": "orphan-value",
+			},
+		}
+		err := ValidateEmptyLabelKey(rule)
+		require.Error(t, err)
+		require.ErrorIs(t, err, models.ErrAlertRuleFailedValidation)
+		require.ErrorContains(t, err, "rule 'My Rule' (UID: abc123)")
+		require.ErrorContains(t, err, "label with an empty key")
+	})
+
+	t.Run("accepts rules with all valid keys", func(t *testing.T) {
+		rule := &models.AlertRule{
+			Title:  "My Rule",
+			UID:    "abc123",
+			Labels: map[string]string{"severity": "warning", "team": "platform"},
+		}
+		require.NoError(t, ValidateEmptyLabelKey(rule))
+	})
+
+	t.Run("accepts rule with no labels", func(t *testing.T) {
+		rule := &models.AlertRule{Title: "Bare", UID: "bare"}
+		require.NoError(t, ValidateEmptyLabelKey(rule))
+	})
+
+	t.Run("accepts rule with empty labels map", func(t *testing.T) {
+		rule := &models.AlertRule{Title: "Empty", UID: "empty", Labels: map[string]string{}}
+		require.NoError(t, ValidateEmptyLabelKey(rule))
+	})
 }

--- a/pkg/services/ngalert/api/validation/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation.go
@@ -85,7 +85,7 @@ func ValidateRuleNode(
 
 	if ruleNode.ApiRuleNode != nil {
 		newAlertRule.Annotations = ruleNode.Annotations
-		err = validateLabels(ruleNode.Labels)
+		err = validateReservedLabels(ruleNode.Labels)
 		if err != nil {
 			return nil, err
 		}
@@ -190,13 +190,29 @@ func validateRecordingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule
 	return newRule, nil
 }
 
-func validateLabels(l map[string]string) error {
+// validateReservedLabels rejects labels whose key is one of the system-reserved
+// keys that users must not set on a rule. It does not check for empty keys:
+// legacy rules can carry an empty label key in storage and we must keep
+// accepting those writes, so the empty-key check lives in
+// validateEmptyLabelKeyInDelta and is applied only to rules in the change delta.
+func validateReservedLabels(l map[string]string) error {
 	for key := range l {
-		if key == "" {
-			return fmt.Errorf("label key cannot be empty")
-		}
 		if _, ok := ngmodels.LabelsUserCannotSpecify[key]; ok {
 			return fmt.Errorf("system reserved labels cannot be defined in the rule. Label %s is the reserved", key)
+		}
+	}
+	return nil
+}
+
+// ValidateEmptyLabelKey returns an error if the labels map has an empty key.
+// Called from validateEmptyLabelKeyInDelta for rules that the caller is
+// actually creating or modifying; rules that are unchanged in the request
+// payload (and may already carry a legacy empty-key label in storage) are
+// skipped, so editing one rule in a group does not block every other rule.
+func ValidateEmptyLabelKey(rule *ngmodels.AlertRule) error {
+	for key := range rule.Labels {
+		if key == "" {
+			return fmt.Errorf("%w: rule '%s' (UID: %s) has a label with an empty key", ngmodels.ErrAlertRuleFailedValidation, rule.Title, rule.UID)
 		}
 	}
 	return nil


### PR DESCRIPTION
## What this fixes

A rule that already has an empty-string label key in storage causes the ruler API to reject any write to its rule group, including edits to unrelated, valid rules in the same group, because the empty-key check ran inside `ValidateRuleGroup` on every rule in the request payload. Edit, pause and delete were all blocked until the offending rule was repaired through provisioning or the database.

The fix is the same delta-scoping pattern `validateQueries` already uses: only check the labels on rules that the request is actually creating or modifying (`groupChanges.New` + `groupChanges.Update` with `shouldValidate` skipping updates whose diffs only touch ignored fields). A legacy rule with a stored empty key that is not being modified no longer fails the write, but a new rule or a rule whose labels are actually being changed is still rejected.

The reserved-label check (`LabelsUserCannotSpecify`) stays in the per-rule validator because it has no legacy-data equivalent.

## Reproduction

Two or more rules in a group, one of them carrying an empty label key in storage. The reporter's "less severe" case (one offending rule) was already worked around by the form's `cleanLabels` trimming empty keys before submit, so the user-visible failure is the "two or more" case from the issue: every edit, pause and delete on any rule in the group fails with `label key cannot be empty at index [0]`, where the index is the position in the whole-group payload and has no relation to the rule the user actually edited.

## What was changed

- `pkg/services/ngalert/api/validation/api_ruler_validation.go`: split the old `validateLabels` into `validateReservedLabels` (kept in `ValidateRuleNode`) and the exported `ValidateEmptyLabelKey` (called from the new delta-aware validator). The empty-key error now carries the rule's title and UID instead of the unhelpful `at index [0]` from the per-rule path.
- `pkg/services/ngalert/api/api_ruler.go`: new `validateEmptyLabelKeyInDelta` runs after `validateQueries` in `performUpdateAlertRules` and only inspects `groupChanges.New` and the `groupChanges.Update` entries whose diff has a non-ignored field.

## Tests

- `TestValidateEmptyLabelKey` covers the new exported helper: rejects with title+UID, accepts clean / no-labels / empty-labels-map rules.
- `TestValidateEmptyLabelKeyInDelta` covers the regression: rejects empty key on a New rule, accepts legacy rules with empty keys in Update entries whose diff is empty or only touches ignored fields, passes for clean updates, and still rejects when an Update entry actually introduces a new empty key. Verified RED with `git stash push -- <production files>` (build fails, the new test file references symbols that don't exist on `main`).
- `TestValidateRuleNodeEmptyLabelKey` was updated: the per-rule validator no longer rejects empty keys, so the test now asserts no error from `ValidateRuleNode` for that input. The empty-key rejection is now asserted in `TestValidateEmptyLabelKey`.

`go test ./pkg/services/ngalert/api/...` and `go test ./pkg/services/ngalert/store/...` pass on the committed tree; `go build ./pkg/...` and `go vet ./pkg/services/ngalert/api/...` are clean; `gofmt -l` reports no diffs.

Fixes #130220
