### PR TITLE
Apiserver: label watch metrics by server instead of reusing collectors

### DIFF
--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -262,7 +262,10 @@ func SetupConfig(
 	serverConfig.OpenAPIV3Config.Info.Version = buildVersion
 
 	serverConfig.SkipOpenAPIInstallation = false
-	serverConfig.BuildHandlerChainFunc = buildHandlerChainFuncFromBuilders(builders, reg)
+	// The chain gets a registerer labelled with the server it belongs to, so a
+	// process that builds more than one chain can register the same collectors
+	// for each.
+	serverConfig.BuildHandlerChainFunc = buildHandlerChainFuncFromBuilders(builders, ServerRegisterer(reg, ServerMain))
 
 	// set priority for aggregated discovery
 	for i, b := range builders {

--- a/pkg/services/apiserver/builder/watch_metrics.go
+++ b/pkg/services/apiserver/builder/watch_metrics.go
@@ -1,11 +1,28 @@
 package builder
 
 import (
-	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// Server names for the handler chains built in one process.
+const (
+	ServerMain          = "main"
+	ServerAPIExtensions = "apiextensions"
+)
+
+// ServerRegisterer labels everything registered through it with the server the
+// handler chain belongs to. A process builds a chain per server, each with its
+// own copy of the chain's metrics, so without the label they would collide on
+// registration. A nil reg stays nil, leaving collectors unregistered.
+func ServerRegisterer(reg prometheus.Registerer, server string) prometheus.Registerer {
+	if reg == nil {
+		return nil
+	}
+	return prometheus.WrapRegistererWith(prometheus.Labels{"server": server}, reg)
+}
 
 // watchMetrics records the watch establishment duration. Watch concurrency is
 // already covered by the upstream apiserver_longrunning_requests gauge, so this
@@ -14,29 +31,19 @@ type watchMetrics struct {
 	establishmentDuration *prometheus.HistogramVec
 }
 
-// newWatchMetrics registers the watch metrics, tolerating repeated registration
-// against the same registerer (the handler chain is built once for the main
-// apiserver and again for the embedded apiextensions server).
+// newWatchMetrics registers the watch metrics for one handler chain. Pass a
+// registerer from ServerRegisterer, so chains built for different servers do not
+// collide.
 func newWatchMetrics(reg prometheus.Registerer) *watchMetrics {
-	h := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "grafana",
-		Subsystem: "apiserver",
-		Name:      "watch_establishment_duration_seconds",
-		Help:      "Time from receiving a watch request to the first byte written to the client, by group and resource.",
-		Buckets:   prometheus.DefBuckets,
-	}, []string{"group", "resource"})
-
-	if reg != nil {
-		if err := reg.Register(h); err != nil {
-			var already prometheus.AlreadyRegisteredError
-			if errors.As(err, &already) {
-				h = already.ExistingCollector.(*prometheus.HistogramVec)
-			} else {
-				panic(err)
-			}
-		}
+	return &watchMetrics{
+		establishmentDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "grafana",
+			Subsystem: "apiserver",
+			Name:      "watch_establishment_duration_seconds",
+			Help:      "Time from receiving a watch request to the first byte written to the client, by server, group and resource.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"group", "resource"}),
 	}
-	return &watchMetrics{establishmentDuration: h}
 }
 
 // observeEstablishment matches filters.WatchEstablishmentRecorder.

--- a/pkg/services/apiserver/builder/watch_metrics_test.go
+++ b/pkg/services/apiserver/builder/watch_metrics_test.go
@@ -1,0 +1,39 @@
+package builder
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// A process builds a handler chain per server against one registry, so both
+// must register and stay apart in the scrape.
+func TestNewWatchMetrics_PerServer(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+
+	main := newWatchMetrics(ServerRegisterer(reg, ServerMain))
+	apiExtensions := newWatchMetrics(ServerRegisterer(reg, ServerAPIExtensions))
+
+	main.observeEstablishment("dashboard.grafana.app", "dashboards", time.Second)
+	apiExtensions.observeEstablishment("example.grafana.app", "widgets", time.Second)
+
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP grafana_apiserver_watch_establishment_duration_seconds Time from receiving a watch request to the first byte written to the client, by server, group and resource.
+# TYPE grafana_apiserver_watch_establishment_duration_seconds histogram
+grafana_apiserver_watch_establishment_duration_seconds_sum{group="dashboard.grafana.app",resource="dashboards",server="main"} 1
+grafana_apiserver_watch_establishment_duration_seconds_count{group="dashboard.grafana.app",resource="dashboards",server="main"} 1
+grafana_apiserver_watch_establishment_duration_seconds_sum{group="example.grafana.app",resource="widgets",server="apiextensions"} 1
+grafana_apiserver_watch_establishment_duration_seconds_count{group="example.grafana.app",resource="widgets",server="apiextensions"} 1
+`), "grafana_apiserver_watch_establishment_duration_seconds_sum",
+		"grafana_apiserver_watch_establishment_duration_seconds_count"))
+}
+
+// A nil registerer leaves the collectors unregistered rather than panicking.
+func TestNewWatchMetrics_NilRegisterer(t *testing.T) {
+	m := newWatchMetrics(ServerRegisterer(nil, ServerMain))
+	require.NotPanics(t, func() { m.observeEstablishment("g", "r", time.Second) })
+}

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -464,7 +464,7 @@ func (s *service) start(ctx context.Context) error {
 			StorageClient:         s.unified,
 			AccessClient:          s.accessClient,
 			AuthorizerRegistry:    s.authorizer,
-			BuildHandlerChainFunc: s.buildHandlerChainFuncFromBuilders(s.builders, s.metrics),
+			BuildHandlerChainFunc: s.buildHandlerChainFuncFromBuilders(s.builders, builder.ServerRegisterer(s.metrics, builder.ServerAPIExtensions)),
 			SecureValues:          s.secrets,
 			ConfigProvider:        s.restConfigProvider,
 			Metrics:               s.metrics,


### PR DESCRIPTION
`newWatchMetrics` caught `AlreadyRegisteredError` and kept the collector that was already registered, because a process builds one handler chain for the main apiserver and another for the embedded apiextensions server. Absorbing a duplicate registration hides the double wiring that caused it — see #131798.

Each chain now gets its registerer through `ServerRegisterer(reg, server)`, which wraps it with a `server` label. Both chains register cleanly, and the scrape says which chain established the watch:

```
grafana_apiserver_watch_establishment_duration_seconds{server="main",group="dashboard.grafana.app",resource="dashboards"}
grafana_apiserver_watch_establishment_duration_seconds{server="apiextensions",...}
```

Note this splits series that were previously merged across both chains. Sums are unaffected.

`BuildHandlerChainFuncFromBuilders` keeps its signature, so grafana-enterprise needs no companion change: it passes its own implementation into `SetupConfig`, and that implementation ignores the registerer it is handed.