### PR TITLE
[release-12.4.10] Dashboard: Smart fill-to-limit pagination and merge-sort for mixed v1/v2 history (#120729)

### DIFF
--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
@@ -145,6 +145,271 @@ describe('UnifiedDashboardAPI', () => {
     });
   });
 
+  describe('listDashboardHistory', () => {
+    it('should return v2 history for pure v2 dashboards (no v1 items)', async () => {
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1', continue: 'v1-token' },
+        items: [],
+      };
+      const mockV2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2', continue: 'v2-token' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '2',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 2,
+            },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '1',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 1,
+            },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+        ],
+      };
+
+      v1Client.listDashboardHistory.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDashboardHistory.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      const result = await api.listDashboardHistory('dash-1');
+
+      expect(v1Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: undefined });
+      expect(v2Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: undefined });
+      expect(result.items).toHaveLength(2);
+      expect(result.items).toEqual(mockV2Response.items);
+
+      const decoded = JSON.parse(atob(result.metadata.continue!));
+      expect(decoded).toEqual({ v1: 'v1-token', v2: 'v2-token' });
+    });
+
+    it('should return v1 history when all v1 items are valid', async () => {
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1', continue: 'v1-token' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '1',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 1,
+            },
+            spec: { title: 'v1', schemaVersion: 30 },
+            status: {},
+          },
+        ],
+      };
+
+      v1Client.listDashboardHistory.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+
+      const result = await api.listDashboardHistory('dash-1');
+
+      expect(result.items).toEqual(mockV1Response.items);
+      expect(v2Client.listDashboardHistory).not.toHaveBeenCalled();
+
+      const decoded = JSON.parse(atob(result.metadata.continue!));
+      expect(decoded).toEqual({ v1: 'v1-token' });
+    });
+
+    it('should merge-sort valid items by generation descending for mixed v1/v2 history', async () => {
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1', continue: 'v1-token' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '1',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 1,
+            },
+            spec: { title: 'v1-valid', schemaVersion: 30 },
+            status: {},
+          },
+          {
+            metadata: { name: 'dash-1', resourceVersion: '2', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v2beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+      const mockV2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2', continue: 'v2-token' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '2',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 2,
+            },
+            spec: { title: 'v2-valid', elements: {} },
+            status: {},
+          },
+          {
+            metadata: { name: 'dash-1', resourceVersion: '1', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v1beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+
+      v1Client.listDashboardHistory.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDashboardHistory.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      const result = await api.listDashboardHistory('dash-1');
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].metadata.generation).toBe(2);
+      expect(result.items[1].metadata.generation).toBe(1);
+
+      const continueToken = result.metadata.continue!;
+      const decoded = JSON.parse(atob(continueToken));
+      expect(decoded).toEqual({ v1: 'v1-token', v2: 'v2-token' });
+    });
+
+    it('should decode composite continue token and pass separate tokens to v1/v2 clients', async () => {
+      const compositeToken = btoa(JSON.stringify({ v1: 'v1-page2', v2: 'v2-page2' }));
+
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '3',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 3,
+            },
+            spec: { title: 'v1', schemaVersion: 30 },
+            status: {},
+          },
+          {
+            metadata: { name: 'dash-1', resourceVersion: '4', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v2beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+      const mockV2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '4',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 4,
+            },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+        ],
+      };
+
+      v1Client.listDashboardHistory.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDashboardHistory.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      await api.listDashboardHistory('dash-1', { limit: 10, continueToken: compositeToken });
+
+      expect(v1Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: 'v1-page2' });
+      expect(v2Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: 'v2-page2' });
+    });
+
+    it('should return undefined continue when both streams are exhausted', async () => {
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '1',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 1,
+            },
+            spec: { title: 'v1', schemaVersion: 30 },
+            status: {},
+          },
+          {
+            metadata: { name: 'dash-1', resourceVersion: '2', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v2beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+      const mockV2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '2',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 2,
+            },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+          {
+            metadata: { name: 'dash-1', resourceVersion: '1', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v1beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+
+      v1Client.listDashboardHistory.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDashboardHistory.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      const result = await api.listDashboardHistory('dash-1');
+
+      expect(result.metadata.continue).toBeUndefined();
+    });
+  });
+
   describe('deleteDashboard', () => {
     it('should not try other version if fails', async () => {
       v1Client.deleteDashboard.mockRejectedValue(new DashboardVersionError('v2beta1', 'Dashboard is V1 format'));
@@ -160,6 +425,9 @@ describe('UnifiedDashboardAPI', () => {
   describe('listDeletedDashboards', () => {
     it('should try v1 first and return result if successful', async () => {
       const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1', continue: 'v1-token' },
         items: [
           { spec: { title: 'deleted-dash-1' }, metadata: { name: 'dash-1' } },
           { spec: { title: 'deleted-dash-2' }, metadata: { name: 'dash-2' } },
@@ -169,16 +437,19 @@ describe('UnifiedDashboardAPI', () => {
 
       const result = await api.listDeletedDashboards({ limit: 10 });
 
-      expect(result).toBe(mockV1Response);
-      expect(v1Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10 });
+      expect(result.items).toEqual(mockV1Response.items);
+      expect(v1Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10, continue: undefined });
       expect(v2Client.listDeletedDashboards).not.toHaveBeenCalled();
+
+      const decoded = JSON.parse(atob(result.metadata.continue!));
+      expect(decoded).toEqual({ v1: 'v1-token' });
     });
 
     it('should combine responses when v1 returns mixed v1/v2 dashboards', async () => {
       const mockV1Response = {
         apiVersion: 'dashboard.grafana.app/v1beta1',
         kind: 'DashboardList',
-        metadata: { resourceVersion: '123' },
+        metadata: { resourceVersion: '123', continue: 'v1-next' },
         items: [
           {
             metadata: { name: 'v2-dash', resourceVersion: '123', creationTimestamp: '2023-01-01T00:00:00Z' },
@@ -197,7 +468,7 @@ describe('UnifiedDashboardAPI', () => {
       const mockV2Response = {
         apiVersion: 'dashboard.grafana.app/v2beta1',
         kind: 'DashboardList',
-        metadata: { resourceVersion: '456' },
+        metadata: { resourceVersion: '456', continue: 'v2-next' },
         items: [
           {
             kind: 'Dashboard',
@@ -219,15 +490,90 @@ describe('UnifiedDashboardAPI', () => {
 
       const result = await api.listDeletedDashboards({ limit: 10 });
 
-      expect(result).toEqual({
-        ...mockV2Response,
+      expect(result.items).toHaveLength(2);
+      expect(result.items).toEqual([mockV1Response.items[1], mockV2Response.items[0]]);
+      expect(v1Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10, continue: undefined });
+      expect(v2Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10, continue: undefined });
+
+      const continueToken = result.metadata.continue!;
+      const decoded = JSON.parse(atob(continueToken));
+      expect(decoded).toEqual({ v1: 'v1-next', v2: 'v2-next' });
+    });
+
+    it('should return v2 deleted dashboards for pure v2 (no v1 items)', async () => {
+      const mockV1Response = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1', continue: 'v1-token' },
+        items: [],
+      };
+      const mockV2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2', continue: 'v2-token' },
         items: [
-          mockV1Response.items[1], // v1 dashboard
-          mockV2Response.items[0], // v2 dashboard
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: { name: 'v2-dash', resourceVersion: '2', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
         ],
-      });
-      expect(v1Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10 });
-      expect(v2Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10 });
+      };
+
+      v1Client.listDeletedDashboards.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDeletedDashboards.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      const result = await api.listDeletedDashboards({ limit: 10 });
+
+      expect(v2Client.listDeletedDashboards).toHaveBeenCalled();
+      expect(result.items).toHaveLength(1);
+
+      const decoded = JSON.parse(atob(result.metadata.continue!));
+      expect(decoded).toEqual({ v1: 'v1-token', v2: 'v2-token' });
+    });
+
+    it('should decode composite continue token and pass separate tokens to v1/v2 clients', async () => {
+      const compositeToken = btoa(JSON.stringify({ v1: 'v1-page2', v2: 'v2-page2' }));
+
+      const mockV1Response = {
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: { name: 'v1-dash', resourceVersion: '1', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: { title: 'v1', schemaVersion: 30 },
+            status: {},
+          },
+          {
+            metadata: { name: 'v2-dash', resourceVersion: '2', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: null,
+            status: { conversion: { failed: true, storedVersion: 'v2beta1', error: 'conversion failed' } },
+          },
+        ],
+      };
+      const mockV2Response = {
+        metadata: { resourceVersion: '2' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: { name: 'v2-dash', resourceVersion: '2', creationTimestamp: '2023-01-01T00:00:00Z' },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+        ],
+      };
+
+      v1Client.listDeletedDashboards.mockResolvedValue(mockV1Response as ResourceList<DashboardDataDTO>);
+      v2Client.listDeletedDashboards.mockResolvedValue(mockV2Response as ResourceList<DashboardV2Spec>);
+
+      await api.listDeletedDashboards({ limit: 10, continue: compositeToken });
+
+      expect(v1Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10, continue: 'v1-page2' });
+      expect(v2Client.listDeletedDashboards).toHaveBeenCalledWith({ limit: 10, continue: 'v2-page2' });
     });
 
     it('should throw error if v1 throws DashboardVersionError', async () => {

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
@@ -5,6 +5,7 @@ import { Resource, ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
+import { VERSIONS_FETCH_LIMIT } from '../types/revisionModels';
 
 import {
   DashboardAPI,
@@ -23,6 +24,33 @@ import {
 import { K8sDashboardAPI } from './v1';
 import { K8sDashboardV2API } from './v2';
 
+interface CompositeContinueToken {
+  v1?: string;
+  v2?: string;
+}
+
+function encodeCompositeToken(v1?: string, v2?: string): string | undefined {
+  if (!v1 && !v2) {
+    return undefined;
+  }
+  return btoa(JSON.stringify({ v1, v2 }));
+}
+
+function decodeCompositeToken(token?: string): CompositeContinueToken {
+  if (!token) {
+    return {};
+  }
+  try {
+    return JSON.parse(atob(token));
+  } catch {
+    return { v1: token };
+  }
+}
+
+function sortByGenerationDesc<T extends Resource<unknown>>(items: T[]): T[] {
+  return [...items].sort((a, b) => (b.metadata.generation ?? 0) - (a.metadata.generation ?? 0));
+}
+
 export class UnifiedDashboardAPI
   implements DashboardAPI<DashboardDTO | DashboardWithAccessInfo<DashboardV2Spec>, Dashboard | DashboardV2Spec>
 {
@@ -34,7 +62,6 @@ export class UnifiedDashboardAPI
     this.v2Client = new K8sDashboardV2API();
   }
 
-  // Get operation depends on the dashboard format to use one of the two clients
   async getDashboardDTO(uid: string) {
     try {
       return await this.v1Client.getDashboardDTO(uid);
@@ -46,7 +73,6 @@ export class UnifiedDashboardAPI
     }
   }
 
-  // Save operation depends on the dashboard format to use one of the two clients
   async saveDashboard(options: SaveDashboardCommand<Dashboard | DashboardV2Spec>) {
     if (isV2DashboardCommand(options)) {
       return await this.v2Client.saveDashboard(options);
@@ -57,26 +83,51 @@ export class UnifiedDashboardAPI
     throw new Error('Invalid dashboard command');
   }
 
-  // Delete operation for any version is supported in the v1 client
   async deleteDashboard(uid: string, showSuccessAlert: boolean) {
     return await this.v1Client.deleteDashboard(uid, showSuccessAlert);
   }
 
   async listDashboardHistory(uid: string, options?: ListDashboardHistoryOptions) {
-    const v1Response = await this.v1Client.listDashboardHistory(uid, options);
-    const filteredV1Items = v1Response.items.filter((item) => !failedFromVersion(item, ['v2']));
+    const limit = options?.limit ?? VERSIONS_FETCH_LIMIT;
+    const { v1: v1Token, v2: v2Token } = decodeCompositeToken(options?.continueToken);
 
-    if (filteredV1Items.length === v1Response.items.length) {
-      return v1Response;
+    const v1Response = await this.v1Client.listDashboardHistory(uid, { limit, continueToken: v1Token });
+    const v1Valid = v1Response.items.filter((item) => !failedFromVersion(item, ['v2']));
+
+    if (v1Valid.length === v1Response.items.length && v1Response.items.length > 0) {
+      return {
+        ...v1Response,
+        metadata: {
+          ...v1Response.metadata,
+          continue: encodeCompositeToken(v1Response.metadata.continue, v2Token),
+        },
+      };
     }
 
-    const v2Response = await this.v2Client.listDashboardHistory(uid, options);
-    const filteredV2Items = v2Response.items.filter((item) => !failedFromVersion(item, ['v0', 'v1']));
+    const v2Response = await this.v2Client.listDashboardHistory(uid, { limit, continueToken: v2Token });
+    const v2Valid = v2Response.items.filter((item) => !failedFromVersion(item, ['v0', 'v1']));
+
+    if (v1Valid.length === 0) {
+      return {
+        ...v2Response,
+        metadata: {
+          ...v2Response.metadata,
+          continue: encodeCompositeToken(v1Response.metadata.continue, v2Response.metadata.continue),
+        },
+      };
+    }
+
+    // Both APIs return the same generation sequence; every generation is valid in
+    // exactly one stream, so v1Valid + v2Valid reconstructs the full range.
+    const merged = sortByGenerationDesc([...v1Valid, ...v2Valid].filter(isResource));
 
     return {
-      ...v2Response,
-      // Make sure we display only valid resources
-      items: [...filteredV1Items, ...filteredV2Items].filter(isResource),
+      ...v1Response,
+      items: merged,
+      metadata: {
+        ...v1Response.metadata,
+        continue: encodeCompositeToken(v1Response.metadata.continue, v2Response.metadata.continue),
+      },
     };
   }
 
@@ -89,41 +140,53 @@ export class UnifiedDashboardAPI
   }
 
   async restoreDashboardVersion(uid: string, version: number) {
-    // Delegate to v1 client - it handles the restore internally
     return await this.v1Client.restoreDashboardVersion(uid, version);
   }
 
-  /**
-   * List deleted dashboards handling mixed v1/v2 versions or pure v2 dashboards.
-   *
-   * Steps:
-   * 1. Call v1 client to get all deleted dashboards
-   * 2. Check if any items have failed conversion from v2 versions
-   * 3. If v2 dashboards are detected, call v2 client
-   * 4. Filter and combine v1 and v2 dashboards into one response
-   */
   async listDeletedDashboards(
     options: ListDeletedDashboardsOptions
   ): Promise<ResourceList<Dashboard | DashboardV2Spec>> {
-    const v1Response = await this.v1Client.listDeletedDashboards(options);
-    const filteredV1Items = v1Response.items.filter((item) => !failedFromVersion(item, ['v2']));
+    const { v1: v1Token, v2: v2Token } = decodeCompositeToken(options.continue);
 
-    if (filteredV1Items.length === v1Response.items.length) {
-      return v1Response;
+    const v1Response = await this.v1Client.listDeletedDashboards({ ...options, continue: v1Token });
+    const v1Valid = v1Response.items.filter((item) => !failedFromVersion(item, ['v2']));
+
+    if (v1Valid.length === v1Response.items.length && v1Response.items.length > 0) {
+      return {
+        ...v1Response,
+        metadata: {
+          ...v1Response.metadata,
+          continue: encodeCompositeToken(v1Response.metadata.continue, v2Token),
+        },
+      };
     }
 
-    const v2Response = await this.v2Client.listDeletedDashboards(options);
-    const filteredV2Items = v2Response.items.filter((item) => !failedFromVersion(item, ['v0', 'v1']));
+    const v2Response = await this.v2Client.listDeletedDashboards({ ...options, continue: v2Token });
+    const v2Valid = v2Response.items.filter((item) => !failedFromVersion(item, ['v0', 'v1']));
+
+    if (v1Valid.length === 0) {
+      return {
+        ...v2Response,
+        metadata: {
+          ...v2Response.metadata,
+          continue: encodeCompositeToken(v1Response.metadata.continue, v2Response.metadata.continue),
+        },
+      };
+    }
+
+    const merged = [...v1Valid, ...v2Valid].filter(isResource);
 
     return {
-      ...v2Response,
-      // Make sure we display only valid resources
-      items: [...filteredV1Items, ...filteredV2Items].filter(isResource),
+      ...v1Response,
+      items: merged,
+      metadata: {
+        ...v1Response.metadata,
+        continue: encodeCompositeToken(v1Response.metadata.continue, v2Response.metadata.continue),
+      },
     };
   }
 
   async restoreDashboard(dashboard: Resource<DashboardDataDTO | DashboardV2Spec>) {
-    // Await returned promise to support proper error handling with try/catch
     if (isDashboardV2Spec(dashboard.spec) && isResource<DashboardV2Spec>(dashboard)) {
       return await this.v2Client.restoreDashboard(dashboard);
     }

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -497,6 +497,57 @@ describe('v1 dashboard API', () => {
     });
   });
 
+  describe('listDashboardHistory', () => {
+    it('should return all versions in a single request when no pagination needed', async () => {
+      const mockHistory = {
+        metadata: { resourceVersion: '1' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 3 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 2 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 1 } },
+        ],
+      };
+      mockGet.mockResolvedValueOnce(mockHistory);
+
+      const api = new K8sDashboardAPI();
+      const result = await api.listDashboardHistory('dash-uid');
+
+      expect(result.items).toHaveLength(3);
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('should follow pagination tokens across multiple pages', async () => {
+      const page1 = {
+        metadata: { resourceVersion: '1', continue: 'token-page2' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 5 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 4 } },
+        ],
+      };
+      const page2 = {
+        metadata: { resourceVersion: '1', continue: 'token-page3' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 3 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 2 } },
+        ],
+      };
+      const page3 = {
+        metadata: { resourceVersion: '1' },
+        items: [{ ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 1 } }],
+      };
+
+      mockGet.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2).mockResolvedValueOnce(page3);
+
+      const api = new K8sDashboardAPI();
+      const result = await api.listDashboardHistory('dash-uid');
+
+      expect(result.items).toHaveLength(5);
+      expect(mockGet).toHaveBeenCalledTimes(3);
+      // Verify continue token is not set on the final result
+      expect(result.metadata.continue).toBeUndefined();
+    });
+  });
+
   describe('listDeletedDashboards', () => {
     it('should return list of deleted dashboards', async () => {
       const mockDeletedDashboards = {

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -18,6 +18,7 @@ import {
   Resource,
   ResourceClient,
   ResourceForCreate,
+  ResourceList,
 } from 'app/features/apiserver/types';
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
@@ -25,6 +26,7 @@ import { buildSourceLink, removeExistingSourceLinks } from 'app/features/provisi
 import { DashboardDataDTO, DashboardDTO, SaveDashboardResponseDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
+import { VERSIONS_FETCH_LIMIT } from '../types/revisionModels';
 
 import {
   DashboardAPI,
@@ -229,13 +231,28 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
     }
   }
 
-  async listDashboardHistory(uid: string, options?: ListDashboardHistoryOptions) {
-    return this.client.list({
-      labelSelector: 'grafana.app/get-history=true',
-      fieldSelector: `metadata.name=${uid}`,
-      limit: options?.limit ?? 10,
-      continue: options?.continueToken,
-    });
+  async listDashboardHistory(
+    uid: string,
+    options?: ListDashboardHistoryOptions
+  ): Promise<ResourceList<DashboardDataDTO>> {
+    const limit = options?.limit ?? VERSIONS_FETCH_LIMIT;
+    let continueToken = options?.continueToken;
+    const items: Array<Resource<DashboardDataDTO>> = [];
+
+    let lastPage: ResourceList<DashboardDataDTO> | undefined;
+
+    do {
+      lastPage = await this.client.list({
+        labelSelector: 'grafana.app/get-history=true',
+        fieldSelector: `metadata.name=${uid}`,
+        limit: limit - items.length,
+        continue: continueToken,
+      });
+      items.push(...lastPage.items);
+      continueToken = lastPage.metadata.continue;
+    } while (items.length < limit && continueToken);
+
+    return { ...lastPage!, metadata: { ...lastPage!.metadata, continue: continueToken }, items };
   }
 
   async getDashboardHistoryVersions(uid: string, versions: number[]) {

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -418,6 +418,56 @@ describe('v2 dashboard API', () => {
     });
   });
 
+  describe('listDashboardHistory', () => {
+    it('should return all versions in a single request when no pagination needed', async () => {
+      const mockHistory = {
+        metadata: { resourceVersion: '1' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 3 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 2 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 1 } },
+        ],
+      };
+      mockGet.mockResolvedValueOnce(mockHistory);
+
+      const api = new K8sDashboardV2API();
+      const result = await api.listDashboardHistory('dash-uid');
+
+      expect(result.items).toHaveLength(3);
+      expect(mockGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('should follow pagination tokens across multiple pages', async () => {
+      const page1 = {
+        metadata: { resourceVersion: '1', continue: 'token-page2' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 5 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 4 } },
+        ],
+      };
+      const page2 = {
+        metadata: { resourceVersion: '1', continue: 'token-page3' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 3 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 2 } },
+        ],
+      };
+      const page3 = {
+        metadata: { resourceVersion: '1' },
+        items: [{ ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 1 } }],
+      };
+
+      mockGet.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2).mockResolvedValueOnce(page3);
+
+      const api = new K8sDashboardV2API();
+      const result = await api.listDashboardHistory('dash-uid');
+
+      expect(result.items).toHaveLength(5);
+      expect(mockGet).toHaveBeenCalledTimes(3);
+      expect(result.metadata.continue).toBeUndefined();
+    });
+  });
+
   describe('listDeletedDashboards', () => {
     it('should return list of deleted dashboards', async () => {
       const mockDeletedDashboards = {

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -14,6 +14,7 @@ import {
   Resource,
   ResourceClient,
   ResourceForCreate,
+  ResourceList,
 } from 'app/features/apiserver/types';
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
@@ -21,6 +22,7 @@ import { buildSourceLink, removeExistingSourceLinks } from 'app/features/provisi
 import { DashboardDTO, SaveDashboardResponseDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
+import { VERSIONS_FETCH_LIMIT } from '../types/revisionModels';
 
 import {
   DashboardAPI,
@@ -177,13 +179,28 @@ export class K8sDashboardV2API
     };
   }
 
-  async listDashboardHistory(uid: string, options?: ListDashboardHistoryOptions) {
-    return this.client.list({
-      labelSelector: 'grafana.app/get-history=true',
-      fieldSelector: `metadata.name=${uid}`,
-      limit: options?.limit ?? 10,
-      continue: options?.continueToken,
-    });
+  async listDashboardHistory(
+    uid: string,
+    options?: ListDashboardHistoryOptions
+  ): Promise<ResourceList<DashboardV2Spec>> {
+    const limit = options?.limit ?? VERSIONS_FETCH_LIMIT;
+    let continueToken = options?.continueToken;
+    const items: Array<Resource<DashboardV2Spec>> = [];
+
+    let lastPage: ResourceList<DashboardV2Spec> | undefined;
+
+    do {
+      lastPage = await this.client.list({
+        labelSelector: 'grafana.app/get-history=true',
+        fieldSelector: `metadata.name=${uid}`,
+        limit: limit - items.length,
+        continue: continueToken,
+      });
+      items.push(...lastPage.items);
+      continueToken = lastPage.metadata.continue;
+    } while (items.length < limit && continueToken);
+
+    return { ...lastPage!, metadata: { ...lastPage!.metadata, continue: continueToken }, items };
   }
 
   async getDashboardHistoryVersions(uid: string, versions: number[]) {


### PR DESCRIPTION
Backport of #120729 to `release-12.4.10`.

## Why

On 12.4.x, dashboard version history shows only a subset of the versions that are actually retained. `listDashboardHistory` returns a single page and stops, so on dashboards with a large spec, where the response page limit truncates each page, the Versions tab shows only a handful of entries.

This is independent of the `dashboardScene` feature toggle: both the Scenes version page and the legacy one go through `getDashboardAPI().listDashboardHistory()`, so the fix applies with Scenes disabled too.

## What

Clean cherry-pick of #120729, no conflicts.

- v1 and v2 clients fill to `limit` across pages instead of returning only the first page
- `UnifiedDashboardAPI` merge-sorts mixed v1/v2 history by generation and encodes both cursors in a composite continue token, so "load more" does not restart one of the streams and duplicate entries

## Verification

- `yarn jest public/app/features/dashboard/api/{UnifiedDashboardAPI,v1,v2}.test.ts`: 57 passed, 6 skipped. The skips are pre-existing and unrelated.
- `yarn typecheck`: clean, 14 projects
- `biome check public/app/features/dashboard/api/`: clean
