### PR TITLE
fix(alerting): report ManagerKind in UpdateAlertRule provenance-mismatch error

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -994,8 +994,8 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user ident
 	if storedManager.Kind != manager.Kind && storedManager.Kind != utils.ManagerKindUnknown {
 		return models.AlertRule{}, errProvenanceMismatch.Build(errutil.TemplateData{
 			Public: map[string]any{
-				"ProvidedProvenance": models.ManagerPropertiesToProvenance(manager),
-				"StoredProvenance":   models.ManagerPropertiesToProvenance(storedManager),
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
 				"Operation":          "update",
 			},
 		})


### PR DESCRIPTION
## What this PR does

`UpdateAlertRule` reported provenance-mismatch errors with the **legacy** provenance names (`file` / `api`) by running `ManagerPropertiesToProvenance` on the stored manager, while `DeleteAlertRule` and `ReplaceRuleGroup` report the **current** `ManagerKind` value (`classic-file-provisioning` / `classic-api-provisioning`).

For the exact same rule, the update path (`PUT` + `X-Disable-Provenance`) surfaced a *different* `StoredProvenance` than the delete path:

- `DELETE /api/v1/provisioning/alert-rules/{uid}` → 409 `needs 'classic-file-provisioning'`
- `PUT  /api/v1/provisioning/alert-rules/{uid}` with `X-Disable-Provenance: true` → 409 `needs 'file'`

This inconsistency (reported in #131777) made an incomplete rename look like the cause and blocked diagnosis of why a classic-file-provisioned rule cannot be removed through any documented path.

## Change

Report `manager.Kind` / `storedManager.Kind` directly in the `UpdateAlertRule` mismatch error, matching the three other `errProvenanceMismatch` sites (DeleteAlertRule + ReplaceRuleGroup delete/update paths). Behaviour is unchanged — only the error payload now reports the stored `ManagerKind`, so all endpoints agree on the same provenance value for the same rule.

## Verification

- `gofmt` clean.
- Existing tests assert `errProvenanceMismatch.Base.Is(err)` (type-level) and are unaffected.
- Provenance transition semantics are intentionally untouched: `UpdateAlertRule` still rejects `file → none` reset attempts (X-Disable-Provenance on a file-backed rule), but the error now tells the caller the real stored kind (`classic-file-provisioning`).

Fixes #131777
