### PR TITLE
[release-13.0.8] Dashboards: Fix version dates and user display names in the legacy version history page

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.test.tsx
@@ -18,6 +18,38 @@ jest.mock('app/features/dashboard/api/dashboard_api', () => ({
     }),
 }));
 
+const mockUseGetDisplayMappingQuery = jest.fn();
+
+jest.mock('app/api/clients/iam/v0alpha1', () => ({
+  useGetDisplayMappingQuery: (...args: unknown[]) => mockUseGetDisplayMappingQuery(...args),
+}));
+
+// all history resources for a dashboard share the dashboard's creationTimestamp, so it cannot
+// be used as the version date
+const DASHBOARD_CREATION_TIMESTAMP = '2020-01-15T12:00:00Z';
+
+function createHistoryResource(
+  version: number,
+  annotations: Record<string, string>,
+  creationTimestamp = DASHBOARD_CREATION_TIMESTAMP
+) {
+  return {
+    apiVersion: 'v1beta1',
+    kind: 'Dashboard',
+    metadata: {
+      name: '_U4zObQMz',
+      generation: version,
+      creationTimestamp,
+      annotations,
+    },
+    spec: { version },
+  };
+}
+
+function historyList(items: Array<ReturnType<typeof createHistoryResource>>) {
+  return { metadata: { continue: '' }, items };
+}
+
 const queryByFullText = (text: string) =>
   screen.queryByText((_, node: Element | undefined | null) => {
     if (node) {
@@ -53,6 +85,7 @@ describe('VersionSettings', () => {
     // see https://github.com/testing-library/user-event/issues/833
     user = userEvent.setup({ delay: null });
     jest.clearAllMocks();
+    mockUseGetDisplayMappingQuery.mockReturnValue({ data: undefined });
     jest.useFakeTimers();
   });
 
@@ -247,5 +280,174 @@ describe('VersionSettings', () => {
     await user.click(screen.getByText(/view json diff/i));
 
     await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+  });
+
+  describe('version dates', () => {
+    test('uses the updatedTimestamp annotation rather than the shared dashboard creationTimestamp', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(2, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-editor',
+          }),
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2023-02-20T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-editor',
+          }),
+        ])
+      );
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      const rows = within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row');
+
+      expect(rows[0]).toHaveTextContent('2024-06-10');
+      expect(rows[1]).toHaveTextContent('2023-02-20');
+      expect(screen.queryByText(/2020-01-15/)).not.toBeInTheDocument();
+    });
+
+    test('falls back to creationTimestamp when the version has no updatedTimestamp', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([createHistoryResource(1, { 'grafana.app/updatedBy': 'user:uid-editor' }, '2021-11-03T12:00:00Z')])
+      );
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      const rows = within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row');
+
+      expect(rows[0]).toHaveTextContent('2021-11-03');
+    });
+  });
+
+  describe('updated by display names', () => {
+    test('resolves identity keys to display names by identity, not by array index', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(2, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-ryan',
+          }),
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2024-06-09T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-bhaskar',
+          }),
+        ])
+      );
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: {
+          keys: ['user:uid-ryan', 'user:uid-bhaskar'],
+          display: [
+            { identity: { type: 'user', name: 'uid-bhaskar' }, displayName: 'Bhaskar Surroy' },
+            { identity: { type: 'user', name: 'uid-ryan' }, displayName: 'Ryan Brown' },
+          ],
+        },
+      });
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      const rows = within(screen.getAllByRole('rowgroup')[1]).getAllByRole('row');
+
+      expect(rows[0]).toHaveTextContent('Ryan Brown');
+      expect(rows[1]).toHaveTextContent('Bhaskar Surroy');
+      expect(screen.queryByText('user:uid-ryan')).not.toBeInTheDocument();
+      expect(screen.queryByText('user:uid-bhaskar')).not.toBeInTheDocument();
+    });
+
+    test('resolves the legacy numeric internalId when that is what the annotation holds', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/updatedBy': '3420',
+          }),
+        ])
+      );
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: {
+          keys: ['3420'],
+          display: [{ identity: { type: 'user', name: 'uid-ivan' }, displayName: 'Ivan Ortega', internalId: 3420 }],
+        },
+      });
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      expect(screen.getByText('Ivan Ortega')).toBeInTheDocument();
+    });
+
+    test('falls back to the createdBy annotation when the version has no updatedBy', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/createdBy': 'user:uid-creator',
+          }),
+        ])
+      );
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: {
+          keys: ['user:uid-creator'],
+          display: [{ identity: { type: 'user', name: 'uid-creator' }, displayName: 'Creator User' }],
+        },
+      });
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      expect(screen.getByText('Creator User')).toBeInTheDocument();
+    });
+
+    test('keeps the raw key when the user no longer exists', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-unknown',
+          }),
+        ])
+      );
+
+      mockUseGetDisplayMappingQuery.mockReturnValue({
+        data: { keys: ['user:uid-unknown'], display: [], invalidKeys: ['user:uid-unknown'] },
+      });
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      expect(screen.getByText('user:uid-unknown')).toBeInTheDocument();
+    });
+
+    test('requests the display mapping once per unique identity key', async () => {
+      mockListDashboardHistory.mockResolvedValue(
+        historyList([
+          createHistoryResource(2, {
+            'grafana.app/updatedTimestamp': '2024-06-10T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-editor',
+          }),
+          createHistoryResource(1, {
+            'grafana.app/updatedTimestamp': '2024-06-09T12:00:00Z',
+            'grafana.app/updatedBy': 'user:uid-editor',
+          }),
+        ])
+      );
+
+      setup();
+
+      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
+
+      expect(mockUseGetDisplayMappingQuery).toHaveBeenLastCalledWith({ key: ['user:uid-editor'] });
+    });
   });
 });

--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -3,7 +3,13 @@ import * as React from 'react';
 
 import { Spinner, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
-import { type Resource } from 'app/features/apiserver/types';
+import {
+  AnnoKeyCreatedBy,
+  AnnoKeyMessage,
+  AnnoKeyUpdatedBy,
+  AnnoKeyUpdatedTimestamp,
+  type Resource,
+} from 'app/features/apiserver/types';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import {
   type DecoratedRevisionModel,
@@ -80,9 +86,14 @@ export class VersionsSettings extends PureComponent<Props, State> {
         checked: false,
         uid: item.metadata.name,
         version: item.metadata.generation ?? 0,
-        created: item.metadata.creationTimestamp ?? new Date().toISOString(),
-        createdBy: item.metadata.annotations?.['grafana.app/updatedBy'] ?? '',
-        message: item.metadata.annotations?.['grafana.app/message'] ?? '',
+        // creationTimestamp on a history resource is the dashboard's creation time, not the version's,
+        // so it is only a fallback for versions saved before updatedTimestamp was recorded
+        created:
+          item.metadata.annotations?.[AnnoKeyUpdatedTimestamp] ??
+          item.metadata.creationTimestamp ??
+          new Date().toISOString(),
+        createdBy: item.metadata.annotations?.[AnnoKeyUpdatedBy] ?? item.metadata.annotations?.[AnnoKeyCreatedBy] ?? '',
+        message: item.metadata.annotations?.[AnnoKeyMessage] ?? '',
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         data: item.spec as object,
       })

--- a/public/app/features/dashboard/components/VersionHistory/VersionHistoryTable.tsx
+++ b/public/app/features/dashboard/components/VersionHistory/VersionHistoryTable.tsx
@@ -1,9 +1,13 @@
 import { css } from '@emotion/css';
+import { skipToken } from '@reduxjs/toolkit/query/react';
 import * as React from 'react';
+import { useMemo } from 'react';
+import Skeleton from 'react-loading-skeleton';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Checkbox, Button, Tag, ModalsController, useStyles2 } from '@grafana/ui';
+import { useGetDisplayMappingQuery } from 'app/api/clients/iam/v0alpha1';
 import { type DecoratedRevisionModel } from 'app/features/dashboard/types/revisionModels';
 
 import { RevertDashboardModal } from './RevertDashboardModal';
@@ -16,6 +20,30 @@ type VersionsTableProps = {
 
 export const VersionHistoryTable = ({ versions, canCompare, onCheck }: VersionsTableProps) => {
   const styles = useStyles2(getStyles);
+
+  const userKeys = useMemo(() => [...new Set(versions.map((v) => v.createdBy).filter(Boolean))], [versions]);
+  const { data: displayData } = useGetDisplayMappingQuery(userKeys.length > 0 ? { key: userKeys } : skipToken);
+  const isLoadingUserDisplayNames = userKeys.length > 0 && !displayData;
+
+  const versionsWithDisplayNames = useMemo(() => {
+    if (!displayData) {
+      return versions;
+    }
+
+    const displayMap = new Map<string, string>();
+    for (const item of displayData.display || []) {
+      displayMap.set(`${item.identity.type}:${item.identity.name}`, item.displayName);
+      if (item.internalId) {
+        displayMap.set(String(item.internalId), item.displayName);
+      }
+    }
+
+    return versions.map((version) => {
+      const displayName = version.createdBy ? displayMap.get(version.createdBy) : undefined;
+      // users that no longer exist are not in the mapping, so keep the raw key
+      return displayName ? { ...version, createdBy: displayName } : version;
+    });
+  }, [versions, displayData]);
 
   return (
     <div className={styles.margin}>
@@ -39,7 +67,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck }: VersionsT
           </tr>
         </thead>
         <tbody>
-          {versions.map((version, idx) => (
+          {versionsWithDisplayNames.map((version, idx) => (
             <tr key={version.id}>
               <td>
                 <Checkbox
@@ -58,7 +86,7 @@ export const VersionHistoryTable = ({ versions, canCompare, onCheck }: VersionsT
               </td>
               <td>{version.version}</td>
               <td>{version.createdDateString}</td>
-              <td>{version.createdBy}</td>
+              <td>{isLoadingUserDisplayNames ? <Skeleton width={100} /> : version.createdBy}</td>
               <td>{version.message}</td>
               <td className="text-right">
                 {idx === 0 ? (


### PR DESCRIPTION
## What this PR does

Fixes two wrong columns in the **legacy (non-Scenes) dashboard version history page**, `public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx`.

| Column | Before | After |
| --- | --- | --- |
| Date | The same value on every row (the dashboard's creation time) | The date the version was saved |
| Updated by | Raw identity key, e.g. `user:u000003420` | The user's display name |

### Root cause

https://github.com/grafana/grafana/pull/114686 moved both version history pages onto the k8s `listDashboardHistory` API. Both then read the history resource raw:

- `metadata.creationTimestamp` on a *history* resource is the **dashboard's** creation time, not the version's, so every row rendered the same date. `created` now prefers the `grafana.app/updatedTimestamp` annotation and only falls back to `creationTimestamp` (for versions saved before that annotation was recorded) and then to now.
- `grafana.app/updatedBy` holds a raw identity key, which was rendered verbatim. Keys are now resolved to display names via `useGetDisplayMappingQuery` from `app/api/clients/iam/v0alpha1`, with `grafana.app/createdBy` as a fallback for the initial version, the legacy numeric `internalId` handled, and the raw key kept for users that no longer exist.

The annotation string literals are also replaced with the exported `AnnoKey*` constants.

## Why this targets a release branch directly instead of main

**There is no main commit to backport.**

https://github.com/grafana/grafana/pull/117668 fixed both bugs, but only in the Scenes component `dashboard-scene/settings/VersionsEditView.tsx`. The later refinements (https://github.com/grafana/grafana/pull/119220, https://github.com/grafana/grafana/pull/120273, https://github.com/grafana/grafana/pull/126762) also touched only that file. The legacy page was never fixed: it was **deleted**, not fixed, by https://github.com/grafana/grafana/pull/126372, which first shipped in v13.1.0.

So the file does not exist on `main` and there is nothing to cherry-pick, while the release branches that still ship the legacy page still have the bug. This PR is therefore a direct fix against `release-13.0.8`.

An equivalent PR targets `release-12.4.10`: https://github.com/grafana/grafana/pull/131808

## Why fix this rather than telling users to enable Scenes

Enabling `dashboardScene` does resolve both columns, and it is a valid answer for anyone able to take it. We are fixing the legacy page anyway because the alternative forces an architecture migration on users who have deliberately deferred one, purely so that a settings page renders correct data. These are also the last releases where that choice exists at all: the toggle and the legacy page are both gone in v13.1.0, so users on the old architecture will migrate regardless. This makes the interim releases correct instead of making the migration a prerequisite for a bug fix.

## Implementation note

`VersionsSettings` is a `PureComponent`, so the display-mapping hook cannot be called in it. The resolution lives in `VersionHistory/VersionHistoryTable.tsx`, which is a function component and has exactly one consumer (`VersionsSettings`). That keeps the class component's `render()` untouched and needs no new wrapper component or extra prop. This matches the Scenes behaviour, where only the table resolves display names.

## Tests

`VersionsSettings.test.tsx` is extended with cases for both fixes: per-version dates from `updatedTimestamp`, the `creationTimestamp` fallback, display-name resolution keyed by identity (not array index), `internalId` resolution, the `createdBy` fallback, deleted users falling back to the raw key, and de-duplication of the identity keys sent to the endpoint. 5 of the 7 new cases fail without the source change.

Verified on this branch: jest on the touched suites (plus the Scenes suite, unchanged and still green), `yarn typecheck`, and `npx biome check` on both touched directories.



## Verified locally

Behaviour was verified on the `release-12.4.10` branch of this change, not on this one. Screenshots and numbers are in https://github.com/grafana/grafana/pull/131808. The two branches differ only in an inline `type` import, the `displayData.display || []` guard this branch needs because `DisplayList.display` is optional here, and an `Array<T>` vs `T[]` formatting choice.

| Before | After |
| --- | --- |
| <img width="440" src="https://github.com/grafana/grafana/raw/c876bccaca87cd4233f280364f09dbec03b508fc/.screenshots/legacy-version-history/before.png" /> | <img width="440" src="https://github.com/grafana/grafana/raw/c876bccaca87cd4233f280364f09dbec03b508fc/.screenshots/legacy-version-history/after.png" /> |

<sub>Screenshots live on the `assets/legacy-version-history-screenshots` branch and are pinned to a commit sha. Please keep that branch; deleting it breaks the images above.</sub>
