### PR TITLE
Dashboards: Fix adhoc and groupby variable datasource on UI import

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -126,6 +126,10 @@ interface QueryVariableModel extends VariableModel {
   datasource?: { uid?: string };
 }
 
+interface VariableWithDatasource extends VariableModel {
+  datasource?: { uid?: string };
+}
+
 interface DatasourceVariableModel {
   type: string;
   current?: { value?: string; text?: string; selected?: boolean };
@@ -969,6 +973,39 @@ describe('applyV1Inputs', () => {
 
     const dsVariable = result.templating?.list?.[1] as DatasourceVariableModel;
     expect(dsVariable.current?.value).toBe('ds-uid');
+  });
+
+  it('resolves templateized datasources on adhoc and groupby variables', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      schemaVersion: 42,
+      templating: {
+        list: [
+          { type: 'adhoc', name: 'Filters', datasource: { type: 'prometheus', uid: '${DS}' } },
+          { type: 'groupby', name: 'GroupBy', datasource: { type: 'prometheus', uid: '${DS}' } },
+        ],
+      },
+    } as unknown as Dashboard;
+
+    const form: ImportDashboardDTO = {
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
+
+    const adhocVariable = result.templating?.list?.[0] as VariableWithDatasource;
+    expect(adhocVariable.datasource?.uid).toBe('ds-uid');
+
+    const groupByVariable = result.templating?.list?.[1] as VariableWithDatasource;
+    expect(groupByVariable.datasource?.uid).toBe('ds-uid');
   });
 
   it('handles legacy string datasource format', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -1048,7 +1048,12 @@ function processVariable(
     }
   }
 
-  if (variableType === 'query' && 'datasource' in variable) {
+  // adhoc and groupby variables carry the same `datasource` shape as query variables, so they
+  // need the same placeholder resolution. The v2 path already remaps all three.
+  if (
+    (variableType === 'query' || variableType === 'adhoc' || variableType === 'groupby') &&
+    'datasource' in variable
+  ) {
     const resolved = resolveDatasource(variable.datasource, inputs.dataSources, form.dataSources);
     if (resolved) {
       return { ...variable, datasource: resolved };


### PR DESCRIPTION
## What this PR does

When a v1 dashboard exported with "Export for sharing externally" is imported through the **UI import dialog**, the frontend interpolation in `applyV1Inputs` resolved `${DS_...}` placeholders only for `query` variables. `adhoc` and `groupby` variables carry the same `datasource` shape, so they kept the literal token and their `datasource.uid` stayed unresolved after import, leaving the Filter / Group by control pointing at a datasource UID that does not exist.

This extends the resolution branch to cover `adhoc` and `groupby`, matching the v2 path (`replaceVariableDatasources`), which already remaps all three.

| | Before | After |
|---|---|---|
| `query` variable | resolved | resolved |
| `adhoc` variable | `${DS_...}` | resolved |
| `groupby` variable | `${DS_...}` | resolved |

Panels, panel targets, annotations and the other variable types were already resolved, which is why the gap was easy to miss.

`POST /api/dashboards/import` is unaffected: it interpolates on the backend via a generic token substitution and already resolved these correctly.

## Which issue(s) this PR fixes

Regression introduced in #116482, which moved v1 UI import interpolation from the backend round-trip into the frontend. Present on `main` and on the 12.4.x, 13.0.x, 13.1.x and 13.2.x lines.

## Testing

New unit test `resolves templateized datasources on adhoc and groupby variables` in `inputs.test.ts`. Verified it fails on the current code (`Expected "ds-uid", Received "${DS}"`) and passes with the change; the rest of the suite is unchanged.
