### PR TITLE
AuthZ: Authorize registered wildcard datasource groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -480,6 +480,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
+	github.com/grafana/grafana-enterprise v0.0.0
 	github.com/grafana/nanogit v1.4.0 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grafana/sqlds/v5 v5.3.0 // indirect
@@ -730,3 +731,5 @@ replace (
 // This was retracted, but seems to be known by the Go module proxy,
 // and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible
+
+replace github.com/grafana/grafana-enterprise => ../grafana-enterprise

--- a/go.mod
+++ b/go.mod
@@ -480,7 +480,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
-	github.com/grafana/grafana-enterprise v0.0.0
 	github.com/grafana/nanogit v1.4.0 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
 	github.com/grafana/sqlds/v5 v5.3.0 // indirect
@@ -731,5 +730,3 @@ replace (
 // This was retracted, but seems to be known by the Go module proxy,
 // and is otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible
-
-replace github.com/grafana/grafana-enterprise => ../grafana-enterprise

--- a/pkg/registry/apis/iam/datasourcek8s/k8s.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s.go
@@ -72,6 +72,17 @@ func legacyActionToK8s(dsType, action string) (string, bool) {
 	return convertedAction, convertedAction != action
 }
 
+// LegacyActionRequiresK8sForm reports whether a legacy datasource action has a k8s
+// equivalent inside a datasource API group, and must therefore be written in k8s form.
+func LegacyActionRequiresK8sForm(action string) bool {
+	k8sAction, ok := legacyActionToK8s("*", action)
+	if !ok {
+		return false
+	}
+	group, _, found := strings.Cut(k8sAction, "/")
+	return found && strings.HasSuffix(group, K8sDatasourceAPIGroupSuffix)
+}
+
 // LegacyDatasourceAction replaces a legacy ds action string with its k8s form
 func LegacyDatasourceAction(dsType string, action *string) {
 	if converted, ok := legacyActionToK8s(dsType, *action); ok {

--- a/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
+++ b/pkg/registry/apis/iam/datasourcek8s/k8s_test.go
@@ -23,6 +23,31 @@ func TestLegacyVerbToK8sAction(t *testing.T) {
 	assert.Equal(t, "datasources:custom", LegacyVerbToK8sAction("loki", "custom"))
 }
 
+func TestLegacyActionRequiresK8sForm(t *testing.T) {
+	tests := []struct {
+		action string
+		want   bool
+	}{
+		{action: "datasources:read", want: true},
+		{action: "datasources:write", want: true},
+		{action: "datasources:delete", want: true},
+		{action: "datasources.permissions:read", want: true},
+		{action: "datasources.permissions:write", want: true},
+		{action: "datasources.caching:read"},
+		{action: "datasources.caching:write"},
+		{action: "datasources.insights:read"},
+		{action: "datasources:create"},
+		{action: "datasources:explore"},
+		{action: "datasources:query"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			assert.Equal(t, tt.want, LegacyActionRequiresK8sForm(tt.action))
+		})
+	}
+}
+
 func TestPluginTypeFromDatasourceAPIGroup(t *testing.T) {
 	assert.Equal(t, "loki", DSTypeFromDatasourceAPIGroup("loki.datasource.grafana.app"))
 	assert.Equal(t, "", DSTypeFromDatasourceAPIGroup("*.datasource.grafana.app"))

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -709,13 +709,14 @@ func NewMapperRegistry() MapperRegistry {
 // then wildcard match. A wildcard key has the form "*.<suffix>" (e.g. "*.datasource.grafana.app");
 // group matches if it has that suffix, is longer than the suffix (non-empty prefix), and the prefix
 // contains no dot (so "loki.datasource.grafana.app" matches but "foo.loki.datasource.grafana.app" does not).
-// Group starting with "*" never matches (so we never exact-match a wildcard registry key as input).
+// A registered wildcard key may also be supplied literally. Unregistered groups starting with "*"
+// are rejected so wildcard registry entries do not become generic input patterns.
 func (m mapper) findGroupKey(group string) (string, bool) {
-	if strings.HasPrefix(group, "*") {
-		return "", false
-	}
 	if _, ok := m[group]; ok {
 		return group, true
+	}
+	if strings.HasPrefix(group, "*") {
+		return "", false
 	}
 	for key := range m {
 		// is this a wildcard key?

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -19,8 +19,12 @@ const testWildcardPattern = "*.test.grafana.app"
 func TestMapperRegistry_DatasourceWildcard(t *testing.T) {
 	reg := NewMapperRegistry()
 
-	// Real config: groups matching *.datasource.grafana.app get the datasources mapping
-	for _, group := range []string{"loki.datasource.grafana.app", "mimir.datasource.grafana.app"} {
+	// Real config: the literal wildcard and concrete matching groups get the datasource mapping.
+	for _, group := range []string{
+		"*.datasource.grafana.app",
+		"loki.datasource.grafana.app",
+		"mimir.datasource.grafana.app",
+	} {
 		mapping, ok := reg.Get(group, "datasources", "")
 		require.True(t, ok, "Get(%q, \"datasources\") should find mapping", group)
 		require.NotNil(t, mapping)
@@ -87,8 +91,10 @@ func TestFindGroupKey_WildcardMatching(t *testing.T) {
 		{"bar.test.grafana.app", []string{testWildcardPattern}, testWildcardPattern, true},
 		// group with nested dots does not match wildcard
 		{"bar.baz.test.grafana.app", []string{testWildcardPattern}, "", false},
-		// Group starts with *: never matches
-		{"*.test.grafana.app", []string{testWildcardPattern}, "", false},
+		// A registered wildcard key resolves when supplied literally.
+		{"*.test.grafana.app", []string{testWildcardPattern}, testWildcardPattern, true},
+		// An unregistered wildcard input never suffix-matches another key.
+		{"*.other.test.grafana.app", []string{testWildcardPattern}, "", false},
 		// Key not a wildcard (no *.): iterate and continue, no match
 		{"foo.test.grafana.app", []string{"dashboard.grafana.app"}, "", false},
 		{"foo.test.grafana.app", []string{"*"}, "", false},
@@ -122,8 +128,8 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 	}
 	var reg MapperRegistry = m
 
-	// Matching groups get the mapping
-	for _, group := range []string{"foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"} {
+	// The registered wildcard key and matching concrete groups get the mapping.
+	for _, group := range []string{testWildcardPattern, "foo.test.grafana.app", "bar.test.grafana.app", "baz.test.grafana.app"} {
 		t.Run("matches_"+group, func(t *testing.T) {
 			mapping, ok := reg.Get(group, "testresources", "")
 			require.True(t, ok, "Get(%q, \"testresources\") should find mapping", group)
@@ -135,12 +141,13 @@ func TestMapperRegistry_WildcardGroup(t *testing.T) {
 		})
 	}
 
-	// Wildcard as input, wrong suffix, no prefix, or unknown group must not resolve
+	// Unregistered wildcard input, nested prefix, wrong suffix, no prefix, or unknown group must not resolve.
 	denyCases := []struct {
 		name  string
 		group string
 	}{
-		{"wildcard_input", testWildcardPattern},
+		{"unregistered_wildcard_input", "*.other.test.grafana.app"},
+		{"nested_prefix", "foo.bar.test.grafana.app"},
 		{"wrong_suffix", "foo.test.grafana.app.evil"},
 		{"no_prefix", "test.grafana.app"},
 		{"unknown_group", "unknown.grafana.app"},

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -700,6 +700,57 @@ func TestService_checkPermission(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "should allow wildcard datasource read with wildcard datasource grant",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:    "datasources:read",
+					Scope:     "datasources:*",
+					Kind:      "datasources",
+					Attribute: "*",
+				},
+			},
+			check: checkRequest{
+				Action:   "datasources:read",
+				Group:    "*.datasource.grafana.app",
+				Resource: "datasources",
+				Name:     "*",
+				Verb:     utils.VerbGet,
+			},
+			expected: true,
+		},
+		{
+			name: "should deny wildcard datasource read with uid-scoped datasource grant",
+			permissions: []accesscontrol.Permission{
+				{
+					Action:     "datasources:read",
+					Scope:      "datasources:uid:ds1",
+					Kind:       "datasources",
+					Attribute:  "uid",
+					Identifier: "ds1",
+				},
+			},
+			check: checkRequest{
+				Action:   "datasources:read",
+				Group:    "*.datasource.grafana.app",
+				Resource: "datasources",
+				Name:     "*",
+				Verb:     utils.VerbGet,
+			},
+			expected: false,
+		},
+		{
+			name:        "should deny wildcard datasource read without a datasource grant",
+			permissions: []accesscontrol.Permission{},
+			check: checkRequest{
+				Action:   "datasources:read",
+				Group:    "*.datasource.grafana.app",
+				Resource: "datasources",
+				Name:     "*",
+				Verb:     utils.VerbGet,
+			},
+			expected: false,
+		},
+		{
 			name: "should allow creating a team (no scope needed)",
 			permissions: []accesscontrol.Permission{
 				{Action: "teams:create"},


### PR DESCRIPTION
## Why the change

Role redirects store wildcard datasource permissions in Kubernetes format. Authorization checks for the literal registered wildcard group were not resolved through the RBAC mapper, causing valid wildcard grants to be denied.

## Summary
- resolve literal registered wildcard mapper keys before rejecting unregistered wildcard-shaped inputs
- derive whether legacy datasource actions require Kubernetes format from the existing converter
- cover wildcard mapper resolution, datasource action conversion, and authorization behavior

## Testing
- targeted RBAC mapper and service tests
- datasource conversion tests