### PR TITLE
[release-12.4.10] Dashboards: Fix adhoc and groupby variable datasource on UI import

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -93,6 +93,10 @@ interface QueryVariableModel extends VariableModel {
   datasource?: { uid?: string };
 }
 
+interface VariableWithDatasource extends VariableModel {
+  datasource?: { uid?: string };
+}
+
 interface DatasourceVariableModel {
   type: string;
   current?: { value?: string; text?: string; selected?: boolean };
@@ -455,6 +459,38 @@ describe('applyV1Inputs', () => {
 
     const dsVariable = result.templating?.list?.[1] as DatasourceVariableModel;
     expect(dsVariable.current?.value).toBe('ds-uid');
+  });
+
+  it('resolves templateized datasources on adhoc and groupby variables', () => {
+    const dashboard = {
+      title: 'old',
+      uid: 'old',
+      schemaVersion: 42,
+      templating: {
+        list: [
+          { type: 'adhoc', name: 'Filters', datasource: { type: 'prometheus', uid: '${DS}' } },
+          { type: 'groupby', name: 'GroupBy', datasource: { type: 'prometheus', uid: '${DS}' } },
+        ],
+      },
+    } as unknown as Dashboard;
+
+    const form: ImportDashboardDTO = {
+      title: 'new-title',
+      uid: 'new-uid',
+      gnetId: '',
+      constants: [],
+      dataSources: [{ uid: 'ds-uid', type: 'prometheus', name: 'My DS' } as DataSourceInstanceSettings],
+      elements: [],
+      folder: { uid: 'folder' },
+    };
+
+    const result = applyV1Inputs(dashboard, sampleV1Inputs, form);
+
+    const adhocVariable = result.templating?.list?.[0] as VariableWithDatasource;
+    expect(adhocVariable.datasource?.uid).toBe('ds-uid');
+
+    const groupByVariable = result.templating?.list?.[1] as VariableWithDatasource;
+    expect(groupByVariable.datasource?.uid).toBe('ds-uid');
   });
 
   it('keeps selections independent for multiple inputs of the same plugin type', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -658,7 +658,13 @@ function processVariable(
     }
   }
 
-  if (variableType === 'query' && 'datasource' in variable && isRecord(variable.datasource)) {
+  // adhoc and groupby variables carry the same `datasource` shape as query variables, so they
+  // need the same placeholder resolution.
+  if (
+    (variableType === 'query' || variableType === 'adhoc' || variableType === 'groupby') &&
+    'datasource' in variable &&
+    isRecord(variable.datasource)
+  ) {
     const datasourceUid = variable.datasource.uid;
     if (typeof datasourceUid === 'string' && datasourceUid.startsWith('$')) {
       const userInput = checkUserInputMatch(datasourceUid, inputs.dataSources, form.dataSources);


### PR DESCRIPTION
Manual backport of #131817 to the 12.4 line. The automated backport did not run for `backport v12.4.x`.