### PR TITLE
[Patch steady] Auth: Backport org users latency and OAuth email lookup fixes

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -432,6 +432,22 @@ func getFirstPublicErrorMessage(err *errutil.Error) string {
 	return errPublic.Message
 }
 
+// newExternallySyncedResolver returns an isExternallySynced function that caches
+// the result per auth module. Each OAuth lookup reads SSO settings twice (client
+// enabled and client config), so caching avoids those reads per user on list
+// endpoints. Not safe for concurrent use.
+func (hs *HTTPServer) newExternallySyncedResolver(ctx context.Context, cfg *setting.Cfg) func(authModule string) bool {
+	cache := make(map[string]bool)
+	return func(authModule string) bool {
+		if synced, ok := cache[authModule]; ok {
+			return synced
+		}
+		synced := hs.isExternallySynced(ctx, cfg, authModule)
+		cache[authModule] = synced
+		return synced
+	}
+}
+
 // isExternalySynced is used to tell if the user roles are externally synced
 // true means that the org role sync is handled by Grafana
 // Note: currently the users authinfo is overridden each time the user logs in

--- a/pkg/api/login_test.go
+++ b/pkg/api/login_test.go
@@ -887,6 +887,31 @@ func TestIsProviderEnabled(t *testing.T) {
 	}
 }
 
+// countingAuthnService counts calls per client name to the two methods that
+// trigger an SSO settings read, so tests can assert the resolver caches per
+// module and keys the cache correctly.
+type countingAuthnService struct {
+	*authntest.FakeService
+	enabledCalls map[string]int
+	configCalls  map[string]int
+}
+
+func (s *countingAuthnService) IsClientEnabled(ctx context.Context, name string) bool {
+	if s.enabledCalls == nil {
+		s.enabledCalls = map[string]int{}
+	}
+	s.enabledCalls[name]++
+	return s.FakeService.IsClientEnabled(ctx, name)
+}
+
+func (s *countingAuthnService) GetClientConfig(ctx context.Context, name string) (authn.SSOClientConfig, bool) {
+	if s.configCalls == nil {
+		s.configCalls = map[string]int{}
+	}
+	s.configCalls[name]++
+	return s.FakeService.GetClientConfig(ctx, name)
+}
+
 type mockSocialService struct {
 	oAuthInfo       *social.OAuthInfo
 	oAuthInfos      map[string]*social.OAuthInfo

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -384,11 +384,12 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 		accessControlMetadata = accesscontrol.GetResourcesMetadata(c.Req.Context(), permissions, "users:id:", userIDs)
 	}
 
+	externallySynced := hs.newExternallySyncedResolver(c.Req.Context(), hs.Cfg)
 	for i := range filteredUsers {
 		filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
 		if module, ok := modules[filteredUsers[i].UserID]; ok {
 			filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
-			filteredUsers[i].IsExternallySynced = hs.isExternallySynced(c.Req.Context(), hs.Cfg, module)
+			filteredUsers[i].IsExternallySynced = externallySynced(module)
 		}
 	}
 
@@ -399,8 +400,12 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 }
 
 func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+	// Shared across pages so the externally-synced check is resolved once per
+	// auth module for the whole request, not once per page.
+	externallySynced := hs.newExternallySyncedResolver(c.Req.Context(), hs.Cfg)
+
 	if query.Limit > 0 || query.UserID != 0 {
-		return hs.searchOrgUsersPageUsingK8s(c, query)
+		return hs.searchOrgUsersPageUsingK8s(c, query, externallySynced)
 	}
 
 	const pageSize = 1000
@@ -410,7 +415,7 @@ func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *
 		pageQuery.Limit = pageSize
 		pageQuery.Page = page
 
-		pageResult, err := hs.searchOrgUsersPageUsingK8s(c, &pageQuery)
+		pageResult, err := hs.searchOrgUsersPageUsingK8s(c, &pageQuery, externallySynced)
 		if err != nil {
 			return nil, err
 		}
@@ -425,7 +430,7 @@ func (hs *HTTPServer) searchOrgUsersUsingK8s(c *contextmodel.ReqContext, query *
 	}
 }
 
-func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, query *org.SearchOrgUsersQuery, externallySynced func(authModule string) bool) (*org.SearchOrgUsersQueryResult, error) {
 	searchResult, err := hs.userService.Search(c.Req.Context(), &user.SearchUsersQuery{
 		SignedInUser:         query.User,
 		OrgID:                query.OrgID,
@@ -449,7 +454,7 @@ func (hs *HTTPServer) searchOrgUsersPageUsingK8s(c *contextmodel.ReqContext, que
 		isExternallySynced := false
 		for _, module := range u.AuthModule {
 			authLabels = append(authLabels, login.GetAuthProviderLabel(module))
-			if hs.isExternallySynced(c.Req.Context(), hs.Cfg, module) {
+			if externallySynced(module) {
 				isExternallySynced = true
 			}
 		}

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -789,6 +789,16 @@ func searchHits(n int, startID int64) []*user.UserSearchHitDTO {
 	return out
 }
 
+// searchHitsWithModules builds n hits, assigning auth modules round-robin so
+// each module appears across the whole range (and across pages).
+func searchHitsWithModules(n int, startID int64, modules ...string) []*user.UserSearchHitDTO {
+	out := searchHits(n, startID)
+	for i, h := range out {
+		h.AuthModule = user.AuthModuleConversion{modules[i%len(modules)]}
+	}
+	return out
+}
+
 func TestSearchOrgUsersUsingK8s(t *testing.T) {
 	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	lastSeen := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -917,6 +927,80 @@ func TestSearchOrgUsersUsingK8s(t *testing.T) {
 		assert.Equal(t, 1, svc.calls, "explicit limit must fetch exactly one page")
 		require.Len(t, res.OrgUsers, 50)
 	})
+}
+
+// The externally-synced check depends only on the auth module, so it is
+// resolved once per module per request, not once per user or per page.
+func TestSearchOrgUsersUsingK8s_ResolvesExternallySyncedPerModule(t *testing.T) {
+	githubModule := login.GithubAuthModule
+	gitlabModule := login.GitLabAuthModule
+
+	svc := &countingAuthnService{
+		FakeService: &authntest.FakeService{ExpectedClientConfig: &authntest.FakeSSOClientConfig{}},
+	}
+	// Two pages force the resolver to span more than one page; both modules
+	// appear on each page.
+	userSvc := &pagedUserService{
+		FakeUserService: &usertest.FakeUserService{},
+		pages: []user.SearchUserQueryResult{
+			{Users: searchHitsWithModules(1000, 1, githubModule, gitlabModule), TotalCount: 1500, Page: 1, PerPage: 1000},
+			{Users: searchHitsWithModules(500, 1001, githubModule, gitlabModule), TotalCount: 1500, Page: 2, PerPage: 1000},
+		},
+	}
+	hs := &HTTPServer{Cfg: setting.NewCfg(), authnService: svc, userService: userSvc}
+	reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)}}
+
+	res, err := hs.searchOrgUsersUsingK8s(reqCtx, &org.SearchOrgUsersQuery{OrgID: 1})
+	require.NoError(t, err)
+	require.Equal(t, 2, userSvc.calls, "both pages must be fetched")
+	require.Len(t, res.OrgUsers, 1500)
+	for _, u := range res.OrgUsers {
+		assert.True(t, u.IsExternallySynced)
+	}
+
+	// Each module is resolved exactly once, regardless of user or page count.
+	want := map[string]int{authn.ClientWithPrefix("github"): 1, authn.ClientWithPrefix("gitlab"): 1}
+	assert.Equal(t, want, svc.enabledCalls)
+	assert.Equal(t, want, svc.configCalls)
+}
+
+// Same invariant as the K8s path, for the legacy searchOrgUsersHelper loop.
+func TestSearchOrgUsersHelper_ResolvesExternallySyncedPerModule(t *testing.T) {
+	const userCount = 50
+	modules := []string{login.GithubAuthModule, login.GitLabAuthModule}
+
+	users := make([]*org.OrgUserDTO, userCount)
+	labels := make(map[int64]string, userCount)
+	for i := range users {
+		id := int64(i + 1)
+		users[i] = &org.OrgUserDTO{UserID: id, Login: fmt.Sprintf("user-%d", id)}
+		labels[id] = modules[i%len(modules)]
+	}
+
+	svc := &countingAuthnService{
+		FakeService: &authntest.FakeService{ExpectedClientConfig: &authntest.FakeSSOClientConfig{}},
+	}
+	hs := &HTTPServer{
+		Cfg:          setting.NewCfg(),
+		authnService: svc,
+		orgService: &orgtest.FakeOrgService{
+			ExpectedSearchOrgUsersResult: &org.SearchOrgUsersQueryResult{OrgUsers: users, TotalCount: userCount},
+		},
+		authInfoService: &authinfotest.FakeService{ExpectedRecentlyUsedLabel: labels},
+	}
+	reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: httptest.NewRequest(http.MethodGet, "/", nil)}}
+
+	res, err := hs.searchOrgUsersHelper(reqCtx, &org.SearchOrgUsersQuery{OrgID: 1})
+	require.NoError(t, err)
+	require.Len(t, res.OrgUsers, userCount)
+	for _, u := range res.OrgUsers {
+		assert.True(t, u.IsExternallySynced)
+	}
+
+	// Each module is resolved exactly once, regardless of user count.
+	want := map[string]int{authn.ClientWithPrefix("github"): 1, authn.ClientWithPrefix("gitlab"): 1}
+	assert.Equal(t, want, svc.enabledCalls)
+	assert.Equal(t, want, svc.configCalls)
 }
 
 func TestGetOrgUsersForCurrentOrg_KubernetesUsersRedirect(t *testing.T) {

--- a/pkg/server/bootstrap/wire/wire_gen.go
+++ b/pkg/server/bootstrap/wire/wire_gen.go
@@ -1006,7 +1006,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts server.Options, apiO
 		return nil, err
 	}
 	ossUserProtectionImpl := authinfoimpl.ProvideOSSUserProtectionService()
-	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokenService, socialService, remoteCache, ldapImpl, tracingService, tempuserService, notificationService)
+	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokenService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationService)
 	if err != nil {
 		return nil, err
 	}
@@ -1767,7 +1767,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	ossUserProtectionImpl := authinfoimpl.ProvideOSSUserProtectionService()
-	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokentestService, socialService, remoteCache, ldapImpl, tracingService, tempuserService, notificationServiceMock)
+	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokentestService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationServiceMock)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	tempuser "github.com/grafana/grafana/pkg/services/temp_user"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type Registration struct{}
@@ -42,7 +43,7 @@ func ProvideRegistration(
 	authInfoService login.AuthInfoService, renderService rendering.Service,
 	features featuremgmt.FeatureToggles, oauthTokenService oauthtoken.OAuthTokenService,
 	socialService social.Service, cache *remotecache.RemoteCache,
-	ldapService service.LDAP,
+	ldapService service.LDAP, settingsProvider setting.Provider,
 	tracer tracing.Tracer, tempUserService tempuser.Service, notificationService notifications.Service,
 ) (Registration, error) {
 	logger := log.New("authn.registration")
@@ -102,7 +103,7 @@ func ProvideRegistration(
 		authnSvc.RegisterClient(clients.ProvideExtendedJWT(cfg, tracer))
 	}
 
-	registerOAuthClients(ctx, logger, authnSvc, cfgProvider, oauthTokenService, socialService, features, tracer)
+	registerOAuthClients(ctx, logger, authnSvc, cfgProvider, oauthTokenService, socialService, settingsProvider, features, tracer)
 
 	if cfg.ProvisioningEnabled {
 		authnSvc.RegisterClient(clients.ProvideProvisioning())
@@ -150,7 +151,8 @@ func ProvideRegistration(
 func registerOAuthClients(
 	ctx context.Context, logger log.Logger, authnSvc authn.Service,
 	cfgProvider configprovider.ConfigProvider, oauthTokenService oauthtoken.OAuthTokenService,
-	socialService social.Service, features featuremgmt.FeatureToggles, tracer tracing.Tracer,
+	socialService social.Service, settingsProvider setting.Provider,
+	features featuremgmt.FeatureToggles, tracer tracing.Tracer,
 ) {
 	oauthProviders, err := socialService.GetOAuthProviders(ctx)
 	if err != nil {
@@ -163,6 +165,6 @@ func registerOAuthClients(
 
 	for name := range oauthProviders {
 		clientName := authn.ClientWithPrefix(name)
-		authnSvc.RegisterClient(clients.ProvideOAuth(clientName, cfgProvider, oauthTokenService, socialService, features, tracer))
+		authnSvc.RegisterClient(clients.ProvideOAuth(clientName, cfgProvider, oauthTokenService, socialService, settingsProvider, features, tracer))
 	}
 }

--- a/pkg/services/authn/authnimpl/registration_test.go
+++ b/pkg/services/authn/authnimpl/registration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social/socialtest"
 	"github.com/grafana/grafana/pkg/services/authn/authntest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestRegisterOAuthClients(t *testing.T) {
@@ -24,6 +25,7 @@ func TestRegisterOAuthClients(t *testing.T) {
 
 		registerOAuthClients(
 			t.Context(), log.NewNopLogger(), authnService, nil, nil, socialService,
+			setting.ProvideProvider(setting.NewCfg()),
 			featuremgmt.WithFeatures(), tracing.InitializeTracerForTest(),
 		)
 
@@ -40,6 +42,7 @@ func TestRegisterOAuthClients(t *testing.T) {
 
 		registerOAuthClients(
 			t.Context(), log.NewNopLogger(), authnService, nil, nil, socialService,
+			setting.ProvideProvider(setting.NewCfg()),
 			featuremgmt.WithFeatures(), tracing.InitializeTracerForTest(),
 		)
 

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -74,14 +74,14 @@ var (
 
 func ProvideOAuth(
 	name string, cfgProvider configprovider.ConfigProvider, oauthService oauthtoken.OAuthTokenService,
-	socialService social.Service,
+	socialService social.Service, settingsProvider setting.Provider,
 	features featuremgmt.FeatureToggles, tracer trace.Tracer,
 ) *OAuth {
 	providerName := strings.TrimPrefix(name, "auth.client.")
 	return &OAuth{
 		name, fmt.Sprintf("oauth_%s", providerName), providerName,
 		log.New(name), cfgProvider, tracer, oauthService,
-		socialService, features,
+		socialService, settingsProvider, features,
 	}
 }
 
@@ -93,9 +93,10 @@ type OAuth struct {
 	cfgProvider  configprovider.ConfigProvider
 	tracer       trace.Tracer
 
-	oauthService  oauthtoken.OAuthTokenService
-	socialService social.Service
-	features      featuremgmt.FeatureToggles
+	oauthService     oauthtoken.OAuthTokenService
+	socialService    social.Service
+	settingsProvider setting.Provider
+	features         featuremgmt.FeatureToggles
 }
 
 func (c *OAuth) Name() string {
@@ -213,6 +214,13 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 	lookupParams := login.UserLookupParams{}
 	allowInsecureEmailLookup := cfg.OAuthAllowInsecureEmailLookup
+	// This setting is still writable through /api/admin/settings and stored by
+	// the runtime settings provider. ConfigProvider does not include those
+	// database overrides, so keep this read on the legacy provider until that
+	// write path is migrated to the settings service.
+	if c.settingsProvider != nil {
+		allowInsecureEmailLookup = c.settingsProvider.KeyValue("auth", "oauth_allow_insecure_email_lookup").MustBool(allowInsecureEmailLookup)
+	}
 	if allowInsecureEmailLookup {
 		lookupParams.Email = &userInfo.Email
 	}

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -189,7 +190,7 @@ func TestOAuth_Authenticate(t *testing.T) {
 			},
 		},
 		{
-			desc: "should return identity for valid request - and lookup user by email",
+			desc: "should use the runtime settings override to look up the user by email",
 			req: &authn.Request{
 				HTTPRequest: &http.Request{
 					Header: map[string][]string{},
@@ -325,8 +326,14 @@ func TestOAuth_Authenticate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			// Keep ConfigProvider at its false default. runtimeCfg models the
+			// database-backed override written through /api/admin/settings.
 			cfg := setting.NewCfg()
-			cfg.OAuthAllowInsecureEmailLookup = tt.allowInsecureTakeover
+			runtimeCfg := setting.NewCfg()
+			auth, err := runtimeCfg.Raw.NewSection("auth")
+			assert.NoError(t, err)
+			_, err = auth.NewKey("oauth_allow_insecure_email_lookup", strconv.FormatBool(tt.allowInsecureTakeover))
+			assert.NoError(t, err)
 
 			if tt.addStateCookie {
 				v := tt.stateCookieValue
@@ -350,7 +357,7 @@ func TestOAuth_Authenticate(t *testing.T) {
 				},
 			}
 
-			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, cfg), nil, fakeSocialSvc, featuremgmt.WithFeatures(tt.features...), tracing.InitializeTracerForTest())
+			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, cfg), nil, fakeSocialSvc, setting.ProvideProvider(runtimeCfg), featuremgmt.WithFeatures(tt.features...), tracing.InitializeTracerForTest())
 
 			identity, err := c.Authenticate(context.Background(), tt.req)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -431,7 +438,7 @@ func TestOAuth_RedirectURL(t *testing.T) {
 
 			cfg := setting.NewCfg()
 
-			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, cfg), nil, fakeSocialSvc, featuremgmt.WithFeatures(), tracing.InitializeTracerForTest())
+			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, cfg), nil, fakeSocialSvc, nil, featuremgmt.WithFeatures(), tracing.InitializeTracerForTest())
 
 			redirect, err := c.RedirectURL(context.Background(), nil)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -544,7 +551,7 @@ func TestOAuth_Logout(t *testing.T) {
 			fakeSocialSvc := &socialtest.FakeSocialService{
 				ExpectedAuthInfoProvider: tt.oauthCfg,
 			}
-			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, tt.cfg), mockService, fakeSocialSvc, featuremgmt.WithFeatures(), tracing.InitializeTracerForTest())
+			c := ProvideOAuth(authn.ClientWithPrefix("azuread"), testConfigProvider(t, tt.cfg), mockService, fakeSocialSvc, nil, featuremgmt.WithFeatures(), tracing.InitializeTracerForTest())
 
 			redirect, ok := c.Logout(context.Background(), &authn.Identity{ID: "1", Type: claims.TypeUser}, &usertoken.UserToken{})
 
@@ -603,6 +610,7 @@ func TestIsEnabled(t *testing.T) {
 				testConfigProvider(t, cfg),
 				nil,
 				fakeSocialSvc,
+				nil,
 				featuremgmt.WithFeatures(),
 				tracing.InitializeTracerForTest())
 			assert.Equal(t, tt.expected, c.IsEnabled(t.Context()))
@@ -628,6 +636,7 @@ func TestOAuthProviderLookupUsesCallerContext(t *testing.T) {
 		testConfigProvider(t, setting.NewCfg()),
 		nil,
 		fakeSocialSvc,
+		nil,
 		featuremgmt.WithFeatures(),
 		tracing.InitializeTracerForTest(),
 	)


### PR DESCRIPTION
## Summary

Backports two Auth fixes into `steady` for RRC version `13.3.0-32244229338`:

- #131753 — resolve the externally-synced check once per auth module in the org users list, avoiding repeated settings reads and secret decryption.
- #131814 — preserve the runtime OAuth insecure email lookup setting written through the admin settings UI or API.

Enterprise companion: https://github.com/grafana/grafana-enterprise/pull/13363

Both PRs use the same branch name so paired CI can test the repositories together.

## Validation

- `go test ./pkg/api -run "TestSearchOrgUsersUsingK8s_ResolvesExternallySyncedPerModule|TestSearchOrgUsersHelper_ResolvesExternallySyncedPerModule"`
- `go test ./pkg/services/authn/clients ./pkg/services/authn/authnimpl ./pkg/server/bootstrap/wire`
- Verified both cherry-picked patches match the merged source commits via stable patch IDs.