### PR TITLE
Dashboards: stop version-history pagination loop and restore over-fetch

### DIFF
--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
@@ -413,6 +413,71 @@ describe('UnifiedDashboardAPI', () => {
 
       expect(result.metadata.continue).toBeUndefined();
     });
+
+    it('should not loop when v1 is exhausted but the incoming composite token still carries v2 work', async () => {
+      // Regression test for #131820 (bug 1). When a previous round set a v2 continue
+      // token, and the next round returns the last page of v1 items (all valid, no v1
+      // continue), the "all v1 valid" fast path used to return early and emit a
+      // composite continue of (undefined, v2Token). The next call would then re-query
+      // v1 with no continue — restarting v1 from page 1 — and re-enter the same fast
+      // path, looping forever. The fix falls through to query v2 in this case so the
+      // merge path can drain v2 to completion.
+      const v1LastPage = {
+        apiVersion: 'dashboard.grafana.app/v1beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '1' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v1beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '5',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 5,
+            },
+            spec: { title: 'v1-last', schemaVersion: 30 },
+            status: {},
+          },
+        ],
+      };
+      const v2Response = {
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'DashboardList',
+        metadata: { resourceVersion: '2' },
+        items: [
+          {
+            kind: 'Dashboard',
+            apiVersion: 'dashboard.grafana.app/v2beta1',
+            metadata: {
+              name: 'dash-1',
+              resourceVersion: '6',
+              creationTimestamp: '2023-01-01T00:00:00Z',
+              generation: 6,
+            },
+            spec: { title: 'v2', elements: {} },
+            status: {},
+          },
+        ],
+      };
+      v1Client.listDashboardHistory.mockResolvedValue(v1LastPage as ResourceList<DashboardDataDTO>);
+      v2Client.listDashboardHistory.mockResolvedValue(v2Response as ResourceList<DashboardV2Spec>);
+
+      const compositeToken = btoa(JSON.stringify({ v1: undefined, v2: 'v2-page2' }));
+      const result = await api.listDashboardHistory('dash-1', { limit: 10, continueToken: compositeToken });
+
+      // The v2 client must be queried even though v1 returned valid items, so the
+      // carried-forward v2 token can advance and the loop terminates.
+      expect(v2Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: 'v2-page2' });
+      expect(v1Client.listDashboardHistory).toHaveBeenCalledWith('dash-1', { limit: 10, continueToken: undefined });
+
+      // v1 exhausted (no continue) and v2 exhausted (no continue) -> undefined
+      expect(result.metadata.continue).toBeUndefined();
+
+      // Both pages of history are present and merged by generation descending.
+      const generations = result.items.map((item) => item.metadata.generation);
+      expect(generations).toEqual([6, 5]);
+    });
   });
 
   describe('deleteDashboard', () => {

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
@@ -94,7 +94,16 @@ export class UnifiedDashboardAPI
     const v1Response = await this.v1Client.listDashboardHistory(uid, { limit, continueToken: v1Token });
     const v1Valid = v1Response.items.filter((item) => !failedFromVersion(item, ['v2']));
 
-    if (v1Valid.length === v1Response.items.length && v1Response.items.length > 0) {
+    // The "all v1 items are valid" fast path is only safe when v1 still has more
+    // pages to fetch OR v2 has no outstanding work. If v1 is exhausted (no continue)
+    // while v2 still has work to do (the incoming v2Token is set), returning early
+    // here would emit a composite continue of (undefined, v2Token). The next call
+    // would then re-query v1 with no continue token, restart v1 from its first
+    // page, and re-enter this same branch — looping forever and re-appending v1's
+    // first page on every "Show more" click. Fall through to query v2 in that
+    // case so the merge path can drain v2 to completion.
+    const v1HasMorePages = Boolean(v1Response.metadata.continue);
+    if (v1Valid.length === v1Response.items.length && v1Response.items.length > 0 && (v1HasMorePages || !v2Token)) {
       return {
         ...v1Response,
         metadata: {

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -550,6 +550,63 @@ describe('v1 dashboard API', () => {
     });
   });
 
+  describe('getDashboardHistoryVersions', () => {
+    it('should not request a large page size that would drain the fill-to-limit loop', async () => {
+      // Regression test for #131820 (bug 2). Previously this method called
+      // listDashboardHistory(uid, { limit: 1000 }) to "attempt finding the versions
+      // in one request". K8sDashboardAPI.listDashboardHistory runs a fill-to-limit
+      // loop that drains toward the requested limit by following k8s continue
+      // tokens, so a 1000-limit call defeated the early-exit and over-fetched the
+      // entire history. The fix uses VERSIONS_FETCH_LIMIT (10) per page so the
+      // outer do-while stops as soon as the requested versions are found.
+      const v1Item = { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 7 } };
+      const v1Item2 = { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 5 } };
+      const historyPage = {
+        metadata: { resourceVersion: '1' },
+        items: [v1Item, v1Item2],
+      };
+      mockGet.mockResolvedValueOnce(historyPage);
+
+      const api = new K8sDashboardAPI();
+      const result = await api.getDashboardHistoryVersions('dash-uid', [7, 5]);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.metadata.generation)).toEqual([7, 5]);
+      // The requested limit must be the small per-page limit (VERSIONS_FETCH_LIMIT = 10),
+      // not 1000, so a 1000-version dashboard does not drain to 1000 items just to
+      // find one specific version. The list call receives the limit via the second
+      // argument (the k8s ListOptions), not in the URL path.
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      const listOpts = mockGet.mock.calls[0][1] as { limit: number; labelSelector: string; fieldSelector: string };
+      expect(listOpts.limit).toBe(10);
+    });
+
+    it('should paginate and stop early once the requested version is found', async () => {
+      const v1Item = { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 1 } };
+      const page1 = {
+        metadata: { resourceVersion: '1', continue: 'token-page2' },
+        items: [
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 5 } },
+          { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 4 } },
+        ],
+      };
+      const page2 = {
+        metadata: { resourceVersion: '1' },
+        items: [{ ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 3 } }, v1Item],
+      };
+      mockGet.mockResolvedValueOnce(page1).mockResolvedValueOnce(page2);
+
+      const api = new K8sDashboardAPI();
+      const result = await api.getDashboardHistoryVersions('dash-uid', [1]);
+
+      expect(result).toEqual([v1Item]);
+      expect(mockGet).toHaveBeenCalledTimes(2);
+      // First call uses no continue (initial fetch), second uses the page1 continue.
+      const secondCallOpts = mockGet.mock.calls[1][1] as { continue: string };
+      expect(secondCallOpts.continue).toBe('token-page2');
+    });
+  });
+
   describe('listDeletedDashboards', () => {
     it('should return table of deleted dashboards', async () => {
       const mockDeletedDashboards = {

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -269,9 +269,13 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
     let continueToken: string | undefined;
 
     do {
-      // using high limit to attempt finding the versions in one request
-      // if not found, pagination will kick in
-      const history = await this.listDashboardHistory(uid, { limit: 1000, continueToken });
+      // Use the per-page fetch limit (same as the version history UI) instead of a
+      // large 1000. K8sDashboardAPI.listDashboardHistory runs a fill-to-limit loop that
+      // drains toward the requested limit by following k8s continue tokens, so a
+      // high-limit call defeats the "found it on the first page" early-exit and
+      // over-fetches the entire history before returning. With a small per-page
+      // limit, the outer loop here stops as soon as every requested version is found.
+      const history = await this.listDashboardHistory(uid, { limit: VERSIONS_FETCH_LIMIT, continueToken });
       for (const item of history.items) {
         if (versionsToFind.has(item.metadata.generation ?? 0)) {
           results.push(item);

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -488,6 +488,34 @@ describe('v2 dashboard API', () => {
     });
   });
 
+  describe('getDashboardHistoryVersions', () => {
+    it('should not request a large page size that would drain the fill-to-limit loop', async () => {
+      // Regression test for #131820 (bug 2). Previously this method called
+      // listDashboardHistory(uid, { limit: 1000 }) to "attempt finding the versions
+      // in one request". K8sDashboardV2API.listDashboardHistory runs a fill-to-limit
+      // loop that drains toward the requested limit by following k8s continue
+      // tokens, so a 1000-limit call defeated the early-exit and over-fetched the
+      // entire history. The fix uses VERSIONS_FETCH_LIMIT (10) per page so the
+      // outer do-while stops as soon as the requested versions are found.
+      const v2Item = { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 7 } };
+      const v2Item2 = { ...mockDashboardDto, metadata: { ...mockDashboardDto.metadata, generation: 5 } };
+      const historyPage = {
+        metadata: { resourceVersion: '1' },
+        items: [v2Item, v2Item2],
+      };
+      mockGet.mockResolvedValueOnce(historyPage);
+
+      const api = new K8sDashboardV2API();
+      const result = await api.getDashboardHistoryVersions('dash-uid', [7, 5]);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.metadata.generation)).toEqual([7, 5]);
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      const listOpts = mockGet.mock.calls[0][1] as { limit: number };
+      expect(listOpts.limit).toBe(10);
+    });
+  });
+
   describe('listDeletedDashboards', () => {
     it('should return table of deleted dashboards', async () => {
       const mockDeletedDashboards = {

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -218,9 +218,13 @@ export class K8sDashboardV2API
     let continueToken: string | undefined;
 
     do {
-      // using high limit to attempt finding the versions in one request
-      // if not found, pagination will kick in
-      const history = await this.listDashboardHistory(uid, { limit: 1000, continueToken });
+      // Use the per-page fetch limit (same as the version history UI) instead of a
+      // large 1000. K8sDashboardV2API.listDashboardHistory runs a fill-to-limit loop
+      // that drains toward the requested limit by following k8s continue tokens, so
+      // a high-limit call defeats the "found it on the first page" early-exit and
+      // over-fetches the entire history before returning. With a small per-page
+      // limit, the outer loop here stops as soon as every requested version is found.
+      const history = await this.listDashboardHistory(uid, { limit: VERSIONS_FETCH_LIMIT, continueToken });
       for (const item of history.items) {
         if (versionsToFind.has(item.metadata.generation ?? 0)) {
           results.push(item);


### PR DESCRIPTION
## Summary

Two defects in version-history pagination, both introduced by #120729 (shipped since v13.0.0):

1. **`UnifiedDashboardAPI.listDashboardHistory` could loop forever** on a dashboard with mixed v1/v2 history. The "all v1 items are valid" fast path returned early with `(undefined, v2Token)` when the last v1 page was reached while a carried-forward v2 token was still set. The next call decoded the token, re-queried v1 with no continue, restarted v1 from its first page, hit the same branch, and emitted the same composite continue again — every "Show more" click re-appended v1's first page.

2. **`K8sDashboardAPI.getDashboardHistoryVersions` and the v2 equivalent over-fetched on restore**. They called `listDashboardHistory(uid, { limit: 1000 })` to "attempt finding the versions in one request", but `listDashboardHistory` runs a fill-to-limit loop that follows k8s continue tokens until it has 1000 items. The early-exit on "found the version" never fired because the inner loop had already drained toward 1000.

## Root cause

Bug 1: `encodeCompositeToken` returns `undefined` only when **both** tokens are falsy. The "all v1 valid" early-return in #120729 re-encodes the incoming `v2Token` without ever querying v2 that round, so once v1 is exhausted while a v2 cursor is still in flight, every subsequent round re-runs the same path with the same stale cursor.

Bug 2: `listDashboardHistory` (v1 and v2) is now a fill-to-limit loop. A `limit: 1000` request from `getDashboardHistoryVersions` defeats the "found it on the first page" early-exit the caller relies on.

## Fix

- Bug 1: gate the "all v1 valid" fast path on `(v1 has more pages OR v2 has no outstanding work)`. When v1 is exhausted but v2 still has work, fall through to query v2 and merge, so the merge path can drain v2 to completion.
- Bug 2: use `VERSIONS_FETCH_LIMIT` (10) per page in `getDashboardHistoryVersions` (v1 and v2). The outer do-while stops as soon as every requested version is found.

## Testing

- **RED proof**: stashed the production files (`UnifiedDashboardAPI.ts`, `v1.ts`, `v2.ts`) with the test files still in place. All three new regression tests fail on the unfixed code:
  - `UnifiedDashboardAPI.test.ts › listDashboardHistory › should not loop when v1 is exhausted but the incoming composite token still carries v2 work` — fails because `v2Client.listDashboardHistory` is never called (`Number of calls: 0`).
  - `v1.test.ts › getDashboardHistoryVersions › should not request a large page size that would drain the fill-to-limit loop` — fails with `Expected: 10, Received: 1000`.
  - `v2.test.ts › getDashboardHistoryVersions › should not request a large page size that would drain the fill-to-limit loop` — fails with `Expected: 10, Received: 1000`.
- **GREEN**: 67/67 tests pass across `UnifiedDashboardAPI.test.ts`, `v1.test.ts`, and `v2.test.ts` (the existing "should return v1 history when all v1 items are valid" continues to pass because `v2Token` is undefined in that test, so the fast path still fires).
- **Static checks**: `prettier --check` clean, `eslint` clean (only an unrelated package-deprecation warning), `tsc --noEmit -p .` clean for the changed files.

Fixes #131820
