### PR TITLE
grafana-router: strip internal hash before dialing openapi upstream

### DIFF
--- a/pkg/router/openapi_cache.go
+++ b/pkg/router/openapi_cache.go
@@ -27,6 +27,26 @@ func stripConditionalHeaders(req *http.Request) {
 	req.Header.Del("If-Modified-Since")
 }
 
+// stripHashQueryParam removes the "hash" query parameter before proxying a
+// request upstream. Our discovery doc (buildOpenAPIV3Index) hash-busts each
+// group-version's serverRelativeURL with our own RV, an opaque cache token
+// with no relation to the backend's content. But kube-openapi's own
+// handler3 treats a client-supplied "hash" as a claim about ITS content
+// hash and 301-redirects to the correct one on mismatch -- a redirect
+// rejectBackendRedirects then turns into a 502. Since our RV essentially
+// never matches the backend's real hash, forwarding it verbatim breaks
+// every cold-cache request. Stripping it here keeps the RV-based
+// busting meaningful for our own cache/ETag while never surfacing our
+// token to a protocol that expects its own.
+func stripHashQueryParam(req *http.Request) {
+	q := req.URL.Query()
+	if !q.Has("hash") {
+		return
+	}
+	q.Del("hash")
+	req.URL.RawQuery = q.Encode()
+}
+
 // captureWriter records a proxied response (status + body) so it can be
 // cached on success before being relayed to the real client, without letting
 // the backend write directly to the real ResponseWriter first.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -268,6 +268,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 	// call to the backend, so an outage must fail fast here too.
 	proxyReq := req.Clone(req.Context())
 	stripConditionalHeaders(proxyReq)
+	stripHashQueryParam(proxyReq)
 	rec := newCaptureWriter()
 	_, err := entry.breaker.Execute(func() (struct{}, error) {
 		entry.handler.ServeHTTP(rec, proxyReq)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The `hash` value is internal to the router and is used to dictate internal caching. Its either `embedded` (a sentinel for core groups without remote manifest) or an RV. Either way, its not a valid ETAG value for upstream servers and sending them this value makes them redirect 301, which currently is handled in the router as a final 502.

Here, we strip the hash before making upstream requests so that it behaves correctly from the pov of backend servers.

**Why do we need this feature?**

Working openapi introspection.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
