### PR TITLE
Dashboards: Fix query variable refresh reset to onDashboardLoad on v2 UI import

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -1860,6 +1860,43 @@ describe('applyV2Inputs', () => {
     expect(sectionConst?.kind === 'ConstantVariable' && sectionConst.spec.query).toBe('row-staging');
   });
 
+  it('keeps the query variable refresh setting when binding the datasource picked at import', () => {
+    const dashboard = {
+      title: 'old',
+      elements: {},
+      annotations: [],
+      variables: [
+        {
+          kind: 'QueryVariable',
+          spec: {
+            name: 'duration',
+            refresh: 'onTimeRangeChanged',
+            options: [],
+            current: { text: '', value: '' },
+            query: {
+              group: 'prometheus',
+              labels: { [ExportLabel]: 'prometheus-1', [ExportDatasourceName]: 'Original Prometheus' },
+            },
+          },
+        },
+      ],
+      layout: { kind: 'GridLayout', spec: { items: [] } },
+    } as unknown as DashboardV2Spec;
+
+    const form: ImportFormDataV2 = {
+      dashboard,
+      folderUid: 'folder',
+      message: '',
+      'datasource-prometheus-1': { uid: 'ds-uid', type: 'prometheus', name: 'My DS' },
+    };
+
+    const result = applyV2Inputs(dashboard, form);
+    const variable = result.variables?.[0] as QueryVariableKind;
+
+    expect(variable.spec.query?.datasource?.name).toBe('ds-uid');
+    expect(variable.spec.refresh).toBe('onTimeRangeChanged');
+  });
+
   it('remaps datasources on section QueryVariables and clears export labels', () => {
     const dashboard = {
       title: 'old',
@@ -2200,17 +2237,10 @@ describe('replaceDatasourcesInDashboard', () => {
     });
 
     it.each([
-      {
-        desc: 'preserves the exported refresh setting when remapping the datasource',
-        refresh: 'onTimeRangeChanged' as const,
-        expectedRefresh: 'onTimeRangeChanged',
-      },
-      {
-        desc: 'upgrades a "never" refresh setting so the cleared options repopulate',
-        refresh: 'never' as const,
-        expectedRefresh: 'onDashboardLoad',
-      },
-    ])('$desc', ({ refresh, expectedRefresh }) => {
+      { refresh: 'onTimeRangeChanged' as const, expected: 'onTimeRangeChanged' },
+      { refresh: 'never' as const, expected: 'never' },
+      { refresh: 'onDashboardLoad' as const, expected: 'onDashboardLoad' },
+    ])('maps refresh $refresh to $expected when remapping the datasource', ({ refresh, expected }) => {
       const base = createQueryVariable('prometheus', 'old-prom-uid');
       // @ts-ignore - using minimal test schema
       const dashboard: DashboardV2Spec = {
@@ -2221,9 +2251,10 @@ describe('replaceDatasourcesInDashboard', () => {
       const result = replaceDatasourcesInDashboard(dashboard, mappings);
       const variable = getQueryVariable(result);
 
-      // confirms the datasource was actually remapped, which is the branch that rewrites refresh
+      // confirms the datasource was actually remapped, which is the branch that rewrote refresh
       expect(variable?.spec.query?.datasource?.name).toBe('new-prom-uid');
-      expect(variable?.spec.refresh).toBe(expectedRefresh);
+      expect(variable?.spec.options).toEqual([]);
+      expect(variable?.spec.refresh).toBe(expected);
     });
 
     it('preserves variable reference and keeps options intact', () => {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -778,10 +778,6 @@ function replaceVariableDatasources(
           },
           options: [],
           current: { text: '', value: '' },
-          // Keep the author's refresh setting (e.g. onTimeRangeChanged). Options are cleared
-          // above, so 'never' has to be upgraded or the variable would never get any values.
-          refresh:
-            variable.spec.refresh && variable.spec.refresh !== 'never' ? variable.spec.refresh : 'onDashboardLoad',
         },
       };
     }


### PR DESCRIPTION
## What this PR does

When a v2 dashboard exported with "Export for sharing externally" is imported through the **UI import dialog**, `replaceVariableDatasources` rebuilds each query variable whose datasource is remapped to the one picked in the form. That rebuild hardcoded `refresh: 'onDashboardLoad'`, dropping whatever the author had configured. The export side leaves `refresh` alone, so this is round-trip data loss.

| Exported `refresh` | Before | After |
|---|---|---|
| `onTimeRangeChanged` | `onDashboardLoad` | `onTimeRangeChanged` |
| `onDashboardLoad` | `onDashboardLoad` | `onDashboardLoad` |
| `never` | `onDashboardLoad` | `never` |

The override is simply dropped, since the surrounding spread already carries `refresh`. `options` is still cleared because it belongs to the previous datasource, and that is safe: `transformSaveModelSchemaV2ToScene` never seeds a query variable's options from the spec, and `SceneVariableSet` runs `validateAndUpdate` on activation without consulting `refresh`, so the options are re-fetched on load whatever the value is.

User-visible effect of the bug: a variable that stops re-evaluating on time range change. Dashboards that pick a query or aggregation tier from the selected range keep resolving against the default range and return data without an error.

Variables keeping a `$datasourceVar` reference were unaffected, and the v1 import path never touched `refresh`, which is why classic round trips preserved it.

## Which issue(s) this PR fixes

Regression introduced in #116482, which added the v2 UI import path. Present on `main` and on the 12.4.x, 13.0.x, 13.1.x and 13.2.x lines.

## Testing

Two new unit tests in `inputs.test.ts`, one at the `applyV2Inputs` entry point and one covering all three `refresh` values at `replaceDatasourcesInDashboard`. Three cases fail on current `main` (`Expected "onTimeRangeChanged", Received "onDashboardLoad"`) and pass with the change.
