### PR TITLE
Feature flags: add reporting.redirectReportSettingsToK8SApi

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3136,6 +3136,15 @@ var (
 			Generate:        Generate{Go: true},
 		},
 		{
+			Name:            "reporting.redirectReportSettingsToK8SApi",
+			Description:     "Redirect legacy report settings API endpoints to the Kubernetes reporting API",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaOperatorExperienceSquad,
+			Expression:      "false",
+			RequiresRestart: true,
+			Generate:        Generate{Go: true},
+		},
+		{
 			Name:        "grafana.onDemandDiagnostics",
 			Description: "Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -364,6 +364,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-01,grafana.growthHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-07-01,kubernetesReporting,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-07-28,reporting.redirectReportsToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,true,false
+2026-08-25,reporting.redirectReportSettingsToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-06-26,grafana.onDemandDiagnostics,experimental,@grafana/data-sources,false,false,false
 2026-07-08,grafana.frontendLegacyAPIHandling,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-08-06,grafana.ofrepRootUrl,experimental,@grafana/grafana-backend-services-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -970,6 +970,10 @@ const (
 	// Redirect legacy report CRUD API endpoints to the Kubernetes reporting API
 	FlagReportingRedirectReportsToK8SApi = "reporting.redirectReportsToK8SApi"
 
+	// FlagReportingRedirectReportSettingsToK8SApi
+	// Redirect legacy report settings API endpoints to the Kubernetes reporting API
+	FlagReportingRedirectReportSettingsToK8SApi = "reporting.redirectReportSettingsToK8SApi"
+
 	// FlagGrafanaOnDemandDiagnostics
 	// Adds a 'Download diagnostics' action that bundles diagnostic artifacts such as HTTP traffic (HAR), server log, dashboard and panel JSONs, and more
 	FlagGrafanaOnDemandDiagnostics = "grafana.onDemandDiagnostics"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5947,6 +5947,20 @@
     },
     {
       "metadata": {
+        "name": "reporting.redirectReportSettingsToK8SApi",
+        "resourceVersion": "1787675413454",
+        "creationTimestamp": "2026-08-25T16:30:13Z"
+      },
+      "spec": {
+        "description": "Redirect legacy report settings API endpoints to the Kubernetes reporting API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "requiresRestart": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "reporting.redirectReportsToK8SApi",
         "resourceVersion": "1786008381487",
         "creationTimestamp": "2026-07-28T04:47:06Z",


### PR DESCRIPTION
## What

Registers a new experimental flag, `reporting.redirectReportSettingsToK8SApi`, separate from the existing `reporting.redirectReportsToK8SApi` just to controll report settings

## Why

Follow-up to #12926 (Report CRUD → `/apis` redirect). The report settings API is getting the same redirect treatment in a companion grafana-enterprise PR. Storage-mode migration (legacy → dual-write → unified) is already independent per resource via `unified_storage.<resource>.reporting.grafana.app` config, but the two resources were sharing one HTTP-redirect flag, which would have forced report and report settings to flip their `/apis` redirect on (or roll it back) together. Splitting the flag lets each roll out independently.

## Testing

`go test ./pkg/services/featuremgmt/...` green; `make gen-feature-toggles` regenerated `toggles_gen.{go,csv,json}`.

## Note

Supersedes #131505, opened fresh off current `main` after CI on that branch hit unrelated infra flakes (a `security-patch-actions` dispatch timeout and a pre-existing E2E flake in `dashboard-restore` specs unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
