### PR TITLE
Number formatting: Bound the decimals count in toFixed

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -294,6 +294,19 @@ describe('Format value', () => {
   // Below is current behavior but it's clearly not working great
   //
 
+  it('with a decimals count the Decimals option itself would reject', () => {
+    // Nothing between dashboard JSON and the formatter bounds field.config.decimals:
+    // numberOverrideProcessor is a bare parseFloat, so the editor's max of 15 does
+    // not apply to a value that arrives any other way.
+    const instance = getDisplayProcessorFromConfig({ decimals: 21 });
+    expect(instance(1.5).text).toEqual(`1.5${'0'.repeat(20)}`);
+
+    // 0 short-circuits to Number.prototype.toFixed, which throws outside 0 to 100.
+    const outOfRange = getDisplayProcessorFromConfig({ decimals: 101 });
+    expect(outOfRange(0).text).toEqual(`0.${'0'.repeat(100)}`);
+    expect(outOfRange(1.5).text).toEqual(`1.5${'0'.repeat(99)}`);
+  });
+
   it('with value 1000 and unit short', () => {
     const value = 1000;
     const instance = getDisplayProcessorFromConfig({ decimals: null, unit: 'short' });

--- a/packages/grafana-data/src/valueFormats/baseFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/baseFormatters.ts
@@ -20,6 +20,13 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
     decimals = getDecimalsForValue(value);
   }
 
+  // Number.prototype.toFixed throws a RangeError outside 0 to 100, and the zero
+  // padding below builds a string of that length, so a count from field config
+  // is bounded before either sees it. The auto path never lands outside this
+  // range; an explicit `decimals` can, because nothing validates it on the way
+  // in from dashboard JSON.
+  decimals = clamp(decimals, 0, 100);
+
   if (value === 0) {
     return value.toFixed(decimals);
   }
@@ -35,7 +42,10 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   const decimalPos = formatted.indexOf('.');
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
-    return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);
+    // `String(factor)` was used as the source of these zeros, which holds only
+    // while the factor stays out of exponential notation: String(10 ** 21) is
+    // '1e+21', so slicing it appended the exponent to the value instead.
+    return (precision ? formatted : formatted + '.') + '0'.repeat(decimals - precision);
   }
 
   return formatted;

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -138,6 +138,22 @@ describe('valueFormats', () => {
       expect(toFixed(Number.POSITIVE_INFINITY)).toBe(posInf);
     });
 
+    it('toFixed should pad with zeros past the point where the factor turns exponential', () => {
+      expect(toFixed(5, 20)).toBe(`5.${'0'.repeat(20)}`);
+      // 10 ** 21 stringifies as '1e+21', so the old padding appended that
+      // exponent to the value and 1.5 rendered as 1.5e+21.
+      expect(toFixed(5, 21)).toBe(`5.${'0'.repeat(21)}`);
+      expect(toFixed(1.5, 21)).toBe(`1.5${'0'.repeat(20)}`);
+      expect(toFixed(1.5, 100)).toBe(`1.5${'0'.repeat(99)}`);
+    });
+
+    it('toFixed should not throw for a decimal count outside the range toFixed accepts', () => {
+      expect(toFixed(0, 101)).toBe(`0.${'0'.repeat(100)}`);
+      expect(toFixed(0, -3)).toBe('0');
+      expect(toFixed(1.5, 101)).toBe(`1.5${'0'.repeat(99)}`);
+      expect(toFixed(1.5, -3)).toBe('2');
+    });
+
     it('scaledUnits should handle non number input gracefully', () => {
       const disp = scaledUnits(5, ['a', 'b', 'c']);
       expect(disp(NaN).text).toBe('NaN');


### PR DESCRIPTION
**What is this feature?**

Two fixes in `baseFormatters.toFixed`, both about the `decimals` count arriving unvalidated.

The zero padding was built by slicing `String(factor)`, where `factor` is `10 ** decimals`. That works while the factor prints in full, but `String(10 ** 21)` is `'1e+21'`, so the slice returned `'e+21'` and appended it to the number. Building the zeros directly is what the slice was standing in for, and it keeps working past 20.

```ts
toFixed(1.5, 21)  // before: '1.5e+21'   after: '1.5' + twenty zeros
toFixed(5, 21)    // before: '5.e+21'    after: '5.' + twenty-one zeros
toFixed(5, 20)    // '5.00000000000000000000' either way
```

Separately, `Number.prototype.toFixed` accepts 0 to 100 and the `value === 0` branch calls it directly, so a count outside that range threw a `RangeError` and the panel rendered blank. One `clamp` above both uses covers that and keeps the padding length bounded.

**Why do we need this feature?**

A field holding `1.5` rendered as `1.5e+21`. That is a wrong number rather than a formatting blemish, and nothing in the output marks it as wrong.

The Decimals option registers `min: 0, max: 15` in `public/app/core/components/OptionsUI/registry.tsx`, so neither case is reachable by clicking. Both are reachable from anything else that writes `field.config.decimals`, because `numberOverrideProcessor` is `parseFloat(String(value))` with no bounds check: dashboard JSON, provisioned dashboards, the HTTP API, and plugins calling the `toFixed` that `@grafana/data` exports.

**Who is this feature for?**

Anyone whose `decimals` reaches a panel by a route other than the options editor, and plugin authors using `toFixed` directly.

**Which issue(s) does this PR fix?**:

Fixes #131843

**Special notes for your reviewer:**

**Overlap with #130936, which I think is complementary rather than competing.** That PR fixes the same `RangeError` for #125688 by validating the value inside `fieldToConfigMapping`, and its description explicitly identifies `baseFormatters.toFixed` as where the throw comes from before choosing to fix the caller. This guards the function itself, so the other routes into `field.config.decimals` are covered too, and the exponent bug is not covered by that PR at all. If you would rather have one of these than both, I am happy for this to be the one that closes.

**Clamping rather than rejecting.** #130936 argues for skipping an out-of-range mapping instead of silently clamping, and that is the right call at the mapping layer, where leaving the option alone is an option. `toFixed` has to return a string, so the choices are clamp or throw, and 100 is the ceiling the native method imposes anyway. Values past it are not representable in a double regardless.

**Deliberately left out:** a non-integer count, say `decimals: 2.5`, still produces `10 ** 2.5` as the factor and formats oddly. It does not throw and it does not emit a wrong exponent, so it is a separate question about what the field config should accept, and #130936 already handles it for the mapping path. Say the word and I will add `Math.floor` here.

**The automatic path is unaffected**, which I checked rather than assumed: with `decimals` omitted, `getDecimalsForValue` only exceeds 20 for values that already stringify in exponential notation, and those hit the early return above the padding. I swept mantissas 1, 1.5, 2.5, 3.7 and 9.99 across every exponent from -30 to 30 and found no case that reaches the padding branch.

**Tests:** added to the existing `valueFormats.test.ts` and `displayProcessor.test.ts` rather than as new files, so there is no CODEOWNERS gap this time. The `displayProcessor` ones go through `getDisplayProcessor` to show these are reachable from field config and not only from a direct call. Whole `packages/grafana-data` suite is green locally: 122 suites, 1986 passed.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. Not applicable, this is a bug fix in an existing formatter.
- [ ] The docs are updated. Not applicable, no documented behaviour changes: the only outputs that change are the ones that were wrong or threw.
