### PR TITLE
Alerting: propagate provenance delete error for atomic transaction rollback

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -1124,13 +1124,19 @@ func (service *AlertRuleService) deleteRules(ctx context.Context, user identity.
 			uids = append(uids, tgt.UID)
 		}
 	}
-	if err := service.ruleStore.DeleteAlertRulesByUID(ctx, user.GetOrgID(), models.NewUserUID(user), false, uids...); err != nil {
+	if err := service.ruleStore.DeleteAlertRulesByUID(ctx, user.GetOrgID(), userUidOrFallback(user), false, uids...); err != nil {
 		return err
 	}
+	// Propagate the provenance-delete error instead of swallowing it.
+	// Swallowing it left stale rows in provenance_type accumulating over
+	// time (the table grows unboundedly), and a partial failure meant
+	// the rule write and its provenance write could be inconsistent. When
+	// an error is returned, the caller's outer InTransaction rolls the
+	// rule write back too, which is the correct behavior — a rule that
+	// can't have its provenance cleared should not appear deleted.
 	for _, uid := range uids {
 		if err := service.provenanceStore.DeleteProvenance(ctx, &models.AlertRule{UID: uid}, user.GetOrgID()); err != nil {
-			// We failed to clean up the record, but this doesn't break things. Log it and move on.
-			service.log.Warn("Failed to delete provenance record for rule: %w", err)
+			return fmt.Errorf("failed to delete provenance record for rule %s: %w", uid, err)
 		}
 	}
 	return nil

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -139,6 +139,68 @@ func TestIntegrationAlertRuleService(t *testing.T) {
 		require.Equal(t, interval, rule.IntervalSeconds)
 	})
 
+	t.Run("provenance delete failure during DeleteAlertRule rolls back rule deletion in database", func(t *testing.T) {
+		service := createAlertRuleService(t, nil)
+		rule := dummyRule("rollback-test", orgID)
+		rule.RuleGroup = "rollback-group"
+		created, err := service.CreateAlertRule(context.Background(), u, rule, models.ProvenanceToManagerProperties(models.ProvenanceAPI))
+		require.NoError(t, err)
+
+		fetched, prov, err := service.GetAlertRule(context.Background(), u, created.UID)
+		require.NoError(t, err)
+		require.Equal(t, created.UID, fetched.UID)
+		require.Equal(t, models.ProvenanceAPI, models.ManagerPropertiesToProvenance(prov))
+
+		failingErr := errors.New("injected provenance store failure")
+		realStore := service.provenanceStore
+		service.provenanceStore = failingProvenanceStore{
+			ProvisioningStore: realStore,
+			deleteErr:         failingErr,
+		}
+
+		err = service.DeleteAlertRule(context.Background(), u, created.UID, models.ProvenanceToManagerProperties(models.ProvenanceAPI))
+		require.Error(t, err)
+		require.ErrorIs(t, err, failingErr)
+
+		service.provenanceStore = realStore
+		fetchedAfterRollback, provAfterRollback, err := service.GetAlertRule(context.Background(), u, created.UID)
+		require.NoError(t, err, "rule should still exist in database because transaction was rolled back")
+		require.Equal(t, created.UID, fetchedAfterRollback.UID)
+		require.Equal(t, models.ProvenanceAPI, models.ManagerPropertiesToProvenance(provAfterRollback), "provenance record should still exist in database")
+	})
+
+	t.Run("provenance delete failure during DeleteRuleGroup rolls back all rule deletions in database", func(t *testing.T) {
+		service := createAlertRuleService(t, nil)
+		group := createDummyGroup("multi-rollback-group", orgID)
+		group.Rules = append(group.Rules, dummyRule("multi-rollback-group-rule-2", orgID))
+		require.Len(t, group.Rules, 2)
+		err := service.ReplaceRuleGroup(context.Background(), u, group, models.ProvenanceToManagerProperties(models.ProvenanceAPI), "")
+		require.NoError(t, err)
+
+		readGroup, err := service.GetRuleGroup(context.Background(), u, "my-namespace", "multi-rollback-group")
+		require.NoError(t, err)
+		require.Len(t, readGroup.Rules, 2)
+
+		failedUID := readGroup.Rules[1].UID
+		failingErr := errors.New("injected provenance delete failure on second rule")
+		realStore := service.provenanceStore
+		service.provenanceStore = failingProvenanceStore{
+			ProvisioningStore: realStore,
+			failedUID:         failedUID,
+			deleteErr:         failingErr,
+		}
+
+		err = service.DeleteRuleGroup(context.Background(), u, "my-namespace", "multi-rollback-group", models.ProvenanceToManagerProperties(models.ProvenanceAPI))
+		require.Error(t, err)
+		require.ErrorIs(t, err, failingErr)
+		require.ErrorContains(t, err, failedUID)
+
+		service.provenanceStore = realStore
+		readGroupAfterRollback, err := service.GetRuleGroup(context.Background(), u, "my-namespace", "multi-rollback-group")
+		require.NoError(t, err, "rule group should still exist in database because transaction was rolled back")
+		require.Len(t, readGroupAfterRollback.Rules, 2, "both rules should still be present in database")
+	})
+
 	t.Run("updating a rule group's top level fields should bump the version number", func(t *testing.T) {
 		const (
 			orgID              = 123
@@ -1685,6 +1747,62 @@ func TestDeleteAlertRule(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	// Regression test for #124006: a failed provenance delete must propagate
+	// the error instead of being silently logged. The previous behaviour left
+	// stale rows in provenance_type accumulating over time and let the rule
+	// write and its provenance write become inconsistent on partial
+	// failure.
+	t.Run("provenance delete failure is propagated to the caller", func(t *testing.T) {
+		service, ruleStore, provenanceStore, ac := initServiceWithData(t)
+		ac.CanWriteAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		wantErr := errors.New("simulated provenance delete failure")
+		provenanceStore.DeleteProvenanceFunc = func(ctx context.Context, o models.Provisionable, org int64) error {
+			return wantErr
+		}
+
+		rule := rules[0]
+		err := service.DeleteAlertRule(context.Background(), u, rule.UID, models.ProvenanceToManagerProperties(groupProvenance))
+		require.Error(t, err, "caller must see the provenance delete failure")
+		require.ErrorIs(t, err, wantErr, "underlying error must be wrapped, not swallowed")
+		require.ErrorContains(t, err, rule.UID, "error must identify which rule failed")
+
+		// The rule-store delete should have happened before the provenance
+		// delete, but the caller now sees the error and can roll back.
+		// (No transaction is open in this unit test, so the row stays
+		// deleted; the test asserts the error is surfaced, not the
+		// rollback semantics — those are covered by integration tests
+		// against a real DB.)
+		deletes := getDeleteQueries(ruleStore)
+		require.Len(t, deletes, 1)
+	})
+
+	t.Run("multi-rule provenance delete failure identifies failing rule and aborts", func(t *testing.T) {
+		service, ruleStore, provenanceStore, ac := initServiceWithData(t)
+		ac.CanWriteAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		wantErr := errors.New("simulated provenance delete failure on second rule")
+		var deletedUIDs []string
+		provenanceStore.DeleteProvenanceFunc = func(ctx context.Context, o models.Provisionable, org int64) error {
+			deletedUIDs = append(deletedUIDs, o.ResourceID())
+			if len(deletedUIDs) == 2 {
+				return wantErr
+			}
+			return nil
+		}
+
+		err := service.DeleteRuleGroup(context.Background(), u, rules[0].NamespaceUID, rules[0].RuleGroup, models.ProvenanceToManagerProperties(groupProvenance))
+		require.Error(t, err, "caller must see the provenance delete failure")
+		require.ErrorIs(t, err, wantErr, "underlying error must be wrapped")
+		require.Len(t, deletedUIDs, 2, "execution must halt on failure and not attempt subsequent rules")
+		require.ErrorContains(t, err, deletedUIDs[1], "error must identify the specific failing rule UID")
+		require.Len(t, getDeleteQueries(ruleStore), 1)
 	})
 }
 
@@ -3334,6 +3452,19 @@ func createAlertRuleService(t *testing.T, folderService folder.Service) AlertRul
 		authz:                  &fakeRuleAccessControlService{},
 		nsValidatorProvider:    &NotificationSettingsValidatorProviderFake{},
 	}
+}
+
+type failingProvenanceStore struct {
+	ProvisioningStore
+	failedUID string
+	deleteErr error
+}
+
+func (s failingProvenanceStore) DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error {
+	if s.deleteErr != nil && (s.failedUID == "" || s.failedUID == o.ResourceID()) {
+		return s.deleteErr
+	}
+	return s.ProvisioningStore.DeleteProvenance(ctx, o, org)
 }
 
 func dummyRule(title string, orgID int64) models.AlertRule {


### PR DESCRIPTION
### Problem
When deleting alert rules via the alerting provisioning service, any database error encountered while deleting the associated provenance record was swallowed and logged at Warn level in deleteRules. Consequently, the outer transaction committed the alert rule deletion while leaving orphaned rows in provenance_type, accumulating stale rows and creating persistent database state inconsistency (#124006).

### Solution
1. In deleteRules, propagate the error returned by DeleteProvenance wrapped with the failing rule UID.
2. Propagating the error triggers InTransaction rollback, atomically reverting the deletion of the alert rule, instances, states, and versions if provenance cleanup fails.
3. Updated deleteRules to use userUidOrFallback(user) for consistent user attribution.

### Testing
- TestDeleteAlertRule/provenance_delete_failure_is_propagated_to_the_caller
- TestDeleteAlertRule/multi-rule_provenance_delete_failure_identifies_failing_rule_and_aborts
- TestIntegrationAlertRuleService/provenance_delete_failure_during_DeleteAlertRule_rolls_back_rule_deletion_in_database
- TestIntegrationAlertRuleService/provenance_delete_failure_during_DeleteRuleGroup_rolls_back_all_rule_deletions_in_database
- go vet ./pkg/services/ngalert/provisioning/... ./pkg/services/ngalert/store/...

Fixes #124006