### PR TITLE
TimePicker: pin a single "now" reference inside convertRawToRange (fix #131634)

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.ts
+++ b/packages/grafana-data/src/datetime/datemath.ts
@@ -43,17 +43,22 @@ export function isMathString(text: string | DateTime | Date): boolean {
  * @param text
  * @param roundUp See parseDateMath function.
  * @param timezone Only string 'utc' is acceptable here, for anything else, local timezone is used.
+ * @param now Reference timestamp used when `text` contains a `now` math
+ * expression. If omitted, the real wall clock is used. Callers parsing several
+ * relative expressions should pass the same value so the results share a single
+ * reference timestamp (#131634).
  */
 export function parse(
   text?: string | DateTime | Date | null,
   roundUp?: boolean,
   timezone?: TimeZone,
-  fiscalYearStartMonth?: number
+  fiscalYearStartMonth?: number,
+  now?: DateTimeInput
 ): DateTime | undefined {
   if (!text) {
     return undefined;
   }
-  return toDateTime(text, { roundUp, timezone, fiscalYearStartMonth });
+  return toDateTime(text, { roundUp, timezone, fiscalYearStartMonth, now });
 }
 
 export interface ConversionOptions {

--- a/packages/grafana-data/src/datetime/parser.ts
+++ b/packages/grafana-data/src/datetime/parser.ts
@@ -21,6 +21,13 @@ export interface DateTimeOptionsWhenParsing extends DateTimeOptions {
    */
   roundUp?: boolean;
   fiscalYearStartMonth?: number;
+  /**
+   * Reference "now" to use when the input contains a `now` math expression. If
+   * unset, the parser falls back to the real wall clock. Callers that parse
+   * multiple relative expressions together should pass the same value to each
+   * call so the endpoints share a single reference timestamp (#131634).
+   */
+  now?: DateTimeInput;
 }
 
 type DateTimeParser<T extends DateTimeOptions = DateTimeOptions> = (value: DateTimeInput, options?: T) => DateTime;
@@ -55,10 +62,10 @@ export const dateTimeParse: DateTimeParser<DateTimeOptionsWhenParsing> = (value,
 const parseString = (value: string, options?: DateTimeOptionsWhenParsing): DateTime => {
   if (value.indexOf('now') !== -1) {
     if (!isValid(value)) {
-      return dateTime();
+      return options?.now !== undefined ? dateTime(options.now) : dateTime();
     }
 
-    const parsed = parse(value, options?.roundUp, options?.timeZone, options?.fiscalYearStartMonth);
+    const parsed = parse(value, options?.roundUp, options?.timeZone, options?.fiscalYearStartMonth, options?.now);
     return parsed || dateTime();
   }
 

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -98,6 +98,60 @@ describe('Range Utils', () => {
       expect(deserialized.raw.to).not.toBe(deserialized.to);
       expect(deserialized.raw.to).toBe(timeRange.to);
     });
+
+    // Regression tests for #131634: `from` and `to` of a relative time range
+    // must share a single reference timestamp, otherwise durations drift by a
+    // few milliseconds per wall-clock read.
+    describe('shared "now" reference (#131634)', () => {
+      it('preserves the duration of now-Nh to now while the clock advances', () => {
+        let now = Date.parse('2024-07-05T12:00:00.000Z');
+        const clock = jest.spyOn(Date, 'now').mockImplementation(() => {
+          const value = now;
+          now += 1;
+          return value;
+        });
+
+        try {
+          const range = convertRawToRange({ from: 'now-6h', to: 'now' }, 'utc');
+          expect(range.to.valueOf() - range.from.valueOf()).toBe(6 * 60 * 60 * 1000);
+        } finally {
+          clock.mockRestore();
+        }
+      });
+
+      it('resolves both now/N endpoints against the same captured now across a clock-tick boundary', () => {
+        // Without the fix, each `dateTimeParse` call reads `Date.now()` once,
+        // so `now-1h` to `now-1m` would be evaluated against two different
+        // wall-clock reads. With the fix, both endpoints share a single
+        // captured reference even when the wall clock advances between them.
+        // Each new read of `Date.now()` would land on a different second, so
+        // an "always returns a fresh now" implementation would produce two
+        // different `to` values for the two `dateTimeParse` calls.
+        let tick = 0;
+        const clock = jest.spyOn(Date, 'now').mockImplementation(() => {
+          const value = Date.parse('2024-07-05T12:00:00.000Z') + tick * 1000;
+          tick += 1;
+          return value;
+        });
+
+        try {
+          const range = convertRawToRange({ from: 'now-1h', to: 'now-1m' }, 'utc');
+          // Both endpoints derive from the first captured `now`. The
+          // expected difference is 59 minutes (3540000 ms); a 1-second shift
+          // between endpoints would mean the fix is not active.
+          expect(range.to.valueOf() - range.from.valueOf()).toBe(59 * 60 * 1000);
+        } finally {
+          clock.mockRestore();
+        }
+      });
+
+      it('accepts an explicit now override and uses it for both endpoints', () => {
+        const fixedNow = dateTime('2024-07-05T12:00:00.000Z');
+        const range = convertRawToRange({ from: 'now-1h', to: 'now' }, 'utc', undefined, undefined, fixedNow);
+        expect(range.to.valueOf()).toBe(fixedNow.valueOf());
+        expect(range.to.valueOf() - range.from.valueOf()).toBe(60 * 60 * 1000);
+      });
+    });
   });
 
   describe('relative time', () => {

--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -11,7 +11,7 @@ import {
 
 import * as dateMath from './datemath';
 import { timeZoneAbbrevation, dateTimeFormat, dateTimeFormatTimeAgo } from './formatter';
-import { isDateTime, type DateTime, dateTime, dateTimeForTimeZone } from './moment_wrapper';
+import { isDateTime, type DateTime, type DateTimeInput, dateTime, dateTimeForTimeZone } from './moment_wrapper';
 import { dateTimeParse } from './parser';
 
 // `fQ` and `fy` are synthesized lookup keys matching the regex group `f[Qy]`
@@ -508,10 +508,20 @@ export const convertRawToRange = (
   raw: RawTimeRange,
   timeZone?: TimeZone,
   fiscalYearStartMonth?: number,
-  format?: string
+  format?: string,
+  // Optional reference timestamp used by `now` math expressions. When the raw
+  // range contains relative endpoints, both `from` and `to` must be resolved
+  // against the same "now" — otherwise the duration of `now-Nh` to `now` drifts
+  // by a few milliseconds, and two `now/d` endpoints can describe different
+  // calendar days when the underlying read crosses midnight (#131634).
+  now?: DateTimeInput
 ): TimeRange => {
-  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format });
-  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format });
+  // Capture the wall clock at most once per call. If the caller already pinned
+  // `now` we use that; otherwise we read `Date.now()` a single time and pass it
+  // through so both endpoints share the same reference.
+  const referenceNow = now !== undefined ? now : dateTime();
+  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format, now: referenceNow });
+  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format, now: referenceNow });
 
   return {
     from,


### PR DESCRIPTION
### What changed

`convertRawToRange` resolved `from` and `to` against two independent reads of `Date.now()` via `dateTimeParse`. A range like `now-6h` to `now` could therefore be a few milliseconds longer than the user typed, and a pair of `now/d` endpoints could straddle midnight and describe different calendar days. The drift was reproducible on the wall clock alone, not just in tests.

The fix plumbs an optional `now` reference through the existing `datemath.parse` and `dateTimeParse` plumbing (one new optional argument on each), and `convertRawToRange` either honours the caller's `now` or captures `dateTime()` once at the top of the call and passes that single value to both endpoint parses. All existing callers continue to work unchanged: the new argument is optional, and unset callers get the single-capture behaviour.

### Why

The reported repro is the user-typed duration `now-6h` to `now` returning 21,599,999 ms instead of 21,600,000 ms. Any downstream consumer of the range (interval calculation, fetch windows, alert evaluation, relative-time UI display) is built on the assumption that the range matches the user's typed duration, so even a millisecond of drift between endpoints is observable.

The `now/d` case is a separate symptom of the same root cause: when the two reads straddle midnight in the requested timezone, the two endpoints pick different calendar days and the resulting range is empty or inverted.

### How

Three small changes plus a regression suite, all in `packages/grafana-data/src/datetime/`:

- `datemath.ts` — `parse(text, roundUp, timezone, fiscalYearStartMonth, now?)` accepts an optional reference and forwards it to `toDateTime`.
- `parser.ts` — `DateTimeOptionsWhenParsing` exposes a public `now?` field, and `parseString` forwards it to `parse` and uses it in the invalid-input fallback so the fallback path doesn't drift away from the explicit-`now` path.
- `rangeutil.ts` — `convertRawToRange` gains a 5th `now?` argument and passes a single captured reference to both `dateTimeParse` calls.
- `rangeutil.test.ts` — three regression tests:
  - `now-6h` to `now` with a mock clock that advances by 1 ms per read. Pre-fix: 21,599,999 ms. Post-fix: 21,600,000 ms.
  - `now-1h` to `now-1m` with a mock clock that advances by 1 s per read. Pre-fix: 59 min ± 1 s. Post-fix: 59 min exactly.
  - explicit override: `convertRawToRange({ from: 'now-1h', to: 'now' }, 'utc', undefined, undefined, fixedNow)`. Pre-fix: ignores the override. Post-fix: `to` equals `fixedNow`.

### Verification

- `yarn jest packages/grafana-data/src/datetime/` — 353/353 pass (was 350/350 before, +3 new tests).
- `yarn jest public/app/core/components/TimePicker/ public/app/features/alerting/unified/components/backtesting/ public/app/features/logs/components/panel/InfiniteScroll.test.tsx` — all green.
- prettier, eslint, tsc on `packages/grafana-data/` — clean.
- The new tests are RED against the unmodified `convertRawToRange` and GREEN after the fix is applied (verified by `git stash` round-trip).

### Fixes

#131634
