### PR TITLE
docs: fix typo "Acccess" to "Access" in git-sync-setup/_index.md

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -82,7 +82,7 @@ For information on how to set up each method, refer to:
 Fill in the following fields:
 
 1. Paste the **Repository URL** for your GitHub repository into the text box.
-1. Paste your **Personal Acccess Token**.
+1. Paste your **Personal Access Token**.
 
 Select **Configure repository** to set up your provisioning folder.
 
@@ -112,7 +112,7 @@ Similarly, you can connect to GitHub Enterprise Server or GitHub Enterprise Clou
 Fill in the following fields:
 
 1. Paste the **Repository URL** for your GitHub repository into the text box.
-1. Paste your **Personal Acccess Token**.
+1. Paste your **Personal Access Token**.
 
 Select **Configure repository** to set up your provisioning folder.
 


### PR DESCRIPTION
**What is this feature?**

Fixes two occurrences of the typo "Acccess" to "Access" in git-sync-setup/_index.md

**Why do we need this feature?**

Typos corrected for clarity.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
