### PR TITLE
Dashboards: Fix secondary template errors in ReqContext.Handle HTML error responses

### DIFF
--- a/pkg/api/webassets/webassets.go
+++ b/pkg/api/webassets/webassets.go
@@ -95,7 +95,11 @@ func GetWebAssets(ctx context.Context, buildDir string, cfg *setting.Cfg, licens
 		result, err = ReadWebAssetsFromFile(filepath.Join(cfg.StaticRootPath, buildDir, AssetsManifestFile))
 		if err == nil {
 			result.PublicPath = PublicPathFor(buildDir)
-			cdn, _ = cfg.GetContentDeliveryURL(license.ContentDeliveryPrefix())
+			var prefix string
+			if license != nil {
+				prefix = license.ContentDeliveryPrefix()
+			}
+			cdn, _ = cfg.GetContentDeliveryURL(prefix)
 			if cdn != "" {
 				result.SetContentDeliveryURL(cdn)
 			}

--- a/pkg/services/contexthandler/model/assets.go
+++ b/pkg/services/contexthandler/model/assets.go
@@ -1,0 +1,103 @@
+package contextmodel
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type errorAsset struct {
+	FilePath string
+}
+
+type errorAssets struct {
+	CSSFiles []errorAsset
+	Dark     string
+	Light    string
+}
+
+type manifestData struct {
+	Entrypoints struct {
+		App struct {
+			Assets struct {
+				CSS []string `json:"css"`
+			} `json:"assets"`
+		} `json:"app"`
+		Dark struct {
+			Assets struct {
+				CSS []string `json:"css"`
+			} `json:"assets"`
+		} `json:"dark"`
+		Light struct {
+			Assets struct {
+				CSS []string `json:"css"`
+			} `json:"assets"`
+		} `json:"light"`
+	} `json:"entrypoints"`
+}
+
+var (
+	errorAssetsMu    sync.RWMutex
+	errorAssetsCache = make(map[string]*errorAssets)
+)
+
+func getErrorAssets(cfg *setting.Cfg) *errorAssets {
+	if cfg == nil {
+		return &errorAssets{
+			CSSFiles: []errorAsset{},
+		}
+	}
+
+	buildDir := "build"
+	manifestPath := filepath.Join(cfg.StaticRootPath, buildDir, "assets-manifest.json")
+
+	errorAssetsMu.RLock()
+	cached, ok := errorAssetsCache[manifestPath]
+	errorAssetsMu.RUnlock()
+	if ok && cfg.Env != setting.Dev {
+		return cached
+	}
+
+	errorAssetsMu.Lock()
+	defer errorAssetsMu.Unlock()
+
+	if cached, ok = errorAssetsCache[manifestPath]; ok && cfg.Env != setting.Dev {
+		return cached
+	}
+
+	assets := &errorAssets{
+		CSSFiles: []errorAsset{},
+	}
+
+	//nolint:gosec
+	f, err := os.Open(manifestPath)
+	if err != nil {
+		errorAssetsCache[manifestPath] = assets
+		return assets
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var manifest manifestData
+	if err := json.NewDecoder(f).Decode(&manifest); err != nil {
+		errorAssetsCache[manifestPath] = assets
+		return assets
+	}
+
+	for _, css := range manifest.Entrypoints.App.Assets.CSS {
+		assets.CSSFiles = append(assets.CSSFiles, errorAsset{FilePath: css})
+	}
+	if len(manifest.Entrypoints.Dark.Assets.CSS) > 0 {
+		assets.Dark = manifest.Entrypoints.Dark.Assets.CSS[0]
+	}
+	if len(manifest.Entrypoints.Light.Assets.CSS) > 0 {
+		assets.Light = manifest.Entrypoints.Light.Assets.CSS[0]
+	}
+
+	errorAssetsCache[manifestPath] = assets
+	return assets
+}

--- a/pkg/services/contexthandler/model/handle_test.go
+++ b/pkg/services/contexthandler/model/handle_test.go
@@ -1,0 +1,215 @@
+package contextmodel_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/infra/log"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestReqContext_Handle(t *testing.T) {
+	viewsPath, err := filepath.Abs("../../../../public/views")
+	require.NoError(t, err)
+
+	t.Run("renders error template with fallback assets when manifest is missing", func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "dark"
+		cfg.StaticRootPath = t.TempDir()
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-dark">`)
+		require.NotContains(t, body, "Error rendering template")
+	})
+
+	t.Run("renders error template with dark stylesheet from manifest", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0755))
+
+		manifestJSON := `{
+			"entrypoints": {
+				"app": { "assets": { "css": ["public/build/grafana.app.12345.css"] } },
+				"dark": { "assets": { "css": ["public/build/grafana.dark.12345.css"] } },
+				"light": { "assets": { "css": ["public/build/grafana.light.12345.css"] } }
+			}
+		}`
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte(manifestJSON), 0600))
+
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "dark"
+		cfg.StaticRootPath = tempDir
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-dark">`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.app.12345.css" />`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.dark.12345.css" />`)
+		require.NotContains(t, body, "public/build/grafana.light.12345.css")
+		require.NotContains(t, body, "Error rendering template")
+	})
+
+	t.Run("renders error template with light stylesheet from manifest", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0755))
+
+		manifestJSON := `{
+			"entrypoints": {
+				"app": { "assets": { "css": ["public/build/grafana.app.12345.css"] } },
+				"dark": { "assets": { "css": ["public/build/grafana.dark.12345.css"] } },
+				"light": { "assets": { "css": ["public/build/grafana.light.12345.css"] } }
+			}
+		}`
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte(manifestJSON), 0600))
+
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "light"
+		cfg.StaticRootPath = tempDir
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-light">`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.app.12345.css" />`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.light.12345.css" />`)
+		require.NotContains(t, body, "public/build/grafana.dark.12345.css")
+		require.NotContains(t, body, "Error rendering template")
+	})
+
+	t.Run("renders error template gracefully when manifest is malformed", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte("invalid-json"), 0600))
+
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "dark"
+		cfg.StaticRootPath = tempDir
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-dark">`)
+		require.NotContains(t, body, "Error rendering template")
+	})
+
+	t.Run("handles nil cfg gracefully", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(nil, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-dark">`)
+		require.NotContains(t, body, "Error rendering template")
+	})
+}

--- a/pkg/services/contexthandler/model/handle_test.go
+++ b/pkg/services/contexthandler/model/handle_test.go
@@ -212,4 +212,98 @@ func TestReqContext_Handle(t *testing.T) {
 		require.Contains(t, body, `<body class="theme-dark">`)
 		require.NotContains(t, body, "Error rendering template")
 	})
+
+	t.Run("resolves system default theme to dark theme type", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0755))
+
+		manifestJSON := `{
+			"entrypoints": {
+				"app": { "assets": { "css": ["public/build/grafana.app.12345.css"] } },
+				"dark": { "assets": { "css": ["public/build/grafana.dark.12345.css"] } },
+				"light": { "assets": { "css": ["public/build/grafana.light.12345.css"] } }
+			}
+		}`
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte(manifestJSON), 0600))
+
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "system"
+		cfg.StaticRootPath = tempDir
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-dark">`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.dark.12345.css" />`)
+		require.NotContains(t, body, "public/build/grafana.light.12345.css")
+		require.NotContains(t, body, "Error rendering template")
+	})
+
+	t.Run("resolves extra light theme ID (desertbloom) to light theme type", func(t *testing.T) {
+		tempDir := t.TempDir()
+		buildDir := filepath.Join(tempDir, "build")
+		require.NoError(t, os.MkdirAll(buildDir, 0755))
+
+		manifestJSON := `{
+			"entrypoints": {
+				"app": { "assets": { "css": ["public/build/grafana.app.12345.css"] } },
+				"dark": { "assets": { "css": ["public/build/grafana.dark.12345.css"] } },
+				"light": { "assets": { "css": ["public/build/grafana.light.12345.css"] } }
+			}
+		}`
+		require.NoError(t, os.WriteFile(filepath.Join(buildDir, "assets-manifest.json"), []byte(manifestJSON), 0600))
+
+		cfg := setting.NewCfg()
+		cfg.ErrTemplateName = "error"
+		cfg.DefaultTheme = "desertbloom"
+		cfg.StaticRootPath = tempDir
+
+		rec := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/render/test", nil)
+		require.NoError(t, err)
+
+		handler := web.EmptyMacaronMiddleware(
+			web.Renderer(viewsPath, "[[", "]]")(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					webCtx := web.FromContext(r.Context())
+					reqCtx := &contextmodel.ReqContext{
+						Context: webCtx,
+						Logger:  log.New("test"),
+					}
+					reqCtx.Handle(cfg, http.StatusBadRequest, "Render parameters error", errors.New("timeout is invalid"))
+				}),
+			),
+		)
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+		body := rec.Body.String()
+		require.Contains(t, body, "<title>Grafana - Error</title>")
+		require.Contains(t, body, `<body class="theme-light">`)
+		require.Contains(t, body, `<link rel="stylesheet" href="public/build/grafana.light.12345.css" />`)
+		require.NotContains(t, body, "public/build/grafana.dark.12345.css")
+		require.NotContains(t, body, "Error rendering template")
+	})
 }

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/org"
+	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -50,8 +51,8 @@ func (ctx *ReqContext) Handle(cfg *setting.Cfg, status int, title string, err er
 	appSubURL := ""
 	errTemplateName := "error"
 	if cfg != nil {
-		if cfg.DefaultTheme != "" {
-			themeType = cfg.DefaultTheme
+		if theme := pref.GetThemeByID(cfg.DefaultTheme); theme != nil && theme.Type == "light" {
+			themeType = "light"
 		}
 		appSubURL = cfg.AppSubURL
 		if cfg.ErrTemplateName != "" {

--- a/pkg/services/contexthandler/model/model.go
+++ b/pkg/services/contexthandler/model/model.go
@@ -44,19 +44,35 @@ type ReqContext struct {
 
 // Handle handles and logs error by given status.
 func (ctx *ReqContext) Handle(cfg *setting.Cfg, status int, title string, err error) {
+	assets := getErrorAssets(cfg)
+
+	themeType := "dark"
+	appSubURL := ""
+	errTemplateName := "error"
+	if cfg != nil {
+		if cfg.DefaultTheme != "" {
+			themeType = cfg.DefaultTheme
+		}
+		appSubURL = cfg.AppSubURL
+		if cfg.ErrTemplateName != "" {
+			errTemplateName = cfg.ErrTemplateName
+		}
+	}
+
 	data := struct {
 		Title     string
 		AppTitle  string
 		AppSubUrl string
 		ThemeType string
 		ErrorMsg  error
-	}{title, "Grafana", cfg.AppSubURL, "dark", nil}
+		Assets    *errorAssets
+	}{title, "Grafana", appSubURL, themeType, nil, assets}
 
 	if err != nil {
 		ctx.Logger.Error(title, "error", err)
 	}
 
-	ctx.HTML(status, cfg.ErrTemplateName, data)
+	ctx.HTML(status, errTemplateName, data)
 }
 
 func (ctx *ReqContext) IsApiRequest() bool {


### PR DESCRIPTION
**What is this feature?**

This PR fixes missing CSS asset and theme wiring for HTML error pages rendered through `ReqContext.Handle(...)`.

Before this change, `public/views/error.html` expected `.Assets.CSSFiles`, `.Assets.Light`, and `.Assets.Dark`, but the data struct passed in `ReqContext.Handle(...)` lacked `.Assets`. Consequently, Go's template engine failed at runtime:
```
template: error:13:29: executing "error" at <.Assets.CSSFiles>: can't evaluate field Assets in type struct { Title string; AppTitle string; AppSubUrl string; ThemeType string; ErrorMsg error }
```
This caused HTML error responses (such as `/render/d/...` upon receiving invalid parameters or index/login error paths) to be returned unstyled and logged a noisy secondary template execution error on every request.

---

**Why do we need this feature?**

- **Correctness**: Error pages render with proper stylesheet references (`.Assets.CSSFiles`, `.Assets.Light` / `.Assets.Dark`) and proper `.theme-*` body class.
- **Log Noise Reduction**: Eliminates secondary template rendering errors from server logs on HTML error paths.
- **Resilience & Fallbacks**: Gracefully falls back to embedded baseline styles without template errors if `assets-manifest.json` is missing or malformed.
- **Thread-safe Performance**: Uses `sync.RWMutex` double-checked caching so `assets-manifest.json` is read at most once in production.

---

**Who is this feature for?**

Grafana operators, developers, and users viewing rendered dashboards or HTML error pages.

---

**Which issue(s) does this PR fix?**:

Fixes #120356

---

**Special notes for your reviewer:**

- `pkg/services/contexthandler/model` is a low-level package heavily imported across `pkg/api` and `pkg/services`. To prevent circular dependencies with `pkg/api/dtos` or `pkg/api/webassets`, manifest loading is implemented cleanly in `assets.go` using standard library packages and `pkg/setting`.
- Added defensive `nil` check for `license` in `pkg/api/webassets/webassets.go` before accessing `ContentDeliveryPrefix()`.
- Added unit tests in `pkg/services/contexthandler/model/handle_test.go` covering missing manifest fallback, dark theme stylesheet, light theme stylesheet, malformed manifest, and `nil cfg`.

---

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
