### PR TITLE
Dashboard: count Unicode characters in tag validation

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"strconv"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -968,7 +969,7 @@ func validateDashboardTags(obj runtime.Object) error {
 	}
 
 	for _, tag := range tags {
-		if len(tag) > 50 {
+		if utf8.RuneCountInString(tag) > 50 {
 			return dashboards.ErrDashboardTagTooLong
 		}
 	}

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	authlib "github.com/grafana/authlib/types"
@@ -26,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	apiserverbuilder "github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -546,4 +548,27 @@ func assertNoTypeSpansMultipleGVKs(t *testing.T, scheme *runtime.Scheme) {
 				"order-fallback, so preferred_api_version would now silently pick the persisted version "+
 				"for this type instead of only ordering API discovery", typ, gvks)
 	}
+}
+func TestValidateDashboardTagsUnicodeLength(t *testing.T) {
+	tag50 := strings.Repeat("á", 50)
+	tag51 := strings.Repeat("á", 51)
+
+	dashboard50 := &dashv1.Dashboard{
+		Spec: common.Unstructured{
+			Object: map[string]interface{}{
+				"tags": []interface{}{tag50},
+			},
+		},
+	}
+
+	dashboard51 := &dashv1.Dashboard{
+		Spec: common.Unstructured{
+			Object: map[string]interface{}{
+				"tags": []interface{}{tag51},
+			},
+		},
+	}
+
+	require.NoError(t, validateDashboardTags(dashboard50))
+	require.ErrorIs(t, validateDashboardTags(dashboard51), dashboards.ErrDashboardTagTooLong)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates dashboard tag validation to count Unicode characters instead of UTF-8 bytes, using `utf8.RuneCountInString`.

A regression test was added to verify that:
- 50 Unicode characters are accepted.
- 51 Unicode characters are rejected.

**Why do we need this feature?**

The existing validation uses `len(tag)`, which counts bytes rather than Unicode characters.

As a result, tags containing multibyte UTF-8 characters such as accented characters could be rejected before reaching the documented 50-character limit.

**Who is this feature for?**

Grafana users who use dashboard tags containing Unicode characters.

**Which issue(s) does this PR fix?**:

Fixes #129193


**Special notes for your reviewer:**

AI assistance was used during development for code navigation, test drafting, and review. I reviewed and understood the final diff and ran the documented test locally.

Tested with:

`go test ./pkg/registry/apis/dashboard -run TestValidateDashboardTagsUnicodeLength -count=1`

Result: PASS.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to the What's New doc.
