### PR TITLE
Flamegraph: Explain truncated other data below top table

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvents from '@testing-library/user-event';
 
 import { createDataFrame } from '@grafana/data';
@@ -12,8 +12,8 @@ import { ColorScheme } from '../types';
 import FlameGraphTopTableContainer, { buildFilteredTable } from './FlameGraphTopTableContainer';
 
 describe('FlameGraphTopTableContainer', () => {
-  const setup = () => {
-    const flameGraphData = createDataFrame(data);
+  const setup = (flameGraphInput = data) => {
+    const flameGraphData = createDataFrame(flameGraphInput);
     const container = new FlameGraphDataContainer(flameGraphData, { collapsing: true });
     const onSearch = jest.fn();
     const onSandwich = jest.fn();
@@ -81,6 +81,32 @@ describe('FlameGraphTopTableContainer', () => {
     await userEvents.click(sandwichButtons[0]);
 
     expect(mocks.onSandwich).toHaveBeenCalledWith('net/http.HandlerFunc.ServeHTTP');
+  });
+
+  it('renders the other aggregate below the table with its actions', async () => {
+    mockBoundingClientRect({ width: 500, height: 500 });
+    const flameGraphWithOther = {
+      fields: [
+        { name: 'level', values: [0, 1, 1, 1] },
+        { name: 'value', values: [10, 4, 3, 3] },
+        { name: 'self', values: [0, 4, 3, 3] },
+        { name: 'label', values: ['total', 'foo', 'bar', 'other'] },
+      ],
+    };
+
+    const { mocks } = setup(flameGraphWithOther);
+    const summary = screen.getByTestId('topTableOtherSummary');
+
+    expect(screen.queryByRole('cell', { name: 'other' })).not.toBeInTheDocument();
+    expect(summary).toHaveTextContent(
+      'A total of 3 was truncated and is represented by other in the flame graph. The smallest included stack trace has a total resource consumption of 3.'
+    );
+
+    await userEvents.click(within(summary).getByLabelText('Search for symbol'));
+    expect(mocks.onSearch).toHaveBeenCalledWith('other');
+
+    await userEvents.click(within(summary).getByLabelText('Show in sandwich view'));
+    expect(mocks.onSandwich).toHaveBeenCalledWith('other');
   });
 });
 

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
@@ -7,12 +7,12 @@ import { mockBoundingClientRect } from '@grafana/test-utils';
 import { FlameGraphDataContainer } from '../FlameGraph/dataTransform';
 import { data } from '../FlameGraph/testData/dataNestedSet';
 import { textToDataContainer } from '../FlameGraph/testHelpers';
-import { ColorScheme } from '../types';
+import { ColorScheme, ColorSchemeDiff } from '../types';
 
 import FlameGraphTopTableContainer, { buildFilteredTable } from './FlameGraphTopTableContainer';
 
 describe('FlameGraphTopTableContainer', () => {
-  const setup = (flameGraphInput = data) => {
+  const setup = (flameGraphInput = data, colorScheme: ColorScheme | ColorSchemeDiff = ColorScheme.ValueBased) => {
     const flameGraphData = createDataFrame(flameGraphInput);
     const container = new FlameGraphDataContainer(flameGraphData, { collapsing: true });
     const onSearch = jest.fn();
@@ -24,7 +24,7 @@ describe('FlameGraphTopTableContainer', () => {
         onSymbolClick={jest.fn()}
         onSearch={onSearch}
         onSandwich={onSandwich}
-        colorScheme={ColorScheme.ValueBased}
+        colorScheme={colorScheme}
       />
     );
 
@@ -107,6 +107,26 @@ describe('FlameGraphTopTableContainer', () => {
 
     await userEvents.click(within(summary).getByLabelText('Show in sandwich view'));
     expect(mocks.onSandwich).toHaveBeenCalledWith('other');
+  });
+
+  it('renders baseline, comparison, and difference totals for a diff flame graph', () => {
+    mockBoundingClientRect({ width: 500, height: 500 });
+    const diffFlameGraphWithOther = {
+      fields: [
+        { name: 'level', values: [0, 1, 1, 1] },
+        { name: 'value', values: [10, 4, 3, 3] },
+        { name: 'self', values: [0, 4, 3, 3] },
+        { name: 'valueRight', values: [20, 6, 6, 8] },
+        { name: 'selfRight', values: [0, 6, 6, 8] },
+        { name: 'label', values: ['total', 'foo', 'bar', 'other'] },
+      ],
+    };
+
+    setup(diffFlameGraphWithOther, ColorSchemeDiff.Default);
+
+    expect(screen.getByTestId('topTableOtherSummary')).toHaveTextContent(
+      'Truncated totals represented by other in the flame graph: baseline 3, comparison 8, difference 5. The smallest included stack trace has a baseline total resource consumption of 3.'
+    );
   });
 });
 

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -11,6 +11,7 @@ import {
   type GrafanaTheme2,
   MappingType,
   escapeStringForRegex,
+  formattedValueToString,
 } from '@grafana/data';
 import {
   IconButton,
@@ -27,6 +28,8 @@ import { diffColorBlindColors, diffDefaultColors } from '../FlameGraph/colors';
 import { type FlameGraphDataContainer } from '../FlameGraph/dataTransform';
 import { TOP_TABLE_COLUMN_WIDTH } from '../constants';
 import { type ColorScheme, ColorSchemeDiff, type TableData } from '../types';
+
+const OTHER_LABEL = 'other';
 
 type Props = {
   data: FlameGraphDataContainer;
@@ -55,6 +58,7 @@ const FlameGraphTopTableContainer = memo(
     colorScheme,
   }: Props) => {
     const table = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
+    const { other, tableWithoutOther } = useMemo(() => separateOther(table), [table]);
 
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
@@ -63,46 +67,123 @@ const FlameGraphTopTableContainer = memo(
 
     return (
       <div className={styles.topTableContainer} data-testid="topTable">
-        <AutoSizer style={{ width: '100%' }}>
-          {({ width, height }) => {
-            if (width < 3 || height < 3) {
-              return null;
-            }
+        <div className={styles.tableContainer}>
+          <AutoSizer style={{ width: '100%' }}>
+            {({ width, height }) => {
+              if (width < 3 || height < 3) {
+                return null;
+              }
 
-            const frame = buildTableDataFrame(
-              data,
-              table,
-              width,
-              onSymbolClick,
-              onSearch,
-              onSandwich,
-              theme,
-              colorScheme,
-              search,
-              sandwichItem
-            );
-            return (
-              <Table
-                initialSortBy={sort}
-                onSortByChange={(s) => {
-                  if (s && s.length) {
-                    onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
-                  }
-                  setSort(s);
-                }}
-                data={frame}
-                width={width}
-                height={height}
-              />
-            );
-          }}
-        </AutoSizer>
+              const frame = buildTableDataFrame(
+                data,
+                tableWithoutOther,
+                width,
+                onSymbolClick,
+                onSearch,
+                onSandwich,
+                theme,
+                colorScheme,
+                search,
+                sandwichItem
+              );
+              return (
+                <Table
+                  initialSortBy={sort}
+                  onSortByChange={(s) => {
+                    if (s && s.length) {
+                      onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
+                    }
+                    setSort(s);
+                  }}
+                  data={frame}
+                  width={width}
+                  height={height}
+                />
+              );
+            }}
+          </AutoSizer>
+        </div>
+        {other && (
+          <OtherSummary
+            data={data}
+            other={other}
+            minimumIncludedTotal={getMinimumTotal(tableWithoutOther)}
+            search={search}
+            sandwichItem={sandwichItem}
+            onSearch={onSearch}
+            onSandwich={onSandwich}
+          />
+        )}
       </div>
     );
   }
 );
 
 FlameGraphTopTableContainer.displayName = 'FlameGraphTopTableContainer';
+
+function separateOther(table: Record<string, TableData>) {
+  const { [OTHER_LABEL]: other, ...tableWithoutOther } = table;
+  return { other, tableWithoutOther };
+}
+
+function getMinimumTotal(table: Record<string, TableData>) {
+  const totals = Object.values(table).map(({ total }) => total);
+  return totals.length > 0 ? Math.min(...totals) : undefined;
+}
+
+type OtherSummaryProps = {
+  data: FlameGraphDataContainer;
+  other: TableData;
+  minimumIncludedTotal?: number;
+  search?: string;
+  sandwichItem?: string;
+  onSearch: (str: string) => void;
+  onSandwich: (str?: string) => void;
+};
+
+function OtherSummary({
+  data,
+  other,
+  minimumIncludedTotal,
+  search,
+  sandwichItem,
+  onSearch,
+  onSandwich,
+}: OtherSummaryProps) {
+  const styles = useStyles2(getOtherSummaryStyles);
+  const otherValue = formattedValueToString(data.valueDisplayProcessor(other.total));
+  const minimumValue =
+    minimumIncludedTotal === undefined
+      ? undefined
+      : formattedValueToString(data.valueDisplayProcessor(minimumIncludedTotal));
+  const isSearched = search === `^${escapeStringForRegex(OTHER_LABEL)}$`;
+  const isSandwiched = sandwichItem === OTHER_LABEL;
+
+  return (
+    <div className={styles.container} data-testid="topTableOtherSummary">
+      <span>
+        A total of {otherValue} was truncated and is represented by <strong>other</strong> in the flame graph.
+        {minimumValue && ` The smallest included stack trace has a total resource consumption of ${minimumValue}.`}
+      </span>
+      <div className={styles.actions}>
+        <IconButton
+          name="search"
+          variant={isSearched ? 'primary' : 'secondary'}
+          tooltip={isSearched ? 'Clear from search' : 'Search for symbol'}
+          aria-label={isSearched ? 'Clear from search' : 'Search for symbol'}
+          onClick={() => onSearch(isSearched ? '' : OTHER_LABEL)}
+        />
+        <IconButton
+          name="gf-show-context"
+          variant={isSandwiched ? 'primary' : 'secondary'}
+          tooltip={isSandwiched ? 'Remove from sandwich view' : 'Show in sandwich view'}
+          aria-label={isSandwiched ? 'Remove from sandwich view' : 'Show in sandwich view'}
+          onClick={() => onSandwich(isSandwiched ? undefined : OTHER_LABEL)}
+        />
+      </div>
+    </div>
+  );
+}
 
 function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>) {
   // Group the data by label, we show only one row per label and sum the values
@@ -367,12 +448,38 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     topTableContainer: css({
       label: 'topTableContainer',
+      display: 'flex',
+      flexDirection: 'column',
       padding: theme.spacing(1),
       backgroundColor: theme.colors.background.secondary,
       height: '100%',
     }),
+    tableContainer: css({
+      label: 'tableContainer',
+      flexGrow: 1,
+      minHeight: 0,
+    }),
   };
 };
+
+const getOtherSummaryStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    label: 'otherSummary',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing(1),
+    paddingTop: theme.spacing(1),
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    color: theme.colors.text.secondary,
+    fontSize: theme.typography.bodySmall.fontSize,
+  }),
+  actions: css({
+    label: 'otherSummaryActions',
+    display: 'flex',
+    flexShrink: 0,
+  }),
+});
 
 const getStylesActionCell = () => {
   return {

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -151,7 +151,14 @@ function OtherSummary({
   onSandwich,
 }: OtherSummaryProps) {
   const styles = useStyles2(getOtherSummaryStyles);
+  const isDiffFlamegraph = data.isDiffFlamegraph();
   const otherValue = formattedValueToString(data.valueDisplayProcessor(other.total));
+  const comparisonValue = isDiffFlamegraph
+    ? formattedValueToString(data.valueDisplayProcessor(other.totalRight))
+    : undefined;
+  const diffValue = isDiffFlamegraph
+    ? formattedValueToString(data.valueDisplayProcessor(other.totalRight - other.total))
+    : undefined;
   const minimumValue =
     minimumIncludedTotal === undefined
       ? undefined
@@ -162,8 +169,18 @@ function OtherSummary({
   return (
     <div className={styles.container} data-testid="topTableOtherSummary">
       <span>
-        A total of {otherValue} was truncated and is represented by <strong>other</strong> in the flame graph.
-        {minimumValue && ` The smallest included stack trace has a total resource consumption of ${minimumValue}.`}
+        {isDiffFlamegraph ? (
+          <>
+            Truncated totals represented by <strong>other</strong> in the flame graph: baseline {otherValue}, comparison{' '}
+            {comparisonValue}, difference {diffValue}.
+          </>
+        ) : (
+          <>
+            A total of {otherValue} was truncated and is represented by <strong>other</strong> in the flame graph.
+          </>
+        )}
+        {minimumValue &&
+          ` The smallest included stack trace has a ${isDiffFlamegraph ? 'baseline ' : ''}total resource consumption of ${minimumValue}.`}
       </span>
       <div className={styles.actions}>
         <IconButton


### PR DESCRIPTION
**What is this feature?**

When a profiling backend aggregates truncated stack traces into the `other` label, the flame graph Top table now removes that aggregate from the sortable symbol rows and presents it as a compact explanatory summary below the table.

The summary reports:

- The formatted total represented by `other`.
- The smallest total among the stack traces that remain in the table.
- The existing search/highlight and sandwich-view actions for the aggregate.

The summary consumes no table height when an `other` aggregate is absent.

**Why do we need this feature?**

`other` is an aggregate created when the backend limits the number of returned stack traces. Displaying it alongside real symbols makes it look like an actionable function and can make it the most prominent row, even though it represents many omitted traces.

Moving it below the table makes the truncation explicit while preserving the actions requested in the issue. The flex layout reserves only the compact summary height and avoids the large empty-state/scroll behavior raised during review of an earlier approach.

**Who is this feature for?**

Grafana and Pyroscope users examining profiles that exceed the backend `maxNodes` limit, especially larger deployments and wider time ranges where `other` can dominate the Top table.

**Which issue(s) does this PR fix?**:

Fixes #110677

## Implementation

- Split the `other` aggregate from the memoized table data before constructing the table DataFrame.
- Keep the virtualized table in a flex child so it receives the remaining available height.
- Format the aggregate and minimum included values through the flame graph data display processor, preserving the configured unit.
- Render search/highlight and sandwich-view buttons with the same active-state semantics as ordinary symbol rows.
- Add component coverage proving that `other` is absent from table cells, the explanatory values render, and both actions dispatch the `other` label.

## Validation

- `yarn jest --no-watch packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx`
  - 10 tests passed.
- `yarn workspace @grafana/flamegraph typecheck`
  - Passed.
- `yarn eslint packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx`
  - Passed.
- `yarn prettier --write` for both changed files
  - Files were already formatted.
- `git diff --check`
  - Passed.

Commands used the Node 24.11.0 and Yarn 4.17.1 versions pinned by the repository.

## Risk assessment

Risk is low and limited to flame graph Top-table presentation. The underlying profile data, flame graph rendering, search query format, sandwich state, sorting logic, and backend requests are unchanged.

The additional summary is rendered only when the exact `other` label exists after the current search filter. Profiles without that aggregate retain the existing full-height table layout.

**Special notes for your reviewer:**

Please check that:
- [x] The automated test covers the user-visible row separation and both retained actions.
- [x] No feature toggle is needed; this corrects existing flame graph presentation.
- [x] No documentation update is needed; no API or user workflow changed.