### PR TITLE
Fix Gziper memory leak on panics

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -184,6 +184,10 @@ func Gziper() func(http.Handler) http.Handler {
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")
 
+			// Close is idempotent, so this only does anything when a panic unwinds
+			// past the close below, which would otherwise leak pgzip's goroutine.
+			defer func() { _ = grw.w.Close() }()
+
 			next.ServeHTTP(grw, req)
 
 			// A failed response write cannot be reported to the caller at this

--- a/pkg/middleware/gziper_test.go
+++ b/pkg/middleware/gziper_test.go
@@ -121,6 +121,24 @@ func TestGziperDoesNotLeakGoroutines(t *testing.T) {
 			serveGzipped(t, http.MethodGet, "/d/abc/dash", &brokenResponseWriter{failAfter: 1, short: true})
 		}
 	})
+
+	t.Run("handlers that panic", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		panicking := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			_, _ = rw.Write(gzipTestBody)
+			panic("rendering failed")
+		})
+		req, err := http.NewRequest(http.MethodGet, "/d/abc/dash", nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept-Encoding", "gzip")
+
+		for range requests {
+			require.Panics(t, func() {
+				Gziper()(panicking).ServeHTTP(web.NewResponseWriter(http.MethodGet, httptest.NewRecorder()), req)
+			})
+		}
+	})
 }
 
 func TestGzipSink(t *testing.T) {

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"embed"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"html/template"
 	"net/http"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
 
@@ -24,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web"
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
@@ -241,7 +240,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	writer.Header().Set("Cache-Control", "no-store")
 	writer.WriteHeader(200)
 	if err := p.index.Execute(writer, &data); err != nil {
-		if errors.Is(err, syscall.EPIPE) { // Client has stopped listening.
+		if web.IsClientDisconnect(err) { // Client has stopped listening.
 			return
 		}
 		panic(fmt.Sprintf("Error rendering index\n %s", err.Error()))

--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -101,12 +101,18 @@ const (
 	contentTypeHTML   = "text/html; charset=UTF-8"
 )
 
+// IsClientDisconnect reports whether err means the client stopped listening,
+// rather than a server-side failure worth panicking over.
+func IsClientDisconnect(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, http.ErrAbortHandler)
+}
+
 // HTML renders the HTML with default template set.
 func (ctx *Context) HTML(status int, name string, data any) {
 	ctx.Resp.Header().Set(headerContentType, contentTypeHTML)
 	ctx.Resp.WriteHeader(status)
 	if err := ctx.template.ExecuteTemplate(ctx.Resp, name, data); err != nil {
-		if errors.Is(err, syscall.EPIPE) { // Client has stopped listening.
+		if IsClientDisconnect(err) {
 			return
 		}
 		panic(fmt.Sprintf("Context.HTML - Error rendering template: %s. You may need to build frontend assets \n %s", name, err.Error()))


### PR DESCRIPTION
### What happened

A Grafana instance accumulated **1379 leaked goroutines out of 2124 total** over ~24h, all blocked in
`pgzip.(*Writer).Write.func1`, holding ~350MB of heap. CPU sat at ~1.9 cores, of which **93% was GC**
(`runtime.gcDrain`) rescanning the leaked buffers — not real work. A pod restart cleared both, and the
accumulation restarted.

### Root cause

`pkg/middleware/gziper.go`:

```go
grw := &gzipResponseWriter{gzip.NewWriter(rw), rw.(web.ResponseWriter)}
grw.Header().Set("Content-Encoding", "gzip")
grw.Header().Set("Vary", "Accept-Encoding")

next.ServeHTTP(grw, req)
_ = grw.w.Close()   // line 80 — NOT deferred
```

`gzip` here is `github.com/klauspost/pgzip`, which spawns one goroutine per compression block inside
`Write()`. Those goroutines only exit on `Close()`. Because line 80 is not deferred, **any panic in the
handler chain skips it**, and every block goroutine of that writer blocks forever on its channel, each
pinning its block buffer.

A panic on this path is not exotic — it is the normal outcome of a client disconnect. `pkg/web/context.go:108`:

```go
if err := ctx.template.ExecuteTemplate(ctx.Resp, name, data); err != nil {
    if errors.Is(err, syscall.EPIPE) { // Client has stopped listening.
        return
    }
    panic(fmt.Sprintf("Context.HTML - Error rendering template: %s ...", name))
}
```

Only `EPIPE` is treated as a disconnect. A client that resets the connection yields `ECONNRESET`, which
falls through to `panic()`. The recovery middleware sits *outside* `Gziper`, so the panic unwinds past
line 80, gets absorbed, and the request looks unremarkable in the logs — while the writer leaks.

### Evidence

`/debug/pprof/goroutine?debug=2` — all identical, ages up to 1480 minutes, parent goroutines already gone:

```
goroutine 178182 [chan receive, 958 minutes]:
github.com/klauspost/pgzip.(*Writer).Write.func1()
        github.com/klauspost/pgzip@v1.2.6/gzip.go:364 +0x54
created by github.com/klauspost/pgzip.(*Writer).Write in goroutine 177505
        github.com/klauspost/pgzip@v1.2.6/gzip.go:360 +0x205
```

`/debug/pprof/heap?debug=1` — the allocating stack names the path:

```
github.com/klauspost/pgzip.(*Writer).Write                    pgzip@v1.2.6/gzip.go:391
github.com/grafana/grafana/pkg/middleware.gzipResponseWriter.Write   pkg/middleware/gziper.go:30
github.com/grafana/grafana/pkg/web.(*responseWriter).Write    pkg/web/response_writer.go:100
text/template.(*state).walk                                   text/template/exec.go:287
html/template.(*Template).ExecuteTemplate                     html/template/template.go:139
github.com/grafana/grafana/pkg/web.(*Context).HTML            pkg/web/context.go:108
github.com/grafana/grafana/pkg/api.(*HTTPServer).LoginView    pkg/api/login.go:160
```

`/debug/pprof/profile?seconds=30`:

```
      flat  flat%   sum%        cum   cum%
     5.04s 18.98% 18.98%      9.64s 36.31%  runtime.scanObject
     0.64s  2.41% 66.44%     24.77s 93.30%  runtime.gcDrain
```

The affected routes were `/login` and 404s on a publicly reachable instance — i.e. scanner traffic that
opens a connection and drops it. Leak rate was ~10 writers/hour under that traffic.

### Suggested fix

```diff
-        next.ServeHTTP(grw, req)
-        _ = grw.w.Close()
+        defer func() { _ = grw.w.Close() }()
+        next.ServeHTTP(grw, req)
```

`pgzip.Writer.Close()` is idempotent-safe here since the writer is per-request and never closed elsewhere.

Optionally, also broaden the disconnect check in `pkg/web/context.go` so a client reset does not panic at all:

```go
if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, http.ErrAbortHandler) {
    return
}
```

The `defer` alone fixes the leak; this second change removes the spurious panics that trigger it.

### Environment

- Grafana **13.2.0** (`commit f681b1359f6a0b8ecb9f2c49a88ac72b75bde73b`)
- `github.com/klauspost/pgzip v1.2.6`
- Kubernetes, official image, `GOMAXPROCS` effectively 1 (CPU limit)

### Workaround

`enable_gzip = false` (`GF_SERVER_ENABLE_GZIP=false`) and let the reverse proxy compress. Confirmed to stop
the accumulation.

Fixes #131859 