### PR TITLE
unified-storage: use BatchGet to retrieve event values

### DIFF
--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -21,6 +21,7 @@ import (
 const (
 	eventsSection        = kv.EventsSection
 	deleteEventBatchSize = 50
+	listEventsBatchSize  = 50
 )
 
 // eventStore is a store for events.
@@ -223,31 +224,61 @@ func (n *eventStore) ListSince(ctx context.Context, sinceRV int64, sortOrder Sor
 	))
 	return func(yield func(Event, error) bool) {
 		defer span.End()
+
+		batch := make([]string, 0, listEventsBatchSize)
+		flush := func() bool {
+			cont, err := n.yieldEventsForKeys(ctx, batch, yield)
+			batch = batch[:0]
+			if err != nil {
+				yield(Event{}, err)
+				return false
+			}
+			return cont
+		}
+
 		for evtKey, err := range n.ListKeysSince(ctx, sinceRV, sortOrder) {
 			if err != nil {
 				yield(Event{}, err)
 				return
 			}
 
-			reader, err := n.kv.Get(ctx, eventsSection, evtKey)
-			if err != nil {
-				yield(Event{}, err)
-				return
-			}
-
-			var event Event
-			if err := json.NewDecoder(reader).Decode(&event); err != nil {
-				_ = reader.Close()
-				yield(Event{}, err)
-				return
-			}
-
-			_ = reader.Close()
-			if !yield(event, nil) {
+			batch = append(batch, evtKey)
+			if len(batch) == listEventsBatchSize && !flush() {
 				return
 			}
 		}
+
+		if len(batch) > 0 {
+			flush()
+		}
 	}
+}
+
+func (n *eventStore) yieldEventsForKeys(ctx context.Context, keys []string, yield func(Event, error) bool) (bool, error) {
+	if len(keys) == 0 {
+		return true, nil
+	}
+
+	events := make([]Event, 0, len(keys))
+	for pair, err := range n.kv.BatchGet(ctx, eventsSection, keys) {
+		if err != nil {
+			return false, err
+		}
+		var event Event
+		decErr := json.NewDecoder(pair.Value).Decode(&event)
+		_ = pair.Value.Close()
+		if decErr != nil {
+			return false, decErr
+		}
+		events = append(events, event)
+	}
+
+	for i := range events {
+		if !yield(events[i], nil) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // CleanupOldEvents deletes events older than the specified retention period.

--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -3,7 +3,11 @@ package resource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +17,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -468,6 +473,83 @@ func testEventStoreListSince(t *testing.T, ctx context.Context, store *eventStor
 	assert.Equal(t, int64(3000), retrievedEvents[1].ResourceVersion)
 	assert.Equal(t, "test-3", retrievedEvents[1].Name)
 	assert.Equal(t, DataActionDeleted, retrievedEvents[1].Action)
+}
+
+// countingEventsKV wraps a KV and counts the reads issued against the events
+// section so a test can prove how a long event backlog is resolved.
+type countingEventsKV struct {
+	KV
+	mu         sync.Mutex
+	getCalls   int
+	batchCalls int
+	batchKeys  int
+}
+
+func (k *countingEventsKV) Get(ctx context.Context, section, key string) (io.ReadCloser, error) {
+	if section == eventsSection {
+		k.mu.Lock()
+		k.getCalls++
+		k.mu.Unlock()
+	}
+	return k.KV.Get(ctx, section, key)
+}
+
+func (k *countingEventsKV) BatchGet(ctx context.Context, section string, keys []string) iter.Seq2[kv.KeyValue, error] {
+	if section == eventsSection {
+		k.mu.Lock()
+		k.batchCalls++
+		k.batchKeys += len(keys)
+		k.mu.Unlock()
+	}
+	return k.KV.BatchGet(ctx, section, keys)
+}
+
+func (k *countingEventsKV) stats() (getCalls, batchCalls, batchKeys int) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.getCalls, k.batchCalls, k.batchKeys
+}
+
+// TestIntegrationEventStore_ListSince_BatchesReads verifies that replaying a
+// long event backlog resolves the payloads with one BatchGet per chunk rather
+// than a Get per event — the per-event Get is one gRPC round trip each once the
+// KV backend is remote.
+func TestIntegrationEventStore_ListSince_BatchesReads(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	counting := &countingEventsKV{KV: setupBadgerKV(t)}
+	store := newEventStore(counting)
+	ctx := context.Background()
+
+	const numEvents = 2*listEventsBatchSize + 5 // spans more than two chunks
+	for i := range numEvents {
+		require.NoError(t, store.Save(ctx, Event{
+			Namespace:       "default",
+			Group:           "apps",
+			Resource:        "resource",
+			Name:            fmt.Sprintf("test-%03d", i),
+			ResourceVersion: int64(1000 + i),
+			Action:          DataActionCreated,
+		}))
+	}
+
+	getsBefore, batchesBefore, keysBefore := counting.stats()
+
+	got := 0
+	var lastRV int64
+	for event, err := range store.ListSince(ctx, 0, SortOrderAsc) {
+		require.NoError(t, err)
+		require.Greater(t, event.ResourceVersion, lastRV, "events must be yielded in ascending resource version order")
+		lastRV = event.ResourceVersion
+		got++
+	}
+	require.Equal(t, numEvents, got)
+
+	getsAfter, batchesAfter, keysAfter := counting.stats()
+	expectedBatches := (numEvents + listEventsBatchSize - 1) / listEventsBatchSize
+	assert.Zero(t, getsAfter-getsBefore, "ListSince must not issue a Get per event")
+	assert.Equal(t, expectedBatches, batchesAfter-batchesBefore, "payloads should be resolved with one BatchGet per chunk")
+	assert.Equal(t, numEvents, keysAfter-keysBefore, "every event should be read exactly once")
 }
 
 func TestIntegrationEventStore_ListSince_Empty(t *testing.T) {

--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -119,16 +119,22 @@ func (qb *queryBuilder) buildBatchGetQuery(keyPaths []string) (string, []interfa
 	argIdx := 1
 
 	for i, kp := range keyPaths {
+		idxPlaceholder := qb.dialect.Placeholder(argIdx)
+		if qb.dialect.Name() == "postgres" {
+			// PostgreSQL otherwise infers the untyped UNION column as text, which
+			// makes the requested indexes sort lexicographically.
+			idxPlaceholder = fmt.Sprintf("CAST(%s AS BIGINT)", idxPlaceholder)
+		}
 		if i == 0 {
 			unionParts = append(unionParts, fmt.Sprintf(
 				"SELECT %s AS idx, %s AS key_path",
-				qb.dialect.Placeholder(argIdx),
+				idxPlaceholder,
 				qb.dialect.Placeholder(argIdx+1),
 			))
 		} else {
 			unionParts = append(unionParts, fmt.Sprintf(
 				"UNION ALL SELECT %s, %s",
-				qb.dialect.Placeholder(argIdx),
+				idxPlaceholder,
 				qb.dialect.Placeholder(argIdx+1),
 			))
 		}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1964,34 +1964,48 @@ func (k *kvStorageBackend) listModifiedSinceDataStore(ctx context.Context, key N
 
 func (k *kvStorageBackend) listModifiedSinceEventStore(ctx context.Context, key NamespacedResource, sinceRv int64) iter.Seq2[*ModifiedResource, error] {
 	return func(yield func(*ModifiedResource, error) bool) {
-		// we only care about the latest revision of every resource in the list
 		seen := make(map[string]struct{})
-		for evtKeyStr, err := range k.eventStore.ListKeysSince(ctx, sinceRv, SortOrderDesc) {
+		dataKeys := func(yield func(DataKey, error) bool) {
+			for evtKeyStr, err := range k.eventStore.ListKeysSince(ctx, sinceRv, SortOrderDesc) {
+				if err != nil {
+					yield(DataKey{}, err)
+					return
+				}
+
+				evtKey, err := ParseEventKey(evtKeyStr)
+				if err != nil {
+					yield(DataKey{}, err)
+					return
+				}
+
+				if evtKey.Group != key.Group || evtKey.Resource != key.Resource {
+					continue
+				}
+				// Empty key.Namespace = cross-namespace scan; otherwise filter to one namespace.
+				if key.Namespace != "" && evtKey.Namespace != key.Namespace {
+					continue
+				}
+
+				// we only care about the latest revision of every resource in the list
+				dedupKey := evtKey.Namespace + "/" + evtKey.Name
+				if _, ok := seen[dedupKey]; ok {
+					continue
+				}
+				seen[dedupKey] = struct{}{}
+
+				if !yield(DataKey(evtKey), nil) {
+					return
+				}
+			}
+		}
+
+		for obj, err := range batchGetResourceKeys(ctx, k.dataStore, dataKeys) {
 			if err != nil {
 				yield(&ModifiedResource{}, err)
 				return
 			}
 
-			evtKey, err := ParseEventKey(evtKeyStr)
-			if err != nil {
-				yield(&ModifiedResource{}, err)
-				return
-			}
-
-			if evtKey.Group != key.Group || evtKey.Resource != key.Resource {
-				continue
-			}
-			// Empty key.Namespace = cross-namespace scan; otherwise filter to one namespace.
-			if key.Namespace != "" && evtKey.Namespace != key.Namespace {
-				continue
-			}
-
-			dedupKey := evtKey.Namespace + "/" + evtKey.Name
-			if _, ok := seen[dedupKey]; ok {
-				continue
-			}
-			seen[dedupKey] = struct{}{}
-			value, err := k.getValueFromDataStore(ctx, DataKey(evtKey))
+			value, err := readAndClose(obj.Value)
 			if err != nil {
 				yield(&ModifiedResource{}, err)
 				return
@@ -1999,13 +2013,13 @@ func (k *kvStorageBackend) listModifiedSinceEventStore(ctx context.Context, key 
 
 			if !yield(&ModifiedResource{
 				Key: resourcepb.ResourceKey{
-					Group:     evtKey.Group,
-					Resource:  evtKey.Resource,
-					Namespace: evtKey.Namespace,
-					Name:      evtKey.Name,
+					Group:     obj.Key.Group,
+					Resource:  obj.Key.Resource,
+					Namespace: obj.Key.Namespace,
+					Name:      obj.Key.Name,
 				},
-				Action:          convertEventType(evtKey.Action),
-				ResourceVersion: evtKey.ResourceVersion,
+				Action:          convertEventType(obj.Key.Action),
+				ResourceVersion: obj.Key.ResourceVersion,
 				Value:           value,
 			}, nil) {
 				return

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -740,6 +740,72 @@ func TestKvStorageBackend_WatchWriteEvents_BatchesValueReads(t *testing.T) {
 	assert.Equal(t, numEvents, keysAfter-keysBefore, "every event should be read exactly once")
 }
 
+// TestKvStorageBackend_ListModifiedSince_BatchesValueReads verifies that the
+// event-store branch of ListModifiedSince resolves resource values with one
+// data-section read per chunk rather than one per resource.
+func TestKvStorageBackend_ListModifiedSince_BatchesValueReads(t *testing.T) {
+	const numResources = 2 * dataBatchSize // spans more than one chunk
+
+	kvStore := &countingKV{KV: setupBadgerKV(t)}
+	backend := setupTestStorageBackend(t, withKV(kvStore), func(opts *KVBackendOptions) {
+		opts.SearchLookback = time.Second
+	})
+	ctx := context.Background()
+
+	// Record a recent resource version to list since, so ListModifiedSince takes
+	// the (recent) event-store branch rather than the data-store scan.
+	sinceRV := snowflakeFromTime(time.Now())
+
+	writtenNames := make(map[string]struct{}, numResources)
+	for i := range numResources {
+		name := fmt.Sprintf("modified-%03d", i)
+		writtenNames[name] = struct{}{}
+		obj, err := createTestObjectWithName(name, appsNamespace, fmt.Sprintf("value-%d", i))
+		require.NoError(t, err)
+		metaAccessor, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
+
+		_, err = backend.WriteEvent(ctx, WriteEvent{
+			Type: resourcepb.WatchEvent_ADDED,
+			Key: &resourcepb.ResourceKey{
+				Namespace: appsNamespace.Namespace,
+				Group:     appsNamespace.Group,
+				Resource:  appsNamespace.Resource,
+				Name:      name,
+			},
+			Value:      objectToJSONBytes(t, obj),
+			Object:     metaAccessor,
+			ObjectOld:  metaAccessor,
+			PreviousRV: 0,
+		})
+		require.NoError(t, err)
+	}
+
+	tripsBefore, keysBefore := kvStore.stats()
+
+	_, seq := backend.ListModifiedSince(ctx, appsNamespace, sinceRV, nil)
+	got := 0
+	var lastRV int64
+	for mr, err := range seq {
+		require.NoError(t, err)
+		_, ok := writtenNames[mr.Key.Name]
+		require.True(t, ok, "ListModifiedSince yielded unexpected resource: %s", mr.Key.String())
+		require.NotEmpty(t, mr.Value, "resolved resource must carry its value")
+		if lastRV != 0 {
+			require.Less(t, mr.ResourceVersion, lastRV, "event-store branch yields in descending resource version order")
+		}
+		lastRV = mr.ResourceVersion
+		got++
+	}
+	require.Equal(t, numResources, got, "every modified resource should be returned exactly once")
+
+	// The data store chunks at dataBatchSize, so the scan costs one read per
+	// chunk. Resolving one resource at a time would cost numResources reads.
+	tripsAfter, keysAfter := kvStore.stats()
+	assert.Equal(t, numResources/dataBatchSize, tripsAfter-tripsBefore, "values should be resolved with one read per chunk")
+	assert.Equal(t, numResources, keysAfter-keysBefore, "every resource value should be read exactly once")
+}
+
 // failingBatchGetKV wraps a KV and fails every batched read of the data section,
 // standing in for a storage outage.
 type failingBatchGetKV struct {


### PR DESCRIPTION
small optimization but nice to have regardless. improve latency when replaying events from the event store (from watch calls) and marginally improves search latency as well when the index needs to update many documents at once.

It also includes a bugfix for `BatchGet` on Postgres, which caused it to return values in the wrong order when calling it with more than 10 items.