### PR TITLE
OpenFeature: Remove stale signed-in gate on frontend init

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -160,14 +160,10 @@ export class GrafanaApp {
       initSystemJSHooks();
       initializeLoggersRegistry();
 
-      // Currently the OpenFeature API requires a signed in user. This means feature flags cannot be used
-      // on the login page.
-      if (contextSrv.user.isSignedIn) {
-        try {
-          await initOpenFeature();
-        } catch (err) {
-          console.error('Failed to initialize OpenFeature provider', err);
-        }
+      try {
+        await initOpenFeature();
+      } catch (err) {
+        console.error('Failed to initialize OpenFeature provider', err);
       }
 
       const initI18nPromise = initializeI18n({


### PR DESCRIPTION
Frontend only called `initOpenFeature()` for signed-in users skipping it on pages like login. Signed-in condition was added in #110587 when OFREP required auth. 
Now, since anonymous access for public flags is added, this gate is not needed anymore.