### PR TITLE
ValueFormats: Fix toFixed() decimals overflow and out-of-range RangeError

### DIFF
--- a/packages/grafana-data/src/valueFormats/baseFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/baseFormatters.ts
@@ -20,22 +20,27 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
     decimals = getDecimalsForValue(value);
   }
 
+  // Number.prototype.toFixed only accepts 0-100, and values above 20 make the
+  // zero-padding below unreliable (Math.pow(10, decimals) switches to
+  // exponential notation), so clamp to a range both can handle safely.
+  decimals = clamp(decimals, 0, 100);
+
   if (value === 0) {
     return value.toFixed(decimals);
   }
 
-  const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
+  const factor = decimals ? Math.pow(10, decimals) : 1;
   const formatted = String(Math.round(value * factor) / factor);
 
   // if exponent return directly
-  if (formatted.indexOf('e') !== -1 || value === 0) {
+  if (formatted.indexOf('e') !== -1) {
     return formatted;
   }
 
   const decimalPos = formatted.indexOf('.');
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
-    return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);
+    return (precision ? formatted : formatted + '.') + '0'.repeat(decimals - precision);
   }
 
   return formatted;

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -151,6 +151,23 @@ describe('valueFormats', () => {
       const str = toFixed(186.123, -2);
       expect(str).toBe('186');
     });
+
+    it('should treat as zero decimals when value is 0', () => {
+      expect(toFixed(0, -2)).toBe('0');
+    });
+  });
+
+  describe('toFixed with out-of-range decimals', () => {
+    it('should pad with zeros instead of leaking the scaling factor exponent above 20 decimals', () => {
+      expect(toFixed(1.5, 21)).toBe('1.500000000000000000000');
+      expect(toFixed(5, 21)).toBe('5.000000000000000000000');
+    });
+
+    it('should clamp decimals above 100 instead of throwing', () => {
+      expect(() => toFixed(0, 101)).not.toThrow();
+      expect(toFixed(0, 101)).toBe(toFixed(0, 100));
+      expect(() => toFixed(1.5, 150)).not.toThrow();
+    });
   });
 
   describe('Resolve old units', () => {


### PR DESCRIPTION
## What this does

Fixes two bugs in `toFixed()` in `packages/grafana-data/src/valueFormats/baseFormatters.ts`, both reported in #131843:

1. **Decimals above 20 leak the scaling factor's exponent into the output.** The zero-padding was built by slicing `String(10 ** decimals)`. That works while the factor prints in full, but `10 ** 21` stringifies as `"1e+21"` in JS, so `toFixed(1.5, 21)` returned `"1.5e+21"` — a wrong number, not just a formatting blemish.
2. **Decimals above 100 (or negative, via a path other than the documented "treat as zero" one) throw a `RangeError`.** The `value === 0` short-circuit called the native `Number.prototype.toFixed` directly with an unvalidated `decimals`, which only accepts 0-100. A series containing a single `0` with `decimals: 101` configured would blank the whole panel.

Neither is reachable through the Decimals option in the UI (`min: 0, max: 15` in `registry.tsx`), but both are reachable via anything that writes `field.config.decimals` directly: dashboard JSON, provisioned dashboards, the HTTP API, and plugins calling the exported `toFixed`.

## The fix

- Clamp `decimals` to the `[0, 100]` range that `Number.prototype.toFixed` can safely accept, before it's used anywhere in the function.
- Build the zero-padding with `'0'.repeat(n)` instead of slicing the scaling factor's string form, so it no longer depends on the factor printing in non-exponential notation.

## Tests

Added regression tests in `valueFormats.test.ts` covering:
- `toFixed(1.5, 21)` / `toFixed(5, 21)` no longer leak `e+21` into the output and pad with zeros correctly.
- `toFixed(0, 101)` / `toFixed(1.5, 150)` no longer throw, and clamp to the same result as `decimals: 100`.
- `toFixed(0, -2)` continues to behave like zero decimals (matching the existing negative-decimals test for non-zero values).

Ran the full `valueFormats.test.ts` suite (70 tests, all passing), plus `@grafana/data` typecheck and ESLint on the changed files.

Fixes #131843