### PR TITLE
Unified storage enable sqlkv integration tests

### DIFF
--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -119,16 +119,22 @@ func (qb *queryBuilder) buildBatchGetQuery(keyPaths []string) (string, []interfa
 	argIdx := 1
 
 	for i, kp := range keyPaths {
+		idxPlaceholder := qb.dialect.Placeholder(argIdx)
+		if qb.dialect.Name() == "postgres" {
+			// PostgreSQL otherwise infers the untyped UNION column as text, which
+			// makes the requested indexes sort lexicographically.
+			idxPlaceholder = fmt.Sprintf("CAST(%s AS BIGINT)", idxPlaceholder)
+		}
 		if i == 0 {
 			unionParts = append(unionParts, fmt.Sprintf(
 				"SELECT %s AS idx, %s AS key_path",
-				qb.dialect.Placeholder(argIdx),
+				idxPlaceholder,
 				qb.dialect.Placeholder(argIdx+1),
 			))
 		} else {
 			unionParts = append(unionParts, fmt.Sprintf(
 				"UNION ALL SELECT %s, %s",
-				qb.dialect.Placeholder(argIdx),
+				idxPlaceholder,
 				qb.dialect.Placeholder(argIdx+1),
 			))
 		}

--- a/pkg/storage/unified/resource/kv/test/kv.go
+++ b/pkg/storage/unified/resource/kv/test/kv.go
@@ -227,10 +227,10 @@ func runTestKVSave(t *testing.T, kv kvpkg.KV, nsPrefix string) {
 		binaryKey := namespacedKey(nsPrefix, "binary-key")
 
 		binaryData := []byte{0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD}
-		saveKVHelper(t, kv, ctx, testSection, binaryKey, bytes.NewReader(binaryData))
+		saveKVHelper(t, kv, ctx, kvpkg.SearchSnapshotDataSection, binaryKey, bytes.NewReader(binaryData))
 
 		// Verify binary data
-		reader, err := kv.Get(ctx, testSection, binaryKey)
+		reader, err := kv.Get(ctx, kvpkg.SearchSnapshotDataSection, binaryKey)
 		require.NoError(t, err)
 
 		value, err := io.ReadAll(reader)

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
-func TestSQLKV(t *testing.T) {
+func TestIntegrationSQLKV(t *testing.T) {
 	dbstore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
 	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
enables sqlkv integration tests so it runs against postgres/sqlite/mysql in CI. caught a couple of edge cases with this.