### PR TITLE
Docs: Fix dead file references in pkg/router and alerting AGENTS.md

### DIFF
--- a/pkg/router/AGENTS.md
+++ b/pkg/router/AGENTS.md
@@ -306,7 +306,7 @@ Wiring follows the standalone-apiserver factory pattern:
   (addr/TLS/timeouts) is a factory concern, not part of `pkg/router`.
 - **binding** — `server.InitializeRouterFactory()` (wire) returns the no-op in OSS
   (`wire_gen.go`) and the enterprise factory in enterprise/pro (`enterprise_wire_gen.go`);
-  `cmd/grafana/main.go` appends the command when non-nil. Keep the wire source
+  `pkg/cmd/grafana/main.go` appends the command when non-nil. Keep the wire source
   (`wire.go` + `wireexts_{oss,enterprise}.go`, set `wireExtsRouterFactorySet`) in sync with the
   generated files so `make gen-go` reproduces them.
 

--- a/public/app/features/alerting/unified/AGENTS.md
+++ b/public/app/features/alerting/unified/AGENTS.md
@@ -253,7 +253,7 @@ For Kubernetes APIs and new schemas – use the `@grafana/alerting` package.
 Mock factories are defined in `packages/grafana-alerting/src/grafana/api/notifications/v1beta1/mocks/fakes`
 MSW handlers in `packages/grafana-alerting/src/grafana/api/notifications/v1beta1/mocks/handlers`
 
-And there are "scenarios" that combine the two above. An example of such is `packages/grafana-alerting/src/grafana/contactPoints/components/ContactPointSelector/ContactPointSelector.test.scenario.ts` and is used for integration tests.
+And there are "scenarios" that combine the two above. An example of such is `packages/grafana-alerting/src/grafana/contactPoints/components/ContactPointSelector/ContactPointSelector.scenario.ts` and is used for integration tests.
 
 Additionally alerting uses **`alertingFactory`** from `mocks/server/db` for building test data:
 


### PR DESCRIPTION
**What is this feature?**

Two one-line corrections to dead file references in agent-facing `AGENTS.md` files.

1. `pkg/router/AGENTS.md` (line 309) cited `cmd/grafana/main.go` as the file that appends the router command. There is no `cmd/` directory at the repo root. The file that actually does this is `pkg/cmd/grafana/main.go`, whose `main()` calls `server.InitializeRouterFactory()` and then `app.Commands = append(app.Commands, cmd)` guarded by `if cmd != nil` — exactly what the sentence describes. Corrected to `pkg/cmd/grafana/main.go`.

2. `public/app/features/alerting/unified/AGENTS.md` (line 256) cited `.../ContactPointSelector/ContactPointSelector.test.scenario.ts`. That file was renamed when #119945 ("Alerting: Rename .test.scenario. files to .scenario.") merged; it now exists as `ContactPointSelector.scenario.ts`. Corrected to match.

**Why do we need this feature?**

`AGENTS.md` files are the context files AI coding agents load in this repo. A path that does not resolve either wastes agent turns on a fruitless search or invites the agent to invent a file that does not exist. Both of these files are actively maintained, so the stale references are likely to be read.

**Who is this feature for?**

Anyone — human or agent — reading these `AGENTS.md` files to orient themselves in `pkg/router` or the alerting codebase.

**Which issue(s) does this PR fix?**:

Fixes #131850

**Special notes for your reviewer:**

Documentation text only. No code, config, or test changes; the diff is two lines across two files.

Verified against `main` at 2d289f6:

- `pkg/cmd/grafana/main.go` is tracked; `git ls-files 'cmd/*'` returns nothing, confirming no root-level `cmd/` directory.
- `packages/grafana-alerting/src/grafana/contactPoints/components/ContactPointSelector/ContactPointSelector.scenario.ts` is tracked. Repo-wide there are zero files matching `test.scenario` and four matching `*.scenario.ts`.
- Grepped `*.md`, `*.go`, `*.ts` and `*.tsx` for other occurrences of either stale reference — these two were the only ones, so no further instances are left behind.

Please check that:
- [x] It works as expected from a user's perspective. Both corrected paths resolve in the tree; the prose around them is unchanged.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. N/A — documentation fix.
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. This PR *is* the docs update; not notable for What's New.
