### PR TITLE
Dashboards: Keep the tabs layout bar visible while scrolling

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { SceneTimeRange } from '@grafana/scenes';
+
+import { DashboardScene } from '../DashboardScene';
+import { RowItem } from '../layout-rows/RowItem';
+import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
+
+import { TabItem } from './TabItem';
+import { TabsLayoutManager } from './TabsLayoutManager';
+
+function renderTabs(layout: TabsLayoutManager) {
+  const scene = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    body: layout,
+  });
+  render(<scene.Component model={scene} />);
+}
+
+describe('TabsLayoutManagerRenderer', () => {
+  it('sticks the top-level tab bar to the top of its scroll container', () => {
+    renderTabs(new TabsLayoutManager({ tabs: [new TabItem({ title: 'Tab 1' })] }));
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist.parentElement).toHaveStyle({ position: 'sticky', top: '0px' });
+  });
+
+  it('does not stick a tab bar nested inside another tab, to avoid overlapping the parent bar', () => {
+    const nestedTabs = new TabsLayoutManager({ tabs: [new TabItem({ title: 'Nested tab' })] });
+    const outerTabs = new TabsLayoutManager({
+      tabs: [new TabItem({ title: 'Outer tab', layout: nestedTabs })],
+    });
+    renderTabs(outerTabs);
+
+    const tablists = screen.getAllByRole('tablist');
+    expect(tablists).toHaveLength(2);
+    // The outer bar (first in DOM order) should stick; the nested one must not, or it would
+    // render at the same sticky offset and overlap the outer bar.
+    expect(tablists[0].parentElement).toHaveStyle({ position: 'sticky' });
+    expect(tablists[1].parentElement).not.toHaveStyle({ position: 'sticky' });
+  });
+
+  it('does not stick a tab bar nested inside a row inside another tab, to avoid overlapping the ancestor bar', () => {
+    // Tab-in-tab is forbidden by the product, but tabs nested inside a row inside another tabs
+    // layout is the supported way to nest tabs - the inner tab bar's immediate parent is a
+    // RowItem, not a TabItem, so it needs its own check to avoid also sticking.
+    const nestedTabs = new TabsLayoutManager({ tabs: [new TabItem({ title: 'Nested tab' })] });
+    const row = new RowItem({ title: 'Row', layout: nestedTabs });
+    const outerTabs = new TabsLayoutManager({
+      tabs: [new TabItem({ title: 'Outer tab', layout: new RowsLayoutManager({ rows: [row] }) })],
+    });
+    renderTabs(outerTabs);
+
+    const tablists = screen.getAllByRole('tablist');
+    expect(tablists).toHaveLength(2);
+    expect(tablists[0].parentElement).toHaveStyle({ position: 'sticky' });
+    expect(tablists[1].parentElement).not.toHaveStyle({ position: 'sticky' });
+  });
+
+  it('does not stick a tab bar nested inside a row of the dashboard\'s root Rows layout', () => {
+    // Dashboard > Rows > Row > Tabs: the root layout here is Rows, not Tabs, so there is no
+    // ancestor tabs bar to overlap - but the nested tab bar still isn't the dashboard's root
+    // layout, so it shouldn't stick either. Otherwise it would stay pinned to the top of the
+    // viewport even after scrolling well past the row it belongs to.
+    const nestedTabs = new TabsLayoutManager({ tabs: [new TabItem({ title: 'Nested tab' })] });
+    const row = new RowItem({ title: 'Row', layout: nestedTabs });
+    const rootRows = new RowsLayoutManager({ rows: [row] });
+
+    const scene = new DashboardScene({
+      $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+      body: rootRows,
+    });
+    render(<scene.Component model={scene} />);
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist.parentElement).not.toHaveStyle({ position: 'sticky' });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
+import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { MultiValueVariable, type SceneComponentProps, sceneGraph, useSceneObjectState } from '@grafana/scenes';
 import { Button, IconButton, TabsBar, useStyles2 } from '@grafana/ui';
 
@@ -22,7 +23,8 @@ import { TabItemRepeater } from './TabItemRepeater';
 import { type TabsLayoutManager } from './TabsLayoutManager';
 
 export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLayoutManager>) {
-  const styles = useStyles2(getStyles);
+  const visualRefreshEnabled = useFlagGrafanaVisualDesignRefresh();
+  const styles = useStyles2(getStyles, visualRefreshEnabled);
   const layoutControlsStyles = useStyles2(getLayoutControlsStyles);
 
   const { tabs, key, placeholder, isDropTarget } = model.useState();
@@ -32,6 +34,11 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
   const { isEditing } = dashboard.useState();
   const { hasCopiedTab } = useClipboardState();
   const isNestedInTab = useMemo(() => model.parent instanceof TabItem, [model.parent]);
+  // Only the dashboard's root layout gets the sticky tab bar. Any nested tabs layout - whether
+  // directly in a tab (forbidden by the product anyway) or reached through one or more rows, e.g.
+  // Dashboard > Rows > Row > Tabs - would stick at the same `top: 0` and either overlap an
+  // ancestor tab bar or stay pinned to the top of the viewport well past the row it belongs to.
+  const isTopLevelLayout = model.parent === dashboard;
   const soloPanelContext = useSoloPanelContext();
   const isMultiSelection = useIsMultiSelection();
 
@@ -98,7 +105,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
 
   return (
     <div className={cx(styles.tabLayoutContainer, { [styles.nestedTabsMargin]: isNestedInTab })}>
-      <TabsBar className={styles.tabsBar}>
+      <TabsBar className={cx(styles.tabsBar, { [styles.tabsBarSticky]: isTopLevelLayout })}>
         <DragDropContext onBeforeDragStart={onBeforeDragStart} onDragEnd={onDragEnd}>
           <div className={styles.tabsRow} {...{ [DASHBOARD_DROP_TARGET_KEY_ATTR]: key }}>
             <div className={styles.tabsScrollArea}>
@@ -217,7 +224,7 @@ function TabWrapper({ tab, manager }: { tab: TabItem; manager: TabsLayoutManager
   return <tab.Component model={tab} key={tab.state.key!} />;
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, visualRefreshEnabled: boolean) => {
   // Single source of truth for the fade inset. Used in both scroll-padding
   // (read back by scrollTabIntoView via getComputedStyle) and mask-image.
   const fadeInset = theme.spacing(6);
@@ -230,6 +237,22 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     tabsBar: css({
       ...dashboardCanvasAddButtonHoverStyles,
+    }),
+    // Keeps the tab strip reachable while a tall tab's panels scroll past it (WCAG 3.2.3
+    // Consistent Navigation), matching the dashboard controls bar's sticky behavior in
+    // DashboardControlsChrome. `top: 0` sticks it to the top of the dashboard's own scroll
+    // container (see scrollContainer in DashboardSidebarSplitter) rather than the viewport,
+    // since that's the nearest scrolling ancestor. Only applied to the dashboard's root layout
+    // (see isTopLevelLayout) — a nested tabs layout would stick at the same offset, overlapping
+    // an ancestor tab bar or staying pinned well past the row/tab it actually belongs to.
+    tabsBarSticky: css({
+      position: 'sticky',
+      top: 0,
+      // Panel chrome (e.g. hover controls) commonly sits at zIndex 1 within the canvas, so match
+      // DashboardControlsChrome's baseline zIndex to make sure this paints above panel content
+      // scrolling underneath it, not just the DOM order it happens to have.
+      zIndex: 2,
+      background: visualRefreshEnabled ? theme.colors.background.page : theme.colors.background.canvas,
     }),
     tabsRow: css({
       display: 'flex',


### PR DESCRIPTION
**What is this feature?**

Makes the top-level tab bar in the dashboard Tabs layout stick to the top of the scroll area while scrolling, instead of scrolling out of view with the panel content.

**Why do we need this feature?**

On a tall tab (enough panels to require scrolling), the tab bar disappears as soon as you scroll down, forcing you to scroll back to the top to switch tabs. This is inconsistent with the variable/filter controls bar right above it, which already stays fixed while scrolling.

Root cause: `DashboardControlsChrome` (the controls bar) renders as a sibling of the dashboard's scrollable canvas, so it's never inside the scrolling box at all. The tabs bar, on the other hand, renders inside `body`, which *is* placed inside that scroll container alongside the panels — so it scrolls with them.

Fix: add `position: sticky; top: 0` to the top-level tab bar, mirroring `DashboardControlsChrome`'s existing pattern. `zIndex` is bumped to `2` (matching `DashboardControlsChrome`'s baseline) because panel chrome commonly sits at `zIndex: 1` within the canvas — without this the tab bar sticks at the correct position but renders underneath scrolling panel content. Only the outermost tab bar sticks; a tab nested inside another tab is left non-sticky, since it would stick at the same offset and overlap its parent's bar (out of scope for this fix).

Relevant WCAG criteria (from the linked issue): 3.2.3 Consistent Navigation, 2.1.1 Keyboard, 2.4.3 Focus Order.

**Who is this feature for?**

Anyone viewing or editing a dashboard that uses the Tabs layout with enough panels in a tab to require scrolling.

**Which issue(s) does this PR fix?**:

Fixes #124567

**Special notes for your reviewer:**

- Verified with new unit tests (`TabsLayoutManagerRenderer.test.tsx`): the outer tab bar gets `position: sticky`, a tab bar nested inside another tab does not.
- Also verified manually in a real browser (Playwright + Chromium against a local dev build): confirmed via `document.elementFromPoint()` hit-testing and screenshots that the tab bar stays visible and interactive after scrolling, both before and after the zIndex fix (initially the bar stuck at the correct position but was painted underneath panel content — that's what the zIndex bump addresses).
- CSS-only change, no new user-facing strings, no `__inputs`/API changes.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A — `dashboardNewLayouts` is already GA)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (N/A — small a11y/UX bug fix, not a new feature)
