### PR TITLE
FeaturesService: Bypass checking for overrides for flags that don't have any

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3179,6 +3179,15 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+			Name:         "features.legacyOverrideLookupBypass",
+			Description:  "Skips checking for flag overrides.",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaBackendServicesSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{Go: true},
+		},
+		{
 			Name:         "grafana.multiTenantNavTree",
 			Description:  "Builds the navigation tree client-side instead of reading it from /bootdata",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -369,6 +369,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-08-06,grafana.ofrepRootUrl,experimental,@grafana/grafana-backend-services-squad,false,false,false
 2026-08-05,assistant.dashboardPlanning,experimental,@grafana/dashboards-squad,false,false,true
 2026-07-17,features.bulkFlagEvalFiltering,experimental,@grafana/grafana-backend-services-squad,false,false,false
+2026-09-01,features.legacyOverrideLookupBypass,experimental,@grafana/grafana-backend-services-squad,false,false,false
 2026-07-14,grafana.multiTenantNavTree,experimental,@grafana/grafana-frontend-navigation,false,false,false
 2026-07-20,grafana.exploreMetricsSidebar,experimental,@grafana/datapro,false,false,true
 2026-07-22,grafana.dynamicTraceToLogs,preview,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -986,6 +986,10 @@ const (
 	// Filters bulk OFREP flag evaluations to public-metadata flags only
 	FlagFeaturesBulkFlagEvalFiltering = "features.bulkFlagEvalFiltering"
 
+	// FlagFeaturesLegacyOverrideLookupBypass
+	// Skips checking for flag overrides.
+	FlagFeaturesLegacyOverrideLookupBypass = "features.legacyOverrideLookupBypass"
+
 	// FlagGrafanaMultiTenantNavTree
 	// Builds the navigation tree client-side instead of reading it from /bootdata
 	FlagGrafanaMultiTenantNavTree = "grafana.multiTenantNavTree"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2708,6 +2708,23 @@
     },
     {
       "metadata": {
+        "name": "features.legacyOverrideLookupBypass",
+        "resourceVersion": "1788267408703",
+        "creationTimestamp": "2026-09-01T11:10:41Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-09-01 12:56:48.703621 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Skips checking for flag overrides.",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-services-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "feedbackButton",
         "resourceVersion": "1779440584464",
         "creationTimestamp": "2024-12-02T17:08:15Z",

--- a/pkg/services/ofrep/proxy.go
+++ b/pkg/services/ofrep/proxy.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/features"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 	goffmodel "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
@@ -25,7 +27,12 @@ func (b *APIBuilder) proxyAllFlagReq(ctx context.Context, isAuthedUser bool, nam
 	r = r.WithContext(ctx)
 	logger := b.logger.FromContext(ctx)
 
-	proxy, err := b.newProxy(ofrepPath, namespace, r.Header.Get("User-Agent"))
+	target := b.upstreamForBulk(ctx, namespace, logger)
+	if target != nil {
+		logger.Debug("selected upstream for bulk eval", "namespace", namespace, "target", target.Host)
+	}
+
+	proxy, err := b.newProxy(ofrepPath, namespace, target, r.Header.Get("User-Agent"))
 	if err != nil {
 		err = tracing.Error(span, err)
 		logger.Error("Failed to create proxy", "error", err)
@@ -78,7 +85,12 @@ func (b *APIBuilder) proxyFlagReq(ctx context.Context, flagKey string, isAuthedU
 	r = r.WithContext(ctx)
 	logger := b.logger.FromContext(ctx)
 
-	proxy, err := b.newProxy(path.Join(ofrepPath, flagKey), namespace, r.Header.Get("User-Agent"))
+	target := b.upstreamForFlag(ctx, flagKey, namespace, logger)
+	if target != nil {
+		logger.Debug("selected upstream for flag eval", "key", flagKey, "namespace", namespace, "target", target.Host)
+	}
+
+	proxy, err := b.newProxy(path.Join(ofrepPath, flagKey), namespace, target, r.Header.Get("User-Agent"))
 	if err != nil {
 		err = tracing.Error(span, err)
 		logger.Error("Failed to create proxy", "key", flagKey, "error", err)
@@ -131,18 +143,36 @@ func (b *APIBuilder) proxyFlagReq(ctx context.Context, flagKey string, isAuthedU
 	proxy.ServeHTTP(w, r)
 }
 
-func (b *APIBuilder) newProxy(proxyPath, namespace, incomingUserAgent string) (*httputil.ReverseProxy, error) {
+func isUnknownNamespace(namespace string) bool {
+	return namespace == "" || namespace == "*"
+}
+
+func (b *APIBuilder) upstreamForFlag(ctx context.Context, flagKey, namespace string, logger log.Logger) *url.URL {
+	if b.bypassEnabled(ctx, logger) && (isUnknownNamespace(namespace) || !b.hgOverrideFlags[flagKey]) {
+		return b.goffURL
+	}
+	return b.url
+}
+
+func (b *APIBuilder) upstreamForBulk(ctx context.Context, namespace string, logger log.Logger) *url.URL {
+	if b.bypassEnabled(ctx, logger) && isUnknownNamespace(namespace) {
+		return b.goffURL
+	}
+	return b.url
+}
+
+func (b *APIBuilder) newProxy(proxyPath, namespace string, targetURL *url.URL, incomingUserAgent string) (*httputil.ReverseProxy, error) {
 	if proxyPath == "" {
 		return nil, fmt.Errorf("proxy path is required")
 	}
 
-	if b.url == nil {
+	if targetURL == nil {
 		return nil, fmt.Errorf("OpenFeatureService provider URL is not set")
 	}
 
 	director := func(req *http.Request) {
-		req.URL.Scheme = b.url.Scheme
-		req.URL.Host = b.url.Host
+		req.URL.Scheme = targetURL.Scheme
+		req.URL.Host = targetURL.Host
 		req.URL.Path = proxyPath
 		req.Header.Set("User-Agent", withStackTag(incomingUserAgent, namespace))
 	}

--- a/pkg/services/ofrep/publicflags.go
+++ b/pkg/services/ofrep/publicflags.go
@@ -61,3 +61,31 @@ func bulkFlagEvalFilteringEnabled(ctx context.Context, logger log.Logger) bool {
 
 	return details.Value
 }
+
+func (b *APIBuilder) bypassEnabled(ctx context.Context, logger log.Logger) bool {
+	if b.goffURL == nil {
+		return false
+	}
+
+	evalCtx := openfeature.TransactionContext(ctx)
+
+	details, err := openfeature.NewDefaultClient().BooleanValueDetails(
+		ctx,
+		featuremgmt.FlagFeaturesLegacyOverrideLookupBypass,
+		false,
+		evalCtx,
+	)
+
+	logger.Debug("legacyOverrideLookupBypass evaluation result",
+		"value", details.Value,
+		"variant", details.Variant,
+		"reason", details.Reason,
+		"errorCode", details.ErrorCode,
+		"errorMessage", details.ErrorMessage,
+		"targetingKey", evalCtx.TargetingKey(),
+		"attributes", evalCtx.Attributes(),
+		"err", err,
+	)
+
+	return details.Value
+}

--- a/pkg/services/ofrep/register.go
+++ b/pkg/services/ofrep/register.go
@@ -35,9 +35,20 @@ type evalContext struct {
 type APIBuilder struct {
 	providerType    setting.OpenFeatureProviderType
 	url             *url.URL
+	goffURL         *url.URL
 	transport       *http.Transport
 	staticEvaluator featuremgmt.StaticFlagEvaluator
 	logger          log.Logger
+	hgOverrideFlags map[string]bool
+}
+
+func (b *APIBuilder) EnableLegacyOverrideLookupBypass(goffURL *url.URL, flagsWithOverrides []string) {
+	b.logger.Info("Legacy override lookup bypass configured", "goffURL", goffURL.String(), "flagsWithOverridesCount", len(flagsWithOverrides))
+	b.goffURL = goffURL
+	b.hgOverrideFlags = make(map[string]bool, len(flagsWithOverrides))
+	for _, f := range flagsWithOverrides {
+		b.hgOverrideFlags[f] = true
+	}
 }
 
 func NewAPIBuilder(providerType setting.OpenFeatureProviderType, url *url.URL, insecure bool, caFile string, staticEvaluator featuremgmt.StaticFlagEvaluator) (*APIBuilder, error) {

--- a/pkg/services/ofrep/upstream_test.go
+++ b/pkg/services/ofrep/upstream_test.go
@@ -1,0 +1,180 @@
+package ofrep
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func newUpstreamTestBuilder(t *testing.T, goffURL *url.URL, overrideFlags ...string) *APIBuilder {
+	t.Helper()
+	flags := make(map[string]bool, len(overrideFlags))
+	for _, f := range overrideFlags {
+		flags[f] = true
+	}
+	return &APIBuilder{
+		providerType:    setting.FeaturesServiceProviderType,
+		url:             mustParseURL(t, "http://override-lookup-provider"),
+		goffURL:         goffURL,
+		hgOverrideFlags: flags,
+		logger:          log.NewNopLogger(),
+	}
+}
+
+func TestAPIBuilder_UpstreamForFlag(t *testing.T) {
+	goff := mustParseURL(t, "http://goff")
+
+	tests := []struct {
+		name          string
+		bypassEnabled bool
+		goffURL       *url.URL
+		overrideFlags []string
+		flagKey       string
+		namespace     string
+		wantGOFF      bool
+	}{
+		{
+			name:          "gate off: always the override-lookup provider, even with GOFF configured and no override",
+			bypassEnabled: false,
+			goffURL:       goff,
+			overrideFlags: []string{"knownOverrideFlag"},
+			flagKey:       "someOtherFlag",
+			namespace:     "stacks-1234",
+			wantGOFF:      false,
+		},
+		{
+			name:          "gate on, no GOFF URL configured: fails closed to the override-lookup provider",
+			bypassEnabled: true,
+			goffURL:       nil,
+			flagKey:       "anyFlag",
+			namespace:     "stacks-1234",
+			wantGOFF:      false,
+		},
+		{
+			name:          "gate on, namespace empty: bypasses even a flag with an override",
+			bypassEnabled: true,
+			goffURL:       goff,
+			overrideFlags: []string{"knownOverrideFlag"},
+			flagKey:       "knownOverrideFlag",
+			namespace:     "",
+			wantGOFF:      true,
+		},
+		{
+			name:          "gate on, namespace wildcard: bypasses even a flag with an override",
+			bypassEnabled: true,
+			goffURL:       goff,
+			overrideFlags: []string{"knownOverrideFlag"},
+			flagKey:       "knownOverrideFlag",
+			namespace:     "*",
+			wantGOFF:      true,
+		},
+		{
+			name:          "gate on, namespace known, flag has an override: override-lookup provider",
+			bypassEnabled: true,
+			goffURL:       goff,
+			overrideFlags: []string{"knownOverrideFlag"},
+			flagKey:       "knownOverrideFlag",
+			namespace:     "stacks-1234",
+			wantGOFF:      false,
+		},
+		{
+			name:          "gate on, namespace known, flag has no override: GOFF",
+			bypassEnabled: true,
+			goffURL:       goff,
+			overrideFlags: []string{"knownOverrideFlag"},
+			flagKey:       "someOtherFlag",
+			namespace:     "stacks-1234",
+			wantGOFF:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagFeaturesLegacyOverrideLookupBypass, tt.bypassEnabled)
+			b := newUpstreamTestBuilder(t, tt.goffURL, tt.overrideFlags...)
+
+			got := b.upstreamForFlag(t.Context(), tt.flagKey, tt.namespace, b.logger)
+
+			if tt.wantGOFF {
+				assert.Equal(t, goff, got)
+			} else {
+				assert.Equal(t, b.url, got)
+			}
+		})
+	}
+}
+
+func TestAPIBuilder_UpstreamForBulk(t *testing.T) {
+	goff := mustParseURL(t, "http://goff")
+
+	tests := []struct {
+		name          string
+		bypassEnabled bool
+		goffURL       *url.URL
+		namespace     string
+		wantGOFF      bool
+	}{
+		{
+			name:          "gate off: always the override-lookup provider",
+			bypassEnabled: false,
+			goffURL:       goff,
+			namespace:     "",
+			wantGOFF:      false,
+		},
+		{
+			name:          "gate on, no GOFF URL configured: fails closed",
+			bypassEnabled: true,
+			goffURL:       nil,
+			namespace:     "",
+			wantGOFF:      false,
+		},
+		{
+			name:          "gate on, namespace empty: bypasses",
+			bypassEnabled: true,
+			goffURL:       goff,
+			namespace:     "",
+			wantGOFF:      true,
+		},
+		{
+			name:          "gate on, namespace wildcard: bypasses",
+			bypassEnabled: true,
+			goffURL:       goff,
+			namespace:     "*",
+			wantGOFF:      true,
+		},
+		{
+			name:          "gate on, namespace known: stays on the override-lookup provider, the override list doesn't apply to bulk",
+			bypassEnabled: true,
+			goffURL:       goff,
+			namespace:     "stacks-1234",
+			wantGOFF:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupOpenFeatureFlag(t, featuremgmt.FlagFeaturesLegacyOverrideLookupBypass, tt.bypassEnabled)
+			b := newUpstreamTestBuilder(t, tt.goffURL)
+
+			got := b.upstreamForBulk(t.Context(), tt.namespace, b.logger)
+
+			if tt.wantGOFF {
+				assert.Equal(t, goff, got)
+			} else {
+				assert.Equal(t, b.url, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds an opt-in bypass: single-flag requests only go through the override lookup when the flag is on a 'flags-that-have-overrides' list *and* the request's namespace is known. Everything else (including any request where the namespace can't be determined, so there's nothing to look an override up for) evaluates directly by GOFF instead. 

Bulk requests get only the unknown-namespace bypass - they can't use the allowlist, since a bulk request doesn't say which flags it wants until the override-lookup provider has already answered.                                       
                                                                       
Entirely gated behind `features.legacyOverrideLookupBypass`, disabled by default. The behavior is unchanged if the flag is disabled or no alternate provider URL is configured.