### PR TITLE
Logs: Preserve original label case in suggested fields

### DIFF
--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -278,7 +278,7 @@ describe('getSuggestedFieldsForLogs', () => {
     expect(result).toEqual([]);
   });
 
-  test('matches suggested fields against labels case-insensitively', () => {
+  test('matches suggested fields against labels without changing them', () => {
     const logs = [
       createLogLine({
         labels: { Service_Name: 'svc', MSG: 'hello', APP: 'web', TraceID: 'abc' },
@@ -286,9 +286,9 @@ describe('getSuggestedFieldsForLogs', () => {
       }),
     ];
     const result = getSuggestedFieldsForLogs(logs);
-    expect(result).toContain('service_name');
-    expect(result).toContain('msg');
-    expect(result).toContain('app');
-    expect(result).toContain('traceid');
+    expect(result).toContain('Service_Name');
+    expect(result).toContain('MSG');
+    expect(result).toContain('APP');
+    expect(result).toContain('TraceID');
   });
 });

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -73,19 +73,28 @@ export function getSuggestedFieldsForLogs(logs: LogListModel[] | LogRowModel[]):
 
   const fields = [...new Set([...suggestedFields, ...otelFields])];
 
-  const availableLabels = new Set<string>();
+  const labelsByLowerCase = new Map<string, string>();
   logs.forEach((log) => {
     for (const label in log.labels) {
-      availableLabels.add(label.toLowerCase());
+      labelsByLowerCase.set(label.toLowerCase(), label);
     }
   });
 
-  return fields.filter(
-    (field) =>
-      field === LOG_LINE_BODY_FIELD_NAME ||
-      field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME ||
-      availableLabels.has(field.toLowerCase())
-  );
+  const suggestedFieldNames: string[] = [];
+  for (const field of fields) {
+    if (field === LOG_LINE_BODY_FIELD_NAME || field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+      suggestedFieldNames.push(field);
+      continue;
+    }
+    // Return the label as it appears in the logs, not the normalized suggestion:
+    // consumers look the value up with `labels[field]`, which is case-sensitive.
+    const label = labelsByLowerCase.get(field.toLowerCase());
+    if (label !== undefined) {
+      suggestedFieldNames.push(label);
+    }
+  }
+
+  return [...new Set(suggestedFieldNames)];
 }
 
 function getSuggestedFieldsForAnyLogs() {


### PR DESCRIPTION
**What is this feature?**

Bug fix. `getSuggestedFieldsForLogs` matches the suggested-field allowlist against log labels case-insensitively, but returns the *allowlist's* spelling rather than the label as it appears in the logs. Downstream, `LogListModel.getDisplayedFieldValue` resolves the value with a case-sensitive `labels[fieldName]` lookup:

```ts
if (this.labels[fieldName] != null) {
  fieldValue = this.labels[fieldName];
} else {
  const field = this.fields.find((field) => field.keys[0] === fieldName);
  fieldValue = field ? field.values.toString() : '';
}
```

So a suggested field whose real name isn't already lowercase is offered in the field selector, added on click, and then renders an empty value.

This changes the function to return the matched label name instead of the normalized one. Case-insensitive matching is unchanged.

**Why do we need this feature?**

Clicking a suggested field in the logs field selector adds it as a displayed field and shows nothing.

The relevant history:

- #119475 asked to expand the suggested list, explicitly including `'traceID'`.
- #119607 shipped it as `['app', 'service_name', 'message', 'msg', 'traceID', 'trace_id', ...]`. A label named `traceID` resolved correctly, because the returned string matched the label exactly.
- #128002 (b2ddcaa39) rewrote the list in lowercase, changing `'traceID'` to `'traceid'`. Matching still succeeds via `toLowerCase()`, so nothing appeared broken, but the returned name no longer resolves.

This affects any label that isn't already lowercase — `traceID`, `TraceId`, `SpanId`, `ServiceName`.

Reproduced on Grafana Cloud with `otelLogsFormatting` enabled, against a ClickHouse datasource whose log labels include `TraceId` and `SpanId`.

**Who is this feature for?**

Anyone using the logs field selector with `otelLogsFormatting` enabled whose log labels are not all lowercase.

**Which issue(s) does this PR fix?**:

None that I could find open. Happy to file one if you'd prefer this tracked separately.

**Special notes for your reviewer:**

**This PR changes assertions in an existing test.** Flagging it up front rather than leaving it to be found:

`formats.test.ts` → `'matches suggested fields against labels case-insensitively'` asserted `expect(result).toContain('traceid')` for a label named `TraceID`. Case-insensitive *matching* is intended and is preserved here; the assertion had encoded the normalized *return value*, which is the defect. Updated to expect the original label names.

I also added `'returns field names that resolve to a value on the log line'`, which asserts through `getDisplayedFieldValue` rather than on the matcher in isolation — that end-to-end gap is what let this through.

On the checklist below: the affected code path is already gated behind the experimental `otelLogsFormatting` toggle, so no new toggle is needed. No docs change, as this is an internal behavior fix with no user-facing API change.

Tests run locally:
- `public/app/features/logs/components/otel/formats.test.ts` — 22/22
- `public/app/features/logs/components/fieldSelector` + `public/app/features/logs/components/panel` — 461/461 across 21 suites
- `eslint public/app/features/logs/components/otel` — clean

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
