### PR TITLE
Alerting: Add the msteamsv2 cloud notifier

### DIFF
--- a/public/app/features/alerting/unified/types/alerting.ts
+++ b/public/app/features/alerting/unified/types/alerting.ts
@@ -77,6 +77,7 @@ export type CloudNotifierType =
   | 'sns'
   | 'discord'
   | 'msteams'
+  | 'msteamsv2'
   | 'jira';
 
 export type NotifierType = GrafanaNotifierType | CloudNotifierType;

--- a/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
+++ b/public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts
@@ -611,6 +611,23 @@ export const cloudNotifierTypes: Array<NotifierDTO<CloudNotifierType>> = [
       }),
     ],
   },
+  {
+    name: 'Microsoft Teams (Power Automate)',
+    description: 'Sends notifications to Microsoft Teams using a Power Automate workflow',
+    type: 'msteamsv2',
+    info: '',
+    heading: 'Microsoft Teams settings',
+    options: [
+      option('webhook_url', 'Webhook URL', 'The incoming webhook URL.'),
+      option('webhook_url_file', 'Webhook URL file', 'The file that contains the incoming webhook URL.'),
+      option('title', 'Title', 'Message title template.', {
+        placeholder: '{{ template "msteamsv2.default.title" . }}',
+      }),
+      option('text', 'Text', 'Message body template.', {
+        placeholder: '{{ template "msteamsv2.default.text" . }}',
+      }),
+    ],
+  },
 ];
 
 export const globalConfigOptions: NotificationChannelOption[] = [

--- a/public/app/features/alerting/unified/utils/receiver-form.test.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.test.ts
@@ -7,7 +7,9 @@ import {
   type ReceiverFormValues,
 } from '../types/receiver-form';
 
+import { cloudNotifierTypes } from './cloud-alertmanager-notifier-types';
 import {
+  cloudReceiverToFormValues,
   convertJiraFieldToJson,
   convertJsonToJiraField,
   formValuesToCloudReceiver,
@@ -587,5 +589,35 @@ describe('convertJiraFieldToJson', () => {
     };
     const result = convertJiraFieldToJson(input);
     expect(result).toEqual(expectedOutput);
+  });
+});
+
+describe('cloudReceiverToFormValues', () => {
+  it('should convert every receiver type the cloud notifier list knows about', () => {
+    for (const notifier of cloudNotifierTypes) {
+      const receiver: Receiver = {
+        name: 'test',
+        [`${notifier.type}_configs`]: [{ send_resolved: true }],
+      };
+
+      const [values] = cloudReceiverToFormValues(receiver, cloudNotifierTypes);
+
+      expect(values.items).toHaveLength(1);
+      expect(values.items[0].type).toBe(notifier.type);
+    }
+  });
+
+  it('should convert an msteamsv2 receiver', () => {
+    const receiver: Receiver = {
+      name: 'test-teams',
+      msteamsv2_configs: [{ send_resolved: true, webhook_url: 'https://example.com/webhook' }],
+    };
+
+    const [values, channelMap] = cloudReceiverToFormValues(receiver, cloudNotifierTypes);
+
+    expect(values.items).toHaveLength(1);
+    expect(values.items[0].type).toBe('msteamsv2');
+    expect(values.items[0].settings.webhook_url).toBe('https://example.com/webhook');
+    expect(channelMap[values.items[0].__id].type).toBe('msteamsv2');
   });
 });


### PR DESCRIPTION
<!--
Thank you for sending a PR!
-->

**What is this feature?**

Fixes #131873.

`cloudReceiverToFormValues` maps each `*_configs` key on an external Alertmanager receiver to a notifier from `cloudNotifierTypes`, and throws `unknown cloud notifier: <type>` when there is no match. `msteamsv2` is missing from that list and from the `CloudNotifierType` union, so viewing a contact point that uses `msteamsv2_configs` fails outright even though the contact point list renders and the Alertmanager config is valid.

This adds the notifier with the fields Alertmanager accepts for it (`webhook_url`, `webhook_url_file`, `title`, `text`, plus the shared `send_resolved`), taken from `MSTeamsV2Config` in `notify/msteamsv2/config.go` upstream, and the default templates it documents.

**Why do we need this feature?**

Without it there is no way to look at, let alone edit, an msteamsv2 contact point on an external Alertmanager from Grafana.

**Who is this feature for?**

Anyone pointing Grafana at a Prometheus Alertmanager that notifies through Power Automate workflows, which is the replacement Microsoft points people at now that the old Office 365 connectors are retired.

**Which issue(s) does this PR fix?**

Fixes #131873

**Special notes for your reviewer:**

Two tests in `receiver-form.test.ts`: one converts an `msteamsv2_configs` receiver and checks the type and settings survive, and one walks every entry in `cloudNotifierTypes` so a future addition to the union that is missing from the notifier list fails here rather than in the UI. On main the first fails with the error from the issue.

`yarn jest public/app/features/alerting/unified/utils/receiver-form.test.ts` is 21 passing, and prettier and eslint are clean on the changed files.
