### PR TITLE
Plugins: permit crypto/x509 certificate environment variables

### DIFF
--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -22,6 +22,9 @@ var permittedHostEnvVarNames = []string{
 	"https_proxy",
 	"NO_PROXY",
 	"no_proxy",
+	// Env vars used by crypto/x509 (Go stdlib) and OpenSSL for custom CA certificate file/dir
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
 }
 
 type Provider interface {

--- a/pkg/plugins/envvars/envvars_test.go
+++ b/pkg/plugins/envvars/envvars_test.go
@@ -30,9 +30,10 @@ func TestPermittedHostEnvVarNames_includesPLUGIN_UNIX_SOCKET_DIR(t *testing.T) {
 }
 
 func TestPermittedHostEnvVars_PLUGIN_UNIX_SOCKET_DIR_Unset(t *testing.T) {
-	prev, hadTMPDIR := os.LookupEnv("PLUGIN_UNIX_SOCKET_DIR")
-	if hadTMPDIR {
-		defer t.Setenv("PLUGIN_UNIX_SOCKET_DIR", prev)
+	if prev, hadTMPDIR := os.LookupEnv("PLUGIN_UNIX_SOCKET_DIR"); hadTMPDIR {
+		t.Cleanup(func() { _ = os.Setenv("PLUGIN_UNIX_SOCKET_DIR", prev) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("PLUGIN_UNIX_SOCKET_DIR") })
 	}
 	_ = os.Unsetenv("PLUGIN_UNIX_SOCKET_DIR")
 
@@ -41,6 +42,53 @@ func TestPermittedHostEnvVars_PLUGIN_UNIX_SOCKET_DIR_Unset(t *testing.T) {
 	for _, v := range vars {
 		if strings.HasPrefix(v, "PLUGIN_UNIX_SOCKET_DIR=") {
 			t.Fatal("PLUGIN_UNIX_SOCKET_DIR should not be present when unset")
+		}
+	}
+}
+
+func TestPermittedHostEnvVarNames_includesSSLCertEnvVars(t *testing.T) {
+	names := PermittedHostEnvVarNames()
+	require.Contains(t, names, "SSL_CERT_FILE", "SSL_CERT_FILE must be in permitted host env var names for custom CA certificate file")
+	require.Contains(t, names, "SSL_CERT_DIR", "SSL_CERT_DIR must be in permitted host env var names for custom CA certificate directory")
+}
+
+func TestPermittedHostEnvVars_respectsSSLCertEnvVars(t *testing.T) {
+	tempDir := t.TempDir()
+	certFile := tempDir + "/custom-ca.pem"
+	certDir := tempDir + "/certs"
+
+	t.Setenv("SSL_CERT_FILE", certFile)
+	t.Setenv("SSL_CERT_DIR", certDir)
+
+	vars := PermittedHostEnvVars()
+
+	require.Contains(t, vars, "SSL_CERT_FILE="+certFile, "SSL_CERT_FILE should be forwarded when set")
+	require.Contains(t, vars, "SSL_CERT_DIR="+certDir, "SSL_CERT_DIR should be forwarded when set")
+}
+
+func TestPermittedHostEnvVars_SSLCertEnvVars_Unset(t *testing.T) {
+	if prevFile, hadFile := os.LookupEnv("SSL_CERT_FILE"); hadFile {
+		t.Cleanup(func() { _ = os.Setenv("SSL_CERT_FILE", prevFile) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("SSL_CERT_FILE") })
+	}
+	_ = os.Unsetenv("SSL_CERT_FILE")
+
+	if prevDir, hadDir := os.LookupEnv("SSL_CERT_DIR"); hadDir {
+		t.Cleanup(func() { _ = os.Setenv("SSL_CERT_DIR", prevDir) })
+	} else {
+		t.Cleanup(func() { _ = os.Unsetenv("SSL_CERT_DIR") })
+	}
+	_ = os.Unsetenv("SSL_CERT_DIR")
+
+	vars := PermittedHostEnvVars()
+
+	for _, v := range vars {
+		if strings.HasPrefix(v, "SSL_CERT_FILE=") {
+			t.Fatal("SSL_CERT_FILE should not be present when unset")
+		}
+		if strings.HasPrefix(v, "SSL_CERT_DIR=") {
+			t.Fatal("SSL_CERT_DIR should not be present when unset")
 		}
 	}
 }


### PR DESCRIPTION
Fixes #131847

### Problem
When datasources like Prometheus and InfluxDB became standalone backend plugins in Grafana 13.2.0, connections using private CA certificates configured via standard environment variables \SSL_CERT_FILE\ and \SSL_CERT_DIR\ fail with \x509: certificate signed by unknown authority\ because backend plugin processes only inherit host environment variables explicitly allowlisted in \permittedHostEnvVarNames\.

### Solution
- Added \SSL_CERT_FILE\ and \SSL_CERT_DIR\ to \permittedHostEnvVarNames\ in \pkg/plugins/envvars/envvars.go\.
- Added unit tests in \pkg/plugins/envvars/envvars_test.go\ verifying inclusion, inheritance, and unset behavior.