### PR TITLE
Storage: avoid filtering on resource_version=0 during unconditional resource deletes

### DIFF
--- a/pkg/storage/unified/resource/event.go
+++ b/pkg/storage/unified/resource/event.go
@@ -44,8 +44,12 @@ func (e *WriteEvent) Validate() error {
 		return fmt.Errorf("watch event type is unknown")
 	}
 
-	if (e.Type == resourcepb.WatchEvent_MODIFIED || e.Type == resourcepb.WatchEvent_DELETED) && e.PreviousRV <= 0 {
-		return fmt.Errorf("previous RV is required for update and delete events")
+	if e.Type == resourcepb.WatchEvent_MODIFIED && e.PreviousRV <= 0 {
+		return fmt.Errorf("previous RV is required for update events")
+	}
+
+	if e.Type == resourcepb.WatchEvent_DELETED && e.PreviousRV < 0 {
+		return fmt.Errorf("previous RV must not be negative")
 	}
 
 	return nil

--- a/pkg/storage/unified/sql/backend_test.go
+++ b/pkg/storage/unified/sql/backend_test.go
@@ -439,13 +439,65 @@ func TestBackend_delete(t *testing.T) {
 		require.Equal(t, int64(200), v)
 	})
 
+	t.Run("WriteEvent unconditional delete passes validation and succeeds", func(t *testing.T) {
+		t.Parallel()
+		b, ctx := setupBackendTest(t)
+
+		validEvent := event
+		validEvent.Value = []byte("{}")
+
+		b.SQLMock.ExpectBegin()
+		expectSuccessfulResourceVersionExec(t, b.TestDBProvider,
+			func() { b.ExecWithResult("delete resource", 0, 1) },
+			func() { b.ExecWithResult("insert resource_history", 0, 1) },
+		)
+		b.SQLMock.ExpectCommit()
+
+		v, err := b.WriteEvent(ctx, validEvent)
+		require.NoError(t, err)
+		require.Equal(t, int64(200), v)
+	})
+
+	t.Run("happy path with previous rv", func(t *testing.T) {
+		t.Parallel()
+		b, ctx := setupBackendTest(t)
+
+		eventWithRV := event
+		eventWithRV.PreviousRV = 12345
+
+		b.SQLMock.ExpectBegin()
+		expectSuccessfulResourceVersionExec(t, b.TestDBProvider,
+			func() { b.ExecWithResult("delete resource", 0, 1) },
+			func() { b.ExecWithResult("insert resource_history", 0, 1) },
+		)
+		b.SQLMock.ExpectCommit()
+
+		v, err := b.delete(ctx, eventWithRV)
+		require.NoError(t, err)
+		require.Equal(t, int64(200), v)
+	})
+
+	t.Run("conflict when zero rows deleted", func(t *testing.T) {
+		t.Parallel()
+		b, ctx := setupBackendTest(t)
+
+		b.SQLMock.ExpectBegin()
+		b.ExecWithResult("delete resource", 0, 0)
+		b.SQLMock.ExpectRollback()
+
+		v, err := b.delete(ctx, event)
+		require.Zero(t, v)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "requested RV does not match current RV")
+	})
+
 	t.Run("error deleting resource", func(t *testing.T) {
 		t.Parallel()
 		b, ctx := setupBackendTest(t)
 
 		b.SQLMock.ExpectBegin()
 		b.ExecWithErr("delete resource", errTest)
-		b.SQLMock.ExpectCommit()
+		b.SQLMock.ExpectRollback()
 
 		v, err := b.delete(ctx, event)
 		require.Zero(t, v)
@@ -460,7 +512,7 @@ func TestBackend_delete(t *testing.T) {
 		b.SQLMock.ExpectBegin()
 		b.ExecWithResult("delete resource", 0, 1)
 		b.ExecWithErr("insert resource_history", errTest)
-		b.SQLMock.ExpectCommit()
+		b.SQLMock.ExpectRollback()
 
 		v, err := b.delete(ctx, event)
 		require.Zero(t, v)

--- a/pkg/storage/unified/sql/data/resource_delete.sql
+++ b/pkg/storage/unified/sql/data/resource_delete.sql
@@ -5,6 +5,8 @@ DELETE FROM {{ .Ident "resource" }}
     AND {{ .Ident "resource" }}  = {{ .Arg .WriteEvent.Key.Resource }}
     {{ if .WriteEvent.Key.Name }}
     AND {{ .Ident "name" }}      = {{ .Arg .WriteEvent.Key.Name }}
+    {{ end }}
+    {{ if (gt .WriteEvent.PreviousRV 0) }}
     AND {{ .Ident "resource_version" }} = {{ .Arg .WriteEvent.PreviousRV }}
     {{ end }}
 ;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_delete-simple.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_delete-simple.sql
@@ -4,5 +4,4 @@ DELETE FROM `resource`
     AND `group`     = 'gg'
     AND `resource`  = 'rr'
     AND `name`      = 'name'
-    AND `resource_version` = 0
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_delete-simple.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_delete-simple.sql
@@ -4,5 +4,4 @@ DELETE FROM "resource"
     AND "group"     = 'gg'
     AND "resource"  = 'rr'
     AND "name"      = 'name'
-    AND "resource_version" = 0
 ;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_delete-simple.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_delete-simple.sql
@@ -4,5 +4,4 @@ DELETE FROM "resource"
     AND "group"     = 'gg'
     AND "resource"  = 'rr'
     AND "name"      = 'name'
-    AND "resource_version" = 0
 ;


### PR DESCRIPTION
Fixes #130334

### Problem
When deleting resources in unified storage without specifying an explicit precondition resource version (\PreviousRV == 0\), \esource_delete.sql\ previously generated \AND resource_version = 0\. Because active resource versions start at 1, this condition matched 0 rows, falsely triggering \checkConflict\ and returning a \409 Conflict: requested RV does not match current RV\ error.

### Solution
- Guarded \AND resource_version = ...\ in \pkg/storage/unified/sql/data/resource_delete.sql\ with \{{ if (gt .WriteEvent.PreviousRV 0) }}\.
- Updated dialect query snapshots for MySQL, PostgreSQL, and SQLite.
- Added unit tests in \pkg/storage/unified/sql/backend_test.go\ covering unconditional deletes, conditional deletes with resource versions, and conflict scenarios.