### PR TITLE
Gziper: defer gzip writer Close() to prevent goroutine leak on panic

### DIFF
--- a/pkg/middleware/gziper.go
+++ b/pkg/middleware/gziper.go
@@ -184,24 +184,26 @@ func Gziper() func(http.Handler) http.Handler {
 			grw.Header().Set("Content-Encoding", "gzip")
 			grw.Header().Set("Vary", "Accept-Encoding")
 
-			next.ServeHTTP(grw, req)
-
-			// A failed response write cannot be reported to the caller at this
-			// point, and this is the only signal it produces, so log it rather than
-			// discard it.
-			err := grw.w.Close()
-			if err == nil {
-				err = sink.err()
-			}
-			if err != nil {
-				logger := gzipLogger.FromContext(req.Context())
-				if req.Context().Err() != nil {
-					// The client hung up. Expected traffic, not a server problem.
-					logger.Debug("Failed to write gzipped response", "path", req.URL.Path, "error", err)
-				} else {
-					logger.Warn("Failed to write gzipped response", "path", req.URL.Path, "error", err)
+			defer func() {
+				// A failed response write cannot be reported to the caller at this
+				// point, and this is the only signal it produces, so log it rather than
+				// discard it.
+				err := grw.w.Close()
+				if err == nil {
+					err = sink.err()
 				}
-			}
+				if err != nil {
+					logger := gzipLogger.FromContext(req.Context())
+					if req.Context().Err() != nil {
+						// The client hung up. Expected traffic, not a server problem.
+						logger.Debug("Failed to write gzipped response", "path", req.URL.Path, "error", err)
+					} else {
+						logger.Warn("Failed to write gzipped response", "path", req.URL.Path, "error", err)
+					}
+				}
+			}()
+
+			next.ServeHTTP(grw, req)
 		})
 	}
 }

--- a/pkg/middleware/gziper_test.go
+++ b/pkg/middleware/gziper_test.go
@@ -121,6 +121,29 @@ func TestGziperDoesNotLeakGoroutines(t *testing.T) {
 			serveGzipped(t, http.MethodGet, "/d/abc/dash", &brokenResponseWriter{failAfter: 1, short: true})
 		}
 	})
+
+	t.Run("responses where handler panics", func(t *testing.T) {
+		defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+		for range requests {
+			func() {
+				defer func() {
+					_ = recover()
+				}()
+
+				req, err := http.NewRequest(http.MethodGet, "/d/abc/dash", nil)
+				require.NoError(t, err)
+				req.Header.Set("Accept-Encoding", "gzip")
+
+				panickingHandler := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+					_, _ = rw.Write(gzipTestBody)
+					panic("handler failure")
+				})
+
+				Gziper()(panickingHandler).ServeHTTP(web.NewResponseWriter(http.MethodGet, httptest.NewRecorder()), req)
+			}()
+		}
+	})
 }
 
 func TestGzipSink(t *testing.T) {

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -241,7 +241,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	writer.Header().Set("Cache-Control", "no-store")
 	writer.WriteHeader(200)
 	if err := p.index.Execute(writer, &data); err != nil {
-		if errors.Is(err, syscall.EPIPE) { // Client has stopped listening.
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, http.ErrAbortHandler) { // Client has stopped listening or handler was aborted.
 			return
 		}
 		panic(fmt.Sprintf("Error rendering index\n %s", err.Error()))

--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -106,7 +106,7 @@ func (ctx *Context) HTML(status int, name string, data any) {
 	ctx.Resp.Header().Set(headerContentType, contentTypeHTML)
 	ctx.Resp.WriteHeader(status)
 	if err := ctx.template.ExecuteTemplate(ctx.Resp, name, data); err != nil {
-		if errors.Is(err, syscall.EPIPE) { // Client has stopped listening.
+		if errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) || errors.Is(err, http.ErrAbortHandler) { // Client has stopped listening or handler was aborted.
 			return
 		}
 		panic(fmt.Sprintf("Context.HTML - Error rendering template: %s. You may need to build frontend assets \n %s", name, err.Error()))

--- a/pkg/web/context_test.go
+++ b/pkg/web/context_test.go
@@ -1,8 +1,11 @@
 package web
 
 import (
+	"fmt"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,4 +113,49 @@ func TestContext_noHandler(t *testing.T) {
 	c.run()
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+type disconnectResponseWriter struct {
+	http.ResponseWriter
+	err error
+}
+
+func (w *disconnectResponseWriter) Write([]byte) (int, error) {
+	return 0, w.err
+}
+
+func TestContext_HTML_disconnectHandling(t *testing.T) {
+	t.Run("gracefully ignores client disconnect errors", func(t *testing.T) {
+		disconnectErrors := []error{
+			syscall.EPIPE,
+			syscall.ECONNRESET,
+			http.ErrAbortHandler,
+		}
+
+		for _, disconnErr := range disconnectErrors {
+			t.Run(fmt.Sprintf("handles %v", disconnErr), func(t *testing.T) {
+				tmpl := template.Must(template.New("test").Parse("hello {{ . }}"))
+				c := &Context{
+					Resp:     NewResponseWriter(http.MethodGet, &disconnectResponseWriter{ResponseWriter: httptest.NewRecorder(), err: disconnErr}),
+					template: tmpl,
+				}
+
+				assert.NotPanics(t, func() {
+					c.HTML(http.StatusOK, "test", "world")
+				})
+			})
+		}
+	})
+
+	t.Run("panics on standard template execution errors", func(t *testing.T) {
+		tmpl := template.Must(template.New("test").Parse("hello {{ .NonExistentField }}"))
+		c := &Context{
+			Resp:     NewResponseWriter(http.MethodGet, httptest.NewRecorder()),
+			template: tmpl,
+		}
+
+		assert.Panics(t, func() {
+			c.HTML(http.StatusOK, "test", struct{}{})
+		})
+	})
 }


### PR DESCRIPTION
Fixes #131859

### Problem
When a downstream HTTP handler panics (e.g. on client abort/disconnect during streaming or template render), \Gziper\ middleware in \pkg/middleware/gziper.go\ previously did not defer \grw.w.Close()\. Because \pgzip.Writer\ spawns concurrent worker block goroutines that only exit upon calling \Close()\, panic unwinding skipped closing the writer, permanently leaking goroutines and compression buffers.

### Solution
- In \pkg/middleware/gziper.go\, deferred \grw.w.Close()\ and error logging.
- In \pkg/web/context.go\ and \pkg/services/frontend/index.go\, recognized \syscall.ECONNRESET\ and \http.ErrAbortHandler\ alongside \syscall.EPIPE\ as standard client disconnects during template rendering to avoid unnecessary panics.
- Added regression tests with \go.uber.org/goleak\ in \pkg/middleware/gziper_test.go\ verifying zero leaked goroutines when handlers panic.