### PR TITLE
valueFormats: clamp decimals to [0, 20] and fix zero-padding in toFixed

### DIFF
--- a/packages/grafana-data/src/valueFormats/baseFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/baseFormatters.ts
@@ -18,6 +18,8 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
 
   if (decimals === null || decimals === undefined) {
     decimals = getDecimalsForValue(value);
+  } else {
+    decimals = clamp(Math.floor(decimals), 0, 20);
   }
 
   if (value === 0) {
@@ -35,7 +37,7 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   const decimalPos = formatted.indexOf('.');
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
-    return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);
+    return (precision ? formatted : formatted + '.') + '0'.repeat(decimals - precision);
   }
 
   return formatted;

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -150,6 +150,18 @@ describe('valueFormats', () => {
     it('should treat as zero decimals', () => {
       const str = toFixed(186.123, -2);
       expect(str).toBe('186');
+      expect(toFixed(0, -5)).toBe('0');
+    });
+  });
+
+  describe('toFixed with large decimals count', () => {
+    it('should clamp decimals above 20 and avoid exponent stringification in padding', () => {
+      expect(toFixed(1.5, 21)).toBe('1.50000000000000000000');
+      expect(toFixed(5, 21)).toBe('5.00000000000000000000');
+      expect(toFixed(5, 20)).toBe('5.00000000000000000000');
+      expect(toFixed(1.5, 101)).toBe('1.50000000000000000000');
+      expect(toFixed(0, 101)).toBe('0.00000000000000000000');
+      expect(toFixed(1.5, 2.7)).toBe('1.50');
     });
   });
 


### PR DESCRIPTION
Fixes #131843

### Problem
When number formatting is configured with \decimals > 20\:
1. Slicing \String(factor)\ where \actor = 10**21\ evaluates to \'1e+21'\, which appended \'e+21'\ directly to formatted numbers (e.g. \	oFixed(1.5, 21)\ rendered as \'1.5e+21'\).
2. When \decimals > 100\ and \alue === 0\, calling native \Number.prototype.toFixed(decimals)\ threw an unhandled \RangeError: toFixed() digits argument must be between 0 and 100\, blanking visualization panels.

### Solution
- In \packages/grafana-data/src/valueFormats/baseFormatters.ts\, clamped \decimals\ to \[0, 20]\ via \clamp(Math.floor(decimals), 0, 20)\.
- Replaced \String(factor).slice(...)\ with \'0'.repeat(decimals - precision)\ for clean zero padding.
- Added comprehensive unit test coverage in \packages/grafana-data/src/valueFormats/valueFormats.test.ts\.