### PR TITLE
fix(dashboard): use continuation token for version history pagination

### DIFF
--- a/public/app/features/dashboard-scene/settings/VersionsEditView.pagination.test.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.pagination.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import { SceneTimeRange } from '@grafana/scenes';
+import { DashboardScene } from '../scene/DashboardScene';
+import { activateFullSceneTree } from '../utils/test-utils';
+
+import { VersionsEditView } from './VersionsEditView';
+
+const mockListDashboardHistory = jest.fn();
+
+jest.mock('app/features/dashboard/api/dashboard_api', () => ({
+  getDashboardAPI: () =>
+    Promise.resolve({
+      listDashboardHistory: mockListDashboardHistory,
+    }),
+}));
+
+jest.mock('app/api/clients/iam/v0alpha1', () => ({
+  useGetDisplayMappingQuery: () => ({ data: undefined }),
+}));
+
+describe('VersionsEditView pagination', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows more versions when the API returns a continuation token', async () => {
+    mockListDashboardHistory.mockResolvedValueOnce({
+      metadata: { continue: 'next-page-token' },
+      items: [createTestResource(3), createTestResource(2)],
+    });
+
+    const versionsView = new VersionsEditView({});
+    const dashboard = new DashboardScene({
+      $timeRange: new SceneTimeRange({}),
+      title: 'test dashboard',
+      uid: 'dash-1',
+      version: 3,
+      meta: { canEdit: true },
+      editview: versionsView,
+    });
+
+    activateFullSceneTree(dashboard);
+    dashboard.onEnterEditMode();
+    versionsView.activate();
+
+    await new Promise(process.nextTick);
+
+    render(
+      <TestProvider>
+        <versionsView.Component model={versionsView} />
+      </TestProvider>
+    );
+
+    expect(await screen.findByRole('button', { name: /show more versions/i })).toBeEnabled();
+  });
+});
+
+function createTestResource(version: number) {
+  return {
+    apiVersion: 'v1beta1',
+    kind: 'Dashboard',
+    metadata: {
+      name: '_U4zObQMz',
+      generation: version,
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      annotations: {
+        'grafana.app/updatedBy': 'admin',
+        'grafana.app/message': '',
+      },
+    },
+    spec: { version },
+  };
+}

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -244,12 +244,8 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
 
   const canCompare = model.versions.filter((version) => version.checked).length === 2;
   const showButtons = model.versions.length > 1;
-  const hasMore = model.versions.length >= model.limit;
-  // older versions may have been cleaned up in the db, so also check if the last page is less than the limit, if so, we are at the end
-  let isLastPage =
-    model.versions.find((rev) => rev.version === 1) ||
-    model.versions.length % model.limit !== 0 ||
-    model.continueToken === '';
+  const hasMore = model.continueToken !== '';
+  const isLastPage = model.continueToken === '';
 
   const viewModeCompare = (
     <>
@@ -293,7 +289,7 @@ function VersionsEditorSettingsListView({ model }: SceneComponentProps<VersionsE
           canCompare={canCompare}
           getVersions={model.fetchVersions}
           getDiff={model.getDiff}
-          isLastPage={!!isLastPage}
+          isLastPage={isLastPage}
         />
       )}
     </>


### PR DESCRIPTION
## What does this PR do?

Fixes #131881.

Dashboard version history can receive a non-empty `metadata.continue` token even when the first response contains fewer than `VERSIONS_FETCH_LIMIT` items. The current UI infers pagination availability from the number of loaded items, so it can hide or disable "Show more versions" even though the API explicitly says another page is available.

### Changes
- Use the API continuation token as the source of truth for whether another page exists.
- Add a regression test covering a partial first page with a non-empty continuation token.

### Why
`VERSIONS_FETCH_LIMIT` is currently 10, so a response containing 2 items with a continuation token is a valid paginated response. The existing `versions.length >= model.limit` check incorrectly treats it as having no next page.

### Testing
- Added a focused regression test in `VersionsEditView.pagination.test.tsx`.
- Full Grafana test execution was not run locally.
