### PR TITLE
fix(home): avoid team request for anonymous users

### DIFF
--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -37,6 +37,14 @@ jest.mock('../analytics/main', () => ({
   homepageViewed: jest.fn(),
 }));
 
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    ...jest.requireActual('app/core/services/context_srv').contextSrv,
+    hasPermission: jest.fn(),
+    isSignedIn: true,
+  },
+}));
+
 // The team dropdown loads its options from the `team` label values on alerts,
 // via the triage fetchTagValues helper; mock it rather than the datasource layer.
 jest.mock('app/features/alerting/unified/triage/scene/tagKeysProviders', () => ({
@@ -145,6 +153,7 @@ beforeEach(async () => {
   jest
     .spyOn(contextSrv, 'hasPermission')
     .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+
   // The team dropdown only renders when the state-history Prometheus datasource is configured.
   config.unifiedAlerting.stateHistory = {
     ...originalStateHistory,

--- a/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
+++ b/public/app/features/home/AlertsIncidents/FiringAlertsCard.test.tsx
@@ -65,6 +65,8 @@ beforeEach(() => {
   jest
     .spyOn(contextSrv, 'hasPermission')
     .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+  jest.replaceProperty(contextSrv, 'isSignedIn', true);
+
   mockTeams([]);
   mockAlerts([]);
 });
@@ -212,7 +214,6 @@ describe('FiringAlertsCard', () => {
     render(<FiringAlertsCardWithData />);
 
     expect(await screen.findByText('No firing alerts for your teams.')).toBeInTheDocument();
-
     expect(screen.queryByText('Show all firing alerts')).not.toBeInTheDocument();
   });
 

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.test.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
   jest
     .spyOn(contextSrv, 'hasPermission')
     .mockImplementation((action: string) => action === AccessControlAction.AlertingInstanceRead);
+  jest.replaceProperty(contextSrv, 'isSignedIn', true);
   mockTeams([]);
   mockAlerts([]);
 });
@@ -82,6 +83,25 @@ describe('canViewFiringAlerts', () => {
 });
 
 describe('useFiringAlerts', () => {
+  it('does not request user teams for anonymous users', async () => {
+    jest.replaceProperty(contextSrv, 'isSignedIn', false);
+
+    const requests: string[] = [];
+
+    server.use(
+      http.get('/api/user/teams', ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { result } = renderHook(() => useFiringAlerts(), { wrapper: getWrapper({}) });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(requests).toEqual([]);
+  });
+
   it('derives counts and severity totals from the fetched alerts', async () => {
     mockAlerts([
       makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } }),
@@ -153,7 +173,7 @@ describe('useFiringAlerts', () => {
       const { result } = renderHook(() => useFiringAlerts('team.one'), { wrapper: getWrapper({}) });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      // escapeRegExp adds '\.', quoteWithEscape doubles the backslash on the wire.
+      // escapeRegExp adds '\\.', quoteWithEscape doubles the backslash on the wire.
       expect(requests).toEqual([['team=~"team\\\\.one"']]);
     });
   });

--- a/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
+++ b/public/app/features/home/AlertsIncidents/useFiringAlerts.ts
@@ -94,9 +94,11 @@ export function useFiringAlerts(selectedTeam?: string) {
 
   // Fetched once — teams change at login granularity. A failed fetch leaves teams
   // undefined, so the card intentionally shows all org alerts unfiltered.
+  const shouldLoadTeams = enabled && contextSrv.isSignedIn;
+
   const { value: teams, loading: teamsLoading } = useAsync(
-    () => (enabled ? getBackendSrv().get<Team[]>('/api/user/teams') : Promise.resolve<Team[]>([])),
-    [enabled]
+    () => (shouldLoadTeams ? getBackendSrv().get<Team[]>('/api/user/teams') : Promise.resolve<Team[]>([])),
+    [shouldLoadTeams]
   );
 
   const teamNames = (teams ?? []).map((t) => t.name);


### PR DESCRIPTION
## What does this PR do?

Fixes #131876.

Anonymous users can view firing alerts, but the home page was also requesting `/api/user/teams`, which requires authentication and can surface an Unauthorized error popup.

### Changes
- Only request the current user's teams when the user is signed in.
- Add a regression test to verify anonymous users do not request `/api/user/teams`.

### Testing
- Focused `useFiringAlerts` test suite passes locally.