### PR TITLE
Fix toFixed decimals bug for values >= 21 and > 100

### DIFF
--- a/packages/grafana-data/src/valueFormats/baseFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/baseFormatters.ts
@@ -20,10 +20,11 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
     decimals = getDecimalsForValue(value);
   }
 
+  // Keep the native toFixed range while avoiding RangeError for untrusted counts.
+  decimals = Math.min(Math.max(0, decimals), 100);
+
   if (value === 0) {
-    // Clamp decimals to the valid range for toFixed (0-100) to avoid RangeError
-    const safeDecimals = Math.min(Math.max(0, decimals ?? 0), 100);
-    return value.toFixed(safeDecimals);
+    return value.toFixed(decimals);
   }
 
   const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
@@ -38,7 +39,7 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
     // Use toFixed for padding when factor is too large (would produce scientific notation)
-    if (factor > 1e21) {
+    if (factor >= 1e21) {
       return value.toFixed(decimals);
     }
     return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);

--- a/packages/grafana-data/src/valueFormats/baseFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/baseFormatters.ts
@@ -21,7 +21,9 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   }
 
   if (value === 0) {
-    return value.toFixed(decimals);
+    // Clamp decimals to the valid range for toFixed (0-100) to avoid RangeError
+    const safeDecimals = Math.min(Math.max(0, decimals ?? 0), 100);
+    return value.toFixed(safeDecimals);
   }
 
   const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
@@ -35,6 +37,10 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
   const decimalPos = formatted.indexOf('.');
   const precision = decimalPos === -1 ? 0 : formatted.length - decimalPos - 1;
   if (precision < decimals) {
+    // Use toFixed for padding when factor is too large (would produce scientific notation)
+    if (factor > 1e21) {
+      return value.toFixed(decimals);
+    }
     return (precision ? formatted : formatted + '.') + String(factor).slice(1, decimals - precision + 1);
   }
 

--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -126,6 +126,11 @@ describe('valueFormats', () => {
       expect(toFixed(0, 1)).toBe('0.0');
       expect(toFixed(0, 2)).toBe('0.00');
     });
+
+    it('toFixed should handle scientific notation and clamp large decimal counts', () => {
+      expect(toFixed(1.5, 21)).toBe('1.500000000000000000000');
+      expect(toFixed(1.5, 101)).toBe(`1.${'5'.padEnd(100, '0')}`);
+    });
   });
 
   describe('format edge cases', () => {


### PR DESCRIPTION
## Description
When decimals >= 21, Math.pow(10, decimals) produces scientific notation (e.g., 10^21 = 1e+21), causing String(factor) to return '1e+21' instead of a full decimal string. This caused the padding logic to append 'e+21' to the output instead of zeros.

Additionally, when value === 0 and decimals > 100, the native Number.toFixed() throws RangeError since it only accepts 0-100.

## The Fix
This fix:
1. Clamps decimals to 0-100 range for value === 0 case to avoid RangeError
2. Uses toFixed directly when factor > 1e21 to avoid scientific notation issue

## Bug Details
- toFixed(1.5, 21) was returning '1.5e+21' instead of proper padding
- toFixed(0, 101) was throwing RangeError: toFixed() digits argument must be between 0 and 100

Fixes: grafana/grafana#131843