### PR TITLE
Remote cache: invalidate entries created in the future

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -67,7 +67,9 @@ func (dc *databaseCache) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 
 		if cacheHit.Expires > 0 {
-			existedButExpired := getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires
+			age := getTime().Unix() - cacheHit.CreatedAt
+			existedButExpired := age < 0 || age >= cacheHit.Expires
+
 			if existedButExpired {
 				err = dc.Delete(ctx, key) // ignore this error since we will return `ErrCacheItemNotFound` anyway
 				if err != nil {

--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -10,7 +10,10 @@ import (
 
 var getTime = time.Now
 
-const databaseCacheType = "database"
+const (
+	databaseCacheType               = "database"
+	databaseCacheClockSkewTolerance = int64(10)
+)
 
 type databaseCache struct {
 	SQLStore db.DB
@@ -68,7 +71,7 @@ func (dc *databaseCache) Get(ctx context.Context, key string) ([]byte, error) {
 
 		if cacheHit.Expires > 0 {
 			age := getTime().Unix() - cacheHit.CreatedAt
-			existedButExpired := age < 0 || age >= cacheHit.Expires
+			existedButExpired := age < -databaseCacheClockSkewTolerance || age >= cacheHit.Expires
 
 			if existedButExpired {
 				err = dc.Delete(ctx, key) // ignore this error since we will return `ErrCacheItemNotFound` anyway

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -80,3 +80,28 @@ func TestIntegrationSecondSet(t *testing.T) {
 	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
 }
+
+func TestIntegrationGetInvalidatesFutureCreatedAt(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	db := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	obj := []byte("future-cache")
+
+	getTime = time.Now
+	err := db.Set(context.Background(), "future-key", obj, 1000*time.Second)
+	assert.Equal(t, err, nil)
+
+	getTime = func() time.Time { return time.Now().AddDate(0, 0, -2) }
+	t.Cleanup(func() {
+		getTime = time.Now
+	})
+
+	_, err = db.Get(context.Background(), "future-key")
+	assert.Equal(t, err, ErrCacheItemNotFound)
+}

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -105,3 +105,31 @@ func TestIntegrationGetInvalidatesFutureCreatedAt(t *testing.T) {
 	_, err = db.Get(context.Background(), "future-key")
 	assert.Equal(t, err, ErrCacheItemNotFound)
 }
+
+func TestIntegrationGetToleratesSmallClockSkew(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+
+	db := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	obj := []byte("clock-skew-cache")
+	baseTime := time.Unix(1700000000, 0)
+
+	getTime = func() time.Time { return baseTime }
+	t.Cleanup(func() {
+		getTime = time.Now
+	})
+
+	err := db.Set(context.Background(), "clock-skew-key", obj, 1000*time.Second)
+	assert.NoError(t, err)
+
+	getTime = func() time.Time { return baseTime.Add(-2 * time.Second) }
+
+	got, err := db.Get(context.Background(), "clock-skew-key")
+	assert.NoError(t, err)
+	assert.Equal(t, obj, got)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->


**What is this feature?**

Updates database-backed remote cache validation to invalidate expiring cache entries when their creation timestamp is later than the current system time.

A regression test was added to simulate the system clock moving backwards after a cache entry is created.

**Why do we need this feature?**

If Grafana creates a cache entry while the system clock is incorrectly ahead and the clock is later corrected, the cache entry can appear to have a negative age.

Previously, this negative age was treated as valid because it did not satisfy the normal expiration check.

The updated validation treats a negative cache age as invalid, deletes the cache entry, and returns `ErrCacheItemNotFound`.

**Who is this feature for?**

Grafana installations where system clock corrections or clock skew can cause cached internal tokens or other expiring cache entries to have creation timestamps in the future.

**Which issue(s) does this PR fix?**

Fixes #121015

**Special notes for your reviewer:**

AI assistance was used during development for code navigation, test drafting, and review. I reviewed and understood the final change and verified its behavior locally.

Tested with:

`go test ./pkg/infra/remotecache -run TestIntegrationGetInvalidatesFutureCreatedAt -count=1`

`go test ./pkg/infra/remotecache -count=1`

Result: PASS.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
