### PR TITLE
Provisioning: Add TestData demo dashboards and mermaid skill

### DIFF
--- a/.claude/skills/mermaid/SKILL.md
+++ b/.claude/skills/mermaid/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: mermaid
+description: Generate a Mermaid diagram at a stated depth (L100, L200, L300, L400) for a topic. Use when the user writes mermaid L100, mermaid L200, mermaid L300, or mermaid L400 followed by a description, or asks for a leveled Mermaid / architecture chart.
+---
+
+# Mermaid
+
+Generate one Mermaid diagram (plus a short legend) at the requested depth.
+
+## Invocation
+
+```
+mermaid L200 <description>
+```
+
+- **Level** (required): `L100` | `L200` | `L300` | `L400` (case-insensitive). If omitted, use **L200**.
+- **Description**: the topic to diagram. Treat "this repo", "this codebase", or an implicit current-project topic as the workspace.
+
+Do not write files unless the user asks. Reply with a fenced `mermaid` block, then a brief legend.
+
+## Levels
+
+Depth is about **abstraction**, not diagram size. Stay inside the node budget. Omit anything the level forbids. Prefer a second diagram over a crowded one.
+
+| Level | Abstraction | Audience | Nodes | What to show | What to omit |
+| --- | --- | --- | --- | --- | --- |
+| **L100** | Conceptual / system context | Anyone, 30s scan | 4–8 | Actors, named systems, one-line purpose of each edge | Dirs, packages, APIs, protocols, tech internals |
+| **L200** | Logical / containers | Engineer new to the area | 8–18 | Major subsystems, process/store boundaries, container-level tech, cross-boundary request path | File paths, function names, individual routes |
+| **L300** | Components | Someone about to change it | 15–35 | Packages, domain services, key modules, important interfaces as labeled edges | Line-level code, every helper, speculative nodes |
+| **L400** | Implementation | Debugging or implementing | scoped | Real files, types, handlers, routes, or a single request/data sequence | The whole system on one canvas |
+
+**L400 rule:** one flow or one component, not the whole system. Split into multiple diagrams if needed.
+
+## Grounding
+
+Decide the source of truth from the description:
+
+- **This workspace / a path / a feature in-repo** → inspect the tree before drawing. Do not invent subsystems.
+- **A general concept** (e.g. OAuth2 code flow) → use domain knowledge; do not pretend it lives in the repo.
+
+How much to inspect:
+
+- **L100** — README / AGENTS.md / top-level dirs
+- **L200** — plus key package READMEs and one listing of major subdirs (`pkg/`, `public/app/`, `packages/`, `apps/`)
+- **L300** — plus entrypoints and domain listings (services, features, plugin dirs)
+- **L400** — read the actual files for the described flow; cite real symbols only
+
+If the tree contradicts a prior mental model, trust the tree.
+
+## Chart type
+
+Pick one primary type from the description:
+
+| Topic sounds like | Type |
+| --- | --- |
+| Structure, architecture, "how is X put together" | `flowchart TB` (use `LR` only if the graph is a shallow pipeline) |
+| Request, lifecycle, handshake | `sequenceDiagram` |
+| States / modes | `stateDiagram-v2` |
+| Types / interfaces at L400 | `classDiagram` |
+| Data model at L300+ | `erDiagram` |
+
+Default: `flowchart TB`. Do not use experimental Mermaid C4.
+
+## Mermaid constraints
+
+- Node and subgraph **IDs**: `[A-Za-z][A-Za-z0-9_]*` — no spaces, no hyphens in IDs.
+- Labels: put punctuation/spaces inside `["..."]` or `["line1<br/>line2"]`.
+- Subgraphs: `subgraph id["Visible title"]` — never `subgraph Visible Title`.
+- Edges: short labels; one idea per edge.
+- No HTML except `<br/>`. No `style`/`classDef` unless the user asks for color.
+- No `click`, no `init`, no `%%{init:...}%%`.
+- Every node you draw must earn its place at this level. Collapse leftovers into one "other" node or drop them and say so in the legend.
+
+## Output
+
+```markdown
+**L200 — <one-line restatement of the description>**
+
+```mermaid
+flowchart TB
+  ...
+```
+
+<2–5 sentences: how to read it, what was intentionally left out, and (L300/L400) which dirs or files you inspected.>
+```
+
+If L400 needs two diagrams (structure + sequence), emit both, each with its own one-line title.
+
+## Workflow
+
+1. Parse level + description. Default level L200.
+2. If the topic is in-repo, inspect at the depth above.
+3. Choose chart type. List nodes that belong at this level; cut the rest.
+4. Draw. Check IDs, budgets, and "no invented boxes".
+5. Write the legend. Name what you omitted.
+
+## Additional resources
+
+- Worked L100–L400 of the same topic: [examples.md](examples.md)

--- a/.claude/skills/mermaid/examples.md
+++ b/.claude/skills/mermaid/examples.md
@@ -1,0 +1,131 @@
+# Examples
+
+Same topic at each level: **Grafana repo architecture**. Copy the shape, not the boxes, when the description is a different system.
+
+## mermaid L100 Grafana repo architecture
+
+**L100 — Grafana as a monitoring UI in front of data sources**
+
+```mermaid
+flowchart TB
+  user["User"]
+  grafana["Grafana"]
+  store["Grafana database"]
+  datasources["External data sources"]
+
+  user --> grafana
+  grafana --> store
+  grafana --> datasources
+```
+
+Users open Grafana to view and alert on telemetry. Grafana persists its own state (dashboards, users, settings) and queries external systems for data. No frontend/backend split, plugins, or storage variants.
+
+## mermaid L200 Grafana repo architecture
+
+**L200 — Grafana monorepo: UI, API, apps, plugins, storage**
+
+```mermaid
+flowchart TB
+  subgraph clients["Clients"]
+    browser["Browser"]
+  end
+
+  subgraph frontend["Frontend"]
+    react["React app"]
+    pkgs["Shared TS packages"]
+    fePlugins["Built-in UI plugins"]
+  end
+
+  subgraph backend["Backend"]
+    api["HTTP API"]
+    services["Domain services"]
+    apps["App SDK apps"]
+    plugins["Plugin system"]
+    tsdb["Query backends"]
+  end
+
+  subgraph storage["Storage"]
+    sql["SQL store"]
+    unified["Unified storage"]
+  end
+
+  dbs["SQLite / Postgres / MySQL"]
+  datasources["Prometheus, Loki, CloudWatch, ..."]
+
+  browser --> react
+  react --> pkgs
+  react --> fePlugins
+  react --> api
+  api --> services
+  api --> apps
+  services --> plugins
+  services --> tsdb
+  services --> sql
+  services --> unified
+  plugins --> fePlugins
+  tsdb --> datasources
+  sql --> dbs
+  unified --> dbs
+```
+
+Container-level view of `public/app`, `packages/`, `pkg/`, `apps/`, and `pkg/storage`. Request path is UI → HTTP API → services or App SDK apps → SQL / unified storage / plugin query backends. File-level handlers and individual services are omitted.
+
+## mermaid L300 Grafana query path
+
+**L300 — Component view of a dashboard query**
+
+```mermaid
+flowchart TB
+  subgraph frontend["public/app"]
+    dash["dashboard / dashboard-scene"]
+    queryUI["query feature"]
+    dsPlugin["datasource plugin UI"]
+  end
+
+  subgraph apiLayer["pkg/api + pkg/services"]
+    queryAPI["query HTTP API"]
+    querySvc["query service"]
+    dsSvc["datasources service"]
+  end
+
+  subgraph exec["Execution"]
+    tsdb["pkg/tsdb backend"]
+    pluginMgr["pkg/plugins manager"]
+    extPlugin["external plugin"]
+  end
+
+  dash --> queryUI
+  queryUI --> dsPlugin
+  dsPlugin --> queryAPI
+  queryAPI --> querySvc
+  querySvc --> dsSvc
+  querySvc --> tsdb
+  querySvc --> pluginMgr
+  pluginMgr --> extPlugin
+```
+
+Packages and domain services on the dashboard query path. Inspect `public/app/features/dashboard`, `public/app/features/query`, `pkg/services/query`, `pkg/tsdb`, `pkg/plugins`. Authn, alerting, and unified storage are out of scope.
+
+## mermaid L400 Grafana query HTTP handler
+
+**L400 — Sequence of one query request through the API**
+
+```mermaid
+sequenceDiagram
+  participant UI as Query editor
+  participant API as pkg/api query handler
+  participant QS as query service
+  participant DS as datasources service
+  participant BE as tsdb or plugin backend
+
+  UI->>API: POST query
+  API->>QS: run queries
+  QS->>DS: resolve datasource
+  DS-->>QS: plugin + settings
+  QS->>BE: execute
+  BE-->>QS: frames
+  QS-->>API: response
+  API-->>UI: series
+```
+
+Single request. Node names must match real packages/handlers you opened; replace this sketch after reading the handler and service entrypoints. Do not expand into dashboard persistence or alerting on the same canvas.

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ public/css/*.min.css
 !.claude/skills/add-e2e-selectors/
 !.claude/skills/frontend-testing-strategy/
 !.claude/skills/panel-testing-strategy/
+!.claude/skills/mermaid/
 
 .eslintcache
 .stylelintcache

--- a/conf/provisioning/dashboards/demo.yaml
+++ b/conf/provisioning/dashboards/demo.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: demo-dummy-data
+    orgId: 1
+    folder: Demo
+    folderUid: demo-dummy
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: conf/provisioning/dashboards/json

--- a/conf/provisioning/dashboards/json/async-processing.json
+++ b/conf/provisioning/dashboards/json/async-processing.json
@@ -1,0 +1,324 @@
+{
+  "uid": "demo-async-processing",
+  "title": "Demo: Async Processing",
+  "tags": ["demo", "dummy", "queue", "async"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "fiscalYearStartMonth": 0,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Queue depth",
+      "description": "Messages waiting in the async processing queue",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1200 }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "queue_depth",
+          "min": 80,
+          "max": 1800,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Consumer lag",
+      "description": "Seconds behind the latest published message",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 30 },
+              { "color": "red", "value": 120 }
+            ]
+          },
+          "unit": "s",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "predictable_pulse",
+          "alias": "consumer_lag",
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "gauge",
+      "title": "Cache hit rate",
+      "description": "Percentage of async jobs served from cache",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "yellow", "value": 70 },
+              { "color": "green", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "cache_hit_rate",
+          "min": 62,
+          "max": 98,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Message throughput",
+      "description": "Messages processed per second",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "yellow", "value": 120 },
+              { "color": "green", "value": 300 }
+            ]
+          },
+          "unit": "mps",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "throughput",
+          "min": 90,
+          "max": 520,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Queue depth by consumer group",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "orders-consumer",
+          "labels": "consumer_group=orders",
+          "min": 40,
+          "max": 900,
+          "seriesCount": 1
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "notifications-consumer",
+          "labels": "consumer_group=notifications",
+          "min": 20,
+          "max": 450,
+          "seriesCount": 1
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "analytics-consumer",
+          "labels": "consumer_group=analytics",
+          "min": 60,
+          "max": 1200,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Message throughput over time",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "mps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "published",
+          "labels": "direction=published",
+          "min": 150,
+          "max": 480,
+          "seriesCount": 1
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "consumed",
+          "labels": "direction=consumed",
+          "min": 120,
+          "max": 460,
+          "seriesCount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/conf/provisioning/dashboards/json/infrastructure.json
+++ b/conf/provisioning/dashboards/json/infrastructure.json
@@ -1,0 +1,244 @@
+{
+  "uid": "demo-infrastructure",
+  "title": "Demo: Infrastructure",
+  "tags": ["demo", "dummy", "infra"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "fiscalYearStartMonth": 0,
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "CPU by host",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "min": 0,
+          "max": 100,
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "cpu",
+          "labels": "host=web-$seriesIndex",
+          "min": 8,
+          "max": 92,
+          "seriesCount": 6
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Memory used",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 40,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "rss",
+          "labels": "host=web-$seriesIndex",
+          "min": 1200000000,
+          "max": 6800000000,
+          "seriesCount": 5
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "heatmap",
+      "title": "Latency heatmap",
+      "description": "Exponential heatmap bucket dummy data",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "scaleDistribution": { "type": "linear" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "ms" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "exponential_heatmap_bucket_data"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "bargauge",
+      "title": "Disk used",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 100,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "lcd",
+        "namePlacement": "top",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "disk",
+          "labels": "volume=/data-$seriesIndex",
+          "min": 22,
+          "max": 97,
+          "seriesCount": 4
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Host inventory (dummy table)",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false,
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk_table"
+        }
+      ]
+    }
+  ]
+}

--- a/conf/provisioning/dashboards/json/observability.json
+++ b/conf/provisioning/dashboards/json/observability.json
@@ -1,0 +1,178 @@
+{
+  "uid": "demo-observability",
+  "title": "Demo: Logs, traces & dependencies",
+  "tags": ["demo", "dummy", "o11y"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "fiscalYearStartMonth": 0,
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "logs",
+      "title": "Application logs",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 12, "w": 14, "x": 0, "y": 0 },
+      "options": {
+        "dedupStrategy": "none",
+        "enableInfiniteScrolling": false,
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "logs",
+          "alias": "checkout-api",
+          "lines": 80,
+          "levelColumn": true
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "piechart",
+      "title": "Error mix (dummy)",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 12, "w": 10, "x": 14, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "errors",
+          "labels": "reason=$seriesIndex",
+          "min": 2,
+          "max": 40,
+          "seriesCount": 5
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "US region traffic",
+      "description": "TestData USA scenario — dummy regional series",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "list", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "usa",
+          "usa": { "mode": "timeseries", "period": "10m", "fields": ["foo"], "states": ["CA", "NY", "TX", "WA", "FL"] }
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Live stream (dummy)",
+      "description": "Streaming TestData client — updates in real time",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 12 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "streaming_client",
+          "stream": { "noise": 8, "speed": 150, "spread": 18, "type": "signal", "bands": 2 }
+        }
+      ]
+    }
+  ]
+}

--- a/conf/provisioning/dashboards/json/service-overview.json
+++ b/conf/provisioning/dashboards/json/service-overview.json
@@ -1,0 +1,390 @@
+{
+  "uid": "demo-service-overview",
+  "title": "Demo: Service Overview",
+  "tags": ["demo", "dummy", "service"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "fiscalYearStartMonth": 0,
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "templating": { "list": [] },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Request rate",
+      "description": "Synthetic RPS from TestData",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 400 },
+              { "color": "red", "value": 700 }
+            ]
+          },
+          "unit": "reqps",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "rps",
+          "min": 180,
+          "max": 620,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "p95 latency",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 180 },
+              { "color": "red", "value": 280 }
+            ]
+          },
+          "unit": "ms",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "p95",
+          "min": 40,
+          "max": 320,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Error rate",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "yellow", "value": 1.5 },
+              { "color": "red", "value": 3 }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "errors",
+          "min": 0.1,
+          "max": 4.2,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "Availability",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "min": 99,
+          "max": 100,
+          "unit": "percent",
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": 0 },
+              { "color": "yellow", "value": 99.5 },
+              { "color": "green", "value": 99.9 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "availability",
+          "min": 99.2,
+          "max": 100,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Traffic by endpoint",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 16, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 18,
+            "gradientMode": "opacity",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "GET /api/orders",
+          "labels": "endpoint=/api/orders,method=GET",
+          "min": 80,
+          "max": 240,
+          "seriesCount": 1
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "POST /api/checkout",
+          "labels": "endpoint=/api/checkout,method=POST",
+          "min": 20,
+          "max": 90,
+          "seriesCount": 1
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "GET /api/catalog",
+          "labels": "endpoint=/api/catalog,method=GET",
+          "min": 120,
+          "max": 360,
+          "seriesCount": 1
+        },
+        {
+          "refId": "D",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "GET /health",
+          "labels": "endpoint=/health,method=GET",
+          "min": 8,
+          "max": 20,
+          "seriesCount": 1
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Latency pulse",
+      "description": "Predictable pulse scenario — dummy SLO-style spikes",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "predictable_pulse",
+          "alias": "latency spikes",
+          "pulseWave": {
+            "timeStep": 5000,
+            "onCount": 2,
+            "onValue": 240,
+            "offCount": 8,
+            "offValue": 55
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Error budget burn",
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "continuous-RdYlGr" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "gradientMode": "scheme",
+            "showPoints": "never",
+            "spanNulls": false,
+            "insertNulls": false,
+            "pointSize": 5,
+            "axisPlacement": "auto",
+            "axisColorMode": "text",
+            "axisBorderShow": false,
+            "scaleDistribution": { "type": "linear" },
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "line+area" },
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }
+          },
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 2 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "5m burn",
+          "min": 0.2,
+          "max": 3.8,
+          "seriesCount": 1
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "grafana-testdata-datasource", "uid": "testdata" },
+          "scenarioId": "random_walk",
+          "alias": "1h burn",
+          "min": 0.1,
+          "max": 1.6,
+          "seriesCount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/conf/provisioning/datasources/testdata.yaml
+++ b/conf/provisioning/datasources/testdata.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: TestData
+    uid: testdata
+    type: grafana-testdata-datasource
+    access: proxy
+    isDefault: true
+    editable: true

--- a/public/app/api/utils.ts
+++ b/public/app/api/utils.ts
@@ -1,7 +1,7 @@
 import { normalizeError } from '@grafana/api-clients';
 import { isObject } from '@grafana/data';
 import { type ThunkDispatch } from 'app/types/store';
-
+// adding a new line
 import { createErrorNotification } from '../core/copy/appNotification';
 import { notifyApp } from '../core/reducers/appNotification';
 import { isStatusFailure } from '../features/apiserver/guards';


### PR DESCRIPTION
**What is this feature?**

Provisions a TestData datasource and four dummy-data dashboards (service overview, infrastructure, logs/observability, and async processing) so a local Grafana instance has something to look at without real backends. Also adds a mermaid skill for L100–L400 architecture diagrams.

**Why do we need this feature?**

A fresh local Grafana checkout has no datasources or dashboards. These provisioned files give a working Demo folder with synthetic metrics, logs, heatmaps, queue/throughput series, and streaming data for demos and local exploration.

**Who is this feature for?**

Developers and anyone running this repo locally who wants sample dashboards without standing up Prometheus, Loki, or other backends.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Dashboards live under `conf/provisioning/` and load into a **Demo** folder. Login is `admin` / `admin` at http://localhost:3000.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.