### PR TITLE
Variables: Fix containsVariable() false positive on format specifier or field path

### DIFF
--- a/public/app/features/variables/inspect/utils.test.ts
+++ b/public/app/features/variables/inspect/utils.test.ts
@@ -18,7 +18,7 @@ import {
 describe('getPropsWithVariable', () => {
   it('when called it should return the correct graph', () => {
     const result = getPropsWithVariable(
-      '$unknownVariable',
+      'unknownVariable',
       {
         key: 'model',
         value: {

--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -191,6 +191,22 @@ describe('containsVariable', () => {
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(containsVariable(value, 'var')).toEqual(expected);
   });
+
+  it('does not match a name that only appears as a format specifier', () => {
+    expect(containsVariable('[[other:csv]]', 'csv')).toBe(false);
+    expect(containsVariable('${other:json}', 'json')).toBe(false);
+  });
+
+  it('does not match a name that only appears as a field path', () => {
+    expect(containsVariable('${data.host}', 'host')).toBe(false);
+  });
+
+  it('still matches the actual variable name in each reference style', () => {
+    expect(containsVariable('$realvar', 'realvar')).toBe(true);
+    expect(containsVariable('[[other:csv]]', 'other')).toBe(true);
+    expect(containsVariable('${other:json}', 'other')).toBe(true);
+    expect(containsVariable('${data.host}', 'data')).toBe(true);
+  });
 });
 
 describe('getVariablesFromUrl', () => {

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -46,7 +46,12 @@ export function containsVariable(...args: any[]) {
     matches !== null
       ? matches.find((match) => {
           const varMatch = variableRegexExec(match);
-          return varMatch !== null && varMatch.indexOf(variableName) > -1;
+          // Capture groups 1, 2 and 4 hold the referenced variable's name ($var1, [[var2]], ${var3}).
+          // Groups 3, 5 and 6 hold a format specifier or field path, which must not count as a match.
+          return (
+            varMatch !== null &&
+            (varMatch[1] === variableName || varMatch[2] === variableName || varMatch[4] === variableName)
+          );
         })
       : false;
 


### PR DESCRIPTION
## What this does

Fixes #125036.

`containsVariable()` in `public/app/features/variables/utils.ts` checks whether a string references a given variable by running it through `variableRegex` and then scanning **every** element of the resulting match array for the name being searched for:

```ts
return varMatch !== null && varMatch.indexOf(variableName) > -1;
```

`variableRegex` has six capture groups. Only groups 1, 2 and 4 hold the referenced variable's name (`$var1`, `[[var2]]`, `${var3}`); groups 3, 5 and 6 hold a format specifier (`csv`, `json`, `regex`, ...) or a field path (`host`, `id`, ...). Because `indexOf` scans the whole array, a name that only appears as a format specifier or field path was wrongly treated as an actual variable reference:

```ts
containsVariable('[[other:csv]]', 'csv')   // true, expected false
containsVariable('${other:json}', 'json')  // true, expected false
containsVariable('${data.host}', 'host')   // true, expected false
containsVariable('$realvar', 'realvar')    // true, correct
```

`containsVariable` backs `dependsOn` in the query, custom, datasource and switch variable adapters (the variable dependency graph) and the variable usage inspector. The false positive makes a variable look like it depends on another one it doesn't reference — e.g. a variable named `host` would appear to be a dependency of any other variable whose query interpolates a field path like `${somevar.host}`, causing unnecessary/incorrect re-queries.

## The fix

Restrict the match to the three name-holding capture groups (1, 2 and 4) instead of scanning the whole match array.

## Tests

- Added regression tests in `utils.test.ts` covering the exact repro cases from the issue: format-specifier collisions (`csv`, `json`), a field-path collision (`host`), and confirmation that real variable-name matches in all three reference styles (`$var`, `[[var:fmt]]`, `${var.field:fmt}`) still work.
- One existing test in `inspect/utils.test.ts` (`getPropsWithVariable`) passed a `'$'`-prefixed string (`'$unknownVariable'`) as the variable id being searched for. That only passed previously because the old buggy implementation also scanned the full match string (array index 0) — not because any real caller passes a decorated name. Both actual production call sites (`variable.id`, and `getVariableName()`'s return value) pass bare names, so I updated the test's input to `'unknownVariable'` to match real usage; the assertion is otherwise unchanged.
- Ran the full `public/app/features/variables` test suite: 50 suites, 696 tests, all passing.
- `tsc --noEmit` and `eslint` clean on all three changed files.