### PR TITLE
Navigation: Add a feedback survey button to the customisable mega menu

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -695,6 +695,8 @@ describe('MegaMenu', () => {
           sectionOrder: ['dashboards'],
         });
 
+        // The button only shows while customising, and it reports the applied (not draft) state.
+        await user.click(await screen.findByRole('button', { name: 'Customise navigation' }));
         await user.click(await screen.findByRole('button', { name: 'Give feedback' }));
 
         expect(events).toHaveLength(1);
@@ -711,11 +713,14 @@ describe('MegaMenu', () => {
         subscription.unsubscribe();
       });
 
-      it('offers the feedback button both at rest and while editing', async () => {
+      it('offers the feedback button only while customising', async () => {
         const { user } = renderMegaMenu();
 
-        expect(await screen.findByRole('button', { name: 'Give feedback' })).toBeInTheDocument();
-        await user.click(await screen.findByRole('button', { name: 'Customise navigation' }));
+        // At rest the footer shows the Customise entry point but no feedback button.
+        await screen.findByRole('button', { name: 'Customise navigation' });
+        expect(screen.queryByRole('button', { name: 'Give feedback' })).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Customise navigation' }));
         expect(screen.getByRole('button', { name: 'Give feedback' })).toBeInTheDocument();
       });
     });

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -1,9 +1,9 @@
 import { HttpResponse } from 'msw';
 import { act, render, screen, testWithFeatureToggles, userEvent, waitFor, within } from 'test/test-utils';
 
-import { type NavModelItem } from '@grafana/data';
+import { EventBusSrv, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { reportInteraction, setBackendSrv } from '@grafana/runtime';
+import { reportInteraction, setAppEvents, setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import {
   customGetUserPreferencesHandler,
@@ -24,6 +24,7 @@ import { AppChromeService } from '../AppChromeService';
 import { MegaMenu } from './MegaMenu';
 import { customisableNavTree, nestedNavTree } from './__mocks__/fixtures';
 import { HIDDEN_ITEMS_STORAGE_KEY, SECTION_ORDER_STORAGE_KEY } from './hooks';
+import { CustomizableNavFeedbackEvent } from './navFeedback';
 
 // The org switcher fetches user orgs on mount when signed in, which is irrelevant here.
 jest.mock('../OrganizationSwitcher/OrganizationSwitcher', () => ({
@@ -672,6 +673,50 @@ describe('MegaMenu', () => {
           'grafana_nav_customise_saved',
           expect.objectContaining({ hiddenCount: 0, pinnedCount: 1 })
         );
+      });
+    });
+
+    describe('feedback', () => {
+      let appEvents: EventBusSrv;
+      beforeEach(() => {
+        // getAppEvents() is not initialised in the test runtime; give the publish (and this test's
+        // subscription) a real bus to share.
+        appEvents = new EventBusSrv();
+        setAppEvents(appEvents);
+      });
+
+      it('publishes the applied customisation and tracks the click', async () => {
+        const events: CustomizableNavFeedbackEvent[] = [];
+        const subscription = appEvents.subscribe(CustomizableNavFeedbackEvent, (event) => events.push(event));
+
+        const { user } = renderMegaMenu({
+          hiddenItemIds: ['explore'],
+          bookmarkUrls: ['/playlists'],
+          sectionOrder: ['dashboards'],
+        });
+
+        await user.click(await screen.findByRole('button', { name: 'Give feedback' }));
+
+        expect(events).toHaveLength(1);
+        // The type is a wire contract with the setupguide-app survey — pin it so a rename can't
+        // silently break the trigger.
+        expect(events[0].type).toBe('customizable-nav-feedback');
+        expect(events[0].payload).toEqual({
+          hiddenItems: ['explore'],
+          pinnedItems: ['/playlists'],
+          sectionOrder: ['dashboards'],
+        });
+        expect(reportInteraction).toHaveBeenCalledWith('grafana_nav_customise_feedback', expect.anything());
+
+        subscription.unsubscribe();
+      });
+
+      it('offers the feedback button both at rest and while editing', async () => {
+        const { user } = renderMegaMenu();
+
+        expect(await screen.findByRole('button', { name: 'Give feedback' })).toBeInTheDocument();
+        await user.click(await screen.findByRole('button', { name: 'Customise navigation' }));
+        expect(screen.getByRole('button', { name: 'Give feedback' })).toBeInTheDocument();
       });
     });
   });

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -7,13 +7,12 @@ import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { ScrollContainer, Stack, Text, useStyles2, Button, IconButton } from '@grafana/ui';
+import { ScrollContainer, Text, useStyles2, Button, IconButton } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useSyncStarredItemsInNav } from 'app/features/stars/hooks';
 
 import { MegaMenuCustomiseControls } from './MegaMenuCustomiseControls';
 import { MegaMenuExtensionPoint } from './MegaMenuExtensionPoint';
-import { MegaMenuFeedbackButton } from './MegaMenuFeedbackButton';
 import { DOCK_MENU_BUTTON_ID, MegaMenuHeader } from './MegaMenuHeader';
 import { MegaMenuItem } from './MegaMenuItem';
 import { MegaMenuPinnedItem } from './MegaMenuPinnedItem';
@@ -267,31 +266,24 @@ export const MegaMenu = memo(
                 saving={isSaving}
               />
             )}
-            {!editMode && (
-              <>
-                {canCustomise && !isLoading && (
-                  <Stack alignItems="center" gap={0.5}>
-                    <Button variant="secondary" onClick={onEnterEditMode} size="sm" icon="sliders-v-alt">
-                      <Trans i18nKey="navigation.megamenu.customise">Customise navigation</Trans>
-                    </Button>
-                    <MegaMenuFeedbackButton onClick={onGiveFeedback} />
-                  </Stack>
-                )}
-                {!state.fullscreenWorkspace && (
-                  <IconButton
-                    id={DOCK_MENU_BUTTON_ID}
-                    className={styles.dockMenuButton}
-                    tooltip={
-                      state.megaMenuDocked
-                        ? t('navigation.megamenu.undock', 'Undock menu')
-                        : t('navigation.megamenu.dock', 'Dock menu')
-                    }
-                    name="web-section-alt"
-                    onClick={handleDockedMenu}
-                    variant="secondary"
-                  />
-                )}
-              </>
+            {!editMode && canCustomise && !isLoading && (
+              <Button variant="secondary" onClick={onEnterEditMode} size="sm" icon="sliders-v-alt">
+                <Trans i18nKey="navigation.megamenu.customise">Customise navigation</Trans>
+              </Button>
+            )}
+            {!editMode && !state.fullscreenWorkspace && (
+              <IconButton
+                id={DOCK_MENU_BUTTON_ID}
+                className={styles.dockMenuButton}
+                tooltip={
+                  state.megaMenuDocked
+                    ? t('navigation.megamenu.undock', 'Undock menu')
+                    : t('navigation.megamenu.dock', 'Dock menu')
+                }
+                name="web-section-alt"
+                onClick={handleDockedMenu}
+                variant="secondary"
+              />
             )}
           </div>
         </nav>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -7,12 +7,13 @@ import { type GrafanaTheme2, type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
-import { ScrollContainer, Text, useStyles2, Button, IconButton } from '@grafana/ui';
+import { ScrollContainer, Stack, Text, useStyles2, Button, IconButton } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useSyncStarredItemsInNav } from 'app/features/stars/hooks';
 
 import { MegaMenuCustomiseControls } from './MegaMenuCustomiseControls';
 import { MegaMenuExtensionPoint } from './MegaMenuExtensionPoint';
+import { MegaMenuFeedbackButton } from './MegaMenuFeedbackButton';
 import { DOCK_MENU_BUTTON_ID, MegaMenuHeader } from './MegaMenuHeader';
 import { MegaMenuItem } from './MegaMenuItem';
 import { MegaMenuPinnedItem } from './MegaMenuPinnedItem';
@@ -51,6 +52,7 @@ export const MegaMenu = memo(
       onResetToDefault,
       onReorderPinned,
       onReorderSection,
+      onGiveFeedback,
       isSaving,
     } = useNavCustomization();
 
@@ -261,27 +263,35 @@ export const MegaMenu = memo(
                 onResetToDefault={onResetToDefault}
                 onCancelEdit={onCancelEdit}
                 onSaveEdit={onSaveEdit}
+                onGiveFeedback={onGiveFeedback}
                 saving={isSaving}
               />
             )}
-            {!editMode && canCustomise && !isLoading && (
-              <Button variant="secondary" onClick={onEnterEditMode} size="sm" icon="sliders-v-alt">
-                <Trans i18nKey="navigation.megamenu.customise">Customise navigation</Trans>
-              </Button>
-            )}
-            {!editMode && !state.fullscreenWorkspace && (
-              <IconButton
-                id={DOCK_MENU_BUTTON_ID}
-                className={styles.dockMenuButton}
-                tooltip={
-                  state.megaMenuDocked
-                    ? t('navigation.megamenu.undock', 'Undock menu')
-                    : t('navigation.megamenu.dock', 'Dock menu')
-                }
-                name="web-section-alt"
-                onClick={handleDockedMenu}
-                variant="secondary"
-              />
+            {!editMode && (
+              <>
+                {canCustomise && !isLoading && (
+                  <Stack alignItems="center" gap={0.5}>
+                    <Button variant="secondary" onClick={onEnterEditMode} size="sm" icon="sliders-v-alt">
+                      <Trans i18nKey="navigation.megamenu.customise">Customise navigation</Trans>
+                    </Button>
+                    <MegaMenuFeedbackButton onClick={onGiveFeedback} />
+                  </Stack>
+                )}
+                {!state.fullscreenWorkspace && (
+                  <IconButton
+                    id={DOCK_MENU_BUTTON_ID}
+                    className={styles.dockMenuButton}
+                    tooltip={
+                      state.megaMenuDocked
+                        ? t('navigation.megamenu.undock', 'Undock menu')
+                        : t('navigation.megamenu.dock', 'Dock menu')
+                    }
+                    name="web-section-alt"
+                    onClick={handleDockedMenu}
+                    variant="secondary"
+                  />
+                )}
+              </>
             )}
           </div>
         </nav>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuCustomiseControls.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuCustomiseControls.tsx
@@ -1,6 +1,8 @@
 import { t } from '@grafana/i18n';
 import { Button, IconButton, Stack } from '@grafana/ui';
 
+import { MegaMenuFeedbackButton } from './MegaMenuFeedbackButton';
+
 interface Props {
   /** There is staged customisation to clear — show the Reset control */
   canReset?: boolean;
@@ -10,14 +12,24 @@ interface Props {
   onCancelEdit?: () => void;
   /** Save the staged customisation and leave customise mode */
   onSaveEdit?: () => void;
+  /** Open the navigation feedback survey */
+  onGiveFeedback?: () => void;
   /** The save is in flight — show a spinner on Done and lock the controls */
   saving?: boolean;
 }
 
-/** The mega menu header controls shown while customising: Reset / Cancel / Done. */
-export function MegaMenuCustomiseControls({ canReset, onResetToDefault, onCancelEdit, onSaveEdit, saving }: Props) {
+/** The mega menu footer controls shown while customising: Give feedback / Reset / Cancel / Done. */
+export function MegaMenuCustomiseControls({
+  canReset,
+  onResetToDefault,
+  onCancelEdit,
+  onSaveEdit,
+  onGiveFeedback,
+  saving,
+}: Props) {
   return (
     <Stack alignItems="center" gap={1}>
+      {onGiveFeedback && <MegaMenuFeedbackButton onClick={onGiveFeedback} />}
       {canReset && (
         <IconButton
           name="history"

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuFeedbackButton.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuFeedbackButton.tsx
@@ -12,7 +12,7 @@ interface Props {
  */
 export function MegaMenuFeedbackButton({ onClick }: Props) {
   return (
-    <Button variant="secondary" fill="text" size="sm" icon="comment-alt-message" onClick={onClick}>
+    <Button variant="secondary" size="sm" icon="comment-alt-message" onClick={onClick}>
       {t('navigation.megamenu.feedback', 'Give feedback')}
     </Button>
   );

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuFeedbackButton.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuFeedbackButton.tsx
@@ -1,0 +1,19 @@
+import { t } from '@grafana/i18n';
+import { Button } from '@grafana/ui';
+
+interface Props {
+  onClick: () => void;
+}
+
+/**
+ * Footer affordance for the customisable mega menu. Its onClick publishes the feedback event that
+ * triggers the "Customisable navigation feedback" survey; shown wherever the customise feature is
+ * available so people who have set up their nav can tell us how it went.
+ */
+export function MegaMenuFeedbackButton({ onClick }: Props) {
+  return (
+    <Button variant="secondary" fill="text" size="sm" icon="comment-alt-message" onClick={onClick}>
+      {t('navigation.megamenu.feedback', 'Give feedback')}
+    </Button>
+  );
+}

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -7,7 +7,7 @@ import { useLocalStorage } from 'react-use';
 import { useListPreferencesQuery, useUpdatePreferencesMutation } from '@grafana/api-clients/rtkq/preferences/v1';
 import { type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { getAppEvents, reportInteraction } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { setBookmark } from 'app/core/reducers/navBarTree';
@@ -16,6 +16,7 @@ import { useDispatch, useSelector } from 'app/types/store';
 import { contextSrv } from '../../../services/context_srv';
 
 import { getNavExperimentPayload, reportNavExperimentViewOnce, setNavExperimentVariant } from './navExperiment';
+import { CustomizableNavFeedbackEvent } from './navFeedback';
 import {
   enrichWithInteractionTracking,
   findByUrl,
@@ -91,6 +92,7 @@ const usePinning = ({
 }): CustomisationDimension & {
   pinnedItems: string[];
   effectivePinnedUrls: string[];
+  appliedPinnedUrls: string[];
   draftPinnedUrls: string[];
   isLoading: boolean;
   isPinned: (url?: string) => boolean;
@@ -195,6 +197,7 @@ const usePinning = ({
   return {
     pinnedItems,
     effectivePinnedUrls,
+    appliedPinnedUrls: pinnedUrls,
     draftPinnedUrls,
     isLoading,
     isPinned,
@@ -256,6 +259,7 @@ const useSectionOrdering = ({
   baseItems: NavModelItem[];
 }): CustomisationDimension & {
   effectiveSectionOrder: string[];
+  appliedSectionOrder: string[];
   draftSectionOrder: string[];
   isLoading: boolean;
   onReorderSection: (fromIndex: number, toIndex: number) => void;
@@ -277,7 +281,16 @@ const useSectionOrdering = ({
   const reset = useCallback(() => setDraftSectionOrder([]), []);
   const commit = useCallback(() => setSectionOrder(draftSectionOrder), [draftSectionOrder, setSectionOrder]);
 
-  return { effectiveSectionOrder, draftSectionOrder, isLoading, onReorderSection, syncFromApplied, reset, commit };
+  return {
+    effectiveSectionOrder,
+    appliedSectionOrder,
+    draftSectionOrder,
+    isLoading,
+    onReorderSection,
+    syncFromApplied,
+    reset,
+    commit,
+  };
 };
 
 /**
@@ -329,6 +342,7 @@ export const useNavCustomization = () => {
   const {
     pinnedItems,
     effectivePinnedUrls,
+    appliedPinnedUrls,
     draftPinnedUrls,
     isLoading: pinningLoading,
     isPinned,
@@ -350,6 +364,7 @@ export const useNavCustomization = () => {
   } = useHiddenSections({ baseItems });
   const {
     effectiveSectionOrder,
+    appliedSectionOrder,
     draftSectionOrder,
     isLoading: orderingLoading,
     onReorderSection,
@@ -468,6 +483,19 @@ export const useNavCustomization = () => {
     resetOrdering();
   }, [resetPinning, resetHiding, resetOrdering]);
 
+  // Publish the current (applied) customisation on the app event bus. The grafana-setupguide-app
+  // plugin listens for this to trigger the "Customisable navigation feedback" survey.
+  const onGiveFeedback = useCallback(() => {
+    reportInteraction('grafana_nav_customise_feedback', { ...getNavExperimentPayload() });
+    getAppEvents().publish(
+      new CustomizableNavFeedbackEvent({
+        hiddenItems: appliedHiddenIds,
+        pinnedItems: appliedPinnedUrls,
+        sectionOrder: appliedSectionOrder,
+      })
+    );
+  }, [appliedHiddenIds, appliedPinnedUrls, appliedSectionOrder]);
+
   return {
     canCustomise,
     isLoading,
@@ -488,5 +516,6 @@ export const useNavCustomization = () => {
     onResetToDefault,
     onReorderPinned,
     onReorderSection,
+    onGiveFeedback,
   };
 };

--- a/public/app/core/components/AppChrome/MegaMenu/navFeedback.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/navFeedback.ts
@@ -1,0 +1,23 @@
+import { BusEventWithPayload } from '@grafana/data';
+
+/**
+ * The user's current nav customisation, sent with the feedback event so the survey can attribute
+ * responses to how the menu is actually set up. Item identity is heterogeneous (matching what each
+ * store keeps): hidden items and section order are keyed by nav id (falling back to url), pinned
+ * items by url — the survey treats each as an opaque string.
+ */
+export interface CustomizableNavFeedbackPayload {
+  hiddenItems: string[];
+  pinnedItems: string[];
+  sectionOrder: string[];
+}
+
+/**
+ * Published on the app event bus when the user clicks "Give feedback" in the customisable mega menu.
+ * The grafana-setupguide-app plugin listens for this to trigger the "Customisable navigation
+ * feedback" survey, so the `type` string and payload shape are a wire contract with that plugin and
+ * must not change without coordinating there.
+ */
+export class CustomizableNavFeedbackEvent extends BusEventWithPayload<CustomizableNavFeedbackPayload> {
+  static type = 'customizable-nav-feedback';
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12857,6 +12857,7 @@
       "customise-saving": "Saving…",
       "dialog-label": "Navigation",
       "dock": "Dock menu",
+      "feedback": "Give feedback",
       "header-title": "Navigation",
       "list-label": "Navigation",
       "open": "Main menu",


### PR DESCRIPTION
<!-- Stacked on #129196 (the customisable mega menu). Review/merge that first — this PR targets that branch. -->

## What is this feature?

Adds a **"Give feedback"** button to the customisable mega menu footer, shown wherever the customise feature is available (both at rest and while editing). Clicking it publishes a `customizable-nav-feedback` event on the app event bus, carrying the user's **applied** customisation — hidden items, pinned items, and section order. Our Grafana Cloud messaging plugin listens for this event to open the navigation feedback survey.

The event `type` and payload shape are a wire contract with that plugin, so there's a unit test pinning them.

## Why do we need this feature?

So we can gather in-product feedback on the customisable navigation experiment straight from the people using it, attributed to how they've actually set up their nav.

## Who is this feature for?

Signed-in users with `grafana.customizableMegaMenu` enabled.

## Notes

- Stacked on #129196 — this PR is based on that branch, not `main`.
- The button reuses the existing `grafana_nav_customise_*` interaction family (`grafana_nav_customise_feedback`) and the experiment-variant stamp.
