### PR TITLE
Auth: clear stale session cookies when token rotation fails

### DIFF
--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -78,7 +78,7 @@ func (hs *HTTPServer) RevokeUserAuthToken(c *contextmodel.ReqContext) response.R
 func (hs *HTTPServer) RotateUserAuthTokenRedirect(c *contextmodel.ReqContext) response.Response {
 	if err := hs.rotateToken(c); err != nil {
 		hs.log.FromContext(c.Req.Context()).Debug("Failed to rotate token", "error", err)
-		if errors.Is(err, auth.ErrInvalidSessionToken) {
+		if errors.Is(err, auth.ErrInvalidSessionToken) || errors.Is(err, auth.ErrUserTokenNotFound) {
 			hs.log.FromContext(c.Req.Context()).Debug("Deleting session cookie")
 			authn.DeleteSessionCookie(c.Resp, hs.Cfg)
 		}
@@ -110,13 +110,9 @@ func (hs *HTTPServer) RotateUserAuthTokenRedirect(c *contextmodel.ReqContext) re
 func (hs *HTTPServer) RotateUserAuthToken(c *contextmodel.ReqContext) response.Response {
 	if err := hs.rotateToken(c); err != nil {
 		hs.log.FromContext(c.Req.Context()).Debug("Failed to rotate token", "error", err)
-		if errors.Is(err, auth.ErrInvalidSessionToken) {
+		if errors.Is(err, auth.ErrInvalidSessionToken) || errors.Is(err, auth.ErrUserTokenNotFound) {
 			hs.log.FromContext(c.Req.Context()).Debug("Deleting session cookie")
 			authn.DeleteSessionCookie(c.Resp, hs.Cfg)
-			return response.ErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), err)
-		}
-
-		if errors.Is(err, auth.ErrUserTokenNotFound) {
 			return response.ErrOrFallback(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), err)
 		}
 

--- a/pkg/api/user_token_stale_cookie_test.go
+++ b/pkg/api/user_token_stale_cookie_test.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/auth"
+	"github.com/grafana/grafana/pkg/services/auth/authtest"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
+)
+
+func TestHTTPServer_RotateUserAuthToken_DeletesCookieWhenTokenNotFound(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		cfg := setting.NewCfg()
+		cfg.LoginCookieName = "grafana_session"
+		cfg.LoginMaxLifetime = 10 * time.Hour
+		hs.Cfg = cfg
+		hs.log = log.New()
+		hs.AuthTokenService = &authtest.FakeUserAuthTokenService{
+			RotateTokenProvider: func(ctx context.Context, cmd auth.RotateCommand) (*auth.UserToken, error) {
+				return nil, auth.ErrUserTokenNotFound
+			},
+		}
+	})
+
+	req := server.NewPostRequest("/api/user/auth-tokens/rotate", nil)
+	req.AddCookie(&http.Cookie{Name: "grafana_session", Value: "stale", Path: "/"})
+
+	res, err := server.Send(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.Equal(t, []string{
+		"grafana_session=; Path=/; Max-Age=0; HttpOnly",
+		"grafana_session_expiry=; Path=/; Max-Age=0",
+	}, res.Header.Values("Set-Cookie"))
+	require.NoError(t, res.Body.Close())
+}
+
+func TestHTTPServer_RotateUserAuthTokenRedirect_DeletesCookieWhenTokenNotFound(t *testing.T) {
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		cfg := setting.NewCfg()
+		cfg.LoginCookieName = "grafana_session"
+		cfg.LoginMaxLifetime = 10 * time.Hour
+		hs.Cfg = cfg
+		hs.log = log.New()
+		hs.AuthTokenService = &authtest.FakeUserAuthTokenService{
+			RotateTokenProvider: func(ctx context.Context, cmd auth.RotateCommand) (*auth.UserToken, error) {
+				return nil, auth.ErrUserTokenNotFound
+			},
+		}
+	})
+
+	req := server.NewGetRequest("/user/auth-tokens/rotate")
+	req.AddCookie(&http.Cookie{Name: "grafana_session", Value: "stale", Path: "/"})
+	req = webtest.RequestWithWebContext(req, &contextmodel.ReqContext{UseSessionStorageRedirect: true})
+
+	var redirectStatusCode int
+	var redirectLocation string
+	server.HttpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.Response == nil {
+			return nil
+		}
+		redirectStatusCode = req.Response.StatusCode
+		redirectLocation = req.Response.Header.Get("Location")
+		return http.ErrUseLastResponse
+	}
+
+	res, err := server.Send(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusFound, redirectStatusCode)
+	assert.Equal(t, "/login", redirectLocation)
+	assert.Equal(t, []string{
+		"grafana_session=; Path=/; Max-Age=0; HttpOnly",
+		"grafana_session_expiry=; Path=/; Max-Age=0",
+	}, res.Header.Values("Set-Cookie"))
+	require.NoError(t, res.Body.Close())
+}


### PR DESCRIPTION
## What this PR does

Fixes #131930 by clearing the Grafana session cookies when auth-token rotation fails because the session token no longer exists.

### Changes
- Treat `auth.ErrUserTokenNotFound` the same as `auth.ErrInvalidSessionToken` in `RotateUserAuthToken`.
- Clear the session cookies in `RotateUserAuthTokenRedirect` for the same stale-token case.
- Add regression coverage for both endpoints, including the 401 response and session-cookie deletion.

### Why
When a token has been revoked/deleted but the browser still has the old `grafana_session` cookies, rotation returns 401 without clearing them. The frontend can repeatedly retry rotation, resulting in an infinite reload loop. Clearing the cookies lets the request fall through to a normal login instead.

Fixes #131930