### PR TITLE
fix: mariadb migration error while table rename for shorturls

### DIFF
--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -391,6 +391,34 @@ func TestIntegrationMySQL_WaitForRenamesQueued(t *testing.T) {
 		}
 	})
 
+	t.Run("timeout reports the rename threads it can see", func(t *testing.T) {
+		table := uniqueTable(t, env.engine)
+		renamer := &mysqlTableRenamer{log: logger, waitDeadline: 500 * time.Millisecond}
+		mg := migrator.NewMigrator(env.engine, setting.NewCfg())
+
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		require.NoError(t, sess.Begin())
+		renamer.Init(sess, mg)
+
+		unlock, results := lockAndQueueRename(t, env.engine, []string{table})
+
+		require.NoError(t, renamer.waitForRenamesQueued(context.Background(), []renamePair{{table, table + legacySuffix}}))
+
+		err := renamer.waitForRenamesQueued(context.Background(), []renamePair{{"nonexistent_xyz", "nonexistent_xyz" + legacySuffix}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "visible RENAME threads")
+		require.Contains(t, err.Error(), table, "diagnostic must name the queued rename so a timeout is triageable without SHOW FULL PROCESSLIST")
+
+		unlock()
+		select {
+		case err := <-results[0]:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("RENAME timed out")
+		}
+	})
+
 	t.Run("context cancellation", func(t *testing.T) {
 		table := uniqueTable(t, env.engine)
 		renamer := &mysqlTableRenamer{log: logger, waitDeadline: time.Minute}

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -408,7 +408,7 @@ func TestIntegrationMySQL_WaitForRenamesQueued(t *testing.T) {
 		err := renamer.waitForRenamesQueued(context.Background(), []renamePair{{"nonexistent_xyz", "nonexistent_xyz" + legacySuffix}})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "visible RENAME threads")
-		require.Contains(t, err.Error(), table, "diagnostic must name the queued rename so a timeout is triageable without SHOW FULL PROCESSLIST")
+		require.Contains(t, err.Error(), table)
 
 		unlock()
 		select {

--- a/pkg/storage/unified/migrations/table_renamer.go
+++ b/pkg/storage/unified/migrations/table_renamer.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -10,7 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/util/xorm"
 )
 
-const legacySuffix = "_legacy"
+const (
+	legacySuffix = "_legacy"
+
+	renameQueuePollInterval   = 100 * time.Millisecond
+	renameQueuedConfirmations = 2
+)
 
 // MigrationTableRenamer renames legacy tables after a successful migration.
 type MigrationTableRenamer interface {
@@ -220,23 +226,27 @@ func (r *mysqlTableRenamer) RenameTables(ctx context.Context, tables []string, d
 }
 
 // waitForRenamesQueued polls information_schema.processlist via sess to confirm all
-// RENAME statements are waiting for metadata locks. Returns error on timeout.
-// NOTE: This relies on exact text matching of the info column in processlist against
-// the SQL we generate. If MySQL ever normalizes the SQL (quoting, casing, whitespace),
-// the match will fail and this will timeout. This is acceptable because we control
-// the SQL generation in RenameTables above.
+// RENAME statements have reached the server and are parked behind the read lock.
+// Returns error on timeout.
+//
+// Matching is on the info column only, which holds the exact SQL generated in
+// RenameTables. The wait state text is deliberately NOT matched: forks report
+// different text for the same condition, e.g. MariaDB Galera parks DDL in total order
+// isolation and reports "Waiting to execute in isolation" rather than "Waiting for
+// table metadata lock". Seeing the full set on renameQueuedConfirmations consecutive
+// polls is what establishes the statements are queued rather than merely in flight.
 func (r *mysqlTableRenamer) waitForRenamesQueued(ctx context.Context, pairs []renamePair) error {
 	deadline := time.NewTimer(r.waitDeadline)
 	defer deadline.Stop()
 
+	confirmations := 0
 	for {
 		found := 0
 		for _, p := range pairs {
 			exactMatch := fmt.Sprintf("RENAME TABLE %s TO %s", r.mg.Dialect.Quote(p.oldName), r.mg.Dialect.Quote(p.newName))
 			var count int
 			_, err := r.sess.SQL(
-				"SELECT COUNT(*) FROM information_schema.processlist "+
-					"WHERE state = 'Waiting for table metadata lock' AND info = ?",
+				"SELECT COUNT(*) FROM information_schema.processlist WHERE info = ?",
 				exactMatch).Get(&count)
 			if err != nil {
 				return err
@@ -246,17 +256,41 @@ func (r *mysqlTableRenamer) waitForRenamesQueued(ctx context.Context, pairs []re
 			}
 		}
 		if found >= len(pairs) {
-			r.log.Info("All MySQL RENAME TABLE statements queued", "count", found)
-			return nil
+			confirmations++
+			if confirmations >= renameQueuedConfirmations {
+				r.log.Info("All MySQL RENAME TABLE statements queued", "count", found)
+				return nil
+			}
+		} else {
+			confirmations = 0
 		}
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("context cancelled while waiting for RENAME statements to queue: %w", ctx.Err())
 		case <-deadline.C:
-			return fmt.Errorf("timeout: only %d of %d RENAME statements confirmed in processlist", found, len(pairs))
-		case <-time.After(100 * time.Millisecond):
+			return fmt.Errorf("timeout: only %d of %d RENAME statements confirmed in processlist%s",
+				found, len(pairs), r.describeRenameThreads())
+		case <-time.After(renameQueuePollInterval):
 		}
 	}
+}
+
+// describeRenameThreads reports every RENAME thread the polling connection can see, so a
+// timeout says why it failed instead of requiring SHOW FULL PROCESSLIST on the server.
+func (r *mysqlTableRenamer) describeRenameThreads() string {
+	rows, err := r.sess.QueryString(
+		"SELECT id, command, state, info FROM information_schema.processlist WHERE info LIKE 'RENAME TABLE %'")
+	if err != nil {
+		return ""
+	}
+	if len(rows) == 0 {
+		return "; no RENAME threads visible in processlist"
+	}
+	seen := make([]string, 0, len(rows))
+	for _, row := range rows {
+		seen = append(seen, fmt.Sprintf("id=%s command=%q state=%q info=%q", row["id"], row["command"], row["state"], row["info"]))
+	}
+	return "; visible RENAME threads: " + strings.Join(seen, ", ")
 }
 
 // rollbackRenames reverses successful renames when some failed, keeping DB consistent.

--- a/pkg/storage/unified/migrations/table_renamer.go
+++ b/pkg/storage/unified/migrations/table_renamer.go
@@ -225,16 +225,9 @@ func (r *mysqlTableRenamer) RenameTables(ctx context.Context, tables []string, d
 	return nil
 }
 
-// waitForRenamesQueued polls information_schema.processlist via sess to confirm all
-// RENAME statements have reached the server and are parked behind the read lock.
-// Returns error on timeout.
-//
-// Matching is on the info column only, which holds the exact SQL generated in
-// RenameTables. The wait state text is deliberately NOT matched: forks report
-// different text for the same condition, e.g. MariaDB Galera parks DDL in total order
-// isolation and reports "Waiting to execute in isolation" rather than "Waiting for
-// table metadata lock". Seeing the full set on renameQueuedConfirmations consecutive
-// polls is what establishes the statements are queued rather than merely in flight.
+// waitForRenamesQueued confirms via processlist that every RENAME is parked behind the
+// read lock. Matches info only: wait-state text differs per fork and per stage (Galera
+// reports "Waiting to execute in isolation"), so consecutive sightings stand in for it.
 func (r *mysqlTableRenamer) waitForRenamesQueued(ctx context.Context, pairs []renamePair) error {
 	deadline := time.NewTimer(r.waitDeadline)
 	defer deadline.Stop()
@@ -275,8 +268,8 @@ func (r *mysqlTableRenamer) waitForRenamesQueued(ctx context.Context, pairs []re
 	}
 }
 
-// describeRenameThreads reports every RENAME thread the polling connection can see, so a
-// timeout says why it failed instead of requiring SHOW FULL PROCESSLIST on the server.
+// describeRenameThreads makes a timeout self-diagnosing: it reports the RENAME threads
+// this connection can see, and the state text that failed to look queued.
 func (r *mysqlTableRenamer) describeRenameThreads() string {
 	rows, err := r.sess.QueryString(
 		"SELECT id, command, state, info FROM information_schema.processlist WHERE info LIKE 'RENAME TABLE %'")


### PR DESCRIPTION
## Match queued RENAMEs by SQL text, not wait state

Escalation: https://github.com/grafana/support-escalations/issues/24016

### Why

Grafana upgrade fails on MariaDB Galera:

    timeout: only 0 of 1 RENAME statements confirmed in processlist

`waitForRenamesQueued` matched `info = <our RENAME> AND state = 'Waiting for table metadata lock'`. Galera orders DDL through Total Order Isolation, so a queued RENAME sits in `state = 'Waiting to execute in isolation'` instead. The rename was queued; only the observation failed.

The timeout returns without calling `doUnlock` and no migration log row is written, so every restart re-runs and fails the same way — startup is blocked, not just the rename.

### What

- Match `info` alone. `info` is SQL this code generates itself, so any matching thread is one of our renames regardless of wait stage.
- Require two consecutive polls (100ms apart). A thread still visible after 100ms is parked, not in transit — that is what the `state` filter used to guarantee.
- On timeout, include the visible `RENAME TABLE ...` threads in the error so the next occurrence doesn't need `SHOW FULL PROCESSLIST` from the customer.

### Testing

Verified against MariaDB 11.8.9 with wsrep (TOI confirmed) using the existing MySQL integration suite. On single-node Galera, TOI grants instantly and the state reduces to plain MDL wait; the customer's `Waiting to execute in isolation` text needs a multi-node cluster, so it isn't asserted in the test.

### Multi-node Galera reproduction

Confirmed on a real 3-node MariaDB Galera cluster (`wsrep_cluster_size=3`, `wsrep_osu_method=TOI`). Held `LOCK TABLES t READ` on node A, ran a slow `ALTER` on node B to hog the TOI slot, then fired `RENAME TABLE t TO t_legacy` on node A and polled `information_schema.processlist` every 100 ms.

    t=11ms    state="Waiting to execute in isolation"   old_pred=0 / new_pred=1
    t=120ms   state="Waiting to execute in isolation"   old_pred=0 / new_pred=1
    ...
    t=794ms   state="Waiting to execute in isolation"   old_pred=0 / new_pred=1
    t=909ms   state="Waiting for table metadata lock"   old_pred=1 / new_pred=1
    [ALTER completes → TOI slot free → RENAME transitions to MDL wait]

For the first ~800 ms the RENAME is invisible to the old `state = 'Waiting for table metadata lock' AND info = ?` predicate; the new `info = ?` predicate matches at every poll (26/26). Releasing the read lock still results in a clean RENAME.

The customer hit the same TOI-ordering wait but held it long enough to exceed the 60 s `waitDeadline`, so the old predicate never caught up and startup was blocked. On a load-free cluster (single- or multi-node) TOI grants in a few ms and both predicates match — that is why the existing single-node integration test still passes on both branches.