### PR TITLE
Dashboard: Default missing repeat direction to horizontal in V1 to V2 conversion

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1.go
@@ -864,6 +864,9 @@ func getRepeatOptionsFromPanel(panelMap map[string]any) *dashv2alpha1.DashboardR
 			direction := dashv2alpha1.DashboardRepeatOptionsDirectionV
 			repeatOptions.Direction = &direction
 		}
+	} else {
+		direction := dashv2alpha1.DashboardRepeatOptionsDirectionH
+		repeatOptions.Direction = &direction
 	}
 
 	if maxPerRow := getIntField(panelMap, "maxPerRow", 0); maxPerRow > 0 {

--- a/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_to_v2alpha1_test.go
@@ -722,6 +722,37 @@ func TestV1ToV2alpha1(t *testing.T) {
 	}
 }
 
+func TestGetRepeatOptionsFromPanel(t *testing.T) {
+	t.Run("defaults missing repeat direction to horizontal", func(t *testing.T) {
+		repeatOptions := getRepeatOptionsFromPanel(map[string]any{
+			"repeat":    "env",
+			"maxPerRow": float64(6),
+		})
+
+		require.NotNil(t, repeatOptions)
+		require.NotNil(t, repeatOptions.Direction)
+		assert.Equal(t, dashv2alpha1.DashboardRepeatOptionsDirectionH, *repeatOptions.Direction)
+
+		require.NotNil(t, repeatOptions.MaxPerRow)
+		assert.Equal(t, int64(6), *repeatOptions.MaxPerRow)
+	})
+
+	t.Run("preserves explicit vertical repeat direction", func(t *testing.T) {
+		repeatOptions := getRepeatOptionsFromPanel(map[string]any{
+			"repeat":          "env",
+			"repeatDirection": "v",
+			"maxPerRow":       float64(2),
+		})
+
+		require.NotNil(t, repeatOptions)
+		require.NotNil(t, repeatOptions.Direction)
+		assert.Equal(t, dashv2alpha1.DashboardRepeatOptionsDirectionV, *repeatOptions.Direction)
+
+		require.NotNil(t, repeatOptions.MaxPerRow)
+		assert.Equal(t, int64(2), *repeatOptions.MaxPerRow)
+	})
+}
+
 // TestV1ToV2alpha1_TimezoneEmptyString verifies that timezone: "" from V1 is left unset in V2
 // so that the user-profile-preference fallback continues to work.
 func TestV1ToV2alpha1_TimezoneEmptyString(t *testing.T) {

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -378,7 +378,7 @@ describe('ResponseTransformers', () => {
             links: [],
             transformations: [],
             repeat: 'var1',
-            repeatDirection: 'h',
+            // repeatDirection intentionally omitted to verify the v1 horizontal default
             timeCompare: '1d',
           },
           {

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -450,7 +450,7 @@ function buildGridItemKind(p: Panel, elementName: string, yOverride?: number): G
             repeat: {
               value: p.repeat,
               mode: 'variable',
-              ...(p.repeatDirection !== undefined && { direction: p.repeatDirection }),
+              direction: p.repeatDirection ?? 'h',
               ...(p.maxPerRow !== undefined && { maxPerRow: p.maxPerRow }),
             },
           }


### PR DESCRIPTION
## What is this feature?

This fixes a regression in V1 → V2 dashboard conversion for repeated panels where `repeat` is set but `repeatDirection` is omitted.

In V1 dashboards, a missing `repeatDirection` implicitly means horizontal (`h`). During V1 → V2 conversion, that default was not being preserved, leaving the converted repeat configuration without a direction.

This change restores the legacy behavior in both conversion paths:

- Backend V1 → V2 conversion now defaults a missing repeat direction to `h`.
- Frontend V1 → V2 response transformation now does the same.
- Existing explicit repeat directions continue to be preserved.

## Why do we need this feature?

Without an explicit direction in the converted V2 layout, repeated panels can be rendered inside the original panel width instead of using the full row.

This causes repeated panels to appear squeezed after upgrading to Grafana 13, particularly for dashboards created through provisioning or the legacy dashboard API, where the dashboard does not pass through the UI editing path that would otherwise normalize the repeat direction.

Grafana 12 treated a missing `repeatDirection` as horizontal, so this restores the previous behavior at the V1 → V2 compatibility boundary rather than changing native V2 layout semantics.

## Who is this feature for?

Users with legacy/V1 dashboards that:

- use repeated panels,
- omit `repeatDirection`, and
- are loaded through provisioning, the legacy dashboard API, or other V1 → V2 conversion paths.

## Which issue(s) does this PR fix?

Fixes #131910

## Special notes for reviewers

The fix is intentionally limited to V1 → V2 conversion.

It does not change the V2 schema, layout serializer, or repeat runtime behavior. A missing direction is normalized to `h` only when converting legacy V1 dashboard data, matching the existing V1 default.

Regression coverage was added for the missing-direction case, while preserving explicit vertical repeat behavior.

### Manual verification

Manually reproduced #131910 using the legacy `/api/dashboards/db` endpoint with a repeated panel that omits `repeatDirection`.

With this fix, the repeated panels use the full dashboard width as expected, rendering four panels on the first row and two on the second instead of being squeezed into the original panel width.
<img width="1920" height="1054" alt="screenshot-2026-09-04_08-51-37" src="https://github.com/user-attachments/assets/b4f1c445-d115-4dae-a64a-476955d4dfb0" />


### Tests

- `yarn jest public/app/features/dashboard/api/ResponseTransformers.test.ts --no-watch --runInBand`
- `go test ./apps/dashboard/pkg/migration/conversion/... -count=1`
- `yarn jest public/app/features/dashboard-scene/serialization/transformSaveModelV1ToV2.test.ts --no-watch --runInBand`
- `yarn typecheck`
- ESLint and Prettier checks for the modified frontend files
- `git diff --check`