### PR TITLE
Fix query variable datasource scoping

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
@@ -10,7 +10,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { getDataSourceInstance, getDataSourceInstanceSettings } from '@grafana/runtime/unstable';
-import { type QueryVariable, type VariableValueOption } from '@grafana/scenes';
+import { type QueryVariable, SafeSerializableSceneObject, type VariableValueOption } from '@grafana/scenes';
 import { type DataSourceRef, type VariableRefresh, type VariableSort } from '@grafana/schema';
 import { Field, FieldSet } from '@grafana/ui';
 import { QueryEditor } from 'app/features/dashboard-scene/settings/variables/components/QueryEditor';
@@ -31,6 +31,7 @@ import { VariableLegend } from './VariableLegend';
 type VariableQueryType = QueryVariable['state']['query'];
 
 interface QueryVariableEditorFormProps {
+  variable: QueryVariable;
   datasource?: DataSourceRef;
   onDataSourceChange: (dsSettings: DataSourceInstanceSettings, preserveQuery?: boolean) => void;
   query: VariableQueryType;
@@ -44,7 +45,7 @@ interface QueryVariableEditorFormProps {
   sort: VariableSort;
   onSortChange: (option: SelectableValue<VariableSort>) => void;
   refresh: VariableRefresh;
-  onRefreshChange: (option: VariableRefresh) => void;
+  onRefreshChange: (option: SelectableValue<VariableRefresh>) => void;
   isMulti: boolean;
   onMultiChange: (event: FormEvent<HTMLInputElement>) => void;
   allowCustomValue?: boolean;
@@ -61,6 +62,7 @@ interface QueryVariableEditorFormProps {
 }
 
 export function QueryVariableEditorForm({
+  variable,
   datasource: datasourceRef,
   onDataSourceChange,
   query,
@@ -90,7 +92,9 @@ export function QueryVariableEditorForm({
   options,
 }: QueryVariableEditorFormProps) {
   const { value: dsConfig } = useAsync(async () => {
-    const datasource = await getDataSourceInstance(datasourceRef ?? '');
+    const datasource = await getDataSourceInstance(datasourceRef ?? '', {
+      __sceneObject: new SafeSerializableSceneObject(variable),
+    });
     const VariableQueryEditor = await getVariableQueryEditor(datasource);
     const defaultQuery = datasource?.variables?.getDefaultQuery?.();
 
@@ -112,7 +116,7 @@ export function QueryVariableEditorForm({
     }
 
     return { datasource, VariableQueryEditor };
-  }, [datasourceRef]);
+  }, [datasourceRef, variable]);
 
   // adjusting type miss match between DataSourcePicker onChange and onDataSourceChange
   const datasourceChangeHandler = useCallback(

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor/QueryVariableEditor.tsx
@@ -10,7 +10,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { getDataSourceInstance } from '@grafana/runtime/unstable';
-import { type QueryVariable, sceneGraph } from '@grafana/scenes';
+import { type QueryVariable, SafeSerializableSceneObject, sceneGraph } from '@grafana/scenes';
 import { type VariableRefresh, type VariableSort } from '@grafana/schema';
 import { Field, Stack } from '@grafana/ui';
 import { QueryEditor } from 'app/features/dashboard-scene/settings/variables/components/QueryEditor';
@@ -104,6 +104,7 @@ export function QueryVariableEditor({ variable, onRunQuery }: QueryVariableEdito
 
   return (
     <QueryVariableEditorForm
+      variable={variable}
       datasource={datasource ?? undefined}
       onDataSourceChange={onDataSourceChange}
       query={query}
@@ -156,7 +157,9 @@ export function Editor({ variable, hideRefresh, hideStaticOptions, hidePreview }
   } = variable.useState();
   const { value: timeRange } = sceneGraph.getTimeRange(variable).useState();
   const { value: dsConfig } = useAsync(async () => {
-    const datasource = await getDataSourceInstance(datasourceRef ?? '');
+    const datasource = await getDataSourceInstance(datasourceRef ?? '', {
+      __sceneObject: new SafeSerializableSceneObject(variable),
+    });
     const VariableQueryEditor = await getVariableQueryEditor(datasource);
     const defaultQuery = datasource?.variables?.getDefaultQuery?.();
 
@@ -189,7 +192,7 @@ export function Editor({ variable, hideRefresh, hideStaticOptions, hidePreview }
   const onRegExChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
     variable.setState({ regex: event.currentTarget.value });
   };
-  const onRegexApplyToChange = (event: VariableRegexApplyTo) => {
+  const onRegexApplyToChange = (event: VariableRegexApplyToChange) => {
     variable.setState({ regexApplyTo: event });
   };
   const onSortChange = (sort: SelectableValue<VariableSort>) => {


### PR DESCRIPTION
Fixes #131924

### What changed
Pass the current `QueryVariable` as the scene scope when resolving its datasource. This allows datasource template variables to resolve against the active row/tab-scoped datasource instead of falling back to the dashboard default.

### Why
Structured query variables can resolve a datasource template such as `$DS_PROMETHEUS` without the active scene scope, while the corresponding classic query path resolves it correctly.

The change is limited to datasource resolution in the query variable editor and uses Grafana's existing `SafeSerializableSceneObject` mechanism for scene-scoped datasource resolution.

### Testing
The final commit was SSH-signed and verified on GitHub. Local test execution was limited by the existing dependency-install issue in the development environment.