### PR TITLE
Handle query response parsing errors instead of showing No data

### DIFF
--- a/packages/grafana-runtime/src/utils/queryResponse.error.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.error.test.ts
@@ -1,0 +1,14 @@
+import { LoadingState } from '@grafana/data';
+
+import { toDataQueryResponse } from './queryResponse';
+
+describe('toDataQueryResponse', () => {
+  it('returns an error when parsing the response body throws', () => {
+    const error = new SyntaxError('Unexpected end of JSON input');
+
+    const response = toDataQueryResponse(error);
+
+    expect(response.state).toBe(LoadingState.Error);
+    expect(response.error?.message).toBe(error.message);
+  });
+});

--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -61,10 +61,17 @@ export function toDataQueryResponse(
   res:
     | { data: BackendDataSourceResponse | undefined }
     | FetchResponse<BackendDataSourceResponse | undefined>
-    | DataQueryError,
+    | DataQueryError
+    | Error,
   queries?: DataQuery[]
 ): DataQueryResponse {
   const rsp: DataQueryResponse = { data: [], state: LoadingState.Done };
+
+  if (res instanceof Error) {
+    rsp.state = LoadingState.Error;
+    rsp.error = toDataQueryError(res);
+    return rsp;
+  }
 
   const traceId = 'traceId' in res ? res.traceId : undefined;
 


### PR DESCRIPTION
Fixes #131944.

When a large /api/ds/query response exceeds the browser's maximum string length, response.json() can reject with a SyntaxError. DataSourceWithBackend currently converts that thrown Error into toDataQueryResponse(), which treats it as an empty successful response and Explore shows "No data".

Handle thrown Error instances explicitly as query errors and add a regression test so the error is surfaced instead of silently returning an empty successful response.