### PR TITLE
Alerting: Fix ruler rules endpoint padding its namespace filter with empty UIDs

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -300,7 +300,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *contextmodel.ReqContext) response.Res
 		return response.JSON(http.StatusOK, result)
 	}
 
-	namespaceUIDs := make([]string, len(namespaceMap))
+	namespaceUIDs := make([]string, 0, len(namespaceMap))
 	for k := range namespaceMap {
 		namespaceUIDs = append(namespaceUIDs, k)
 	}

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -733,6 +733,37 @@ func TestRouteGetRulesConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("should query only the namespaces visible to the user", func(t *testing.T) {
+		orgID := rand.Int63()
+		ruleStore := fakes.NewRuleStore(t)
+		folders := []*folder.Folder{randFolder(), randFolder(), randFolder()}
+		ruleStore.Folders[orgID] = folders
+
+		rules := make([]*models.AlertRule, 0, len(folders))
+		expected := make([]string, 0, len(folders))
+		for _, f := range folders {
+			groupKey := models.GenerateGroupKey(orgID)
+			groupKey.NamespaceUID = f.UID
+			rules = append(rules, gen.With(gen.WithGroupKey(groupKey)).GenerateRef())
+			expected = append(expected, f.UID)
+		}
+		ruleStore.PutRule(context.Background(), rules...)
+
+		req := createRequestContextWithPerms(orgID, createPermissionsForRules(rules, orgID), nil)
+		response := createService(ruleStore, usertest.NewUserServiceFake()).RouteGetRulesConfig(req)
+		require.Equal(t, http.StatusOK, response.Status())
+
+		queries := ruleStore.GetRecordedCommands(func(cmd any) (any, bool) {
+			q, ok := cmd.(models.ListAlertRulesQuery)
+			return q, ok
+		})
+		require.Len(t, queries, 1)
+
+		// make([]string, len(m)) followed by append would pad this with as many
+		// empty UIDs as there are folders, doubling the IN list in SQL.
+		require.ElementsMatch(t, expected, queries[0].(models.ListAlertRulesQuery).NamespaceUIDs)
+	})
+
 	t.Run("should return rules in group sorted by group index", func(t *testing.T) {
 		orgID := rand.Int63()
 		folder := randFolder()


### PR DESCRIPTION
**What is this feature?**

A one-line fix to `RouteGetRulesConfig` (`GET /api/ruler/grafana/api/v1/rules`), which was building its namespace filter with `make([]string, len(namespaceMap))` and then `append`ing to it:

```go
namespaceUIDs := make([]string, len(namespaceMap))
for k := range namespaceMap {
    namespaceUIDs = append(namespaceUIDs, k)
}
```

`make([]string, N)` allocates a slice already *containing* N empty strings, so the real UIDs land after them. The slice ends up twice the intended length, half of it `""`:

```
["", "", … ×N, "uid1", "uid2", … ×N]
```

Every element becomes a bind parameter in the `namespace_uid IN (...)` clause built by `buildListAlertRulesQuery`, so the SQL sent to the database carries twice as many terms as there are folders.

Changed to `make([]string, 0, len(namespaceMap))`, which is what the equivalent code in
`api_prometheus.go` already does.

**Why do we need this feature?**

The empty UIDs are harmless for correctness but the cost is pure waste, and it scales linearly with folder count:

- Twice as many `IN` terms for the database to evaluate per candidate row.
- Twice as much SQL text to build, transmit, and parse per request.
- Pushes the predicate further past MySQL's `eq_range_index_dive_limit` (default 200),
  making the optimizer more likely to cost the range off index statistics rather than diving.
