### PR TITLE
AuthZ: rebuild the folder tree once per request, not once per missing folder

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -932,17 +932,35 @@ func (s *Service) getUserBasicRoleWithCache(ctx context.Context, ns types.Namesp
 // folderTreeGetter is a lazily-evaluated, memoized function that returns the folder tree for a namespace.
 // Create one instance per logical call-site (e.g. per batch group or per single Check) so that the tree
 // is fetched at most once even when multiple items share the same getter.
-type folderTreeGetter func() (*folderTree, error)
+//
+// Pass refresh to ask for a tree built from storage, which a caller does when the
+// folder it is checking is missing from the tree it was given. That rebuild is
+// memoized too: a batch where many folders are missing would otherwise list every
+// folder in the namespace once per item.
+type folderTreeGetter func(refresh bool) (*folderTree, error)
 
-// newFolderTreeGetter returns a folderTreeGetter that fetches the folder tree at most once.
+// newFolderTreeGetter returns a folderTreeGetter that fetches the folder tree at most once,
+// and rebuilds it at most once more.
 // If skipCache is false it tries the cache first before calling buildFolderTree.
 func (s *Service) newFolderTreeGetter(ctx context.Context, ns types.NamespaceInfo, skipCache bool) folderTreeGetter {
 	var (
-		result   *folderTree
-		fetchErr error
-		fetched  bool
+		result    *folderTree
+		fetchErr  error
+		fetched   bool
+		refreshed bool
 	)
-	return func() (*folderTree, error) {
+	return func(refresh bool) (*folderTree, error) {
+		if refresh && !refreshed {
+			refreshed = true
+			tree, err := s.buildFolderTree(ctx, ns)
+			if err != nil {
+				// Keep whatever the earlier fetch returned: one caller's failed rebuild
+				// should not turn every later check in the batch into an error.
+				return nil, err
+			}
+			result, fetchErr, fetched = &tree, nil, true
+			return result, nil
+		}
 		if fetched {
 			return result, fetchErr
 		}
@@ -1187,7 +1205,7 @@ func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[st
 	defer span.End()
 	ctxLogger := s.logger.FromContext(ctx)
 
-	tree, err := getTree()
+	tree, err := getTree(false)
 	if err != nil {
 		ctxLogger.Error("could not get folder tree", "error", err)
 		return false, err
@@ -1195,13 +1213,13 @@ func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[st
 
 	// If the folder is missing from the tree, try a fresh build to recover from a stale cache.
 	if tree == nil || !s.isFolderInTree(*tree, req.ParentFolder) {
-		fresh, err := s.buildFolderTree(ctx, req.Namespace)
+		fresh, err := getTree(true)
 		if err != nil {
 			ctxLogger.Error("could not build folder and dashboard tree", "error", err)
 			return false, err
 		}
-		tree = &fresh
-		if !s.isFolderInTree(*tree, req.ParentFolder) {
+		tree = fresh
+		if tree == nil || !s.isFolderInTree(*tree, req.ParentFolder) {
 			// Not erroring here as the permission might exist but the folder wasn't synchronized yet
 			// Once in mode 5 we can deny access here
 			ctxLogger.Error("parent folder not found in folder tree", "folder", req.ParentFolder)

--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -3479,6 +3479,8 @@ type fakeStore struct {
 	userPermissions []accesscontrol.Permission
 	err             bool
 	calls           int
+	// folderListCalls counts only ListFolders, since calls counts every store call.
+	folderListCalls int
 }
 
 func (f *fakeStore) GetBasicRoles(ctx context.Context, namespace types.NamespaceInfo, query store.BasicRoleQuery) (*store.BasicRole, error) {
@@ -3525,6 +3527,7 @@ func (f *fakeStore) ListFolders(ctx context.Context, namespace types.NamespaceIn
 		return nil, fmt.Errorf("namespace mismatch")
 	}
 	f.calls++
+	f.folderListCalls++
 	if f.err {
 		return nil, fmt.Errorf("store error")
 	}
@@ -4750,4 +4753,54 @@ func (t *trackingPermissionStore) GetUserPermissions(ctx context.Context, ns typ
 		t.folderPermCalls++
 	}
 	return t.inner.GetUserPermissions(ctx, ns, query)
+}
+
+// Checking a folder that is missing from the tree rebuilds the tree, and a batch can
+// be mostly missing folders: a trash listing names the folders things were deleted
+// from. Rebuilding per item lists every folder in the namespace once per item.
+func TestService_BatchCheckRebuildsFolderTreeAtMostOnce(t *testing.T) {
+	callingService := authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+		Claims: jwt.Claims{
+			Subject:  types.NewTypeID(types.TypeAccessPolicy, "some-service"),
+			Audience: []string{"authzservice"},
+		},
+		Rest: authn.AccessTokenClaims{Namespace: "org-12"},
+	})
+
+	s := setupService()
+	ctx := types.WithAuthInfo(context.Background(), callingService)
+
+	// The tree holds one folder, so every check below asks about a folder missing
+	// from it.
+	fStore := &fakeStore{
+		userID:          &store.UserIdentifiers{UID: "test-uid", ID: 1},
+		userPermissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:known"}},
+		folders:         []store.Folder{{UID: "known"}},
+	}
+	s.store = fStore
+	s.permissionStore = fStore
+	s.folderStore = fStore
+
+	checks := make([]*authzv1.BatchCheckItem, 0, 20)
+	for i := range 20 {
+		checks = append(checks, &authzv1.BatchCheckItem{
+			CorrelationId: fmt.Sprintf("check%d", i),
+			Group:         "dashboard.grafana.app",
+			Resource:      "dashboards",
+			Verb:          "get",
+			Name:          fmt.Sprintf("dash%d", i),
+			Folder:        fmt.Sprintf("missing-%d", i),
+		})
+	}
+
+	resp, err := s.BatchCheck(ctx, &authzv1.BatchCheckRequest{
+		Namespace: "org-12",
+		Subject:   "user:test-uid",
+		Checks:    checks,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Results, len(checks))
+
+	assert.LessOrEqual(t, fStore.folderListCalls, 2,
+		"the folder list is fetched once and rebuilt at most once, not once per item")
 }


### PR DESCRIPTION
When a check names a folder missing from the folder tree, `checkInheritedPermissions` rebuilds the tree to recover from a stale cache. That rebuild called `buildFolderTree` directly instead of going through the memoized getter, so a batch rebuilt the tree once per missing folder and discarded each result.

Any batch of checks on folders outside the live tree is affected. We see it on the dashboard `/trash` endpoint: in a dev trace, one `BatchCheck` of 79 items spent 2.3 of its 2.4 seconds on 24 full `ListFolders` calls.

The refresh now goes through the same getter and is memoized like the initial fetch. A failed refresh keeps the earlier tree, so one failed rebuild does not fail the rest of the batch.

`TestService_BatchCheckRebuildsFolderTreeAtMostOnce`: 20 checks on missing folders produce 21 folder lists before, 2 after.

Possible follow-ups, not part of this fix:

1. **Two folder lists could be one.** A request that misses the folder cache builds the tree from storage, and then the first missing folder rebuilds it again. A tree that just came from storage cannot be improved by a rebuild, so the getter could answer that refresh from the memo and only rebuild when the tree came from the cache.
2. **For a deleted parent folder the rebuild can never succeed.** `ListFolders` returns live folders only, so a folder that was deleted is absent from every rebuild. Trash checks are exactly this case, which makes the one remaining rebuild per request wasted work. Avoiding it needs a way for the caller to say a missing folder is expected.
3. **The ERROR log is noisy for trash.** `checkInheritedPermissions` logs `parent folder not found in folder tree` per item, so a normal dashboard trash listing writes tens of ERROR lines for something that is expected there. Worth downgrading, or suppressing, once point 2 has a signal to key off.

Happy for you to take a different approach; the bypassed memo looks unintended either way.
