### PR TITLE
Add X-Grafana-Source to datasource requests

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -72,6 +72,7 @@ enum PluginRequestHeaders {
   SkipQueryCache = 'X-Cache-Skip', // used by datasources to skip the query cache
   DashboardTitle = 'X-Dashboard-Title', // used by datasources to identify the dashboard title
   PanelTitle = 'X-Panel-Title', // used by datasources to identify the panel title
+  GrafanaSource = 'X-Grafana-Source',
 }
 
 /**
@@ -242,6 +243,22 @@ class DataSourceWithBackend<
     const headers: Record<string, string> = request.headers ?? {};
     headers[PluginRequestHeaders.PluginID] = Array.from(pluginIDs).join(', ');
     headers[PluginRequestHeaders.DatasourceUID] = Array.from(dsUIDs).join(', ');
+    switch (request.app) {
+      case 'explore':
+        headers[PluginRequestHeaders.GrafanaSource] = 'explore';
+        break;
+      case 'dashboard':
+      case 'panel-editor':
+      case 'panel-viewer':
+        headers[PluginRequestHeaders.GrafanaSource] = 'dashboard';
+        break;
+      case 'cloud-alerting':
+      case 'unified-alerting':
+        headers[PluginRequestHeaders.GrafanaSource] = 'alerting';
+        break;
+      default:
+        headers[PluginRequestHeaders.GrafanaSource] = 'api';
+    }
 
     let url = '/api/ds/query?ds_type=' + this.type;
 

--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -45,6 +45,7 @@ var expectedHeaders = map[string]string{
 	strings.ToLower(queryService.HeaderDashboardTitle): queryService.HeaderDashboardTitle,
 	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
 	strings.ToLower(queryService.HeaderCallerID):       queryService.HeaderCallerID,
+	strings.ToLower(queryService.HeaderGrafanaSource):  queryService.HeaderGrafanaSource,
 	strings.ToLower("User-Agent"):                      "User-Agent",
 	strings.ToLower("X-Real-IP"):                       "X-Real-IP",
 	strings.ToLower("X-Forwarded-For"):                 "X-Forwarded-For",

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -11,14 +11,15 @@ import (
 	"golang.org/x/text/transform"
 
 	"github.com/grafana/grafana/pkg/services/contexthandler"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/query"
 )
 
 // NewTracingHeaderMiddleware creates a new backend.HandlerMiddleware that will
 // populate useful tracing headers on outgoing backend.Handler and HTTP
 // requests.
-// Tracing headers are X-Datasource-Uid, X-Dashboard-Uid,
-// X-Panel-Id, X-Grafana-Org-Id.
+// Tracing headers include datasource/dashboard/panel metadata and the
+// X-Grafana-Source attribution header.
 func NewTracingHeaderMiddleware() backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &TracingHeaderMiddleware{
@@ -32,9 +33,26 @@ type TracingHeaderMiddleware struct {
 }
 
 func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.ForwardHTTPHeaders) {
+	if req == nil {
+		return
+	}
+
+	// Dashboard/Explore source is supplied by the frontend. Alert evaluations are
+	// server-side and must override any client-provided source value.
+	source := query.GrafanaSourceAPI
+	if req.GetHTTPHeader(models.FromAlertHeaderName) == "true" {
+		source = query.GrafanaSourceAlerting
+	} else {
+		switch req.GetHTTPHeader(query.HeaderGrafanaSource) {
+		case query.GrafanaSourceDashboard, query.GrafanaSourceExplore, query.GrafanaSourceAlerting:
+			source = req.GetHTTPHeader(query.HeaderGrafanaSource)
+		}
+	}
+	req.SetHTTPHeader(query.HeaderGrafanaSource, source)
+
 	reqCtx := contexthandler.FromContext(ctx)
-	// If no HTTP request context then skip middleware.
-	if req == nil || reqCtx == nil || reqCtx.Req == nil {
+	// If no HTTP request context then skip the HTTP tracing headers.
+	if reqCtx == nil || reqCtx.Req == nil {
 		return
 	}
 
@@ -49,6 +67,16 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		query.HeaderDashboardTitle,
 		query.HeaderPanelTitle,
 		query.HeaderCallerID,
+	}
+
+	if req.GetHTTPHeader(query.HeaderGrafanaSource) == query.GrafanaSourceAPI {
+		switch incomingSource := reqCtx.Req.Header.Get(query.HeaderGrafanaSource); incomingSource {
+		case query.GrafanaSourceDashboard, query.GrafanaSourceExplore, query.GrafanaSourceAlerting:
+			req.SetHTTPHeader(query.HeaderGrafanaSource, incomingSource)
+		}
+	}
+	if reqCtx.Req.Header.Get(models.FromAlertHeaderName) == "true" {
+		req.SetHTTPHeader(query.HeaderGrafanaSource, query.GrafanaSourceAlerting)
 	}
 
 	for _, headerName := range headersList {

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_source_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_source_test.go
@@ -1,0 +1,76 @@
+package clientmiddleware
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracingHeaderMiddlewareSourceAttribution(t *testing.T) {
+	tests := []struct {
+		name           string
+		incomingSource string
+		fromAlert      bool
+		wantSource     string
+	}{
+		{name: "defaults to api", wantSource: query.GrafanaSourceAPI},
+		{name: "dashboard", incomingSource: query.GrafanaSourceDashboard, wantSource: query.GrafanaSourceDashboard},
+		{name: "explore", incomingSource: query.GrafanaSourceExplore, wantSource: query.GrafanaSourceExplore},
+		{name: "alerting", incomingSource: query.GrafanaSourceAlerting, wantSource: query.GrafanaSourceAlerting},
+		{name: "unknown source defaults to api", incomingSource: "unknown", wantSource: query.GrafanaSourceAPI},
+		{name: "alerting overrides client source", incomingSource: query.GrafanaSourceDashboard, fromAlert: true, wantSource: query.GrafanaSourceAlerting},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &backend.QueryDataRequest{Headers: map[string]string{}}
+			if tc.incomingSource != "" {
+				req.Headers[query.HeaderGrafanaSource] = tc.incomingSource
+			}
+			if tc.fromAlert {
+				req.Headers[models.FromAlertHeaderName] = "true"
+			}
+
+			(&TracingHeaderMiddleware{}).applyHeaders(context.Background(), req)
+
+			require.Equal(t, tc.wantSource, req.GetHTTPHeader(query.HeaderGrafanaSource))
+		})
+	}
+}
+
+func TestTracingHeaderMiddlewareSourceAttributionFromHTTPContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		incomingSource string
+		fromAlert      bool
+		wantSource     string
+	}{
+		{name: "dashboard", incomingSource: query.GrafanaSourceDashboard, wantSource: query.GrafanaSourceDashboard},
+		{name: "explore", incomingSource: query.GrafanaSourceExplore, wantSource: query.GrafanaSourceExplore},
+		{name: "alerting", incomingSource: query.GrafanaSourceAlerting, wantSource: query.GrafanaSourceAlerting},
+		{name: "alerting overrides client source", incomingSource: query.GrafanaSourceDashboard, fromAlert: true, wantSource: query.GrafanaSourceAlerting},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &backend.QueryDataRequest{Headers: map[string]string{}}
+			httpReq, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+			require.NoError(t, err)
+			if tc.incomingSource != "" {
+				httpReq.Header.Set(query.HeaderGrafanaSource, tc.incomingSource)
+			}
+			if tc.fromAlert {
+				httpReq.Header.Set(models.FromAlertHeaderName, "true")
+			}
+
+			(&TracingHeaderMiddleware{}).applyHeaders(WithReqContext(httpReq, nil), req)
+
+			require.Equal(t, tc.wantSource, req.GetHTTPHeader(query.HeaderGrafanaSource))
+		})
+	}
+}

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -39,7 +39,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 0)
+			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 1)
+			require.Equal(t, `api`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Source`))
 		})
 
 		t.Run("tracing headers are not set for health check", func(t *testing.T) {
@@ -57,7 +58,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 0)
+			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 1)
+			require.Equal(t, `api`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Source`))
 		})
 
 		t.Run("tracing headers are not set for call resource", func(t *testing.T) {
@@ -74,7 +76,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, nopCallResourceSender)
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CallResourceReq.GetHTTPHeaders(), 0)
+			require.Len(t, cdt.CallResourceReq.GetHTTPHeaders(), 1)
+			require.Equal(t, `api`, cdt.CallResourceReq.GetHTTPHeader(`X-Grafana-Source`))
 		})
 	})
 	t.Run("When a request comes in with tracing headers empty", func(t *testing.T) {
@@ -100,7 +103,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 0)
+			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 1)
+
 		})
 
 		t.Run("tracing headers are not set for health check", func(t *testing.T) {
@@ -118,7 +122,8 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 0)
+			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 1)
+			require.Equal(t, `api`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Source`))
 		})
 	})
 	t.Run("When a request comes in with tracing headers set", func(t *testing.T) {
@@ -152,7 +157,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.QueryDataReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.QueryDataReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -160,6 +165,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.QueryDataReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-From-Expr`))
 			require.Equal(t, `grafana-assistant-app`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
+			require.Equal(t, `api`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Source`))
 		})
 
 		t.Run("tracing headers are set for query chunked data", func(t *testing.T) {
@@ -177,7 +183,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, nopChunkedWriter{})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryChunkedDataReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.QueryChunkedDataReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.QueryChunkedDataReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.QueryChunkedDataReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.QueryChunkedDataReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -202,7 +208,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.CheckHealthReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.CheckHealthReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -226,7 +232,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, nopCallResourceSender)
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CallResourceReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.CallResourceReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.CallResourceReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.CallResourceReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.CallResourceReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -251,7 +257,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -276,7 +282,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.PublishStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.PublishStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -301,7 +307,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, &backend.StreamSender{})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 7)
+			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 8)
 			require.Equal(t, `lN53lOcVk`, cdt.RunStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.RunStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
@@ -309,6 +315,50 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.RunStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
 			require.Equal(t, `grafana-assistant-app`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
+		})
+
+		t.Run("sets source attribution", func(t *testing.T) {
+			cases := []struct {
+				name           string
+				incomingSource string
+				fromAlert      string
+				wantSource     string
+			}{
+				{name: "defaults to api", wantSource: "api"},
+				{name: "dashboard", incomingSource: "dashboard", wantSource: "dashboard"},
+				{name: "explore", incomingSource: "explore", wantSource: "explore"},
+				{name: "alerting overrides client source", incomingSource: "dashboard", fromAlert: "true", wantSource: "alerting"},
+				{name: "unknown source defaults to api", incomingSource: "unknown", wantSource: "api"},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+					require.NoError(t, err)
+
+					if tc.incomingSource != "" {
+						req.Header.Set(`X-Grafana-Source`, tc.incomingSource)
+					}
+					if tc.fromAlert != "" {
+						req.Header.Set(`FromAlert`, tc.fromAlert)
+					}
+
+					cdt := handlertest.NewHandlerMiddlewareTest(t,
+						WithReqContext(req, &user.SignedInUser{
+							IsAnonymous: true,
+							Login:       "anonymous",
+						}),
+						handlertest.WithMiddlewares(NewTracingHeaderMiddleware()),
+					)
+
+					_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+						PluginContext: pluginCtx,
+						Headers:       map[string]string{},
+					})
+					require.NoError(t, err)
+					require.Equal(t, tc.wantSource, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Source`))
+				})
+			}
 		})
 
 		t.Run("sanitizes header values to printable ASCII for gRPC", func(t *testing.T) {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -43,6 +43,12 @@ const (
 	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
 	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries
 	HeaderCallerID       = "X-Grafana-Caller-Id" // identifies the caller that initiated this query (e.g. an app plugin id or external tool name)
+	HeaderGrafanaSource  = "X-Grafana-Source"
+
+	GrafanaSourceDashboard = "dashboard"
+	GrafanaSourceExplore   = "explore"
+	GrafanaSourceAlerting  = "alerting"
+	GrafanaSourceAPI       = "api"
 )
 
 func ProvideService(


### PR DESCRIPTION
Fixes #131950.

Adds `X-Grafana-Source` to outgoing datasource requests with `dashboard`, `explore`, `alerting`, and `api` values. Dashboard/Explore are derived from the frontend `DataQueryRequest.app`; server-side Grafana Alerting is derived from the existing `FromAlert` marker. The backend tracing middleware normalizes and forwards the header so both backend-plugin and HTTP datasource paths receive it. The query-service header allowlist is updated and focused regression coverage is included.