### PR TITLE
Live: support Math expressions for single-query streams

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -23,12 +23,19 @@ export { StreamingFrameAction, type StreamingFrameOptions } from '@grafana/data'
 /**
  * @alpha
  */
+export interface LiveMathExpressionOptions {
+  sourceRefId: string;
+  resultRefId: string;
+  expression: string;
+}
+
 export interface LiveDataStreamOptions {
   addr: LiveChannelAddress;
   frame?: DataFrameJSON; // initial results
   key?: string;
   buffer?: Partial<StreamingFrameOptions>;
   filter?: LiveDataFilter;
+  mathExpression?: LiveMathExpressionOptions;
 }
 
 /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -124,6 +124,17 @@ function toHealthCheckResult(v: DatasourcesV0HealthCheckResult): HealthCheckResu
   };
 }
 
+const liveMathReferenceIds = (expression: string): string[] => {
+  const refs = new Set<string>();
+  const pattern = /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+  for (const match of expression.matchAll(pattern)) {
+    refs.add(match[1] ?? match[2]);
+  }
+
+  return [...refs];
+};
+
 interface PreparedQuery {
   query: DataQuery;
   /** Absent for expression queries, which are not backed by a data source instance. */
@@ -523,12 +534,55 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     return of(rsp); // add warning?
   }
 
+  const liveSourceRefIds = new Set<string>();
+  for (const f of rsp.data) {
+    const addr = parseLiveChannelAddress(f.meta?.channel);
+    if (!addr) {
+      continue;
+    }
+
+    const sourceRefId = f.refId ?? '';
+    const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
+    if (sourceRefId) {
+      liveSourceRefIds.add(sourceRefId);
+    }
+  }
+
+  const liveMathResultRefIds = new Set<string>();
+  for (const target of req.targets) {
+    if (
+      target.hide ||
+      !target.refId ||
+      !target.expression ||
+      target.type !== 'math' ||
+      !isExpressionReference(target.datasource)
+    ) {
+      continue;
+    }
+
+    const refs = liveMathReferenceIds(target.expression);
+    if (refs.length === 1 && liveSourceRefIds.has(refs[0])) {
+      liveMathResultRefIds.add(target.refId);
+    }
+  }
+
   const staticdata: DataFrame[] = [];
   const streams: Array<Observable<DataQueryResponse>> = [];
   for (const f of rsp.data) {
     const addr = parseLiveChannelAddress(f.meta?.channel);
-    if (addr) {
-      const frame: DataFrame = f;
+    if (!addr) {
+      if (!liveMathResultRefIds.has(f.refId ?? '')) {
+        staticdata.push(f);
+      }
+      continue;
+    }
+
+    const frame: DataFrame = f;
+    const sourceRefId = frame.refId ?? '';
+    const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
+
+    // Preserve the normal live stream unless the source query itself is hidden.
+    if (!sourceQuery?.hide) {
       streams.push(
         live.getDataStream({
           addr,
@@ -536,8 +590,39 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
           frame: dataFrameToJSON(f),
         })
       );
-    } else {
-      staticdata.push(f);
+    }
+
+    // Live Math support is intentionally limited to expressions referencing
+    // exactly one live query. Multi-query expressions continue through the
+    // existing expression path.
+    for (const target of req.targets) {
+      if (
+        target.hide ||
+        !target.refId ||
+        !target.expression ||
+        target.type !== 'math' ||
+        !isExpressionReference(target.datasource)
+      ) {
+        continue;
+      }
+
+      const refs = liveMathReferenceIds(target.expression);
+      if (refs.length !== 1 || refs[0] !== sourceRefId) {
+        continue;
+      }
+
+      streams.push(
+        live.getDataStream({
+          addr,
+          buffer: getter(req, frame),
+          frame: dataFrameToJSON(f),
+          mathExpression: {
+            sourceRefId,
+            resultRefId: target.refId,
+            expression: target.expression,
+          },
+        })
+      );
     }
   }
   if (staticdata.length) {

--- a/public/app/features/expressions/liveMath.test.ts
+++ b/public/app/features/expressions/liveMath.test.ts
@@ -1,0 +1,23 @@
+import { expect, describe, it } from 'vitest';
+
+import { createLiveMathTransform, referencedRefIds } from './liveMath';
+
+describe('live math expressions', () => {
+  it('evaluates arithmetic against a single live field', () => {
+    const transform = createLiveMathTransform(
+      { sourceRefId: 'A', resultRefId: 'B', expression: '$A * 2 + 1' },
+      [1]
+    );
+
+    expect(transform.values([[1000, 2000], [2, 3]])).toEqual([[1000, 2000], [5, 7]]);
+  });
+
+  it('extracts grafana expression references', () => {
+    expect(referencedRefIds('($A * 2) + ${B}')).toEqual(['A', 'B']);
+  });
+
+  it('supports function calls', () => {
+    const transform = createLiveMathTransform({ sourceRefId: 'A', resultRefId: 'B', expression: 'abs($A) + floor(2.9)' }, [0]);
+    expect(transform.values([[-4, 5]])).toEqual([[6, 7]]);
+  });
+});

--- a/public/app/features/expressions/liveMath.ts
+++ b/public/app/features/expressions/liveMath.ts
@@ -1,0 +1,144 @@
+type SerializedLiveField = {
+  values?: unknown[];
+  [key: string]: unknown;
+};
+
+type SerializedLiveFrame = {
+  fields: SerializedLiveField[];
+  refId?: string;
+  [key: string]: unknown;
+};
+
+export type LiveMathExpression = {
+  sourceRefId: string;
+  resultRefId: string;
+  expression: string;
+};
+
+type Token = { kind: 'number' | 'identifier' | 'variable' | 'operator'; value: string } | { kind: 'paren' | 'comma'; value: '(' | ')' | ',' };
+
+const refs = /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+export function referencedRefIds(expression: string): string[] {
+  const result = new Set<string>();
+  for (const match of expression.matchAll(refs)) {
+    result.add(match[1] ?? match[2]);
+  }
+  return [...result];
+}
+
+function tokenize(expression: string): Token[] {
+  const out: Token[] = [];
+  let i = 0;
+  while (i < expression.length) {
+    if (/\s/.test(expression[i])) {
+      i++;
+      continue;
+    }
+    const variable = expression.slice(i).match(/^\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/);
+    if (variable) {
+      out.push({ kind: 'variable', value: variable[1] ?? variable[2] });
+      i += variable[0].length;
+      continue;
+    }
+    const number = expression.slice(i).match(/^(?:0[xX][0-9a-fA-F]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)/);
+    if (number) {
+      out.push({ kind: 'number', value: number[0] });
+      i += number[0].length;
+      continue;
+    }
+    const identifier = expression.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*/);
+    if (identifier) {
+      out.push({ kind: 'identifier', value: identifier[0] });
+      i += identifier[0].length;
+      continue;
+    }
+    const op = expression.slice(i).match(/^(?:\*\*|>=|<=|==|!=|&&|\|\||[+\-*/%<>()!,])/);
+    if (!op) {
+      throw new Error(`unsupported character ${expression[i]}`);
+    }
+    const value = op[0];
+    out.push(value === '(' || value === ')' ? { kind: 'paren', value } : value === ',' ? { kind: 'comma', value } : { kind: 'operator', value });
+    i += value.length;
+  }
+  return out;
+}
+
+class Parser {
+  private index = 0;
+  constructor(private readonly tokens: Token[], private readonly value: unknown) {}
+  parse() {
+    const result = this.logicalOr();
+    if (this.index !== this.tokens.length) {
+      throw new Error(`unexpected token ${this.tokens[this.index].value}`);
+    }
+    return result;
+  }
+  private peek(value: string) { return this.tokens[this.index]?.value === value; }
+  private take(value: string) { if (this.peek(value)) { this.index++; return true; } return false; }
+  private number(v: unknown) { return v == null ? NaN : Number(v); }
+  private truthy(v: unknown) { return v != null && v !== false && Number(v) !== 0 && !Number.isNaN(Number(v)); }
+  private logicalOr() {
+    let v = this.logicalAnd();
+    while (this.take('||')) {
+      const r = this.logicalAnd();
+      v = this.truthy(v) || this.truthy(r) ? 1 : 0;
+    }
+    return v;
+  }
+  private logicalAnd() {
+    let v = this.equality();
+    while (this.take('&&')) {
+      const r = this.equality();
+      v = this.truthy(v) && this.truthy(r) ? 1 : 0;
+    }
+    return v;
+  }
+  private equality() { let v = this.relational(); while (this.peek('==') || this.peek('!=')) { const op = this.tokens[this.index++].value; const r = this.relational(); v = op === '==' ? (v === r ? 1 : 0) : (v !== r ? 1 : 0); } return v; }
+  private relational() { let v = this.additive(); while (this.peek('<') || this.peek('>') || this.peek('<=') || this.peek('>=')) { const op = this.tokens[this.index++].value; const a = this.number(v), b = this.number(this.additive()); v = op === '<' ? (a < b ? 1 : 0) : op === '>' ? (a > b ? 1 : 0) : op === '<=' ? (a <= b ? 1 : 0) : (a >= b ? 1 : 0); } return v; }
+  private additive() { let v = this.multiplicative(); while (this.peek('+') || this.peek('-')) { const op = this.tokens[this.index++].value; const r = this.number(this.multiplicative()); v = op === '+' ? this.number(v) + r : this.number(v) - r; } return v; }
+  private multiplicative() { let v = this.power(); while (this.peek('*') || this.peek('/') || this.peek('%')) { const op = this.tokens[this.index++].value; const a = this.number(v), b = this.number(this.power()); v = op === '*' ? a * b : op === '/' ? a / b : a % b; } return v; }
+  private power() { const v = this.unary(); return this.take('**') ? Math.pow(this.number(v), this.number(this.power())) : v; }
+  private unary() { if (this.take('!')) {return this.truthy(this.unary()) ? 0 : 1;} if (this.take('-')) {return -this.number(this.unary());} if (this.take('+')) {return this.number(this.unary());} return this.primary(); }
+  private primary(): unknown {
+    const token = this.tokens[this.index++];
+    if (!token) {throw new Error('unexpected end of expression');}
+    if (token.kind === 'number') {return token.value.startsWith(('0x')) || token.value.startsWith('0X') ? Number.parseInt(token.value, 16) : Number(token.value);}
+    if (token.kind === 'variable') {return this.value;}
+    if (token.kind === 'paren' && token.value === '(') { const v = this.logicalOr(); if (!this.take(')')) {throw new Error('missing closing parenthesis');} return v; }
+    if (token.kind === 'identifier') {
+      if (!this.take('(')) {throw new Error(`unknown identifier ${token.value}`);}
+      const args: unknown[] = [];
+      if (!this.peek(')')) { do {args.push(this.logicalOr());} while (this.take(',')); }
+      if (!this.take(')')) {throw new Error(`missing closing parenthesis for ${token.value}`);}
+      const n = (x = args[0]) => this.number(x);
+      switch (token.value) {
+        case 'abs': return Math.abs(n()); case 'ceil': return Math.ceil(n()); case 'floor': return Math.floor(n()); case 'round': return Math.round(n());
+        case 'exp': return Math.exp(n()); case 'log': return Math.log(n()); case 'log10': return Math.log10(n()); case 'sqrt': return Math.sqrt(n());
+        case 'sin': return Math.sin(n()); case 'cos': return Math.cos(n()); case 'tan': return Math.tan(n()); case 'pow': return Math.pow(n(), this.number(args[1]));
+        case 'min': return Math.min(...args.map((v) => n(v))); case 'max': return Math.max(...args.map((v) => n(v)));
+        case 'is_inf': return typeof args[0] === 'number' && Number.isFinite(args[0]) === false && Number.isNaN(args[0]) === false ? 1 : 0;
+        case 'is_nan': return typeof args[0] === 'number' && Number.isNaN(args[0]) ? 1 : 0; case 'is_null': return args[0] == null ? 1 : 0;
+        case 'is_number': return typeof args[0] === 'number' && Number.isFinite(args[0]) ? 1 : 0; case 'inf': return Infinity; case 'infn': return -Infinity; case 'nan': return NaN; case 'null': return null;
+        default: throw new Error(`unsupported live math function ${token.value}`);
+      }
+    }
+    throw new Error(`unexpected token ${token.value}`);
+  }
+}
+
+export function createLiveMathTransform(expression: LiveMathExpression, fieldIndexes: number[]) {
+  const tokens = tokenize(expression.expression);
+  const evaluate = (value: unknown) => new Parser(tokens, value).parse();
+  const values = (input: unknown[][]) => input.map((column, index) => fieldIndexes.includes(index) ? column.map(evaluate) : column);
+  return {
+    frame: (input: SerializedLiveFrame): SerializedLiveFrame => ({
+      ...input,
+      refId: expression.resultRefId,
+      fields: input.fields.map((field, index) =>
+        fieldIndexes.includes(index) ? { ...field, values: field.values?.map(evaluate) } : field
+      ),
+    }),
+    values,
+  };
+}

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -20,6 +20,7 @@ import {
   toDataQueryError,
 } from '@grafana/runtime';
 
+import { createLiveMathTransform } from '../../expressions/liveMath';
 import { StreamingResponseDataType } from '../data/utils';
 
 import { type DataStreamSubscriptionKey, type StreamingDataQueryResponse } from './service';
@@ -237,6 +238,16 @@ export class LiveDataStream<T = unknown> {
     this.prepareInternalStreamForNewSubscription(options);
 
     const shouldSendLastPacketOnly = options?.buffer?.action === StreamingFrameAction.Replace;
+
+    const mathTransform = options.mathExpression
+      ? createLiveMathTransform(
+          options.mathExpression,
+          this.frameBuffer.fields
+            .map((field, index) => (field.type === 'number' ? index : -1))
+            .filter((index) => index >= 0)
+        )
+      : undefined;
+
     const fieldsNamesFilter = options.filter?.fields;
     const dataNeedsFiltering = fieldsNamesFilter?.length;
     const fieldFilterPredicate = dataNeedsFiltering ? ({ name }: Field) => fieldsNamesFilter.includes(name) : undefined;
@@ -257,7 +268,10 @@ export class LiveDataStream<T = unknown> {
           data: [
             {
               type: StreamingResponseDataType.FullFrame,
-              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer),
+              frame: (() => {
+                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer);
+                return mathTransform?.frame(serialized) ?? serialized;
+              })(),
             },
           ],
           error,
@@ -320,6 +334,7 @@ export class LiveDataStream<T = unknown> {
           : reduceNewValuesSameSchemaMessages(messages).values;
 
       const filteredValues = matchingFieldIndexes ? values.filter((v, i) => matchingFieldIndexes?.includes(i)) : values;
+      const transformedValues = mathTransform?.values(filteredValues) ?? filteredValues;
 
       return {
         key: subKey,
@@ -327,7 +342,7 @@ export class LiveDataStream<T = unknown> {
         data: [
           {
             type: StreamingResponseDataType.NewValuesSameSchema,
-            values: filteredValues,
+            values: transformedValues,
           },
         ],
       };


### PR DESCRIPTION
**What is this feature?**

Adds support for single-query Math expressions on Grafana Live streams.

**Why do we need this feature?**

Live users can apply basic single-point Math expressions to streaming data without requiring multi-point expression evaluation.

**Who is this feature for?**

Grafana Live users ingesting streaming data such as MQTT or Telegraf who need simple per-point transformations.

**Which issue(s) does this PR fix?**

Fixes #131854

**Special notes for your reviewer:**

- Supports Math expressions referencing exactly one live query; multi-query expressions continue through the existing path.
- Includes arithmetic, Grafana reference parsing, and function-call coverage.
- Live Math transformations are applied using the current filtered schema and on Replace-mode full frames.