### PR TITLE
IAM: Allow the current-user permissions endpoint to skip the cache

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/iam/v0alpha1/endpoints.gen.ts
@@ -437,7 +437,12 @@ const injectedRtkApi = api
         providesTags: ['Display'],
       }),
       getCurrentUserPermissions: build.query<GetCurrentUserPermissionsApiResponse, GetCurrentUserPermissionsApiArg>({
-        query: () => ({ url: `/users/~/permissions` }),
+        query: (queryArg) => ({
+          url: `/users/~/permissions`,
+          params: {
+            skipCache: queryArg.skipCache,
+          },
+        }),
         providesTags: ['User'],
       }),
     }),
@@ -899,7 +904,10 @@ export type GetUserTeamsApiArg = {
 export type GetCurrentUserDisplayApiResponse = /** status 200 undefined */ Display;
 export type GetCurrentUserDisplayApiArg = void;
 export type GetCurrentUserPermissionsApiResponse = /** status 200 undefined */ UserPermissions;
-export type GetCurrentUserPermissionsApiArg = void;
+export type GetCurrentUserPermissionsApiArg = {
+  /** recompute the permissions instead of serving the cached snapshot */
+  skipCache?: boolean;
+};
 export type ApiResource = {
   /** categories is a list of the grouped resources this resource belongs to (e.g. 'all') */
   categories?: string[];

--- a/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/iam.grafana.app-v0alpha1.json
@@ -2891,7 +2891,16 @@
         "tags": ["User"],
         "description": "Get effective permissions for the currently authenticated identity",
         "operationId": "getCurrentUserPermissions",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "skipCache",
+            "in": "query",
+            "description": "recompute the permissions instead of serving the cached snapshot",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/pkg/registry/apis/iam/userpermissions/handler.go
+++ b/pkg/registry/apis/iam/userpermissions/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -19,6 +20,7 @@ import (
 
 const userPermissionsDelegatedGrant = "authz.grafana.app/userpermissions:get"
 const currentUserPermissionsPath = "users/~/permissions"
+const skipCacheParam = "skipCache"
 
 // Handler serves the current identity's effective permissions.
 type Handler struct {
@@ -45,6 +47,12 @@ func (h *Handler) GetAPIRoutes(_ map[string]common.OpenAPIDefinition) *builder.A
 				Required:    true,
 				Description: "workspace",
 				Schema:      spec.StringProperty(),
+			}}, {ParameterProps: spec3.ParameterProps{
+				Name:        skipCacheParam,
+				In:          "query",
+				Required:    false,
+				Description: "recompute the permissions instead of serving the cached snapshot",
+				Schema:      spec.BooleanProperty(),
 			}}},
 			Responses: &spec3.Responses{ResponsesProps: spec3.ResponsesProps{StatusCodeResponses: map[int]*spec3.Response{
 				200: {ResponseProps: spec3.ResponseProps{Content: map[string]*spec3.MediaType{
@@ -78,8 +86,15 @@ func (h *Handler) handle(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	// Callers that refresh after granting themselves permissions need the
+	// recomputed set; a cached snapshot would omit the grant they just made and
+	// stay in their session until something else refreshes it. Defaults to the
+	// cache so routine reads (every boot, for one) stay cheap.
+	skipCache, _ := strconv.ParseBool(req.URL.Query().Get(skipCacheParam))
+
 	response, err := h.client.GetUserPermissions(ctx, delegatedAuthInfo{AuthInfo: info, groups: groups}, authlib.GetUserPermissionsRequest{
 		Namespace: namespace,
+		SkipCache: skipCache,
 	})
 	if err != nil {
 		errhttp.Write(ctx, err, w)

--- a/pkg/registry/apis/iam/userpermissions/handler_test.go
+++ b/pkg/registry/apis/iam/userpermissions/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,37 @@ func TestHandlerUsesExternalGroupsWhenConfigured(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, []string{"idp-group"}, client.info.GetGroups())
+}
+
+func TestHandlerSkipsCacheWhenRequested(t *testing.T) {
+	caller := &identity.StaticRequester{Type: authlib.TypeUser, UserUID: "u1", Namespace: "org-1"}
+
+	for _, tc := range []struct {
+		query     string
+		skipCache bool
+	}{
+		{query: "?skipCache=true", skipCache: true},
+		{query: "?skipCache=1", skipCache: true},
+		{query: "?skipCache=false", skipCache: false},
+		{query: "?skipCache=", skipCache: false},
+		// A value we can't parse falls back to the cache rather than erroring, so a
+		// malformed refresh still returns permissions
+		{query: "?skipCache=yes-please", skipCache: false},
+		{query: "", skipCache: false},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			client := &fakeUserPermissionsClient{}
+			handler := NewHandler(client, false)
+			req := permissionsRequest(t, caller, "org-1")
+			req.URL.RawQuery = strings.TrimPrefix(tc.query, "?")
+			rec := httptest.NewRecorder()
+
+			handler.handle(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, tc.skipCache, client.request.SkipCache)
+		})
+	}
 }
 
 func TestHandlerRejectsNamespaceMismatch(t *testing.T) {

--- a/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/iam.grafana.app-v0alpha1.json
@@ -3230,6 +3230,14 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "skipCache",
+            "in": "query",
+            "description": "recompute the permissions instead of serving the cached snapshot",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## What is this feature?

Adds an optional `skipCache` query parameter to `GET /apis/iam.grafana.app/v0alpha1/namespaces/{namespace}/users/~/permissions`, so a client can ask for the current user's permissions to be recomputed instead of served from the AuthZ cache. Reads default to the cache, so nothing changes unless a caller opts in.

## Why do we need this feature?

The legacy `/api/access-control/user/actions` had `reloadcache` for exactly this, and we needed this in order to accurately refresh the permissions from the frontend. Although this is a different endpoint, we're consuming it in order to compute the same information that the legacy actions endpoint provided, so we need a similar way to cache bust

The handler always read through the cache, which is 30 seconds by default (`authorization.cache_ttl`).

## Who is this feature for?
The frontend, which is moving `contextSrv.fetchUserPermissions()` onto this endpoint in #131623 — that's where the refresh-after-grant callers live.
