### PR TITLE
Home: Default to the Incidents tab in the alerts and incidents section

### DIFF
--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -1,4 +1,4 @@
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, delay, http } from 'msw';
 import { useState, type Ref } from 'react';
 import { act, render, screen, waitFor } from 'test/test-utils';
 
@@ -275,21 +275,165 @@ describe('AlertIncidentTabs', () => {
     expect(screen.queryByRole('tab', { name: /firing alerts/i })).not.toBeInTheDocument();
   });
 
-  it('switches to the Incidents tab and renders incident content', async () => {
+  describe('default tab', () => {
+    it('renders the Incidents tab ahead of the Firing alerts tab', async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockIrmPlugin();
+      mockIncidents([activeIncident]);
+
+      render(<AlertIncidentTabsWithData />);
+
+      await screen.findByText('Database outage');
+      expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+        expect.stringMatching(/incidents/i),
+        expect.stringMatching(/firing alerts/i),
+      ]);
+    });
+
+    it('selects the Incidents tab when incidents are active', async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockIrmPlugin();
+      mockIncidents([activeIncident]);
+
+      render(<AlertIncidentTabsWithData />);
+
+      // Both counts start unknown, so the choice only lands once the initial loads settle.
+      expect(await screen.findByText('Database outage')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /incidents/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('selects the Incidents tab when both sides are empty', async () => {
+      mockAlerts([]);
+      mockIrmPlugin();
+      mockIncidents([]);
+
+      render(<AlertIncidentTabsWithData />);
+
+      const incidentsTab = await screen.findByRole('tab', { name: /incidents/i });
+      // The counters only lose their undefined placeholder once both queries have settled.
+      await waitFor(() => expect(incidentsTab).toHaveTextContent('0'));
+      expect(incidentsTab).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('selects the Firing alerts tab when there are no incidents but alerts are firing', async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockIrmPlugin();
+      mockIncidents([]);
+
+      render(<AlertIncidentTabsWithData />);
+
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: /incidents/i })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('stays on the Incidents tab when the incidents request fails', async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockIrmPlugin();
+      server.use(
+        http.post('/api/plugins/:pluginId/resources/api/v1/IncidentsService.QueryIncidentPreviews', () =>
+          HttpResponse.json({ message: 'boom' }, { status: 500 })
+        )
+      );
+
+      render(<AlertIncidentTabsWithData />);
+
+      const alertsTab = await screen.findByRole('tab', { name: /firing alerts/i });
+      await waitFor(() => expect(alertsTab).toHaveTextContent('1'));
+      // A failed fetch isn't the same as "no incidents" — keep the error on screen.
+      expect(screen.getByRole('tab', { name: /incidents/i })).toHaveAttribute('aria-selected', 'true');
+      expect(alertsTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('stays on the Incidents tab when there are no incidents and the alerts request fails', async () => {
+      server.use(
+        http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', () =>
+          HttpResponse.json({ message: 'boom' }, { status: 500 })
+        )
+      );
+      mockIrmPlugin();
+      mockIncidents([]);
+
+      render(<AlertIncidentTabsWithData />);
+
+      const incidentsTab = await screen.findByRole('tab', { name: /incidents/i });
+      await waitFor(() => expect(incidentsTab).toHaveTextContent('0'));
+      // An errored alerts fetch isn't proof of firing alerts, so it doesn't win the tab.
+      expect(incidentsTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it("keeps the user's tab choice made before the incidents query settles", async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockIrmPlugin();
+      // Only the incidents query is delayed; the plugin bridge still resolves promptly,
+      // so the Incidents tab is clickable while its count is still unknown.
+      server.use(
+        http.post('/api/plugins/:pluginId/resources/api/v1/IncidentsService.QueryIncidentPreviews', async () => {
+          await delay(100);
+          return HttpResponse.json({
+            incidentPreviews: [activeIncident],
+            cursor: { hasMore: false, nextValue: '' },
+          });
+        })
+      );
+
+      const { user } = render(<AlertIncidentTabsWithData />);
+
+      await user.click(await screen.findByRole('tab', { name: /incidents/i }));
+      await user.click(screen.getByRole('tab', { name: /firing alerts/i }));
+
+      const incidentsTab = screen.getByRole('tab', { name: /incidents/i });
+      await waitFor(() => expect(incidentsTab).toHaveTextContent('1'));
+      // The settled incidents would otherwise claim the tab back.
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('does not move the tab when a later team filter change empties the alerts', async () => {
+      mockTeams([{ name: 'Team A' }]);
+      mockTeamLabelValues(['Team A', 'Team C']);
+      // The user's own teams have a firing alert; the explicitly selected team has none.
+      server.use(
+        http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', ({ request }) => {
+          const filters = new URL(request.url).searchParams.getAll('filter');
+          const isSelectedTeamFilter = filters.some((f) => f.includes('Team C'));
+          return HttpResponse.json(
+            isSelectedTeamFilter ? [] : [makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]
+          );
+        })
+      );
+      mockIrmPlugin();
+      // No incidents, so the first load settles on the Firing alerts tab.
+      mockIncidents([]);
+
+      const { user } = render(<AlertIncidentTabsWithData />);
+
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      await user.click(await screen.findByRole('combobox', { name: /filter alerts by team/i }));
+      await user.click(await screen.findByRole('option', { name: 'Team C' }));
+
+      // The auto-selection is a first-load decision only, so the empty result leaves the tab alone.
+      expect(await screen.findByText('No firing alerts for Team C.')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  it('switches to the Firing alerts tab and renders alert content', async () => {
     mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
     mockIrmPlugin();
     mockIncidents([activeIncident]);
 
     const { user } = render(<AlertIncidentTabsWithData />);
 
-    // Alerts tab is active by default.
-    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+    // Incidents tab is active by default while incidents are open.
+    expect(await screen.findByText('Database outage')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Alerts & incidents' })).toBeInTheDocument();
 
-    await user.click(await screen.findByRole('tab', { name: /incidents/i }));
+    await user.click(await screen.findByRole('tab', { name: /firing alerts/i }));
 
-    expect(await screen.findByText('Database outage')).toBeInTheDocument();
-    expect(screen.queryByText('CPU Critical')).not.toBeInTheDocument();
+    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+    expect(screen.queryByText('Database outage')).not.toBeInTheDocument();
   });
 
   it('switchRef handle switches tabs imperatively', async () => {
@@ -306,15 +450,8 @@ describe('AlertIncidentTabs', () => {
       />
     );
 
-    expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
-    expect(handle).not.toBeNull();
-
-    await act(async () => {
-      handle?.switch(INCIDENTS_TAB_ID, false);
-    });
-
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
-    expect(screen.queryByText('CPU Critical')).not.toBeInTheDocument();
+    expect(handle).not.toBeNull();
 
     await act(async () => {
       handle?.switch(ALERTS_TAB_ID, false);
@@ -322,6 +459,13 @@ describe('AlertIncidentTabs', () => {
 
     expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
     expect(screen.queryByText('Database outage')).not.toBeInTheDocument();
+
+    await act(async () => {
+      handle?.switch(INCIDENTS_TAB_ID, false);
+    });
+
+    expect(await screen.findByText('Database outage')).toBeInTheDocument();
+    expect(screen.queryByText('CPU Critical')).not.toBeInTheDocument();
   });
 
   it('switchRef handle scrolls by default and skips scrolling when requested', async () => {
@@ -345,22 +489,22 @@ describe('AlertIncidentTabs', () => {
         />
       );
 
-      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      expect(await screen.findByText('Database outage')).toBeInTheDocument();
 
       await act(async () => {
-        handle?.switch(INCIDENTS_TAB_ID);
+        handle?.switch(ALERTS_TAB_ID);
       });
 
-      expect(await screen.findByText('Database outage')).toBeInTheDocument();
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
 
       scrollIntoView.mockClear();
 
       await act(async () => {
-        handle?.switch(ALERTS_TAB_ID, false);
+        handle?.switch(INCIDENTS_TAB_ID, false);
       });
 
-      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      expect(await screen.findByText('Database outage')).toBeInTheDocument();
       expect(scrollIntoView).not.toHaveBeenCalled();
     } finally {
       window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
@@ -416,19 +560,21 @@ describe('AlertIncidentTabs', () => {
 
       const { user } = render(<AlertIncidentTabsWithData />);
 
-      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
-      expect(await screen.findByRole('combobox', { name: /filter alerts by team/i })).toBeInTheDocument();
-
-      await user.click(screen.getByRole('tab', { name: /incidents/i }));
-
-      // Hidden from the accessibility tree, but kept mounted so its fetched values survive.
+      // Open incidents win the default tab, where the dropdown is hidden from the
+      // accessibility tree but kept mounted so its fetched values survive.
       expect(await screen.findByText('Database outage')).toBeInTheDocument();
       expect(screen.queryByRole('combobox', { name: /filter alerts by team/i })).not.toBeInTheDocument();
 
-      // Switching back shows the dropdown again without refetching the team values.
       await user.click(screen.getByRole('tab', { name: /firing alerts/i }));
 
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
       expect(await screen.findByRole('combobox', { name: /filter alerts by team/i })).toBeInTheDocument();
+
+      // Switching back hides it again, without having refetched the team values.
+      await user.click(screen.getByRole('tab', { name: /incidents/i }));
+
+      expect(await screen.findByText('Database outage')).toBeInTheDocument();
+      expect(screen.queryByRole('combobox', { name: /filter alerts by team/i })).not.toBeInTheDocument();
       expect(fetchTagValues).toHaveBeenCalledTimes(1);
     });
 

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.test.tsx
@@ -317,6 +317,18 @@ describe('AlertIncidentTabs', () => {
       expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'false');
     });
 
+    it('selects the Firing alerts tab when the incidents plugin is not installed', async () => {
+      mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
+      mockNoIrmPlugin();
+
+      render(<AlertIncidentTabsWithData />);
+
+      // Incidents is the default, so with no Incidents tab to select the alerts tab has to win.
+      expect(await screen.findByText('CPU Critical')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /firing alerts/i })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.queryByRole('tab', { name: /incidents/i })).not.toBeInTheDocument();
+    });
+
     it('selects the Firing alerts tab when there are no incidents but alerts are firing', async () => {
       mockAlerts([makeAlert({ labels: { alertname: 'CPU Critical', severity: 'critical' } })]);
       mockIrmPlugin();

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -1,4 +1,4 @@
-import { useImperativeHandle, useRef, useState, type Ref } from 'react';
+import { useEffect, useImperativeHandle, useRef, useState, type Ref } from 'react';
 
 import { t } from '@grafana/i18n';
 import { Box, ScrollContainer, Stack, Tab, TabContent, TabsBar, Text } from '@grafana/ui';
@@ -40,7 +40,8 @@ export function AlertIncidentTabs({
   const canViewIncidents = !!incidentsData.enabled;
   const canViewAlerts = alertsData.enabled;
 
-  // Default to alerts tab if alerts are available, otherwise default to incidents tab
+  // Incidents is the preferred default, but the plugin probe hasn't resolved on first render,
+  // so start on the only tab known to exist and let the effect below settle the choice.
   const [activeTab, setActiveTab] = useState<TabId>(canViewAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
   const { count, hasAlerts, hasTeams, loading, canCreate, newRuleHref, viewAllHref, error } = alertsData;
   const {
@@ -58,10 +59,14 @@ export function AlertIncidentTabs({
     canViewIncidents && !incidentsLoading && !incidentsError && activeTab === INCIDENTS_TAB_ID;
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const userPickedTabRef = useRef(false);
+  const autoSelectSettledRef = useRef(false);
+
   useImperativeHandle(
     switchRef,
     () => ({
       switch: (tab: TabId, scroll = true) => {
+        userPickedTabRef.current = true;
         setActiveTab(tab);
         if (scroll) {
           containerRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -70,6 +75,22 @@ export function AlertIncidentTabs({
     }),
     []
   );
+
+  // Neither count is known at mount, so the default lands once the initial loads settle:
+  // Incidents wins unless it is confirmed empty while alerts are firing. Evaluated once, so
+  // later team-filter refetches don't move the tab under the user.
+  useEffect(() => {
+    if (autoSelectSettledRef.current || userPickedTabRef.current || !canViewIncidents) {
+      return;
+    }
+    if (loading || incidentsLoading) {
+      return;
+    }
+    autoSelectSettledRef.current = true;
+    // An errored fetch isn't the same as an empty one, so neither side falls through on error.
+    const preferAlerts = !incidentsError && incidentsCount === 0 && canViewAlerts && !error && count > 0;
+    setActiveTab(preferAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
+  }, [canViewAlerts, canViewIncidents, loading, incidentsLoading, count, incidentsCount, error, incidentsError]);
 
   // Hide the tabs if neither alerts nor incidents are available
   if (!canViewAlerts && !canViewIncidents) {
@@ -84,16 +105,6 @@ export function AlertIncidentTabs({
         : t('home.alerts-incidents.title-alerts', 'Alerts');
 
   const tabs = [
-    ...(canViewAlerts
-      ? [
-          {
-            id: ALERTS_TAB_ID,
-            label: t('home.alerts-incidents.alert-tab-label', 'Firing alerts'),
-            // Undefined while loading so the counter doesn't flash 0 before the alerts arrive.
-            counter: loading ? undefined : count,
-          },
-        ]
-      : []),
     ...(canViewIncidents
       ? [
           {
@@ -104,6 +115,16 @@ export function AlertIncidentTabs({
             // the strictly-greater-than cap renders "{limit}+" instead of the misleading exact count.
             counter: incidentsLoading ? undefined : incidentsHasMore ? incidentsCount + 1 : incidentsCount,
             counterCappedAt: ACTIVE_INCIDENTS_QUERY_LIMIT,
+          },
+        ]
+      : []),
+    ...(canViewAlerts
+      ? [
+          {
+            id: ALERTS_TAB_ID,
+            label: t('home.alerts-incidents.alert-tab-label', 'Firing alerts'),
+            // Undefined while loading so the counter doesn't flash 0 before the alerts arrive.
+            counter: loading ? undefined : count,
           },
         ]
       : []),
@@ -133,6 +154,7 @@ export function AlertIncidentTabs({
               active={activeTab === tab.id}
               counter={tab.counter}
               onChangeTab={() => {
+                userPickedTabRef.current = true;
                 setActiveTab(tab.id);
                 tabChanged({ tab: tab.id });
               }}

--- a/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
+++ b/public/app/features/home/AlertsIncidents/AlertIncidentTabs.tsx
@@ -40,9 +40,7 @@ export function AlertIncidentTabs({
   const canViewIncidents = !!incidentsData.enabled;
   const canViewAlerts = alertsData.enabled;
 
-  // Incidents is the preferred default, but the plugin probe hasn't resolved on first render,
-  // so start on the only tab known to exist and let the effect below settle the choice.
-  const [activeTab, setActiveTab] = useState<TabId>(canViewAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
+  const [activeTab, setActiveTab] = useState<TabId>(INCIDENTS_TAB_ID);
   const { count, hasAlerts, hasTeams, loading, canCreate, newRuleHref, viewAllHref, error } = alertsData;
   const {
     loading: incidentsLoading,
@@ -53,56 +51,6 @@ export function AlertIncidentTabs({
     canDeclare: incidentsCanDeclare,
     canAccess: incidentsCanAccess,
   } = incidentsData;
-
-  const isAlertActionsVisible = canViewAlerts && !loading && !error && activeTab === ALERTS_TAB_ID;
-  const isIncidentsActionsVisible =
-    canViewIncidents && !incidentsLoading && !incidentsError && activeTab === INCIDENTS_TAB_ID;
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const userPickedTabRef = useRef(false);
-  const autoSelectSettledRef = useRef(false);
-
-  useImperativeHandle(
-    switchRef,
-    () => ({
-      switch: (tab: TabId, scroll = true) => {
-        userPickedTabRef.current = true;
-        setActiveTab(tab);
-        if (scroll) {
-          containerRef.current?.scrollIntoView({ behavior: 'smooth' });
-        }
-      },
-    }),
-    []
-  );
-
-  // Neither count is known at mount, so the default lands once the initial loads settle:
-  // Incidents wins unless it is confirmed empty while alerts are firing. Evaluated once, so
-  // later team-filter refetches don't move the tab under the user.
-  useEffect(() => {
-    if (autoSelectSettledRef.current || userPickedTabRef.current || !canViewIncidents) {
-      return;
-    }
-    if (loading || incidentsLoading) {
-      return;
-    }
-    autoSelectSettledRef.current = true;
-    // An errored fetch isn't the same as an empty one, so neither side falls through on error.
-    const preferAlerts = !incidentsError && incidentsCount === 0 && canViewAlerts && !error && count > 0;
-    setActiveTab(preferAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
-  }, [canViewAlerts, canViewIncidents, loading, incidentsLoading, count, incidentsCount, error, incidentsError]);
-
-  // Hide the tabs if neither alerts nor incidents are available
-  if (!canViewAlerts && !canViewIncidents) {
-    return null;
-  }
-
-  const title =
-    canViewAlerts && canViewIncidents
-      ? t('home.alerts-incidents.title', 'Alerts & incidents')
-      : canViewIncidents
-        ? t('home.alerts-incidents.title-incidents', 'Incidents')
-        : t('home.alerts-incidents.title-alerts', 'Alerts');
 
   const tabs = [
     ...(canViewIncidents
@@ -130,6 +78,57 @@ export function AlertIncidentTabs({
       : []),
   ];
 
+  // Incidents is the default, but the plugin probe hasn't resolved on first render, so the
+  // state can name a tab that isn't available (yet, or ever). Fall back to the one that is.
+  const effectiveTab = tabs.some((tab) => tab.id === activeTab) ? activeTab : tabs[0]?.id;
+
+  const isAlertActionsVisible = canViewAlerts && !loading && !error && effectiveTab === ALERTS_TAB_ID;
+  const isIncidentsActionsVisible =
+    canViewIncidents && !incidentsLoading && !incidentsError && effectiveTab === INCIDENTS_TAB_ID;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const userPickedTabRef = useRef(false);
+  const autoSelectSettledRef = useRef(false);
+
+  useImperativeHandle(
+    switchRef,
+    () => ({
+      switch: (tab: TabId, scroll = true) => {
+        userPickedTabRef.current = true;
+        setActiveTab(tab);
+        if (scroll) {
+          containerRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }
+      },
+    }),
+    []
+  );
+
+  // Neither count is known at mount, so the default lands once the initial loads settle:
+  // Incidents wins unless it is confirmed empty while alerts are firing. Evaluated once, so
+  // later team-filter refetches don't move the tab under the user.
+  useEffect(() => {
+    if (autoSelectSettledRef.current || userPickedTabRef.current || !canViewIncidents || loading || incidentsLoading) {
+      return;
+    }
+    autoSelectSettledRef.current = true;
+    // An errored fetch isn't the same as an empty one, so neither side falls through on error.
+    const preferAlerts = !incidentsError && incidentsCount === 0 && canViewAlerts && !error && count > 0;
+    setActiveTab(preferAlerts ? ALERTS_TAB_ID : INCIDENTS_TAB_ID);
+  }, [canViewAlerts, canViewIncidents, loading, incidentsLoading, count, incidentsCount, error, incidentsError]);
+
+  // Hide the tabs if neither alerts nor incidents are available
+  if (!canViewAlerts && !canViewIncidents) {
+    return null;
+  }
+
+  const title =
+    canViewAlerts && canViewIncidents
+      ? t('home.alerts-incidents.title', 'Alerts & incidents')
+      : canViewIncidents
+        ? t('home.alerts-incidents.title-incidents', 'Incidents')
+        : t('home.alerts-incidents.title-alerts', 'Alerts');
+
   return (
     <Stack direction="column" gap={1} minWidth={0} ref={containerRef}>
       <Stack justifyContent="space-between" alignItems="center" minHeight={4}>
@@ -139,7 +138,7 @@ export function AlertIncidentTabs({
         {canViewAlerts && (
           // Hidden rather than unmounted on the Incidents tab, so the combobox keeps
           // its fetched team values instead of refetching them on every tab switch.
-          <div hidden={activeTab !== ALERTS_TAB_ID}>
+          <div hidden={effectiveTab !== ALERTS_TAB_ID}>
             <TeamFilterCombobox selectedTeam={team} onChange={setTeam} userHasTeams={hasTeams} />
           </div>
         )}
@@ -151,7 +150,7 @@ export function AlertIncidentTabs({
             <Tab
               key={tab.id}
               label={tab.label}
-              active={activeTab === tab.id}
+              active={effectiveTab === tab.id}
               counter={tab.counter}
               onChangeTab={() => {
                 userPickedTabRef.current = true;
@@ -168,8 +167,8 @@ export function AlertIncidentTabs({
             maxHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
             minHeight={`${DASHBOARD_TABS_SCROLL_HEIGHT_REDESIGN}px`}
           >
-            {activeTab === ALERTS_TAB_ID && <FiringAlertsCard data={alertsData} hideFooterActions />}
-            {activeTab === INCIDENTS_TAB_ID && <IncidentsCard data={incidentsData} hideFooterActions />}
+            {effectiveTab === ALERTS_TAB_ID && <FiringAlertsCard data={alertsData} hideFooterActions />}
+            {effectiveTab === INCIDENTS_TAB_ID && <IncidentsCard data={incidentsData} hideFooterActions />}
           </ScrollContainer>
 
           <Box padding={1} paddingTop={1.5}>


### PR DESCRIPTION
## What is this feature?

On the redesigned homepage (`grafana.growthHomepage`), the "Alerts & incidents" section now puts **Incidents** first in the tab bar and selects it by default. It falls through to **Firing alerts** only when incidents are confirmed empty while alerts are firing — if both sides are empty, it stays on Incidents.

Neither count is known when the section mounts: the Alertmanager query is still in flight and the IRM plugin probe hasn't resolved (`incidentsData.enabled` is `undefined` on first render). So the choice lands once both loads settle, and it's a first-load decision only — a tab click, a header pill, or a later team-filter refetch won't move it. An errored fetch isn't treated as an empty one, so neither side wins the tab on error.

Because the tab state can name a tab that isn't available yet (or ever, when the IRM plugin isn't installed), the rendered tab is derived from the tabs that actually exist and falls back to Firing alerts. That keeps the pre-probe render identical to today rather than showing an empty card.

## Why do we need this feature?

Previously the default was a synchronous permission check, so anyone with `AlertingInstanceRead` always landed on Firing alerts — including when that tab resolved to an empty "all clear" state while there were active incidents worth looking at. Incidents are the more urgent signal, so they should be what you see first.

## Who is this feature for?

Grafana Cloud users on the redesigned homepage with the IRM plugin installed.

## Which issue(s) does this PR fix?

n/a

## Special notes for your reviewer

- The section heading is still "Alerts & incidents", and the header pills still render alerts-first, so they no longer match the tab order. Happy to change either if you'd prefer.
- Four existing tests assumed the alerts-first default (the two `switchRef` tests, the tab-switch test, and the team-dropdown visibility test) — I inverted their direction rather than weakening the assertions.
