### PR TITLE
fix(packaging): preserve bundled plugins on empty package upgrades

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -36,9 +36,10 @@ if [ "$1" = configure ]; then
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
   # plugin auto-updater can replace them; the service points
   # paths.bundled_plugins there. Copy instead of move so the packaged files
-  # stay in place and `dpkg --verify` stays clean. Any copy already at the
-  # destination is safe to clobber.
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # stay in place and `dpkg --verify` stays clean. Only replace the existing
+  # bundled plugins when the package actually contains plugin definitions.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && \
+     find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print | grep -q .; then
     if [ "$IS_UPGRADE" = "true" ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
       if command -v systemctl >/dev/null; then
         systemctl stop grafana-server || true

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -39,9 +39,10 @@ if [ "$1" -eq 1 ] ; then
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
   # plugin auto-updater can replace them; the service points
   # paths.bundled_plugins there. Copy instead of move so the packaged files
-  # stay in place and `rpm -V` stays clean. Any copy already at the
-  # destination is safe to clobber
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # stay in place and `rpm -V` stays clean. Only replace the existing
+  # bundled plugins when the package actually contains plugin definitions.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && \
+     find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print | grep -q .; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
@@ -101,7 +102,10 @@ elif [ "$1" -ge 2 ] ; then
 
   # Replace the bundled plugins with the ones shipped in the new package.
   # See the matching copy in the fresh-install branch above.
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # Do not remove an existing bundled plugin tree when the package only
+  # contains an empty placeholder left by an earlier package version.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && \
+     find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print | grep -q .; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"


### PR DESCRIPTION
Fixes grafana/grafana#131956.

When upgrading from 13.2.0, the packaged `data/plugins-bundled` directory can exist but be empty because 13.2.0 moved the bundled plugins into the data directory. The 13.2.1 deb/rpm postinst scripts currently remove the existing `$DATA_DIR/plugins-bundled` tree before copying that empty directory, leaving Grafana without the bundled plugins.

On an offline installation, the background preinstaller then tries to download the missing plugins from grafana.com.

This keeps the existing bundled-plugin tree unless the package actually contains plugin definitions, so an empty packaged placeholder cannot destroy a working installation. The guard is applied to both deb and rpm postinst scripts.