### PR TITLE
Dashboarding: Apply isDraggable after Assistant changes

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -17,6 +17,7 @@ import { type DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 
 import { buildPanelEditScene } from '../../panel-edit/PanelEditor';
 import { type DashboardScene } from '../../scene/DashboardScene';
+import { type DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { transformSaveModelSchemaV2ToScene } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import { findVizPanelByKey, getLibraryPanelBehavior } from '../../utils/utils';
 
@@ -240,5 +241,23 @@ describe('APPLY_SPEC with a panel open for editing', () => {
     expect((await applySpec(scene, makeSpec())).success).toBe(true);
 
     expect(editedPanelKey(scene)).toBeUndefined();
+  });
+});
+
+describe('APPLY_SPEC entering edit mode from view mode', () => {
+  it('makes the rebuilt grid draggable and resizable', async () => {
+    const scene = buildScene(makeSpec());
+    expect(scene.state.isEditing).toBeFalsy();
+
+    expect((await applySpec(scene, makeSpec())).success).toBe(true);
+
+    // Read scene.state.body only now, post-rebuild. The reason is that entering edit mode also fires editModeChanged,
+    // but on the pre-rebuild body, which applySpec's internal swap will discard
+    expect(scene.state.isEditing).toBe(true);
+    const layout = scene.state.body as unknown as DefaultGridLayoutManager;
+    await waitFor(() => {
+      expect(layout.state.grid.state.isDraggable).toBe(true);
+      expect(layout.state.grid.state.isResizable).toBe(true);
+    });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -180,6 +180,11 @@ export const applySpecCommand: MutationCommand<ApplySpecPayload> = {
 
       scene.setState({ ...newState, editPanel: undefined });
 
+      // applies isDraggable state since the dashboard is in edit mode now
+      if (scene.state.isEditing) {
+        scene.state.body.editModeChanged?.(true);
+      }
+
       // The swapped-in children have never seen the URL, so url-only state is gone and a tabs
       // layout writes its default over `?dtab=`. Per child rather than for the scene itself: that
       // keeps the dashboard's own keys out of the pass, leaving the re-open below the only path

--- a/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/specValidation.test.ts
@@ -59,7 +59,7 @@ const stubContext = { scene: {} as DashboardScene } satisfies MutationContext;
 // (edit-mode entry, metadata envelope, state swap), so the rebuild is reached.
 function makeSceneContext(): MutationContext {
   const scene = {
-    state: { isEditing: true, key: 'scene-key', meta: {} },
+    state: { isEditing: true, key: 'scene-key', meta: {}, body: { editModeChanged: jest.fn() } },
     onEnterEditMode: jest.fn(),
     activateSidebar: jest.fn(),
     serializer: {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/24012 
(and follows the recommended fix stated in the [comment](https://github.com/grafana/support-escalations/issues/24012#issuecomment-5515496270))

Verified locally