### PR TITLE
fix(packaging): preserve bundled plugins on empty upgrade source

### DIFF
--- a/packaging/deb/control/postinst
+++ b/packaging/deb/control/postinst
@@ -36,9 +36,9 @@ if [ "$1" = configure ]; then
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
   # plugin auto-updater can replace them; the service points
   # paths.bundled_plugins there. Copy instead of move so the packaged files
-  # stay in place and `dpkg --verify` stays clean. Any copy already at the
-  # destination is safe to clobber.
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # stay in place and `dpkg --verify` stays clean. Only replace an existing
+  # bundled-plugin tree when the package actually contains plugin definitions.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && [ -n "$(find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print -quit)" ]; then
     if [ "$IS_UPGRADE" = "true" ] && [ "$RESTART_ON_UPGRADE" = "true" ]; then
       if command -v systemctl >/dev/null; then
         systemctl stop grafana-server || true

--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -39,9 +39,9 @@ if [ "$1" -eq 1 ] ; then
   # Bundled plugins must live under $DATA_DIR (writable by grafana) so the
   # plugin auto-updater can replace them; the service points
   # paths.bundled_plugins there. Copy instead of move so the packaged files
-  # stay in place and `rpm -V` stays clean. Any copy already at the
-  # destination is safe to clobber
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # stay in place and `rpm -V` stays clean. Only replace an existing
+  # bundled-plugin tree when the package actually contains plugin definitions.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && [ -n "$(find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print -quit)" ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"
@@ -100,8 +100,9 @@ elif [ "$1" -ge 2 ] ; then
   fi
 
   # Replace the bundled plugins with the ones shipped in the new package.
-  # See the matching copy in the fresh-install branch above.
-  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ]; then
+  # See the matching copy in the fresh-install branch above. Keep the existing
+  # tree if an upgrade leaves the packaged source empty.
+  if [ -d "$GRAFANA_HOME/data/plugins-bundled" ] && [ -n "$(find "$GRAFANA_HOME/data/plugins-bundled" -type f -name plugin.json -print -quit)" ]; then
     mkdir -p "$DATA_DIR"
     rm -rf "${DATA_DIR:?}/plugins-bundled"
     cp -a "$GRAFANA_HOME/data/plugins-bundled" "$DATA_DIR"


### PR DESCRIPTION
Fixes grafana/grafana#131956.

During an upgrade from 13.2.0, the packaged `data/plugins-bundled` directory can exist without any plugin definitions because the bundled plugins were moved out in 13.2.0.

The deb and rpm postinst scripts currently remove the working `$DATA_DIR/plugins-bundled` tree and copy that empty directory over it. Grafana then treats the bundled plugins as missing and tries to download them.

Only replace the data-dir copy when the package actually contains a `plugin.json`, so an empty packaged source doesn't wipe the existing bundled plugins.