### PR TITLE
PanelEditNext: surface datasource change errors

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -1411,6 +1411,23 @@ describe('PanelDataPaneNext', () => {
       expect(mockQueryRunner.runQueries).not.toHaveBeenCalled();
     });
 
+    it('should clear dsError after a subsequent successful datasource change', async () => {
+      mockQueryRunnerState.datasource = { uid: 'prom-uid', type: 'prometheus' };
+      mockQueryRunnerState.queries = [{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }];
+
+      mockGetInstanceSettings.mockReturnValueOnce(undefined);
+
+      await testDataPane.changeDataSource({ uid: 'nonexistent-uid', type: 'unknown' }, 'A');
+
+      expect(testDataPane.state.dsError).toBeInstanceOf(Error);
+
+      mockGetInstanceSettings.mockReturnValue(promInstance2Settings);
+
+      await testDataPane.changeDataSource({ uid: 'prom-uid-2', type: 'prometheus' }, 'A');
+
+      expect(testDataPane.state.dsError).toBeUndefined();
+    });
+
     it('should set dsError and not update queries when get() fails during a type-change DS switch', async () => {
       mockQueryRunnerState.datasource = { uid: 'prom-uid', type: 'prometheus' };
       mockQueryRunnerState.queries = [{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }];
@@ -1671,6 +1688,23 @@ describe('PanelDataPaneNext', () => {
 
       expect(testDataPane.state.dsError).toBeInstanceOf(Error);
       expect(mockQueryRunner.setState).not.toHaveBeenCalled();
+    });
+
+    it('clears dsError after a subsequent successful bulk datasource change', async () => {
+      mockQueryRunnerState.datasource = { uid: 'prom-uid', type: 'prometheus' };
+      mockQueryRunnerState.queries = [{ refId: 'A', datasource: { uid: 'prom-uid', type: 'prometheus' } }];
+
+      mockGetInstanceSettings.mockReturnValueOnce(undefined);
+
+      await testDataPane.bulkChangeDataSource(['A'], { uid: 'nonexistent', type: 'unknown' });
+
+      expect(testDataPane.state.dsError).toBeInstanceOf(Error);
+
+      mockGetInstanceSettings.mockReturnValue(promInstance2Settings);
+
+      await testDataPane.bulkChangeDataSource(['A'], { uid: 'prom-uid-2', type: 'prometheus' });
+
+      expect(testDataPane.state.dsError).toBeUndefined();
     });
 
     it('runs queries after a successful datasource change', async () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -500,6 +500,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       });
     }
 
+    this.setState({ dsError: undefined });
     this.resolveUniformDatasource();
     queryRunner.runQueries();
   };
@@ -711,6 +712,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
       queryRunner.setState({ queries });
     }
 
+    this.setState({ dsError: undefined });
     this.resolveUniformDatasource();
     queryRunner.runQueries();
   };

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/DatasourceErrorAlert.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/DatasourceErrorAlert.tsx
@@ -1,0 +1,18 @@
+import { t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+import { useDatasourceContext } from './QueryEditorContext';
+
+export function DatasourceErrorAlert() {
+  const { dsError } = useDatasourceContext();
+
+  if (!dsError) {
+    return null;
+  }
+
+  return (
+    <Alert severity="error" title={t('query-editor-renderer.datasource-error-title', 'Datasource error')}>
+      {dsError.message}
+    </Alert>
+  );
+}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -84,12 +84,14 @@ const queryB: TestQuery = { refId: 'B', legendFormat: 'series-b' };
 
 function renderRenderer(
   selectedQuery: DataQuery | null,
-  uiStateOverrides: NonNullable<Parameters<typeof renderWithQueryEditorProvider>[1]>['uiStateOverrides'] = {}
+  uiStateOverrides: NonNullable<Parameters<typeof renderWithQueryEditorProvider>[1]>['uiStateOverrides'] = {},
+  dsState: NonNullable<Parameters<typeof renderWithQueryEditorProvider>[1]>['dsState'] = {}
 ) {
   return renderWithQueryEditorProvider(<QueryEditorRenderer />, {
     queries: [queryA, queryB],
     selectedQuery,
     uiStateOverrides: { selectedQueryDsData, ...uiStateOverrides },
+    dsState,
   });
 }
 
@@ -124,6 +126,11 @@ describe('QueryEditorRenderer', () => {
     renderRenderer(queryA, { selectedQueryDsData: null });
     expect(screen.getByText(/failed to load datasource for this query/i)).toBeInTheDocument();
     expect(screen.getByText(/select a datasource for this query/i)).toBeInTheDocument();
+  });
+
+  it('shows an error when a datasource change fails', () => {
+    renderRenderer(queryA, {}, { dsError: new Error('Failed to load datasource: Prometheus') });
+    expect(screen.getByText(/failed to load datasource: prometheus/i)).toBeInTheDocument();
   });
 
   it('renders the query editor for the selected query', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -128,8 +128,10 @@ describe('QueryEditorRenderer', () => {
     expect(screen.getByText(/select a datasource for this query/i)).toBeInTheDocument();
   });
 
-  it('shows an error when a datasource change fails', () => {
+  it('shows a datasource error', () => {
     renderRenderer(queryA, {}, { dsError: new Error('Failed to load datasource: Prometheus') });
+
+    expect(screen.getByText('Datasource error')).toBeInTheDocument();
     expect(screen.getByText(/failed to load datasource: prometheus/i)).toBeInTheDocument();
   });
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -14,7 +14,12 @@ import { Alert, ErrorBoundaryAlert, Spinner, Stack, Text } from '@grafana/ui';
 import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
 import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 
-import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
+import {
+  useActionsContext,
+  useDatasourceContext,
+  useQueryEditorUIContext,
+  useQueryRunnerContext,
+} from './QueryEditorContext';
 import { QueryCoauthoringSurface } from './coauthoring/QueryCoauthoringSurface';
 import {
   type InternalQueryEditorCoauthoringPropsV1,
@@ -183,21 +188,32 @@ export function QueryEditorPanel({
 }
 
 export function QueryEditorRenderer() {
+  const { dsError } = useDatasourceContext();
   const { queries, data } = useQueryRunnerContext();
   const { selectedQuery, selectedQueryDsData, selectedQueryDsLoading } = useQueryEditorUIContext();
   const { updateSelectedQuery, addQuery, runQueries, startQueryPreview } = useActionsContext();
 
   return (
-    <QueryEditorPanel
-      query={selectedQuery}
-      queryDsData={selectedQueryDsData}
-      queryDsLoading={selectedQueryDsLoading}
-      queries={queries}
-      data={data}
-      updateQuery={updateSelectedQuery}
-      addQuery={addQuery}
-      runQueries={runQueries}
-      startQueryPreview={startQueryPreview}
-    />
+    <>
+      {dsError && (
+        <Alert
+          severity="error"
+          title={t('query-editor-renderer.datasource-change-error-title', 'Failed to change datasource')}
+        >
+          {dsError.message}
+        </Alert>
+      )}
+      <QueryEditorPanel
+        query={selectedQuery}
+        queryDsData={selectedQueryDsData}
+        queryDsLoading={selectedQueryDsLoading}
+        queries={queries}
+        data={data}
+        updateQuery={updateSelectedQuery}
+        addQuery={addQuery}
+        runQueries={runQueries}
+        startQueryPreview={startQueryPreview}
+      />
+    </>
   );
 }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -14,12 +14,8 @@ import { Alert, ErrorBoundaryAlert, Spinner, Stack, Text } from '@grafana/ui';
 import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
 import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 
-import {
-  useActionsContext,
-  useDatasourceContext,
-  useQueryEditorUIContext,
-  useQueryRunnerContext,
-} from './QueryEditorContext';
+import { DatasourceErrorAlert } from './DatasourceErrorAlert';
+import { useActionsContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
 import { QueryCoauthoringSurface } from './coauthoring/QueryCoauthoringSurface';
 import {
   type InternalQueryEditorCoauthoringPropsV1,
@@ -188,21 +184,13 @@ export function QueryEditorPanel({
 }
 
 export function QueryEditorRenderer() {
-  const { dsError } = useDatasourceContext();
   const { queries, data } = useQueryRunnerContext();
   const { selectedQuery, selectedQueryDsData, selectedQueryDsLoading } = useQueryEditorUIContext();
   const { updateSelectedQuery, addQuery, runQueries, startQueryPreview } = useActionsContext();
 
   return (
     <>
-      {dsError && (
-        <Alert
-          severity="error"
-          title={t('query-editor-renderer.datasource-change-error-title', 'Failed to change datasource')}
-        >
-          {dsError.message}
-        </Alert>
-      )}
+      <DatasourceErrorAlert />
       <QueryEditorPanel
         query={selectedQuery}
         queryDsData={selectedQueryDsData}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.test.tsx
@@ -59,12 +59,16 @@ const transformations: Transformation[] = [
   { transformId: 'organize-0', transformConfig: { id: 'organize', options: {} }, registryItem },
 ];
 
-function renderStackedEditor(uiStateOverrides: Partial<QueryEditorUIState> = {}) {
+function renderStackedEditor(
+  uiStateOverrides: Partial<QueryEditorUIState> = {},
+  dsState: NonNullable<Parameters<typeof renderWithQueryEditorProvider>[1]>['dsState'] = {}
+) {
   return renderWithQueryEditorProvider(<StackedEditorRenderer />, {
     queries,
     transformations,
     selectedQuery: queries[0],
     uiStateOverrides: { stackedMode: makeStackedMode({ enabled: true }), ...uiStateOverrides },
+    dsState,
   });
 }
 
@@ -88,6 +92,13 @@ describe('StackedEditorRenderer', () => {
     renderStackedEditor();
 
     expect(screen.getByText('Showing 3 items')).toBeInTheDocument();
+  });
+
+  it('shows datasource errors in stacked mode', () => {
+    renderStackedEditor({}, { dsError: new Error('Failed to load datasource: Prometheus') });
+
+    expect(screen.getByText('Datasource error')).toBeInTheDocument();
+    expect(screen.getByText(/failed to load datasource: prometheus/i)).toBeInTheDocument();
   });
 
   it('marks the selected query as the current section', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.tsx
@@ -79,7 +79,9 @@ export function StackedEditorRenderer() {
         </Button>
       </div>
 
-      <DatasourceErrorAlert />
+      <div className={styles.errorAlert}>
+        <DatasourceErrorAlert />
+      </div>
 
       <div
         className={styles.scrollArea}
@@ -127,6 +129,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(0.5, 2),
     backgroundColor: theme.colors.background.secondary,
     borderBottom: `1px solid ${theme.colors.border.weak}`,
+  }),
+  errorAlert: css({
+    flex: '0 0 auto',
   }),
   scrollArea: css({
     flex: 1,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/StackedEditor/StackedEditorRenderer.tsx
@@ -6,6 +6,7 @@ import { t, Trans } from '@grafana/i18n';
 import { Button, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { QueryEditorType } from '../../constants';
+import { DatasourceErrorAlert } from '../DatasourceErrorAlert';
 import { usePanelContext, useQueryEditorUIContext, useQueryRunnerContext } from '../QueryEditorContext';
 
 import { StackedSection } from './StackedSection';
@@ -77,6 +78,9 @@ export function StackedEditorRenderer() {
           <Trans i18nKey="query-editor-next.stacked.exit">Exit stacked view</Trans>
         </Button>
       </div>
+
+      <DatasourceErrorAlert />
+
       <div
         className={styles.scrollArea}
         ref={containerRef}


### PR DESCRIPTION
**What is this feature?**

Shows datasource change errors in the PanelEditNext query editor.

It also clears a previous `dsError` once a later datasource change succeeds, for both single-query and bulk changes.

**Why do we need this feature?**

`dsError` was already being set when a datasource change failed, but nothing in the query editor displayed it. From the user's side, the datasource change could fail and it would just look like nothing happened.

The error could also stay around even after a later datasource change succeeded.

**Who is this feature for?**

Anyone editing panel queries and switching datasources in PanelEditNext.

**Which issue(s) does this PR fix?**

Fixes #130945

**Special note for the reviewer**

Added regression coverage for:
- surfacing datasource errors in the query editor
- surfacing the same error in stacked mode
- clearing stale errors after successful single-query datasource changes
- clearing stale errors after successful bulk datasource changes

The three affected test suites pass with 98/98 tests.

The two affected test suites pass with 90/90 tests.