### PR TITLE
Explore: Show an error instead of "No data" when the browser cannot parse the query response

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -1,4 +1,4 @@
-import { firstValueFrom, of } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
 import {
   type DataQuery,
@@ -12,6 +12,7 @@ import {
   type AdHocVariableFilter,
   type ScopedVars,
   getDefaultTimeRange,
+  LoadingState,
 } from '@grafana/data';
 
 import { config } from '../config';
@@ -195,6 +196,31 @@ describe('DataSourceWithBackend', () => {
         } as DataQueryRequest)
       )
     ).rejects.toThrow('Unknown Datasource');
+  });
+
+  test('surfaces an error when the response body cannot be parsed', async () => {
+    const { ds } = createMockDatasource();
+    // backend_srv rejects like this when response.json() fails, e.g. because the body is larger
+    // than the browser's maximum string length
+    const parseError = new SyntaxError('Unexpected end of JSON input');
+    const fetchSpy = jest.spyOn(backendSrv, 'fetch').mockReturnValueOnce(throwError(() => parseError));
+
+    try {
+      const response = await firstValueFrom(
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A' }],
+          range: getDefaultTimeRange(),
+        } as DataQueryRequest)
+      );
+
+      expect(response.state).toBe(LoadingState.Error);
+      expect(response.data).toEqual([]);
+      expect(response.error?.message).toBe('Unexpected end of JSON input');
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   test('does not prepare the request until the observable is subscribed to', async () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -329,10 +329,10 @@ class DataSourceWithBackend<
               }
               return of(rsp);
             }),
-            // Scoped to the fetch chain on purpose: toDataQueryResponse can only map fetch-shaped
-            // errors, and would turn a plain thrown Error (e.g. the unknown-datasource throw in
-            // createBackendRequest) into a silent empty success. Those errors are left to reach the
-            // subscriber, where runRequest turns them into a query error.
+            // Scoped to the fetch chain on purpose: errors thrown while preparing the request (e.g. the
+            // unknown-datasource throw in createBackendRequest) are left to reach the subscriber, where
+            // runRequest turns them into a query error. Errors from the fetch itself, including a
+            // response body the browser could not parse, are mapped to an error response here.
             catchError((err) => {
               return of(toDataQueryResponse(err));
             })

--- a/packages/grafana-runtime/src/utils/queryResponse.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.test.ts
@@ -1,4 +1,4 @@
-import { type DataQuery, toDataFrameDTO, type DataFrame } from '@grafana/data';
+import { type DataQuery, toDataFrameDTO, type DataFrame, LoadingState } from '@grafana/data';
 
 import { type FetchError, type FetchResponse } from '../services';
 
@@ -335,6 +335,15 @@ describe('Query Response parser', () => {
     expect(res.errors).toHaveLength(2);
     expect(res.errors?.[0].traceId).toBeUndefined();
     expect(res.errors?.[1].traceId).toBeUndefined();
+  });
+
+  test('should return an error response for a thrown Error', () => {
+    // e.g. response.json() rejecting because the body exceeds the browser's maximum string length
+    const err = new SyntaxError('Unexpected end of JSON input');
+    const res = toDataQueryResponse(err);
+    expect(res.state).toBe(LoadingState.Error);
+    expect(res.data).toEqual([]);
+    expect(res.error?.message).toBe('Unexpected end of JSON input');
   });
 
   test('should handle an error-response with traceIds', () => {

--- a/packages/grafana-runtime/src/utils/queryResponse.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.ts
@@ -61,9 +61,17 @@ export function toDataQueryResponse(
   res:
     | { data: BackendDataSourceResponse | undefined }
     | FetchResponse<BackendDataSourceResponse | undefined>
-    | DataQueryError,
+    | DataQueryError
+    | Error,
   queries?: DataQuery[]
 ): DataQueryResponse {
+  // A thrown Error has no HTTP shape, so the checks below would let it fall through as an empty
+  // successful response and hide the failure behind "No data". This happens, for example, when the
+  // browser rejects response.json() because the body exceeds its maximum string length.
+  if (res instanceof Error) {
+    return { data: [], state: LoadingState.Error, error: toDataQueryError(res) };
+  }
+
   const rsp: DataQueryResponse = { data: [], state: LoadingState.Done };
 
   const traceId = 'traceId' in res ? res.traceId : undefined;

--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -195,6 +195,19 @@ describe('parseResponseBody', () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('throws a descriptive error when the JSON body cannot be parsed', async () => {
+    // response.json() rejects like this for a body larger than the browser's maximum string length
+    const parseError = new SyntaxError('Unexpected end of JSON input');
+    const json = jest.fn().mockRejectedValueOnce(parseError);
+
+    const result = parseResponseBody({ ...rsp, json }, 'json');
+
+    await expect(result).rejects.toThrow(
+      'Failed to parse the response body as JSON: Unexpected end of JSON input. The response may be too large for the browser to process.'
+    );
+    await expect(result).rejects.toHaveProperty('cause', parseError);
+  });
+
   it('parses text', async () => {
     const value = 'RAW TEXT';
     const body = await parseResponseBody(

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -2,7 +2,7 @@ import { omitBy } from 'lodash';
 import { type Observable, of, throwError } from 'rxjs';
 
 import { deprecationWarning, validatePath } from '@grafana/data';
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { type BackendSrvRequest, TracedError } from '@grafana/runtime';
 
 export const parseInitFromOptions = (options: BackendSrvRequest): RequestInit => {
   const method = options.method;
@@ -142,7 +142,18 @@ export async function parseResponseBody<T>(
           console.warn(`${response.url} returned an invalid JSON`);
           return {} as T;
         }
-        return await response.json();
+        try {
+          return await response.json();
+        } catch (err) {
+          // The request itself succeeded, so a bare SyntaxError is misleading here. The most common
+          // cause is a body larger than the browser's maximum string length (~512 MB in Chromium):
+          // text() then resolves to "" and json() rejects with "Unexpected end of JSON input".
+          const reason = err instanceof Error ? err.message : String(err);
+          throw new TracedError(
+            `Failed to parse the response body as JSON: ${reason}. The response may be too large for the browser to process.`,
+            err
+          );
+        }
 
       case 'text':
         // this specifically returns a Promise<string>


### PR DESCRIPTION
**What is this feature?**

A query whose `/api/ds/query` response is too large for the browser to parse (larger than the browser's maximum string length, roughly 512 MB in Chromium) currently renders as a bare "No data" in Explore and in dashboard panels, with no error anywhere. This PR surfaces it as a query error with a message that names the likely cause.

Two layers are changed so the error is both surfaced and understandable:

- `toDataQueryResponse` (`@grafana/runtime`): a thrown `Error` has no HTTP shape, so it fell through every check and came back as `{ data: [], state: Done }`. It is now mapped to `{ data: [], state: Error, error }`. This is the root of the silent failure, and it also fixes `publicDashboardQueryHandler`, which uses the same `catchError(err => of(toDataQueryResponse(err)))` pattern.
- `parseResponseBody` (`public/app/core/utils/fetch.ts`): when `response.json()` rejects, the bare `SyntaxError: Unexpected end of JSON input` is misleading because the request itself succeeded. The rejection is now wrapped in a `TracedError` (keeps the original stack for Faro) with the message:

  > Failed to parse the response body as JSON: Unexpected end of JSON input. The response may be too large for the browser to process.

The now-inaccurate comment above the `catchError` in `DataSourceWithBackend.query` is updated to match.

**Why do we need this feature?**

Users cannot tell the difference between "the query really returned nothing" and "the browser could not decode a successful response". The datasource returned data, the network tab shows a full body, and Grafana shows "No data". See the reproduction and root-cause analysis in the linked issue.

**Who is this feature for?**

Anyone running large queries in Explore or dashboards, and anyone debugging a "No data" result.

**Which issue(s) does this PR fix?**:

Fixes #131944

**Special notes for your reviewer:**

- Regression tests were added at all three layers (`fetch.test.ts`, `queryResponse.test.ts`, `DataSourceWithBackend.test.ts`). Each was confirmed to fail with the source changes stashed and pass with them applied.
- Only `Error` instances are treated as errors in `toDataQueryResponse`. Plain fetch-shaped objects (`FetchError`, the cancelled-request object) keep their existing handling, so `{ data: undefined }` inputs still produce an empty successful response as before.
- The `TracedError` message deliberately says the response "may be" too large: the body is already consumed by the time `json()` rejects, so the size cannot be verified without reading the body twice.
- Related: #131945 takes a similar approach in `toDataQueryResponse` only. This PR additionally fixes the message at the parse site and covers `DataSourceWithBackend` end to end.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A, bug fix)
- [ ] The docs are updated. (N/A, no user-facing configuration or behavior beyond the error message)
