### PR TITLE
team: handle legacy NULL team membership fields

### DIFF
--- a/pkg/services/team/teamimpl/queries/get_team_members.sql
+++ b/pkg/services/team/teamimpl/queries/get_team_members.sql
@@ -7,8 +7,8 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  team_member.external,
-  team_member.permission,
+  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid
 FROM {{ .Ident .TeamMemberTable }} AS team_member

--- a/pkg/services/team/teamimpl/queries/get_team_members.sql
+++ b/pkg/services/team/teamimpl/queries/get_team_members.sql
@@ -7,7 +7,7 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.external, FALSE) AS {{ .Ident "external" }},
   COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid

--- a/pkg/services/team/teamimpl/testdata/mysql--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_team_members-all_filters.sql
@@ -7,8 +7,8 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  team_member.external,
-  team_member.permission,
+  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid
 FROM `test_schema`.`team_member` AS team_member

--- a/pkg/services/team/teamimpl/testdata/mysql--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/mysql--get_team_members-all_filters.sql
@@ -7,7 +7,7 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.external, FALSE) AS `external`,
   COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid

--- a/pkg/services/team/teamimpl/testdata/postgres--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_team_members-all_filters.sql
@@ -7,8 +7,8 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  team_member.external,
-  team_member.permission,
+  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid
 FROM "test_schema"."team_member" AS team_member

--- a/pkg/services/team/teamimpl/testdata/postgres--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/postgres--get_team_members-all_filters.sql
@@ -7,7 +7,7 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.external, FALSE) AS "external",
   COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_team_members-all_filters.sql
@@ -7,8 +7,8 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  team_member.external,
-  team_member.permission,
+  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid
 FROM "test_schema"."team_member" AS team_member

--- a/pkg/services/team/teamimpl/testdata/sqlite--get_team_members-all_filters.sql
+++ b/pkg/services/team/teamimpl/testdata/sqlite--get_team_members-all_filters.sql
@@ -7,7 +7,7 @@ SELECT
   team_user.name,
   team_user.login,
   team_user.uid AS user_uid,
-  COALESCE(team_member.external, FALSE) AS external,
+  COALESCE(team_member.external, FALSE) AS "external",
   COALESCE(team_member.permission, 0) AS permission,
   user_auth.auth_module,
   team.uid AS team_uid


### PR DESCRIPTION
Fixes #119465

Legacy Grafana databases can retain NULL values in `team_member.external` and `team_member.permission` because both columns were introduced as nullable. The legacy team-members query scans those columns directly into non-nullable Go fields, so loading dashboards can fail with a SQL scan error after upgrading.

Use `COALESCE` for both legacy nullable fields so existing rows are read with their zero-value semantics. Update the SQL fixtures for MySQL, PostgreSQL, and SQLite.

Verification:
- Updated the shared query and all three database-specific generated SQL fixtures.
- Repository CI should exercise the query template tests across supported dialects.

Signed-off-by: Devansh Pandey <231b094@juetguna.in>