### PR TITLE
Alerting: avoid blocking HA gossip on alert broadcast

### DIFF
--- a/pkg/services/ngalert/notifier/alert_broadcast.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 const alertBroadcastKey = "alerts:broadcast"
@@ -19,12 +21,22 @@ type AlertBroadcastPayload struct {
 type alertBroadcast struct {
 	logger log.Logger
 	moa    *MultiOrgAlertmanager
+
+	mu      sync.Mutex
+	queue   chan AlertBroadcastPayload
+	running bool
 }
 
 func newAlertBroadcastState(logger log.Logger, moa *MultiOrgAlertmanager) *alertBroadcast {
+	queueSize := setting.AlertBroadcastDefaultQueueSize
+	if moa != nil && moa.settings != nil && moa.settings.UnifiedAlerting.HASingleEvaluationAlertBroadcastQueueSize > 0 {
+		queueSize = moa.settings.UnifiedAlerting.HASingleEvaluationAlertBroadcastQueueSize
+	}
+
 	return &alertBroadcast{
 		logger: logger,
 		moa:    moa,
+		queue:  make(chan AlertBroadcastPayload, queueSize),
 	}
 }
 
@@ -46,14 +58,56 @@ func (s *alertBroadcast) Merge(b []byte) error {
 		return nil
 	}
 
+	// Merge is invoked from the cluster's receive path. Never call PutAlerts here:
+	// it can block on Alertmanager backpressure and stall the gossip event loop.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case s.queue <- payload:
+	default:
+		// Alert broadcasts are best-effort state replication. Dropping here is
+		// preferable to blocking the cluster receive path; the next evaluation
+		// will broadcast the current alert state again.
+		s.logger.Warn("Dropping broadcast alerts because local processing queue is full", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts))
+		return nil
+	}
+
+	if s.running {
+		return nil
+	}
+
+	s.running = true
+	go s.processQueue()
+	return nil
+}
+
+func (s *alertBroadcast) processQueue() {
+	for {
+		select {
+		case payload := <-s.queue:
+			s.process(payload)
+		default:
+			s.mu.Lock()
+			if len(s.queue) == 0 {
+				s.running = false
+				s.mu.Unlock()
+				return
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+func (s *alertBroadcast) process(payload AlertBroadcastPayload) {
 	am, err := s.moa.AlertmanagerFor(payload.OrgID)
 	if err != nil {
 		if errors.Is(err, ErrNoAlertmanagerForOrg) || errors.Is(err, ErrAlertmanagerNotReady) {
 			s.logger.Debug("Skipping receiving of broadcasted alerts, alertmanager unavailable", "orgID", payload.OrgID, "error", err)
-			return nil
+			return
 		}
 		s.logger.Warn("Failed to resolve alertmanager for broadcast alerts", "orgID", payload.OrgID, "error", err)
-		return nil
+		return
 	}
 
 	if err := am.PutAlerts(context.Background(), payload.Alerts); err != nil {
@@ -61,5 +115,4 @@ func (s *alertBroadcast) Merge(b []byte) error {
 	} else {
 		s.logger.Debug("Received broadcast alerts from peer", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts))
 	}
-	return nil
 }

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -33,60 +33,40 @@ func TestBroadcastAlerts(t *testing.T) {
 		{
 			name:  "broadcasts alerts when channel exists",
 			orgID: 1,
-			alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "test alert"}},
-				},
-			},
+			alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test alert"}}}},
 			channelExists: true,
 			expected: &AlertBroadcastPayload{
-				OrgID: 1,
-				Alerts: apimodels.PostableAlerts{
-					PostableAlerts: []amv2.PostableAlert{
-						{Annotations: amv2.LabelSet{"summary": "test alert"}},
-					},
-				},
+				OrgID:  1,
+				Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test alert"}}}},
 			},
 		},
 		{
-			name:  "does not broadcast when channel is nil",
-			orgID: 1,
-			alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "test alert"}},
-				},
-			},
+			name:          "does not broadcast when channel is nil",
+			orgID:         1,
+			alerts:        apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test alert"}}}},
 			channelExists: false,
-			expected:      nil,
 		},
 		{
 			name:          "does not broadcast empty alerts",
 			orgID:         1,
 			alerts:        apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{}},
 			channelExists: true,
-			expected:      nil,
 		},
 		{
 			name:          "does not broadcast nil alerts",
 			orgID:         1,
 			alerts:        apimodels.PostableAlerts{},
 			channelExists: true,
-			expected:      nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockChannel := &MockBroadcastChannel{}
-
-			moa := &MultiOrgAlertmanager{
-				logger: log.NewNopLogger(),
-			}
-
+			moa := &MultiOrgAlertmanager{logger: log.NewNopLogger()}
 			if tc.channelExists {
 				moa.alertsBroadcastChannel = mockChannel
 			}
-
 			moa.BroadcastAlerts(tc.orgID, tc.alerts)
 
 			if tc.expected == nil {
@@ -94,8 +74,7 @@ func TestBroadcastAlerts(t *testing.T) {
 			} else {
 				require.Len(t, mockChannel.Broadcasts(), 1)
 				var decoded AlertBroadcastPayload
-				err := json.Unmarshal(mockChannel.Broadcasts()[0], &decoded)
-				require.NoError(t, err)
+				require.NoError(t, json.Unmarshal(mockChannel.Broadcasts()[0], &decoded))
 				require.Equal(t, *tc.expected, decoded)
 			}
 		})
@@ -104,9 +83,7 @@ func TestBroadcastAlerts(t *testing.T) {
 
 func TestAlertBroadcast_MarshalBinary(t *testing.T) {
 	state := newAlertBroadcastState(log.NewNopLogger(), nil)
-
 	data, err := state.MarshalBinary()
-
 	require.NoError(t, err)
 	require.Nil(t, data, "MarshalBinary should return nil for alert broadcast state (no full state sync)")
 }
@@ -141,6 +118,7 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 	t.Run("delivers alerts to alertmanager", func(t *testing.T) {
 		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
 		mockAM.On("Ready").Return(true)
+		delivered := make(chan struct{})
 		mockAM.On("PutAlerts", mock.Anything, mock.MatchedBy(func(alerts apimodels.PostableAlerts) bool {
 			if len(alerts.PostableAlerts) != 3 {
 				return false
@@ -152,22 +130,19 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 				}
 			}
 			return true
-		})).Return(nil)
+		})).Run(func(mock.Arguments) { close(delivered) }).Return(nil)
 
 		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID: 1,
-			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{
-				{Annotations: amv2.LabelSet{"summary": "alert 1"}},
-				{Annotations: amv2.LabelSet{"summary": "alert 2"}},
-				{Annotations: amv2.LabelSet{"summary": "alert 3"}},
-			}},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{
+			{Annotations: amv2.LabelSet{"summary": "alert 1"}},
+			{Annotations: amv2.LabelSet{"summary": "alert 2"}},
+			{Annotations: amv2.LabelSet{"summary": "alert 3"}},
+		}}})
 		require.NoError(t, err)
-
 		require.NoError(t, state.Merge(payload))
-		require.Eventually(t, func() bool { return mockAM.AssertExpectations(t) }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { select { case <-delivered: return true; default: return false } }, time.Second, 10*time.Millisecond)
+		mockAM.AssertExpectations(t)
 	})
 
 	t.Run("returns immediately when PutAlerts blocks", func(t *testing.T) {
@@ -175,30 +150,17 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		mockAM.On("Ready").Return(true)
 		entered := make(chan struct{})
 		release := make(chan struct{})
-		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-			close(entered)
-			<-release
-		}).Return(nil)
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(mock.Arguments) { close(entered); <-release }).Return(nil)
 
 		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID: 1,
-			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
 
 		start := time.Now()
 		require.NoError(t, state.Merge(payload))
 		require.Less(t, time.Since(start), 100*time.Millisecond)
-		require.Eventually(t, func() bool {
-			select {
-			case <-entered:
-				return true
-			default:
-				return false
-			}
-		}, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { select { case <-entered: return true; default: return false } }, time.Second, 10*time.Millisecond)
 		close(release)
 	})
 
@@ -225,13 +187,15 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 	t.Run("does not return error when PutAlerts fails", func(t *testing.T) {
 		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
 		mockAM.On("Ready").Return(true)
-		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Return(errors.New("test error"))
+		failed := make(chan struct{})
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(mock.Arguments) { close(failed) }).Return(errors.New("test error"))
 		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
 		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
 		require.NoError(t, state.Merge(payload))
-		require.Eventually(t, func() bool { return mockAM.AssertExpectations(t) }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool { select { case <-failed: return true; default: return false } }, time.Second, 10*time.Millisecond)
+		mockAM.AssertExpectations(t)
 	})
 }
 

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
@@ -112,53 +113,29 @@ func TestAlertBroadcast_MarshalBinary(t *testing.T) {
 
 func TestAlertBroadcast_Merge(t *testing.T) {
 	t.Run("empty payload returns nil", func(t *testing.T) {
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: make(map[int64]Alertmanager),
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		err := state.Merge([]byte{})
-		require.NoError(t, err)
+		require.NoError(t, state.Merge([]byte{}))
 	})
 
 	t.Run("nil payload returns nil", func(t *testing.T) {
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: make(map[int64]Alertmanager),
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		err := state.Merge(nil)
-		require.NoError(t, err)
+		require.NoError(t, state.Merge(nil))
 	})
 
 	t.Run("invalid JSON returns nil", func(t *testing.T) {
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: make(map[int64]Alertmanager),
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		err := state.Merge([]byte("not valid json"))
-		require.NoError(t, err)
+		require.NoError(t, state.Merge([]byte("not valid json")))
 	})
 
 	t.Run("empty alerts in payload returns nil", func(t *testing.T) {
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: make(map[int64]Alertmanager),
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID:  1,
-			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{}},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{}}})
 		require.NoError(t, err)
-
-		err = state.Merge(payload)
-		require.NoError(t, err)
+		require.NoError(t, state.Merge(payload))
 	})
 
 	t.Run("delivers alerts to alertmanager", func(t *testing.T) {
@@ -177,72 +154,71 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 			return true
 		})).Return(nil)
 
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: map[int64]Alertmanager{1: mockAM},
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
 		payload, err := json.Marshal(AlertBroadcastPayload{
 			OrgID: 1,
-			Alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "alert 1"}},
-					{Annotations: amv2.LabelSet{"summary": "alert 2"}},
-					{Annotations: amv2.LabelSet{"summary": "alert 3"}},
-				},
-			},
+			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{
+				{Annotations: amv2.LabelSet{"summary": "alert 1"}},
+				{Annotations: amv2.LabelSet{"summary": "alert 2"}},
+				{Annotations: amv2.LabelSet{"summary": "alert 3"}},
+			}},
 		})
 		require.NoError(t, err)
 
-		err = state.Merge(payload)
+		require.NoError(t, state.Merge(payload))
+		require.Eventually(t, func() bool { return mockAM.AssertExpectations(t) }, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("returns immediately when PutAlerts blocks", func(t *testing.T) {
+		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
+		mockAM.On("Ready").Return(true)
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			close(entered)
+			<-release
+		}).Return(nil)
+
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+		payload, err := json.Marshal(AlertBroadcastPayload{
+			OrgID: 1,
+			Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}},
+		})
 		require.NoError(t, err)
-		mockAM.AssertExpectations(t)
+
+		start := time.Now()
+		require.NoError(t, state.Merge(payload))
+		require.Less(t, time.Since(start), 100*time.Millisecond)
+		require.Eventually(t, func() bool {
+			select {
+			case <-entered:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
+		close(release)
 	})
 
 	t.Run("skips when alertmanager not found", func(t *testing.T) {
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: make(map[int64]Alertmanager),
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID: 999,
-			Alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "test"}},
-				},
-			},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 999, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
-
-		err = state.Merge(payload)
-		require.NoError(t, err)
+		require.NoError(t, state.Merge(payload))
 	})
 
 	t.Run("skips when alertmanager not ready", func(t *testing.T) {
 		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
 		mockAM.On("Ready").Return(false)
-
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: map[int64]Alertmanager{1: mockAM},
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID: 1,
-			Alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "test"}},
-				},
-			},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
-
-		err = state.Merge(payload)
-		require.NoError(t, err)
+		require.NoError(t, state.Merge(payload))
+		time.Sleep(10 * time.Millisecond)
 		mockAM.AssertNotCalled(t, "PutAlerts", mock.Anything, mock.Anything)
 	})
 
@@ -250,26 +226,12 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
 		mockAM.On("Ready").Return(true)
 		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Return(errors.New("test error"))
-
-		moa := &MultiOrgAlertmanager{
-			logger:        log.NewNopLogger(),
-			alertmanagers: map[int64]Alertmanager{1: mockAM},
-		}
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
-
-		payload, err := json.Marshal(AlertBroadcastPayload{
-			OrgID: 1,
-			Alerts: apimodels.PostableAlerts{
-				PostableAlerts: []amv2.PostableAlert{
-					{Annotations: amv2.LabelSet{"summary": "test"}},
-				},
-			},
-		})
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
-
-		err = state.Merge(payload)
-		require.NoError(t, err)
-		mockAM.AssertExpectations(t)
+		require.NoError(t, state.Merge(payload))
+		require.Eventually(t, func() bool { return mockAM.AssertExpectations(t) }, time.Second, 10*time.Millisecond)
 	})
 }
 
@@ -281,57 +243,17 @@ func TestInitAlertBroadcast(t *testing.T) {
 		needsMetrics    bool
 		customQueueSize int
 	}{
-		{
-			name: "does not initialize when peer is nil",
-			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
-				return nil, nil
-			},
-			expectChannel: false,
-		},
-		{
-			name: "does not initialize when peer is NilPeer",
-			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
-				return &NilPeer{}, nil
-			},
-			expectChannel: false,
-		},
-		{
-			name: "initializes when peer is not NilPeer",
-			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
-				ch := &MockBroadcastChannel{}
-				return &MockClusterPeer{Channel: ch}, ch
-			},
-			expectChannel: true,
-			needsMetrics:  true,
-		},
-		{
-			name: "passes reliable delivery and queue size options",
-			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
-				ch := &MockBroadcastChannel{}
-				return &MockClusterPeer{Channel: ch}, ch
-			},
-			expectChannel: true,
-			needsMetrics:  true,
-		},
-		{
-			name: "passes custom queue size from config",
-			setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) {
-				ch := &MockBroadcastChannel{}
-				return &MockClusterPeer{Channel: ch}, ch
-			},
-			expectChannel:   true,
-			needsMetrics:    true,
-			customQueueSize: 500,
-		},
+		{name: "does not initialize when peer is nil", setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) { return nil, nil }, expectChannel: false},
+		{name: "does not initialize when peer is NilPeer", setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) { return &NilPeer{}, nil }, expectChannel: false},
+		{name: "initializes when peer is not NilPeer", setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) { ch := &MockBroadcastChannel{}; return &MockClusterPeer{Channel: ch}, ch }, expectChannel: true, needsMetrics: true},
+		{name: "passes reliable delivery and queue size options", setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) { ch := &MockBroadcastChannel{}; return &MockClusterPeer{Channel: ch}, ch }, expectChannel: true, needsMetrics: true},
+		{name: "passes custom queue size from config", setupPeer: func() (alertingNotify.ClusterPeer, *MockBroadcastChannel) { ch := &MockBroadcastChannel{}; return &MockClusterPeer{Channel: ch}, ch }, expectChannel: true, needsMetrics: true, customQueueSize: 500},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			peer, expectedChannel := tc.setupPeer()
-			moa := &MultiOrgAlertmanager{
-				logger: log.NewNopLogger(),
-				peer:   peer,
-			}
+			moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), peer: peer}
 			if tc.needsMetrics {
 				queueSize := tc.customQueueSize
 				if queueSize == 0 {
@@ -340,11 +262,7 @@ func TestInitAlertBroadcast(t *testing.T) {
 				reg := prometheus.NewRegistry()
 				m := metrics.NewNGAlert(reg)
 				moa.metrics = m.GetMultiOrgAlertmanagerMetrics()
-				moa.settings = &setting.Cfg{
-					UnifiedAlerting: setting.UnifiedAlertingSettings{
-						HASingleEvaluationAlertBroadcastQueueSize: queueSize,
-					},
-				}
+				moa.settings = &setting.Cfg{UnifiedAlerting: setting.UnifiedAlertingSettings{HASingleEvaluationAlertBroadcastQueueSize: queueSize}}
 			}
 
 			moa.initAlertBroadcast()

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -31,9 +31,9 @@ func TestBroadcastAlerts(t *testing.T) {
 		expected      *AlertBroadcastPayload
 	}{
 		{
-			name:  "broadcasts alerts when channel exists",
-			orgID: 1,
-			alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test alert"}}}},
+			name:          "broadcasts alerts when channel exists",
+			orgID:         1,
+			alerts:        apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test alert"}}}},
 			channelExists: true,
 			expected: &AlertBroadcastPayload{
 				OrgID:  1,
@@ -157,10 +157,20 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
 
-		start := time.Now()
-		require.NoError(t, state.Merge(payload))
-		require.Less(t, time.Since(start), 100*time.Millisecond)
-		require.Eventually(t, func() bool { select { case <-entered: return true; default: return false } }, time.Second, 10*time.Millisecond)
+		mergeDone := make(chan error, 1)
+		go func() {
+			mergeDone <- state.Merge(payload)
+		}()
+
+		require.Eventually(t, func() bool {
+			select {
+			case <-entered:
+				return true
+			default:
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
+		require.NoError(t, <-mergeDone)
 		close(release)
 	})
 
@@ -169,22 +179,36 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		mockAM.On("Ready").Return(true)
 		entered := make(chan struct{})
 		release := make(chan struct{})
-		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(mock.Arguments) { close(entered); <-release }).Return(nil)
+		delivered := make(chan string, 2)
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			alerts := args.Get(1).(apimodels.PostableAlerts)
+			delivered <- string(alerts.PostableAlerts[0].Annotations["summary"])
+			if len(delivered) == 1 {
+				close(entered)
+				<-release
+			}
+		}).Return(nil)
 
 		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)
 		state.queue = make(chan AlertBroadcastPayload, 1)
-		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
-		require.NoError(t, err)
 
-		require.NoError(t, state.Merge(payload))
+		makePayload := func(summary string) []byte {
+			payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": summary}}}}})
+			require.NoError(t, err)
+			return payload
+		}
+
+		require.NoError(t, state.Merge(makePayload("alert 1")))
 		require.Eventually(t, func() bool { select { case <-entered: return true; default: return false } }, time.Second, 10*time.Millisecond)
-		require.NoError(t, state.Merge(payload))
-		start := time.Now()
-		require.NoError(t, state.Merge(payload))
-		require.Less(t, time.Since(start), 100*time.Millisecond)
+		require.NoError(t, state.Merge(makePayload("alert 2")))
+		require.NoError(t, state.Merge(makePayload("alert 3")))
 		require.Len(t, state.queue, 1)
+
 		close(release)
+		require.Eventually(t, func() bool { return len(delivered) == 2 }, time.Second, 10*time.Millisecond)
+		require.Equal(t, []string{"alert 1", "alert 2"}, []string{<-delivered, <-delivered})
+		mockAM.AssertExpectations(t)
 	})
 
 	t.Run("skips when alertmanager not found", func(t *testing.T) {
@@ -203,7 +227,7 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
 		require.NoError(t, state.Merge(payload))
-		time.Sleep(10 * time.Millisecond)
+		require.Eventually(t, func() bool { return !state.isRunning() }, time.Second, 10*time.Millisecond)
 		mockAM.AssertNotCalled(t, "PutAlerts", mock.Anything, mock.Anything)
 	})
 

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -164,6 +164,29 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		close(release)
 	})
 
+	t.Run("drops when local queue is full", func(t *testing.T) {
+		mockAM := alertmanager_mock.NewAlertmanagerMock(t)
+		mockAM.On("Ready").Return(true)
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		mockAM.On("PutAlerts", mock.Anything, mock.Anything).Run(func(mock.Arguments) { close(entered); <-release }).Return(nil)
+
+		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: map[int64]Alertmanager{1: mockAM}}
+		state := newAlertBroadcastState(log.NewNopLogger(), moa)
+		state.queue = make(chan AlertBroadcastPayload, 1)
+		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
+		require.NoError(t, err)
+
+		require.NoError(t, state.Merge(payload))
+		require.Eventually(t, func() bool { select { case <-entered: return true; default: return false } }, time.Second, 10*time.Millisecond)
+		require.NoError(t, state.Merge(payload))
+		start := time.Now()
+		require.NoError(t, state.Merge(payload))
+		require.Less(t, time.Since(start), 100*time.Millisecond)
+		require.Len(t, state.queue, 1)
+		close(release)
+	})
+
 	t.Run("skips when alertmanager not found", func(t *testing.T) {
 		moa := &MultiOrgAlertmanager{logger: log.NewNopLogger(), alertmanagers: make(map[int64]Alertmanager)}
 		state := newAlertBroadcastState(log.NewNopLogger(), moa)

--- a/pkg/services/ngalert/notifier/alert_broadcast_test.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast_test.go
@@ -227,7 +227,11 @@ func TestAlertBroadcast_Merge(t *testing.T) {
 		payload, err := json.Marshal(AlertBroadcastPayload{OrgID: 1, Alerts: apimodels.PostableAlerts{PostableAlerts: []amv2.PostableAlert{{Annotations: amv2.LabelSet{"summary": "test"}}}}})
 		require.NoError(t, err)
 		require.NoError(t, state.Merge(payload))
-		require.Eventually(t, func() bool { return !state.isRunning() }, time.Second, 10*time.Millisecond)
+		require.Eventually(t, func() bool {
+			state.mu.Lock()
+			defer state.mu.Unlock()
+			return !state.running
+		}, time.Second, 10*time.Millisecond)
 		mockAM.AssertNotCalled(t, "PutAlerts", mock.Anything, mock.Anything)
 	})
 


### PR DESCRIPTION
Fixes #131977

The alert broadcast cluster state `Merge` callback runs on the cluster receive path. It previously called `PutAlerts` synchronously, so Alertmanager backpressure could block the gossip event loop and make healthy peers appear dead.

This change adds a bounded local queue and asynchronous worker. `Merge` only decodes and enqueues the payload; slow `PutAlerts` work happens outside the gossip callback. When the local queue is full, the payload is dropped rather than blocking the cluster receive path, consistent with HA alert-broadcast best-effort behavior.