### PR TITLE
Zanzana: Fix MT reconciler crash from duplicate lease metrics registration

### DIFF
--- a/pkg/infra/leaderelection/kvlease/elector.go
+++ b/pkg/infra/leaderelection/kvlease/elector.go
@@ -31,6 +31,7 @@ type Elector struct {
 	kvStore       kv.KV
 	leaseName     string
 	identity      string
+	component     string
 	leaseDuration time.Duration
 	retryPeriod   time.Duration
 	logger        log.Logger
@@ -50,10 +51,12 @@ func WithManagerOptions(opts ...lease.ManagerOption) Option {
 }
 
 // New creates an Elector. If cfg.Identity is empty, it is auto-generated
-// from hostname:PID.
+// from hostname:PID. component is the lease.Manager metrics component label,
+// which must be unique per elector sharing a process registry.
 func New(
 	kvStore kv.KV,
 	cfg leaderelection.Config,
+	component string,
 	logger log.Logger,
 	reg prometheus.Registerer,
 	opts ...Option,
@@ -78,6 +81,7 @@ func New(
 		kvStore:       kvStore,
 		leaseName:     cfg.LeaseName,
 		identity:      identity,
+		component:     component,
 		leaseDuration: cfg.LeaseDuration,
 		retryPeriod:   cfg.RetryPeriod,
 		logger:        logger,
@@ -105,7 +109,7 @@ func (k *Elector) Run(ctx context.Context, fn func(ctx context.Context), opts ..
 		}),
 	}, opts)
 
-	mgr := lease.NewManager(k.kvStore, k.identity, k.reg, k.managerOpts...)
+	mgr := lease.NewManager(k.kvStore, k.identity, k.component, k.reg, k.managerOpts...)
 
 	for {
 		if err := ctx.Err(); err != nil {

--- a/pkg/infra/leaderelection/kvlease/elector_test.go
+++ b/pkg/infra/leaderelection/kvlease/elector_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/leaderelection"
@@ -41,11 +42,68 @@ func testElectorOpts() []Option {
 	}
 }
 
+// TestKVLeaseElector_ScopesLeaseMetrics ensures the elector's lease.Manager
+// registers under its own component label, so it coexists with another
+// lease.Manager (e.g. the storage backend's) already on the same process
+// registry instead of panicking on a duplicate collector.
+func TestKVLeaseElector_ScopesLeaseMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	store := newTestKV(t)
+
+	// A lease.Manager already on this registry, as the storage backend would be.
+	_ = lease.NewManager(store, "storage-holder", "storage", reg, lease.WithGarbageCollectionDisabled)
+
+	elector, err := New(store, testElectionConfig(), "zanzana_reconciler", log.NewNopLogger(), reg, testElectorOpts()...)
+	require.NoError(t, err)
+
+	// Run builds the lease.Manager (registering its metrics) before checking the
+	// context, so a cancelled context still exercises the registration path.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.NotPanics(t, func() {
+		_ = elector.Run(ctx, func(context.Context) {})
+	})
+
+	// Both managers report the same lease_manager_* metric, distinguished by
+	// the component label.
+	require.ElementsMatch(t,
+		[]string{"storage", "zanzana_reconciler"},
+		componentLabelValues(t, reg, "lease_manager_acquire_duration_seconds"),
+	)
+}
+
+// componentLabelValues gathers reg and returns the distinct "component" label
+// values present on the metric family named name.
+func componentLabelValues(t *testing.T, reg prometheus.Gatherer, name string) []string {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+
+	seen := map[string]struct{}{}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "component" {
+					seen[l.GetValue()] = struct{}{}
+				}
+			}
+		}
+	}
+	values := make([]string, 0, len(seen))
+	for v := range seen {
+		values = append(values, v)
+	}
+	return values
+}
+
 func TestKVLeaseElector_AcquireLeadership(t *testing.T) {
 	kvp := newTestKV(t)
 	cfg := testElectionConfig()
 
-	elector, err := New(kvp, cfg, log.NewNopLogger(), nil, testElectorOpts()...)
+	elector, err := New(kvp, cfg, "test", log.NewNopLogger(), nil, testElectorOpts()...)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -70,7 +128,7 @@ func TestKVLeaseElector_GracefulRelease(t *testing.T) {
 	kvp := newTestKV(t)
 	cfg := testElectionConfig()
 
-	elector, err := New(kvp, cfg, log.NewNopLogger(), nil, testElectorOpts()...)
+	elector, err := New(kvp, cfg, "test", log.NewNopLogger(), nil, testElectorOpts()...)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
@@ -105,7 +163,7 @@ func TestKVLeaseElector_LeadershipHandoff(t *testing.T) {
 		Identity:      "holder-1",
 		LeaseDuration: cfg.LeaseDuration,
 		RetryPeriod:   cfg.RetryPeriod,
-	}, log.NewNopLogger(), nil, testElectorOpts()...)
+	}, "test", log.NewNopLogger(), nil, testElectorOpts()...)
 	require.NoError(t, err)
 
 	elector2, err := New(kvp, leaderelection.Config{
@@ -113,7 +171,7 @@ func TestKVLeaseElector_LeadershipHandoff(t *testing.T) {
 		Identity:      "holder-2",
 		LeaseDuration: cfg.LeaseDuration,
 		RetryPeriod:   cfg.RetryPeriod,
-	}, log.NewNopLogger(), nil, testElectorOpts()...)
+	}, "test", log.NewNopLogger(), nil, testElectorOpts()...)
 	require.NoError(t, err)
 
 	ctx1, cancel1 := context.WithCancel(t.Context())
@@ -160,7 +218,7 @@ func TestKVLeaseElector_IdentityAutoGeneration(t *testing.T) {
 		Identity:      "",
 		LeaseDuration: time.Second,
 		RetryPeriod:   200 * time.Millisecond,
-	}, log.NewNopLogger(), nil)
+	}, "test", log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, elector.identity)
 	require.Contains(t, elector.identity, ":")
@@ -171,13 +229,13 @@ func TestKVLeaseElector_MissingLeaseName(t *testing.T) {
 
 	_, err := New(kvp, leaderelection.Config{
 		LeaseName: "",
-	}, log.NewNopLogger(), nil)
+	}, "test", log.NewNopLogger(), nil)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "leader_election_lease_name")
 }
 
 func TestKVLeaseElector_NilKVRejected(t *testing.T) {
-	_, err := New(nil, testElectionConfig(), log.NewNopLogger(), nil)
+	_, err := New(nil, testElectionConfig(), "test", log.NewNopLogger(), nil)
 	require.Error(t, err)
 }
 

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -142,7 +142,7 @@ func ProvideEmbeddedZanzanaElector(cfg *setting.Cfg, features featuremgmt.Featur
 		return nil, fmt.Errorf("KV lease leader election requires unified storage KV backend")
 	}
 
-	le, err := kvlease.New(kvStore, cfg.ZanzanaReconciler.LeaderElection, log.New("zanzana.mt-reconciler"), reg)
+	le, err := kvlease.New(kvStore, cfg.ZanzanaReconciler.LeaderElection, "zanzana_reconciler", log.New("zanzana.mt-reconciler"), reg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create KV lease elector: %w", err)
 	}

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -142,7 +142,7 @@ type Manager struct {
 
 // NewManager returns a Manager that uses store for persistence and identifies
 // itself as holder.
-func NewManager(store kv.KV, holder string, reg prometheus.Registerer, opts ...ManagerOption) *Manager {
+func NewManager(store kv.KV, holder string, component string, reg prometheus.Registerer, opts ...ManagerOption) *Manager {
 	m := &Manager{
 		store:        store,
 		holder:       holder,
@@ -150,7 +150,7 @@ func NewManager(store kv.KV, holder string, reg prometheus.Registerer, opts ...M
 		maxClockSkew: defaultMaxClockSkew,
 		log:          logging.DefaultLogger.With("logger", "lease-manager"),
 		now:          time.Now,
-		metrics:      NewMetrics(reg),
+		metrics:      NewMetrics(reg, component),
 	}
 	m.garbageCollector = newGarbageCollector(store, m.log, m.now, m.metrics)
 	for _, opt := range opts {

--- a/pkg/storage/unified/resource/lease/lease_test.go
+++ b/pkg/storage/unified/resource/lease/lease_test.go
@@ -24,7 +24,7 @@ func TestLease(t *testing.T) {
 }
 
 func TestAcquireNameValidation(t *testing.T) {
-	m := lease.NewManager(newMapKV(), "holder-validation", nil, lease.WithGarbageCollectionDisabled)
+	m := lease.NewManager(newMapKV(), "holder-validation", "test", nil, lease.WithGarbageCollectionDisabled)
 
 	t.Run("invalid keys are rejected", func(t *testing.T) {
 		for _, name := range []string{"", "invalid key", "invalid\nkey"} {
@@ -59,7 +59,7 @@ func TestAcquireNameValidation(t *testing.T) {
 
 func TestAcquireTTLValidation(t *testing.T) {
 	const minTTL = 100 * time.Millisecond
-	m := lease.NewManager(newMapKV(), "holder-validation", nil, lease.WithInternalMinTTL(minTTL), lease.WithGarbageCollectionDisabled)
+	m := lease.NewManager(newMapKV(), "holder-validation", "test", nil, lease.WithInternalMinTTL(minTTL), lease.WithGarbageCollectionDisabled)
 
 	testCases := []struct {
 		d       time.Duration

--- a/pkg/storage/unified/resource/lease/metrics.go
+++ b/pkg/storage/unified/resource/lease/metrics.go
@@ -42,9 +42,7 @@ type Metrics struct {
 // exercising unrelated behavior) can pass nil rather than wiring up a
 // throwaway registry.
 func NewMetrics(reg prometheus.Registerer, component string) *Metrics {
-	if reg != nil {
-		reg = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, reg)
-	}
+	reg = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, reg)
 	m := &Metrics{
 		AcquireDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "lease_manager_acquire_duration_seconds",

--- a/pkg/storage/unified/resource/lease/metrics.go
+++ b/pkg/storage/unified/resource/lease/metrics.go
@@ -41,7 +41,10 @@ type Metrics struct {
 // unregistered — callers that don't care about exposing metrics (e.g. tests
 // exercising unrelated behavior) can pass nil rather than wiring up a
 // throwaway registry.
-func NewMetrics(reg prometheus.Registerer) *Metrics {
+func NewMetrics(reg prometheus.Registerer, component string) *Metrics {
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{"component": component}, reg)
+	}
 	m := &Metrics{
 		AcquireDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "lease_manager_acquire_duration_seconds",

--- a/pkg/storage/unified/resource/lease/metrics_test.go
+++ b/pkg/storage/unified/resource/lease/metrics_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMetricsAcquireRelease(t *testing.T) {
-	m := lease.NewManager(newMapKV(), "holder-ar", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-ar", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -43,7 +43,7 @@ func TestMetricsAcquireRelease(t *testing.T) {
 }
 
 func TestMetricsAcquireErrorOutcome(t *testing.T) {
-	m := lease.NewManager(newMapKV(), "holder-err", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-err", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -59,7 +59,7 @@ func TestMetricsAcquireErrorOutcome(t *testing.T) {
 }
 
 func TestMetricsAcquireAlreadyHeldOutcome(t *testing.T) {
-	m := lease.NewManager(newMapKV(), "holder-already-held", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-already-held", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -81,7 +81,7 @@ func TestMetricsAcquireAlreadyHeldOutcome(t *testing.T) {
 func TestMetricsReleaseLostOutcome(t *testing.T) {
 	const ttl = 50 * time.Millisecond
 
-	m := lease.NewManager(newMapKV(), "holder-release-lost", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-release-lost", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(ttl),
 	)
@@ -107,7 +107,7 @@ func TestMetricsReleaseLostOutcome(t *testing.T) {
 
 func TestMetricsAcquireRetries(t *testing.T) {
 	failing := &retryKV{KV: newMapKV()}
-	m := lease.NewManager(failing, "holder-retry", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(failing, "holder-retry", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -125,7 +125,7 @@ func TestMetricsAcquireRetries(t *testing.T) {
 func TestMetricsLossOnExpiry(t *testing.T) {
 	const ttl = 50 * time.Millisecond
 
-	m := lease.NewManager(newMapKV(), "holder-loss", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-loss", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(ttl),
 	)
@@ -148,7 +148,7 @@ func TestMetricsLossOnExpiry(t *testing.T) {
 func TestMetricsRenewalSuccess(t *testing.T) {
 	const ttl = 100 * time.Millisecond
 
-	m := lease.NewManager(newMapKV(), "holder-renew", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-renew", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(ttl),
 	)
@@ -171,7 +171,7 @@ func TestMetricsRenewalFailureLost(t *testing.T) {
 	const ttl = 100 * time.Millisecond
 
 	store := newMapKV()
-	a := lease.NewManager(store, "holder-a", prometheus.NewPedanticRegistry(),
+	a := lease.NewManager(store, "holder-a", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(ttl),
 	)
@@ -185,7 +185,7 @@ func TestMetricsRenewalFailureLost(t *testing.T) {
 	// a's renewal goroutine ticks it tries to create the same generation key
 	// and fails with ErrLeaseLost.
 	future := func() time.Time { return time.Now().Add(time.Hour) }
-	b := lease.NewManager(store, "holder-b", nil,
+	b := lease.NewManager(store, "holder-b", "test", nil,
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(ttl),
 		lease.WithInternalNowFunc(future),
@@ -205,7 +205,7 @@ func TestMetricsRenewalFailureLost(t *testing.T) {
 }
 
 func TestMetricsGCExecuted(t *testing.T) {
-	m := lease.NewManager(newMapKV(), "holder-gc-exec", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(newMapKV(), "holder-gc-exec", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -223,7 +223,7 @@ func TestMetricsGCSkipped(t *testing.T) {
 	// Simulate another GC instance currently holding the internal key.
 	writeGCInternalKey(t, store, time.Now().Add(time.Minute))
 
-	m := lease.NewManager(store, "holder-gc-skip", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(store, "holder-gc-skip", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 	)
 	metrics := m.Metrics()
@@ -245,7 +245,7 @@ func TestMetricsGCScannedAndDeleted(t *testing.T) {
 	now := base
 	nowFunc := func() time.Time { return now }
 
-	m := lease.NewManager(store, "holder-gc-counts", prometheus.NewPedanticRegistry(),
+	m := lease.NewManager(store, "holder-gc-counts", "test", prometheus.NewPedanticRegistry(),
 		lease.WithGarbageCollectionDisabled,
 		lease.WithInternalMinTTL(shortTTL),
 		lease.WithInternalNowFunc(nowFunc),

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -413,7 +413,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 			cancel()
 			return nil, errors.New("holder is required when enable_kv_leases is true")
 		}
-		leaseManager = lease.NewManager(kv, opts.Holder, opts.Reg)
+		leaseManager = lease.NewManager(kv, opts.Holder, "storage", opts.Reg)
 	}
 
 	backend := &kvStorageBackend{

--- a/pkg/storage/unified/resource/usagestats/ingester_test.go
+++ b/pkg/storage/unified/resource/usagestats/ingester_test.go
@@ -20,7 +20,7 @@ import (
 
 func newTestLeases(t *testing.T) *lease.Manager {
 	t.Helper()
-	mgr := lease.NewManager(newBadgerKV(t), "test-holder", nil,
+	mgr := lease.NewManager(newBadgerKV(t), "test-holder", "test", nil,
 		lease.WithInternalMinTTL(time.Second), lease.WithGarbageCollectionDisabled)
 	t.Cleanup(mgr.Stop)
 	return mgr
@@ -324,7 +324,7 @@ func TestIngesterFlushUnderLease(t *testing.T) {
 	ctx := context.Background()
 	const day = "2026-06-23"
 
-	mgr := lease.NewManager(newBadgerKV(t), "holder-a", nil,
+	mgr := lease.NewManager(newBadgerKV(t), "holder-a", "test", nil,
 		lease.WithInternalMinTTL(time.Second), lease.WithGarbageCollectionDisabled)
 	t.Cleanup(mgr.Stop)
 

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -39,7 +39,7 @@ func newTestBadgerKV(t *testing.T) kv.KV {
 
 func newTestLeaseManager(t *testing.T, store kv.KV, holder string) *lease.Manager {
 	t.Helper()
-	mgr := lease.NewManager(store, holder, nil,
+	mgr := lease.NewManager(store, holder, "test", nil,
 		lease.WithInternalMinTTL(kvTestMinTTL),
 		lease.WithGarbageCollectionDisabled,
 	)

--- a/pkg/storage/unified/sql/service_test.go
+++ b/pkg/storage/unified/sql/service_test.go
@@ -337,7 +337,7 @@ func TestBuildKVSnapshotStore(t *testing.T) {
 	t.Run("constructs store when everything is wired", func(t *testing.T) {
 		cfg := &setting.Cfg{EnableKVLeases: true}
 		store := newTestKV(t)
-		mgr := lease.NewManager(store, "test-holder", nil)
+		mgr := lease.NewManager(store, "test-holder", "test", nil)
 		t.Cleanup(mgr.Stop)
 		backend := &stubKVBackend{kv: store, mgr: mgr}
 

--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -45,7 +45,7 @@ func RunLeaseTest(t *testing.T, store kv.KV) {
 
 func newLeaseManagerNoGC(store kv.KV, holder string, opts ...lease.ManagerOption) *lease.Manager {
 	opts = append(opts, lease.WithGarbageCollectionDisabled)
-	return lease.NewManager(store, holder, nil, opts...)
+	return lease.NewManager(store, holder, "test", nil, opts...)
 }
 
 func runLeaseHappyPath(t *testing.T, store kv.KV) {


### PR DESCRIPTION
**What is this feature?**

`lease.NewManager` / `NewMetrics` now take a `component` const label that is set on every `lease_manager_*` collector, and `kvlease.New` takes a component for its elector. The storage backend registers as `component="storage"` and the zanzana reconciler's leader elector as `component="zanzana_reconciler"`.

**Why do we need this feature?**

With `enable_kv_leases`, `[zanzana.reconciler] mode = mt` and `leader_election_enabled = true`, the storage backend's `lease.Manager` and the reconciler elector's `lease.Manager` both register the unlabeled `lease_manager_*` collectors on the process-global registry, so the second registration hits `promauto`'s `MustRegister` and panics at startup (`duplicate metrics collector registration attempted`), crash-looping the pod. The `component` const label lets both managers register and report the same metric family on one registry, distinguished by `component`; registering the same component twice still fails.

**Who is this feature for?**

Operators running the multi-tenant Zanzana reconciler with KV-lease leader election.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Requires the enterprise companion PR grafana/grafana-enterprise#13383 (same branch name), which passes a component to `kvlease.New`. Adds `TestKVLeaseElector_ScopesLeaseMetrics`, which gathers the registry and asserts both component values are present (and panics without the fix).