### PR TITLE
Public dashboards: sanitize custom frame metadata

### DIFF
--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -437,6 +437,7 @@ func sanitizeMetadataFromQueryData(res *backend.QueryDataResponse) {
 		for i := range frames {
 			if frames[i].Meta != nil {
 				frames[i].Meta.ExecutedQueryString = ""
+				frames[i].Meta.Custom = nil
 			}
 		}
 	}

--- a/pkg/services/publicdashboards/internal/service/query_test.go
+++ b/pkg/services/publicdashboards/internal/service/query_test.go
@@ -1153,9 +1153,9 @@ func TestSanitizeMetadataFromQueryData(t *testing.T) {
 		}
 		sanitizeMetadataFromQueryData(fakeResponse)
 		assert.Equal(t, fakeResponse.Responses["A"].Frames[0].Meta.ExecutedQueryString, "")
-		assert.Equal(t, fakeResponse.Responses["A"].Frames[0].Meta.Custom, map[string]string{"test1": "test1"})
+		assert.Nil(t, fakeResponse.Responses["A"].Frames[0].Meta.Custom)
 		assert.Equal(t, fakeResponse.Responses["A"].Frames[1].Meta.ExecutedQueryString, "")
-		assert.Equal(t, fakeResponse.Responses["A"].Frames[1].Meta.Custom, map[string]string{"test2": "test2"})
+		assert.Nil(t, fakeResponse.Responses["A"].Frames[1].Meta.Custom)
 		assert.Equal(t, fakeResponse.Responses["B"].Frames[0].Meta.ExecutedQueryString, "")
 		assert.Nil(t, fakeResponse.Responses["B"].Frames[0].Meta.Custom)
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates public dashboard query response sanitization to remove `FrameMeta.Custom` before returning data.

The existing sanitization already clears `ExecutedQueryString`; this change also clears custom frame metadata.

**Why do we need this feature?**

`FrameMeta.Custom` may contain datasource-specific or internal metadata that should not be exposed through public dashboards.

Previously, this metadata was preserved after sanitization.

The updated behavior removes it before the response is returned.

**Who is this feature for?**

Grafana users who expose dashboards publicly.

**Which issue(s) does this PR fix?**

Fixes #123661

**Special notes for your reviewer:**

AI assistance was used during development for code navigation, test drafting, and review. I reviewed and understood the final change and verified its behavior locally.

Tested with:

`go test ./pkg/services/publicdashboards/internal/service -run TestSanitizeMetadataFromQueryData -count=1`

`go test ./pkg/services/publicdashboards/internal/service -count=1`

Result: PASS.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.