### PR TITLE
fix(pluginproxy): enforce path segment boundaries in route matching

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -370,7 +370,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		if r2 == "." && route.Path != "." {
 			r2 = ""
 		}
-		if !strings.HasPrefix(r1, r2) {
+		if r2 != "" && r1 != r2 && !strings.HasPrefix(r1, r2+"/") {
 			continue
 		}
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -1430,6 +1430,37 @@ func Test_PathCheck(t *testing.T) {
 	require.Equal(t, routes[1], proxy.matchedRoute)
 }
 
+func Test_PathCheck_SegmentBoundary(t *testing.T) {
+	routes := []*plugins.Route{
+		{
+			Path:    "api",
+			URL:     "https://admin.example.com",
+			ReqRole: org.RoleAdmin,
+			Method:  http.MethodGet,
+		},
+		{
+			Path:    "api-v2",
+			URL:     "https://viewer.example.com",
+			ReqRole: org.RoleViewer,
+			Method:  http.MethodGet,
+		},
+	}
+
+	req, err := http.NewRequest("GET", "http://localhost/api/datasources/proxy/1/api-v2", nil)
+	require.NoError(t, err)
+	ctx := &contextmodel.ReqContext{
+		Context:      &web.Context{Req: req},
+		SignedInUser: &user.SignedInUser{OrgRole: org.RoleViewer},
+	}
+
+	proxy, err := setupDSProxyTest(t, ctx, &datasources.DataSource{}, routes, "api-v2")
+	require.NoError(t, err)
+
+	err = proxy.validateRequest()
+	require.NoError(t, err)
+	require.Equal(t, routes[1], proxy.matchedRoute)
+}
+
 func setupDSProxyTest(t *testing.T, ctx *contextmodel.ReqContext, ds *datasources.DataSource, routes []*plugins.Route, path string, opts ...func(proxy *DataSourceProxy)) (*DataSourceProxy, error) {
 	t.Helper()
 


### PR DESCRIPTION
## Why
In `pkg/api/pluginproxy/ds_proxy.go`, `DataSourceProxy.validateRequest()` tests whether an incoming request path matches a configured plugin route using `strings.HasPrefix(r1, r2)`.

This performs a raw string prefix comparison rather than a path segment boundary comparison. If a plugin defines Route A with path `"api"` (requiring `RoleAdmin`) and Route B with path `"api-v2"` (requiring `RoleViewer`), a request for `"api-v2"` matches Route A because `strings.HasPrefix("api-v2", "api")` evaluates to `true`. This causes unprivileged requests to Route B to be falsely rejected with 403 Forbidden (`errPluginProxyRouteAccessDenied`). Conversely, if Route A has lower privilege requirements than Route B, requests targeting Route B are evaluated under Route A's rules.

In URL paths, segments are delimited by `/`. A route path `r2` matches `r1` if and only if `r1 == r2` or `r1` starts with `r2 + "/"`.

## Scope
- In `pkg/api/pluginproxy/ds_proxy.go`, updated `validateRequest()` so that non-empty route paths match only on exact path equality or directory segment prefixes (`strings.HasPrefix(r1, r2+"/")`).
- In `pkg/api/pluginproxy/ds_proxy_test.go`, added `Test_PathCheck_SegmentBoundary` verifying that a request to `"api-v2"` correctly resolves Route B rather than colliding with Route A (`"api"`).

## Blast Radius
Affects data source proxy route resolution. Child path matching (such as `"api/v1"` matching `"api"`) and catch-all routes (`""`) continue to function unchanged. Sibling path collisions (`"api-v2"` matching `"api"`) are eliminated.

## Verification
- Added `Test_PathCheck_SegmentBoundary` in `pkg/api/pluginproxy/ds_proxy_test.go`. Before the fix, the test failed with `plugin proxy route access denied`. With the fix, the test passes.
- Ran the full `pkg/api/pluginproxy` test suite (`go test ./pkg/api/pluginproxy`), confirming all package tests pass.