### PR TITLE
Alerting: Reject sub-second intervals and guard division by zero in interval validation

### DIFF
--- a/pkg/services/ngalert/api/validation/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation.go
@@ -251,7 +251,11 @@ func validateGroupInterval(incoming prommodels.Duration, limits RuleLimits) (tim
 		interval = limits.DefaultRuleEvaluationInterval
 	}
 
-	if interval < 0 || int64(interval.Seconds())%int64(limits.BaseInterval.Seconds()) != 0 {
+	if limits.BaseInterval <= 0 {
+		return 0, fmt.Errorf("base interval must be positive duration")
+	}
+
+	if interval <= 0 || interval < limits.BaseInterval || interval%limits.BaseInterval != 0 || interval%time.Second != 0 {
 		return 0, fmt.Errorf("rule evaluation interval (%d second) should be positive number that is multiple of the base interval of %d seconds", int64(interval.Seconds()), int64(limits.BaseInterval.Seconds()))
 	}
 
@@ -260,19 +264,17 @@ func validateGroupInterval(incoming prommodels.Duration, limits RuleLimits) (tim
 }
 
 func ValidateInterval(interval, baseInterval time.Duration) (int64, error) {
-	intervalSeconds := int64(interval.Seconds())
+	if baseInterval <= 0 {
+		return 0, fmt.Errorf("base interval must be positive duration")
+	}
 
 	baseIntervalSeconds := int64(baseInterval.Seconds())
 
-	if interval <= 0 {
-		return 0, fmt.Errorf("rule evaluation interval must be positive duration that is multiple of the base interval %d seconds", baseIntervalSeconds)
-	}
-
-	if intervalSeconds%baseIntervalSeconds != 0 {
+	if interval <= 0 || interval < baseInterval || interval%baseInterval != 0 || interval%time.Second != 0 {
 		return 0, fmt.Errorf("rule evaluation interval %d should be multiple of the base interval of %d seconds", int64(interval.Seconds()), baseIntervalSeconds)
 	}
 
-	return intervalSeconds, nil
+	return int64(interval.Seconds()), nil
 }
 
 // validateForInterval validates ApiRuleNode.For and converts it to time.Duration. If the field is not specified returns 0 if GrafanaManagedAlert.UID is empty and -1 if it is not.

--- a/pkg/services/ngalert/api/validation/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation_test.go
@@ -14,9 +14,8 @@ func TestValidateInterval_SubsecondTruncation(t *testing.T) {
 
 	t.Run("sub-second interval should fail validation", func(t *testing.T) {
 		interval := 500 * time.Millisecond
-		sec, err := validation.ValidateInterval(interval, baseInterval)
+		_, err := validation.ValidateInterval(interval, baseInterval)
 		require.Error(t, err, "sub-second interval must fail validation")
-		require.NotEqual(t, int64(0), sec, "should not return 0-second interval")
 	})
 
 	t.Run("fractional interval should fail validation", func(t *testing.T) {

--- a/pkg/services/ngalert/api/validation/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation_test.go
@@ -1,0 +1,40 @@
+package validation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/validation"
+)
+
+func TestValidateInterval_SubsecondTruncation(t *testing.T) {
+	baseInterval := 10 * time.Second
+
+	t.Run("sub-second interval should fail validation", func(t *testing.T) {
+		interval := 500 * time.Millisecond
+		sec, err := validation.ValidateInterval(interval, baseInterval)
+		require.Error(t, err, "sub-second interval must fail validation")
+		require.NotEqual(t, int64(0), sec, "should not return 0-second interval")
+	})
+
+	t.Run("fractional interval should fail validation", func(t *testing.T) {
+		interval := 10500 * time.Millisecond // 10.5 seconds
+		_, err := validation.ValidateInterval(interval, baseInterval)
+		require.Error(t, err, "non-multiple fractional interval must fail validation")
+	})
+
+	t.Run("exact multiple of base interval succeeds", func(t *testing.T) {
+		interval := 20 * time.Second
+		sec, err := validation.ValidateInterval(interval, baseInterval)
+		require.NoError(t, err)
+		require.Equal(t, int64(20), sec)
+	})
+
+	t.Run("zero base interval should return error without panic", func(t *testing.T) {
+		interval := 10 * time.Second
+		_, err := validation.ValidateInterval(interval, 0)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Why
In `pkg/services/ngalert/api/validation/api_ruler_validation.go`, `ValidateInterval` and `validateGroupInterval` checked whether an alert rule's interval was a multiple of the base interval using float conversion: `intervalSeconds := int64(interval.Seconds())` followed by `intervalSeconds % baseIntervalSeconds != 0`.

This created two critical flaws:
1. When an interval was specified with positive sub-second duration (such as `500ms`), `int64(interval.Seconds())` truncated to `0`. Because `0 % baseIntervalSeconds == 0`, `ValidateInterval` succeeded and returned `(0, nil)`. The rule was persisted with `IntervalSeconds = 0`, causing the scheduler (`pkg/services/ngalert/schedule`) to permanently skip evaluating the rule without error.
2. Fractional durations (such as `10.5s` with a `10s` base interval) had their fractional second component silently truncated (`int64(10.5) == 10`), passing validation despite not being integer multiples of the base interval.
3. If `baseInterval` was 0, `intervalSeconds % baseIntervalSeconds` triggered a runtime panic (`integer divide by zero`).

## Scope
- In `pkg/services/ngalert/api/validation/api_ruler_validation.go`:
  - Updated `ValidateInterval` and `validateGroupInterval` to validate using exact `time.Duration` modulo operations (`interval % baseInterval != 0` and `interval % time.Second != 0`), ensuring only positive whole-second multiples of the base interval pass.
  - Added an explicit guard against non-positive base intervals (`baseInterval <= 0`), eliminating division-by-zero panics.
- In `pkg/services/ngalert/api/validation/api_ruler_validation_test.go`, added unit tests covering sub-second intervals, fractional intervals, and zero base intervals.

## Blast Radius
Affects rule group and alert rule interval validation at the API boundary. Valid alert rules with whole-second multiples of `baseInterval` continue to validate unchanged.

## Verification
- Added `TestValidateInterval_SubsecondTruncation` in `api_ruler_validation_test.go`. Before the fix, the test failed on all three edge cases (nil error returned on sub-second, nil error on fractional, panic on zero base interval). After the fix, all cases pass.
- Ran the full `pkg/services/ngalert/api/...` test suite (`go test ./pkg/services/ngalert/api/...`), confirming all packages pass.