### PR TITLE
Fix: Bump @grafana/plugin-e2e to 3.12.0 and fix flaky panels smoke test

### DIFF
--- a/e2e-playwright/smoke-tests-suite/panels.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/panels.spec.ts
@@ -29,13 +29,6 @@ test.describe(
         return win.grafanaBootData?.settings?.panels ?? {};
       });
 
-      const vizPicker = editPage.getByGrafanaSelector(selectors.components.PanelEditor.toggleVizPicker);
-
-      // the viz picker is auto-opened for new unconfigured panels
-      if (await vizPicker.filter({ hasText: 'Back' }).isVisible()) {
-        await vizPicker.click({ force: true });
-      }
-
       // Loop through every panel type and ensure no crash
       for (const [_, panel] of Object.entries(panelTypes)) {
         if (panel.hideFromList || panel.state === 'deprecated') {
@@ -43,7 +36,7 @@ test.describe(
         }
 
         try {
-          editPage.setVisualization(panel.name);
+          await editPage.setVisualization(panel.name);
 
           // Verify panel type is selected
           await expect(
@@ -59,10 +52,6 @@ test.describe(
             page.getByText('An unexpected error happened'),
             'ensure no unexpected error occurred'
           ).toBeHidden();
-
-          // open the viz picker to get ready to select the next panel type
-          await expect(vizPicker.filter({ hasText: 'Change' }), 'we should be viewing panel options').toBeVisible();
-          await vizPicker.click({ force: true });
         } catch (error) {
           throw new Error(`Panel '${panel.name}' failed: ${error}`);
         }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/levitate": "0.17.2",
-    "@grafana/plugin-e2e": "^3.11.2",
+    "@grafana/plugin-e2e": "https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/levitate": "0.17.2",
-    "@grafana/plugin-e2e": "https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e",
+    "@grafana/plugin-e2e": "^3.12.0",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@grafana/eslint-config": "8.2.0",
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/levitate": "0.17.2",
-    "@grafana/plugin-e2e": "^3.10.0",
+    "@grafana/plugin-e2e": "^3.11.2",
     "@grafana/test-utils": "workspace:*",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,11 +2789,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^3.10.0":
-  version: 3.10.0
-  resolution: "@grafana/plugin-e2e@npm:3.10.0"
+"@grafana/plugin-e2e@npm:^3.11.2":
+  version: 3.11.2
+  resolution: "@grafana/plugin-e2e@npm:3.11.2"
   dependencies:
-    "@grafana/e2e-selectors": "npm:13.1.0-25644485979"
+    "@grafana/e2e-selectors": "npm:13.2.0-30594044109"
     yaml: "npm:^2.3.4"
   peerDependencies:
     "@axe-core/playwright": ^4.11.1
@@ -2801,7 +2801,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/a175d02b1b7a169db74262a7d2499746cf0a6ad954a81c47aa28aeca29760a087159a53df84d59794f464ce8f50e7f0814c80676cf508fddf71951a364af94ee
+  checksum: 10/4bec02d7892627d3ebb36b8a24b9ebde8a2f6d55768a6f6c34827e67d124d32bea1d9b8dde4bcdc1a3b0991f6ff7d48e8846c19991805089058a213d7f69f0ac
   languageName: node
   linkType: hard
 
@@ -19988,7 +19988,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:^0.4.1"
     "@grafana/llm": "npm:1.0.9"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^3.10.0"
+    "@grafana/plugin-e2e": "npm:^3.11.2"
     "@grafana/plugin-ui": "npm:^0.17.3"
     "@grafana/prometheus": "npm:13.1.2"
     "@grafana/runtime": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,9 +2789,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@npm:^3.11.2":
+"@grafana/plugin-e2e@https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e":
   version: 3.11.2
-  resolution: "@grafana/plugin-e2e@npm:3.11.2"
+  resolution: "@grafana/plugin-e2e@https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e"
   dependencies:
     "@grafana/e2e-selectors": "npm:13.2.0-30594044109"
     yaml: "npm:^2.3.4"
@@ -2801,7 +2801,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/4bec02d7892627d3ebb36b8a24b9ebde8a2f6d55768a6f6c34827e67d124d32bea1d9b8dde4bcdc1a3b0991f6ff7d48e8846c19991805089058a213d7f69f0ac
+  checksum: 10/f85b8c5512454001793678f115bb1eac5566a5bc519a5b1a797a7bbbd527f99620f460bcd78787023c75b02903abe77d5f7cccddb4fd3862e184456160b679ad
   languageName: node
   linkType: hard
 
@@ -19988,7 +19988,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:^0.4.1"
     "@grafana/llm": "npm:1.0.9"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "npm:^3.11.2"
+    "@grafana/plugin-e2e": "https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e"
     "@grafana/plugin-ui": "npm:^0.17.3"
     "@grafana/prometheus": "npm:13.1.2"
     "@grafana/runtime": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,9 +2789,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/plugin-e2e@https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e":
-  version: 3.11.2
-  resolution: "@grafana/plugin-e2e@https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e"
+"@grafana/plugin-e2e@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@grafana/plugin-e2e@npm:3.12.0"
   dependencies:
     "@grafana/e2e-selectors": "npm:13.2.0-30594044109"
     yaml: "npm:^2.3.4"
@@ -2801,7 +2801,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10/f85b8c5512454001793678f115bb1eac5566a5bc519a5b1a797a7bbbd527f99620f460bcd78787023c75b02903abe77d5f7cccddb4fd3862e184456160b679ad
+  checksum: 10/2adca30f839c63bacbb83d621dd2b0b1646f85fdd79c08c7d652342e8118a15648dc9c6ceb20ae152d1f21723ce0196f35857c1a3a46a3b9384c8e7f358ad04b
   languageName: node
   linkType: hard
 
@@ -19988,7 +19988,7 @@ __metadata:
     "@grafana/lezer-logql": "npm:^0.4.1"
     "@grafana/llm": "npm:1.0.9"
     "@grafana/o11y-ds-frontend": "workspace:*"
-    "@grafana/plugin-e2e": "https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@717b66e"
+    "@grafana/plugin-e2e": "npm:^3.12.0"
     "@grafana/plugin-ui": "npm:^0.17.3"
     "@grafana/prometheus": "npm:13.1.2"
     "@grafana/runtime": "workspace:*"


### PR DESCRIPTION
Bumps @grafana/plugin-e2e to 3.12.0 (includes the setVisualization fixes from grafana/plugin-tools#2860) and fixes a race in panels.spec.ts's setVisualization loop that was causing spurious failures.