### PR TITLE
Tests: Skip failing panelEditPage.spec.ts tests

### DIFF
--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelEditPage.spec.ts
@@ -69,7 +69,7 @@ test.describe(
       });
     });
 
-    test.describe('edit panel plugin settings', () => {
+    test.describe.skip('edit panel plugin settings', () => {
       test('change viz to table panel, set panel title and collapse section', async ({
         panelEditPage,
         selectors,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this PR does
Skips the failing `edit panel plugin settings` test suite in `panelEditPage.spec.ts`.

## Why
These tests are currently failing in PRs, main branch, and locally. The tests assume the page is already in panel edit mode but the test setup doesn't navigate there first. All tests in this suite call `setVisualization()` as their first action, which requires being in panel edit mode.

The root cause is that `PanelEditPage` fixtures expect to already be in edit mode, but the tests don't establish that state before running.

## Related
CI failure example: https://github.com/grafana/grafana/actions/runs/33843630453/job/100934118502#step:8:873

## Next steps
This is a temporary skip while the underlying issue is investigated. The proper fix requires either:
1. Updating the test setup to navigate to panel edit mode first
2. Updating the `@grafana/plugin-e2e` fixtures to handle this case
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C03MCTKAJA0/p1788766007784329?thread_ts=1788766007.784329&cid=C03MCTKAJA0)

<div><a href="https://cursor.com/agents/bc-da4ad5f5-f7f8-5928-ac73-35576cd948f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da4ad5f5-f7f8-5928-ac73-35576cd948f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

