### PR TITLE
TraceView: Add Cloud Provider cross-sell promo

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.test.ts
@@ -1,5 +1,6 @@
 import {
   groupAttributesByCategory,
+  isCloudProviderAttribute,
   isDatabaseAttribute,
   isFrontendObservabilityAttribute,
   isKnowledgeGraphAttribute,
@@ -62,6 +63,24 @@ describe('isKnowledgeGraphAttribute', () => {
       expect(isKnowledgeGraphAttribute(key)).toBe(false);
     }
   );
+});
+
+describe('isCloudProviderAttribute', () => {
+  it.each([
+    'cloud.provider',
+    'cloud.region',
+    'aws.region',
+    'aws_account_id',
+    'gcp.project.id',
+    'azure.resourcegroup.name',
+    'google.cloud.location',
+  ])('matches %s', (key) => {
+    expect(isCloudProviderAttribute(key)).toBe(true);
+  });
+
+  it.each(['service.name', 'k8s.pod.name', 'db.system', 'http.method', 'session.id'])('does not match %s', (key) => {
+    expect(isCloudProviderAttribute(key)).toBe(false);
+  });
 });
 
 describe('groupAttributesByCategory', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/attributeCategories.ts
@@ -263,6 +263,11 @@ export function isKnowledgeGraphAttribute(key: string): boolean {
   return isServiceAttribute(key);
 }
 
+/** Returns true when an attribute key matches Cloud Provider (AWS / Azure / GCP) resource namespaces. */
+export function isCloudProviderAttribute(key: string): boolean {
+  return matchesPrefixes(key, ['cloud', 'aws', 'gcp', 'azure', 'google']);
+}
+
 export function groupAttributesByCategory(
   attributes: TraceKeyValuePair[],
   sectionType: AttributeSectionType

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.test.ts
@@ -4,6 +4,7 @@ import { config, isAppPluginEnabled } from '@grafana/runtime';
 import { useAppPluginMetas } from '@grafana/runtime/internal';
 
 import {
+  isCloudProviderAttribute,
   isDatabaseAttribute,
   isFrontendObservabilityAttribute,
   isKnowledgeGraphAttribute,
@@ -64,11 +65,16 @@ describe('getAttributePluginPromos', () => {
     expect(promos.find((promo) => promo.pluginId === 'grafana-asserts-app')?.match('service.name')).toBe(true);
     expect(promos.find((promo) => promo.pluginId === 'grafana-asserts-app')?.match('k8s.cluster.name')).toBe(false);
     expect(promos.find((promo) => promo.pluginId === 'grafana-k8s-app')?.match('k8s.cluster.name')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-csp-app')?.match('cloud.provider')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-csp-app')?.match('aws.region')).toBe(true);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-csp-app')?.match('k8s.pod.name')).toBe(false);
+    expect(promos.find((promo) => promo.pluginId === 'grafana-k8s-app')?.match('cloud.provider')).toBe(false);
 
     expect(isFrontendObservabilityAttribute('session.id')).toBe(true);
     expect(isServiceAttribute('service.name')).toBe(true);
     expect(isKubernetesAttribute('k8s.pod.name')).toBe(true);
     expect(isKnowledgeGraphAttribute('service.name')).toBe(true);
+    expect(isCloudProviderAttribute('cloud.provider')).toBe(true);
   });
 
   it('omits Database Observability promo on on-prem', () => {
@@ -193,6 +199,7 @@ describe('useAttributePluginPromoGetter', () => {
       'session.id',
       'k8s.pod.name',
       'k8s.cluster.name',
+      'cloud.provider',
     ];
     const { result } = renderHook(() => useAttributePluginPromoGetter(keys));
 
@@ -205,6 +212,21 @@ describe('useAttributePluginPromoGetter', () => {
     expect(promoted).toEqual(['service.name', 'db.system', 'session.id']);
     expect(result.current('k8s.pod.name')).toBeUndefined();
     expect(result.current('service.namespace')).toBeUndefined();
+    expect(result.current('cloud.provider')).toBeUndefined();
+  });
+
+  it('assigns Cloud Provider promo to cloud attributes when a slot remains', async () => {
+    mockUseAppPluginMetas.mockReturnValue({ loading: false, error: undefined, value: [] });
+
+    const { result } = renderHook(() =>
+      useAttributePluginPromoGetter(['service.name', 'cloud.provider', 'aws.region'])
+    );
+
+    await waitFor(() => {
+      expect(result.current('service.name')?.pluginId).toBe('grafana-asserts-app');
+    });
+    expect(result.current('cloud.provider')?.pluginId).toBe('grafana-csp-app');
+    expect(result.current('aws.region')).toBeUndefined();
   });
 
   it('assigns overlapping service keys to different inactive plugins', async () => {
@@ -284,5 +306,20 @@ describe('selectAttributeKeysForPromos', () => {
     expect(selected.get('service.name')?.pluginId).toBe('grafana-app-observability-app');
     expect(selected.get('db.system')?.pluginId).toBe('grafana-dbo11y-app');
     expect(selected.get('k8s.pod.name')?.pluginId).toBe('grafana-k8s-app');
+  });
+
+  it('prefers Kubernetes over Cloud Provider when both match and the promo cap is reached', () => {
+    const promos = getAttributePluginPromos();
+    const inactive = new Set(['grafana-dbo11y-app', 'grafana-kowalski-app', 'grafana-k8s-app', 'grafana-csp-app']);
+
+    const selected = selectAttributeKeysForPromos(
+      ['db.system', 'session.id', 'k8s.pod.name', 'cloud.provider'],
+      inactive,
+      promos
+    );
+
+    expect([...selected.keys()]).toEqual(['db.system', 'session.id', 'k8s.pod.name']);
+    expect(selected.get('k8s.pod.name')?.pluginId).toBe('grafana-k8s-app');
+    expect(selected.has('cloud.provider')).toBe(false);
   });
 });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/pluginPromo/attributePluginPromos.ts
@@ -8,6 +8,7 @@ import { useAppPluginMetas } from '@grafana/runtime/internal';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
 import {
+  isCloudProviderAttribute,
   isDatabaseAttribute,
   isFrontendObservabilityAttribute,
   isKnowledgeGraphAttribute,
@@ -29,7 +30,7 @@ export const MAX_ATTRIBUTE_PLUGIN_PROMOS = 3;
 /**
  * Promos shown on attribute values when the related app plugin is not installed,
  * or is installed but not activated (enabled).
- * Add new entries here as other apps (Knowledge Graph, App O11y, etc.) adopt this pattern.
+ * Add new entries here as other apps (Knowledge Graph, App O11y, Cloud Provider, etc.) adopt this pattern.
  * Cloud-only: never shown on on-prem OSS or Enterprise (`isOnPrem()`).
  */
 export function getAttributePluginPromos(): AttributePluginPromo[] {
@@ -87,6 +88,16 @@ export function getAttributePluginPromos(): AttributePluginPromo[] {
         'Kubernetes Monitoring turns trace attributes into navigation to clusters, namespaces, workloads, and pods — with metrics and health context in one place.'
       ),
       match: isKubernetesAttribute,
+    },
+    {
+      pluginId: 'grafana-csp-app',
+      icon: 'cloud-provider',
+      title: t('explore.trace-view.cloud-provider-promo.title', 'Investigate your cloud services'),
+      body: t(
+        'explore.trace-view.cloud-provider-promo.body',
+        'Cloud Provider Observability maps AWS, Azure, and GCP trace attributes to cloud services, regions, and resources — so you can go from a span to infrastructure health in one place.'
+      ),
+      match: isCloudProviderAttribute,
     },
   ];
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9161,6 +9161,10 @@
       "attribute-plugin-promo": {
         "learn-more": "Learn more"
       },
+      "cloud-provider-promo": {
+        "body": "Cloud Provider Observability maps AWS, Azure, and GCP trace attributes to cloud services, regions, and resources — so you can go from a span to infrastructure health in one place.",
+        "title": "Investigate your cloud services"
+      },
       "database-observability-promo": {
         "body": "Database Observability surfaces visual explain plans, wait events, and query samples — helping you diagnose issues beyond trace spans.",
         "title": "Find slow queries faster"


### PR DESCRIPTION
**What is this feature?**

Part of https://github.com/grafana/grafana/issues/129072

Add Cloud Provider cross-sell promo in Trace View.

**Why do we need this feature?**

Links added here https://github.com/grafana/grafana-csp-app/pull/1652
Similar to https://github.com/grafana/grafana/pull/131472

- Add a Cloud-only attribute promo for Cloud Provider Observability (`grafana-csp-app`)
- Match `cloud.*`, `aws.*`, `gcp.*`, `azure.*`, and `google.*` attributes

**Who is this feature for?**

Trace View users.
