### PR TITLE
[release-13.2.2] Plugins: Forward SSL certificate environment variables

### DIFF
--- a/pkg/plugins/envvars/envvars.go
+++ b/pkg/plugins/envvars/envvars.go
@@ -22,6 +22,9 @@ var permittedHostEnvVarNames = []string{
 	"https_proxy",
 	"NO_PROXY",
 	"no_proxy",
+	// Env vars used by crypto/x509 to override CA certificate locations.
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
 }
 
 type Provider interface {

--- a/pkg/plugins/envvars/envvars_test.go
+++ b/pkg/plugins/envvars/envvars_test.go
@@ -44,3 +44,13 @@ func TestPermittedHostEnvVars_PLUGIN_UNIX_SOCKET_DIR_Unset(t *testing.T) {
 		}
 	}
 }
+
+func TestPermittedHostEnvVars_forwardsSSLCertVars(t *testing.T) {
+	t.Setenv("SSL_CERT_FILE", "/etc/ssl/custom-bundle.pem")
+	t.Setenv("SSL_CERT_DIR", "/etc/ssl/custom-certs")
+
+	vars := PermittedHostEnvVars()
+
+	require.Contains(t, vars, "SSL_CERT_FILE=/etc/ssl/custom-bundle.pem")
+	require.Contains(t, vars, "SSL_CERT_DIR=/etc/ssl/custom-certs")
+}


### PR DESCRIPTION
Backport 44b4599ad51525f9675b10f2b3ce1c9d48a4ed0e from #131848

---

**What is this feature?**

Adds `SSL_CERT_FILE` and `SSL_CERT_DIR` to the host environment variables permitted for plugin processes.

**Why do we need this feature?**

Plugin processes using Go's `crypto/x509` cannot use custom CA locations through these variables without forwarding the complete host environment.

This was observed with Prometheus and InfluxDB after they became standalone plugins in Grafana 13.2.

**Who is this feature for?**

Operators running backend plugins with custom CA locations.

**Which issue(s) does this PR fix?**:

Fixes #131847

**Special notes for your reviewer:**

Tested with:

- `go test -count=1 ./pkg/plugins/envvars/...`
- `git diff --check`

The regression and `forward_host_env_vars` workaround were reproduced. The patched binary has not been tested end-to-end.

Please check that:

- [ ] It works as expected from a user's perspective.
- [x] Pre-GA feature toggle: not applicable.
- [x] Documentation and What's New: not applicable; this introduces no new user-facing configuration.
