### PR TITLE
Navigation: Mark missing navigation items for translation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -982,7 +982,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/isOnPrem.ts @grafana/grafana-frontend-navigation
 /public/app/core/utils/isRecord.ts @grafana/dashboards-squad
 /public/app/core/utils/kbn* @grafana/grafana-frontend-platform
-/public/app/core/utils/navBarItem-translations.ts @grafana/grafana-frontend-navigation
+/public/app/core/utils/navBarItem-translations* @grafana/grafana-frontend-navigation
 /public/app/core/utils/object* @grafana/grafana-frontend-platform
 /public/app/core/utils/query* @grafana/grafana-datasources-core-services
 /public/app/core/utils/richHistory* @grafana/datapro

--- a/public/app/core/utils/navBarItem-translations.test.ts
+++ b/public/app/core/utils/navBarItem-translations.test.ts
@@ -1,0 +1,47 @@
+import { getNavSubTitle, getNavTitle } from './navBarItem-translations';
+
+describe('navBarItem-translations', () => {
+  describe('getNavTitle', () => {
+    it.each([
+      ['alert-rules', 'Alert rules'],
+      ['notification-config', 'Notification configuration'],
+      ['alerts-history', 'History'],
+      ['extensions', 'Extensions'],
+      ['provisioning', 'Provisioning'],
+      ['observability', 'Observability'],
+    ])('returns the %s title', (navId, title) => {
+      expect(getNavTitle(navId)).toBe(title);
+    });
+
+    it('returns undefined for an unknown nav ID', () => {
+      expect(getNavTitle('not-a-real-nav-id')).toBeUndefined();
+    });
+
+    it('returns undefined when no nav ID is given', () => {
+      expect(getNavTitle(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('getNavSubTitle', () => {
+    it.each([
+      ['alert-rules', 'Rules that determine whether an alert will fire'],
+      ['notification-config', 'Manage contact points, notification policies, templates, and time intervals'],
+      ['extensions', 'Extend the UI of plugins and Grafana'],
+      ['provisioning', 'View and manage your provisioning connections'],
+      [
+        'observability',
+        "Monitor infrastructure and applications in real time with Grafana Cloud's fully managed observability suite",
+      ],
+    ])('returns the %s subtitle', (navId, subTitle) => {
+      expect(getNavSubTitle(navId)).toBe(subTitle);
+    });
+
+    it('returns undefined for an unknown nav ID', () => {
+      expect(getNavSubTitle('not-a-real-nav-id')).toBeUndefined();
+    });
+
+    it('returns undefined when no nav ID is given', () => {
+      expect(getNavSubTitle(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/public/app/core/utils/navBarItem-translations.ts
+++ b/public/app/core/utils/navBarItem-translations.ts
@@ -76,6 +76,7 @@ export function getNavTitle(navId: string | undefined) {
     case 'alert-home':
       return t('nav.alerting-home.title', 'Home');
     case 'alert-list':
+    case 'alert-rules':
       return t('nav.alerting-list.title', 'Alert rules');
     case 'alert-list-legacy':
       return t('nav.alert-list-legacy.title', 'Alert rules');
@@ -83,6 +84,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerting-receivers.title', 'Contact points');
     case 'am-routes':
       return t('nav.alerting-am-routes.title', 'Notification policies');
+    case 'notification-config':
+      return t('alerting.alert.notification-configuration.group-title', 'Notification configuration');
     case 'channels':
       return t('nav.alerting-channels.title', 'Notification channels');
     case 'silences':
@@ -93,6 +96,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.alerting-alerts.title', 'Alert activity');
     case 'alert-activity':
       return t('nav.alerting-activity.title', 'Alert activity');
+    case 'alerts-history':
+      return t('alerting.use-page-nav.page-nav.text.history', 'History');
     case 'alerting-admin':
       return t('nav.alerting-admin.title', 'Settings');
     case 'alerts/recently-deleted':
@@ -121,6 +126,8 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.teams.title', 'Teams');
     case 'plugins':
       return t('nav.plugins.title', 'Plugins');
+    case 'extensions':
+      return t('nav.extensions.title', 'Extensions');
     case 'org-settings':
       return t('nav.org-settings.title', 'Default preferences');
     case 'serviceaccounts':
@@ -139,10 +146,14 @@ export function getNavTitle(navId: string | undefined) {
       return t('nav.storage.title', 'Storage');
     case 'migrate-to-cloud':
       return t('nav.migrate-to-cloud.title', 'Migrate to Grafana Cloud');
+    case 'provisioning':
+      return t('nav.provisioning.title', 'Provisioning');
     case 'upgrading':
       return t('nav.upgrading.title', 'Stats and license');
     case 'monitoring':
       return t('nav.monitoring.title', 'Observability');
+    case 'observability':
+      return t('nav.observability.title', 'Observability');
     case 'infrastructure':
       return t('nav.infrastructure.title', 'Infrastructure');
     case 'frontend':
@@ -253,6 +264,7 @@ export function getNavSubTitle(navId: string | undefined) {
         'Manage Alertmanager configurations and enable receiving Grafana-managed alerts'
       );
     case 'alert-list':
+    case 'alert-rules':
       return t('nav.alerting-list.subtitle', 'Rules that determine whether an alert will fire');
     case 'receivers':
       return t(
@@ -261,6 +273,11 @@ export function getNavSubTitle(navId: string | undefined) {
       );
     case 'am-routes':
       return t('nav.alerting-am-routes.subtitle', 'Determine how alerts are routed to contact points');
+    case 'notification-config':
+      return t(
+        'nav.alerting-notification-config.subtitle',
+        'Manage contact points, notification policies, templates, and time intervals'
+      );
     case 'silences':
       return t('nav.alerting-silences.subtitle', 'Stop notifications from one or more alerting rules');
     case 'groups':
@@ -281,6 +298,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.teams.subtitle', 'Groups of users that have common dashboard and permission needs');
     case 'plugins':
       return t('nav.plugins.subtitle', 'Extend the Grafana experience with plugins');
+    case 'extensions':
+      return t('nav.extensions.subtitle', 'Extend the UI of plugins and Grafana');
     case 'org-settings':
       return t('nav.org-settings.subtitle', 'Manage preferences across an organization');
     case 'serviceaccounts':
@@ -295,6 +314,8 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.storage.subtitle', 'Manage file storage');
     case 'migrate-to-cloud':
       return t('nav.migrate-to-cloud.subtitle', 'Copy resources from your self-managed installation to a cloud stack');
+    case 'provisioning':
+      return t('nav.provisioning.subtitle', 'View and manage your provisioning connections');
     case 'support-bundles':
       return t('nav.support-bundles.subtitle', 'Download support bundles');
     case 'admin':
@@ -312,6 +333,11 @@ export function getNavSubTitle(navId: string | undefined) {
       return t('nav.apps.subtitle', 'App plugins that extend the Grafana experience');
     case 'monitoring':
       return t('nav.monitoring.subtitle', 'Out-of-the-box observability solutions');
+    case 'observability':
+      return t(
+        'nav.observability.subtitle',
+        "Monitor infrastructure and applications in real time with Grafana Cloud's fully managed observability suite"
+      );
     case 'infrastructure':
       return t('nav.infrastructure.subtitle', "Understand your infrastructure's health");
     case 'frontend':

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12490,6 +12490,9 @@
       "subtitle": "Rules that determine whether an alert will fire",
       "title": "Alert rules"
     },
+    "alerting-notification-config": {
+      "subtitle": "Manage contact points, notification policies, templates, and time intervals"
+    },
     "alerting-receivers": {
       "subtitle": "Choose how to notify your contact points when an alert instance fires",
       "title": "Contact points"
@@ -12594,6 +12597,10 @@
     "explore": {
       "title": "Explore"
     },
+    "extensions": {
+      "subtitle": "Extend the UI of plugins and Grafana",
+      "title": "Extensions"
+    },
     "frontend": {
       "subtitle": "Gain real user monitoring insights",
       "title": "Frontend"
@@ -12674,6 +12681,10 @@
       "subtitle": "Investigation notebooks created from workspaces, dashboards, alerts, and incidents.",
       "title": "Notebooks"
     },
+    "observability": {
+      "subtitle": "Monitor infrastructure and applications in real time with Grafana Cloud's fully managed observability suite",
+      "title": "Observability"
+    },
     "oncall": {
       "title": "OnCall"
     },
@@ -12704,6 +12715,10 @@
     },
     "profiles": {
       "title": "Profiles"
+    },
+    "provisioning": {
+      "subtitle": "View and manage your provisioning connections",
+      "title": "Provisioning"
     },
     "recently-deleted": {
       "subtitle": "Deleted dashboards are kept for up to 12 months.",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds missing navigation menus to the translation mapping.

**Why do we need this feature?**

Some navigation menu names are not supported i18n now.

**Who is this feature for?**

Users who use Grafana in a non-English language.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #132000

**Special notes for your reviewer:**

Non-English translations are managed through Crowdin and are not included in this PR.

  Please check that:
  - [x] It works as expected from a user's perspective.
  - [x] Not applicable — no pre-GA feature is introduced.
  - [x] Not applicable — no documentation update is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation label changes only; no auth, data, or routing logic.
> 
> **Overview**
> Adds **i18n mappings** for nav IDs that were falling back to untranslated backend text in the mega menu and page nav. `getNavTitle` and `getNavSubTitle` now handle **`alert-rules`**, **`notification-config`**, **`alerts-history`**, **`extensions`**, **`provisioning`**, and **`observability`** (including shared cases with existing IDs like `alert-list`).
> 
> English locale strings are added in **`grafana.json`** (including **`nav.alerting-notification-config`** subtitle), with **unit tests** for the new mappings. **CODEOWNERS** now covers `navBarItem-translations*` so the new test file is owned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0b06d171cd469e89f5b94359b850e5d4c07535. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->