### PR TITLE
PanelStatus: Allow to copy messages

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx
@@ -46,17 +46,26 @@ export function PanelStatus({ message, items, onClick, ariaLabel = 'status' }: P
     return <PanelStatusPopover items={items} onInspect={onClick} ariaLabel={ariaLabel} />;
   }
 
-  return (
+  const button = (
     <Button
       onClick={onClick}
       variant={'destructive'}
       icon="exclamation-triangle"
       size="sm"
-      tooltip={message || ''}
       aria-label={ariaLabel}
       data-testid={selectors.components.Panels.Panel.status('error')}
     />
   );
+
+  if (message) {
+    return (
+      <Tooltip content={message} placement="bottom-start" interactive>
+        {button}
+      </Tooltip>
+    );
+  }
+
+  return button;
 }
 
 interface PanelStatusPopoverProps {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/131913

The support to copy was already in place, with the interactive prop for the tooltip:

https://github.com/grafana/grafana/blob/32bb8f77e9ff510de58e1723a48d50fcc1db7395/packages/grafana-ui/src/components/PanelChrome/PanelStatus.tsx#L99

https://github.com/grafana/grafana/blob/32bb8f77e9ff510de58e1723a48d50fcc1db7395/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx#L34

But it was only being used when `items` were passed to the component. When there were no items and a `message`, this behavior was bypassed.

Demo comparing before and after:

https://github.com/user-attachments/assets/5549fe96-215c-4291-94bf-29577da0e8e6

