### PR TITLE
Dashboards: Preserve query variable refresh setting on v2 dashboard import

### DIFF
--- a/public/app/features/manage-dashboards/import/utils/inputs.test.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.test.ts
@@ -2199,6 +2199,33 @@ describe('replaceDatasourcesInDashboard', () => {
       expect(variable?.spec.refresh).toBe('onDashboardLoad');
     });
 
+    it.each([
+      {
+        desc: 'preserves the exported refresh setting when remapping the datasource',
+        refresh: 'onTimeRangeChanged' as const,
+        expectedRefresh: 'onTimeRangeChanged',
+      },
+      {
+        desc: 'upgrades a "never" refresh setting so the cleared options repopulate',
+        refresh: 'never' as const,
+        expectedRefresh: 'onDashboardLoad',
+      },
+    ])('$desc', ({ refresh, expectedRefresh }) => {
+      const base = createQueryVariable('prometheus', 'old-prom-uid');
+      // @ts-ignore - using minimal test schema
+      const dashboard: DashboardV2Spec = {
+        ...baseDashboard,
+        variables: [{ ...base, spec: { ...base.spec, refresh } }],
+      };
+
+      const result = replaceDatasourcesInDashboard(dashboard, mappings);
+      const variable = getQueryVariable(result);
+
+      // confirms the datasource was actually remapped, which is the branch that rewrites refresh
+      expect(variable?.spec.query?.datasource?.name).toBe('new-prom-uid');
+      expect(variable?.spec.refresh).toBe(expectedRefresh);
+    });
+
     it('preserves variable reference and keeps options intact', () => {
       // @ts-ignore - using minimal test schema
       const dashboard: DashboardV2Spec = {

--- a/public/app/features/manage-dashboards/import/utils/inputs.ts
+++ b/public/app/features/manage-dashboards/import/utils/inputs.ts
@@ -778,7 +778,10 @@ function replaceVariableDatasources(
           },
           options: [],
           current: { text: '', value: '' },
-          refresh: 'onDashboardLoad' as const,
+          // Keep the author's refresh setting (e.g. onTimeRangeChanged). Options are cleared
+          // above, so 'never' has to be upgraded or the variable would never get any values.
+          refresh:
+            variable.spec.refresh && variable.spec.refresh !== 'never' ? variable.spec.refresh : 'onDashboardLoad',
         },
       };
     }


### PR DESCRIPTION
**What is this feature?**

Fixes the v2 dashboard import path silently rewriting a query variable's `refresh` setting to `onDashboardLoad`.

When `replaceVariableDatasources` remaps a query variable's datasource (i.e. the user picks a datasource in the import form and the variable doesn't reference a `$dsVar`), it hardcoded `refresh: 'onDashboardLoad'`, discarding whatever the author had set. This PR preserves the original value.

`options` are cleared on that same branch, so `never` is still upgraded to `onDashboardLoad` — otherwise the variable would never populate any values. That mirrors the existing v1 export behaviour in `exporters.ts`.

**Why do we need this feature?**

A dashboard exported with `"refresh": "onTimeRangeChanged"` and re-imported into the same Grafana version came back as `"refresh": "onDashboardLoad"`. The variable then stopped re-evaluating when the time range changed.

This fails silently and is a data-correctness problem: a reported case used a query variable to select a pre-aggregated summary table by time window, so panels kept querying the wrong granularity tier without any error.

Classic (v1) imports were unaffected — the legacy path only replaces the datasource and never touches `refresh` — which is why this only showed up after the v2 import path landed.

Section (row/tab) variables go through the same function, so they're covered by the same fix.

**Who is this feature for?**

Anyone importing v2-schema dashboards via the UI, particularly users distributing dashboards where variable refresh behaviour matters.

**Which issue(s) does this PR fix?**:

Fixes an internal support escalation (gz#241961).

**Special notes for your reviewer:**

This is preventative only — already-imported dashboards have `onDashboardLoad` persisted in storage and need to be corrected manually. I didn't add a migration: `onDashboardLoad` is also a legitimate author choice, so corrupted values are indistinguishable from intentional ones after the fact.

Tests: added a parameterised regression test in `inputs.test.ts` covering both the preserved `onTimeRangeChanged` case and the `never` upgrade. The `onTimeRangeChanged` case fails on `main` with `Expected: "onTimeRangeChanged" / Received: "onDashboardLoad"`. The existing `replaces hardcoded datasource and resets options/current` test still passes unchanged, since `onDashboardLoad` is preserved by the new logic.
