### PR TITLE
Docs: document nil Prometheus registerers

### DIFF
--- a/contribute/backend/instrumentation.md
+++ b/contribute/backend/instrumentation.md
@@ -142,6 +142,8 @@ To guarantee the existence of metrics before any observations have happened, you
 
 Register collectors on the `prometheus.Registerer` your service is given, using `promauto.With(reg)`. A nil registerer leaves the collectors unregistered, which is what tests usually want.
 
+These helpers handle nil registerers directly. `promauto.With(nil)` returns a factory whose `New*` methods create unregistered collectors. `prometheus.WrapRegistererWith` and `prometheus.WrapRegistererWithPrefix` also accept nil and return a no-op registerer, so callers do not need nil checks before using them.
+
 Do not declare collectors as package-level variables with `promauto.NewCounter` and friends. Those register on the global default registry at init, so they ignore the registry your service was wired with and they leak between tests.
 
 ### Duplicate registration


### PR DESCRIPTION
Documents how Prometheus helper functions handle nil registerers, clarifying that callers do not need explicit nil checks before using them.