### PR TITLE
[release-13.1.6] CI: hooks SBOM generation into release workflow as workflow call

### DIFF
--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -144,6 +144,23 @@ jobs:
       dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
       latest: ${{ needs.setup.outputs.latest }}
 
+  # Attach the SBOM to the GitHub release. Needs create_github_release because the upload targets an
+  # existing release; the SBOM itself is scanned from the release branch.
+  # Skipped on dry runs.
+  export_sbom:
+    name: Export SBOM and attach to the GitHub release
+    needs:
+      - setup
+      - create_github_release
+    if: ${{ needs.setup.outputs.dry_run != 'true' }}
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/sbom-on-release.yml
+    with:
+      version: ${{ needs.setup.outputs.version }}
+      dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+
   # Attach this release's deb/rpm to the GitHub release so the external apt/yum repo-sync can consume
   # them. Runs for every non-+security, non-dry-run public release. The gcom public packages API is the
   # authoritative manifest (it holds exactly this version's build), so no build id is needed. Sources

--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -1,0 +1,85 @@
+name: "SBOM on Release"
+
+# Not triggered by `on: release: published`: the release is created by github-release.yml
+# using secrets.GITHUB_TOKEN, and GitHub does not fire new workflow runs for events produced
+# by the default GITHUB_TOKEN. That native trigger silently never fired for releases created
+# by the automated pipeline, so release-comms.yml calls this explicitly once its
+# create_github_release job has completed.
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: The version being released, with or without a leading `v` (e.g. 11.2.3 or v11.2.3)
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: The version being released, with or without a leading `v` (e.g. 11.2.3 or v11.2.3)
+        type: string
+      dry_run:
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  export-sbom:
+    name: "Export SBOM and attach to release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload the SBOM as a release asset
+      id-token: write # to authenticate to Vault
+    steps:
+      # inputs.version may or may not carry a leading `v` depending on the caller (e.g.
+      # release-comms.yml passes it v-prefixed) -- strip it once here so tag/release_branch are
+      # unambiguous for every step below, matching the same `${VERSION#v}` idiom release-comms.yml
+      # already uses.
+      - name: "Resolve tag and release branch"
+        id: version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          bare="${VERSION#v}"
+          {
+            echo "tag=v${bare}"
+            echo "release_branch=release-${bare}"
+          } >> "$GITHUB_OUTPUT"
+
+      # Socket scans the dependency manifests (package.json/yarn.lock, go.mod/go.sum, etc.) in the
+      # checkout, so it needs the release branch's tree at release time, not the runner's default ref.
+      - name: "Checkout release branch"
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.version.outputs.release_branch }}
+
+      - name: "Get Socket API token from Vault"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          common_secrets: |
+            SOCKET_API_TOKEN=socket:SOCKET_API_KEY
+
+      - name: "Export SPDX SBOM from Socket"
+        id: export-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@73f73d35ceadf46221741d45faefec0c5a990e6b # socket-export-sbom/v1.0.0
+        with:
+          socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
+          socket_org: grafana
+          branch: ${{ steps.version.outputs.release_branch }}
+          output_file: ${{ github.event.repository.name }}-${{ steps.version.outputs.tag }}.spdx.json
+
+      - name: "Upload SBOM to release"
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
+        run: gh release upload "$TAG" "$SBOM_PATH" --clobber


### PR DESCRIPTION
Backport 3241361292b38d5cf596b530c698ca58acecc10a from #130231.

Converts `sbom-on-release.yml` from an event-triggered workflow (`on: release: published`) into a reusable workflow (`workflow_call` + `workflow_dispatch`), and calls it from `release-comms.yml` once `create_github_release` has completed.

The native trigger never fired for automated releases: `github-release.yml` creates the release with `secrets.GITHUB_TOKEN`, and GitHub does not start new workflow runs for events produced by the default token. Calling the workflow explicitly removes the dependency on that event firing.

### Backport note

This diff is larger than the original PR's. #128430, which added `sbom-on-release.yml`, was never backported to `release-13.1.6`, so the cherry-pick hit a modify/delete conflict. Resolved by taking the incoming file, meaning this PR both creates `sbom-on-release.yml` and applies #130231's changes to it. The committed file is byte-identical to `sbom-on-release.yml` at 3241361292b on main.
