### PR TITLE
Chore: bump @faker-js/faker to 10.6.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@
 process.env.TZ = 'Pacific/Easter'; // UTC-06:00 or UTC-05:00 depending on daylight savings
 
 const esModules = [
+  '@faker-js/faker',
   '@wojtekmaj/date-utils',
   'ol',
   'd3',

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.13.5",
-    "@faker-js/faker": "^9.8.0",
+    "@faker-js/faker": "^10.6.0",
     "@grafana/api-clients": "13.3.0-pre",
     "@grafana/i18n": "13.3.0-pre",
     "@reduxjs/toolkit": "^2.10.1",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -138,7 +138,7 @@
     "uwrap": "^0.1.2"
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.0.0",
+    "@faker-js/faker": "^10.6.0",
     "@grafana/test-utils": "workspace:*",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@storybook/addon-a11y": "10.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1987,10 +1987,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^9.0.0, @faker-js/faker@npm:^9.8.0":
-  version: 9.9.0
-  resolution: "@faker-js/faker@npm:9.9.0"
-  checksum: 10/b24b1be0fb3090d54abaaa3a814f37d1a7551f1207dcd330a1af2c70f6312a8b95ebb82653577757dd62f4cbbb56caa3c83513053253654dc3e286a05040ecbe
+"@faker-js/faker@npm:^10.6.0":
+  version: 10.6.0
+  resolution: "@faker-js/faker@npm:10.6.0"
+  checksum: 10/f45220ceae76133d831dee8c8f5c8566767bfd857b7f872b5ec58866b68da889dabe96e805a598e095a6c58eae250363a7f335aa0afc513cb2ad5fe69e2a967f
   languageName: node
   linkType: hard
 
@@ -2330,7 +2330,7 @@ __metadata:
   resolution: "@grafana/alerting@workspace:packages/grafana-alerting"
   dependencies:
     "@emotion/css": "npm:^11.13.5"
-    "@faker-js/faker": "npm:^9.8.0"
+    "@faker-js/faker": "npm:^10.6.0"
     "@grafana/api-clients": "npm:13.3.0-pre"
     "@grafana/i18n": "npm:13.3.0-pre"
     "@grafana/test-utils": "workspace:*"
@@ -3260,7 +3260,7 @@ __metadata:
     "@emotion/css": "npm:^11.13.5"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/serialize": "npm:^1.3.3"
-    "@faker-js/faker": "npm:^9.0.0"
+    "@faker-js/faker": "npm:^10.6.0"
     "@floating-ui/react": "npm:^0.27.19"
     "@grafana/data": "npm:13.3.0-pre"
     "@grafana/e2e-selectors": "npm:13.3.0-pre"


### PR DESCRIPTION
## What is this feature?

Bumps `@faker-js/faker` from 9.x to 10.6.0 in `@grafana/alerting` and `@grafana/ui`.

## Why do we need this feature?

`yarn npm audit` flags the package for [GHSA-qxc2-j82w-r537](https://github.com/advisories/GHSA-qxc2-j82w-r537) (high severity — `faker.helpers.fake` is exploitable into arbitrary code execution). The advisory covers everything up to and including 10.4.0, so there is no patched 9.x to move to; 10.5.0 was the first fixed release.

Nothing in this repo calls `helpers.fake`, so the vulnerability was not actually reachable here — the usages are all simple generators (`string.alphanumeric`, `helpers.arrayElement`, `number.int`, `lorem.paragraphs`, etc.) in test mocks and factories. This is about clearing the audit finding.

## Notes for the reviewer

Three things worth a look:

- **`@grafana/ui` is bumped too**, even though the audit only named `@grafana/alerting`. Both workspaces shared one resolution at 9.9.0. Bumping only `grafana-alerting` would have left a second, still-vulnerable copy in the lockfile via `grafana-ui`'s `^9.0.0`, and the audit would keep failing.

- **Faker 10 dropped its CommonJS build** (`"type": "module"`, ESM-only `exports`), so it is added to the `esModules` list in `jest.config.js`. Without that, every faker-importing test fails to load.

- **Faker is a runtime `dependency` of `@grafana/alerting`**, not a dev one, and rollup leaves it external — so the published CJS build emits `require('@faker-js/faker')`. That `require` now relies on Node's require-of-ESM support, which is fine on Node >= 20.19/22.12 (what faker 10's own `engines` demands anyway) and fine through bundlers. It would only bite a consumer importing `@grafana/alerting/testing` from CJS on older Node. Moving faker to `devDependencies` so the factories do not ship in the runtime bundle would be the tidier end state, but that is a bigger change than a CVE bump so it is left out of scope here.

## Verification

- `yarn typecheck` — clean across all 15 projects
- 17 faker-touching suites pass (256 tests): all of `packages/grafana-alerting`, `packages/grafana-ui/src/components/Table/utils.test.ts`, and the two `public/app` tests that consume `@grafana/alerting/testing`
- `@grafana/alerting` rollup build succeeds
- `yarn npm audit --recursive` no longer reports faker; lockfile has a single resolution at 10.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)