### PR TITLE
Provisioning: attach repositoryType to RepositoryController failure/retry logs

### DIFF
--- a/pkg/registry/apis/provisioning/controller/processed_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/processed_metrics_test.go
@@ -104,9 +104,9 @@ func TestRepositoryController_RecordsProcessingByTrigger(t *testing.T) {
 				drainTimeout: 5 * time.Second,
 				processed:    usinformer.NewProcessedMetrics(reg, "repositories", tt.natsBacked),
 				keyFunc:      repoKeyFunc,
-				processFn: func(string) error {
+				processFn: func(string) (string, error) {
 					close(processedDone)
-					return nil
+					return "", nil
 				},
 			}
 			rc.enqueueRepository = rc.enqueue
@@ -153,7 +153,7 @@ func TestRepositoryController_DirtyRedeliveryKeepsLiveTrigger(t *testing.T) {
 	rc.enqueueRepository = rc.enqueue
 
 	var enqueuedDuringFlight atomic.Bool
-	rc.processFn = func(string) error {
+	rc.processFn = func(string) (string, error) {
 		// On the first reconcile, a live update (bumped RV) arrives while the key
 		// is in flight — the classic self-induced status update — marking it dirty.
 		if enqueuedDuringFlight.CompareAndSwap(false, true) {
@@ -162,7 +162,7 @@ func TestRepositoryController_DirtyRedeliveryKeepsLiveTrigger(t *testing.T) {
 				&provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "repo", ResourceVersion: "6"}},
 			)
 		}
-		return nil
+		return "", nil
 	}
 
 	// Initial live add (apiserver watch, full RV, non-initial).
@@ -192,9 +192,9 @@ func TestRepositoryController_InternalRescheduleNotCounted(t *testing.T) {
 		logger:    logging.DefaultLogger.With("logger", "test"),
 		processed: usinformer.NewProcessedMetrics(reg, "repositories", false),
 		keyFunc:   repoKeyFunc,
-		processFn: func(string) error {
+		processFn: func(string) (string, error) {
 			close(processedDone)
-			return nil
+			return "", nil
 		},
 	}
 	rc.enqueueRepository = rc.enqueue

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -67,7 +67,7 @@ type RepositoryController struct {
 	healthChecker     *RepositoryHealthChecker
 	quotaChecker      *RepositoryQuotaChecker
 	// To allow injection for testing.
-	processFn         func(key string) error
+	processFn         func(key string) (repoType string, err error)
 	enqueueRepository func(obj any, trigger usinformer.ProcessTrigger)
 	keyFunc           func(obj any) (string, error)
 
@@ -336,13 +336,16 @@ func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
 		rc.processed.RecordProcessed(trigger)
 	}
 
-	err := rc.processFn(key)
+	repoType, err := rc.processFn(key)
 	if err == nil {
 		rc.queue.Forget(key)
 		return true
 	}
 
-	logger = logger.With("error", err, "attempts", attempts)
+	// repoType is empty when process failed before resolving the object (bad key
+	// or not-found); the field is still emitted so type-scoped log filters match
+	// every failure/retry line for a resolvable repository.
+	logger = logger.With("repositoryType", repoType, "error", err, "attempts", attempts)
 	logger.Error("RepositoryController failed to process key")
 
 	if attempts >= maxAttempts {
@@ -714,14 +717,18 @@ func repoSpanAttrs(obj *provisioning.Repository) trace.SpanStartOption {
 	)
 }
 
+// repoType is a named return so processNextWorkItem can attribute its
+// failure/retry log lines to a repository type. It stays empty until the object
+// is resolved below (an unparsable key or a not-found repository yields "").
+//
 //nolint:gocyclo
-func (rc *RepositoryController) process(key string) (err error) {
+func (rc *RepositoryController) process(key string) (repoType string, err error) {
 	logger := rc.logger.With("key", key)
 	ctx := logging.Context(context.Background(), logger)
 
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		return err
+		return repoType, err
 	}
 
 	// process runs from a background context, so this opens a fresh trace per
@@ -744,15 +751,16 @@ func (rc *RepositoryController) process(key string) (err error) {
 	obj, err := rc.repos.Get(ctx, namespace, name)
 	switch {
 	case apierrors.IsNotFound(err):
-		return errors.New("repository not found")
+		return repoType, errors.New("repository not found")
 	case err != nil:
-		return err
+		return repoType, err
 	}
+	repoType = string(obj.Spec.Type)
 
 	logger = logger.With(
 		"namespace", namespace,
 		"repository", name,
-		"repositoryType", string(obj.Spec.Type),
+		"repositoryType", repoType,
 		"connection", obj.ConnectionName(),
 	)
 	ctx = logging.Context(ctx, logger)
@@ -764,32 +772,32 @@ func (rc *RepositoryController) process(key string) (err error) {
 
 	ctx, _, err = identity.WithProvisioningIdentity(ctx, namespace)
 	if err != nil {
-		return err
+		return repoType, err
 	}
 	ctx = request.WithNamespace(ctx, namespace)
 	logger = logger.WithContext(ctx)
 
 	if obj.DeletionTimestamp != nil {
-		return rc.handleDelete(ctx, obj)
+		return repoType, rc.handleDelete(ctx, obj)
 	}
 
 	// Skip reconciliation for resources whose namespace is being soft-deleted.
 	if appcontroller.IsPendingDelete(obj.Labels) {
 		logger.Info("skipping reconciliation: namespace is pending deletion")
-		return nil
+		return repoType, nil
 	}
 
 	// Check quota state early - before trigger evaluation
 	// This allows blocked repos to check if they can unblock even without other triggers
 	newQuota, err := rc.resolveQuotaStatus(ctx, obj)
 	if err != nil {
-		return err
+		return repoType, err
 	}
 	quotaCtx, quotaSpan := rc.tracer.Start(ctx, "provisioning.controller.check_quota", repoSpanAttrs(obj))
 	quotaCondition, err := rc.quotaChecker.RepositoryQuotaConditions(quotaCtx, namespace, newQuota)
 	quotaSpan.End()
 	if err != nil {
-		return fmt.Errorf("check repository quota: %w", err)
+		return repoType, fmt.Errorf("check repository quota: %w", err)
 	}
 	isCurrentlyBlocked := isQuotaExceeded(obj.Status.Conditions)
 	isOverQuota := isQuotaExceeded([]v1.Condition{quotaCondition})
@@ -885,7 +893,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	default:
 		span.SetAttributes(attribute.String("reconcile.reason", "skipped"))
 		logger.Info("skipping as conditions are not met", "status", obj.Status, "generation", obj.Generation, "sync_spec", obj.Spec.Sync)
-		return nil
+		return repoType, nil
 	}
 	span.SetAttributes(attribute.String("reconcile.reason", reason))
 
@@ -903,13 +911,13 @@ func (rc *RepositoryController) process(key string) (err error) {
 		c, err := rc.client.Connections(obj.Namespace).Get(ctx, obj.Spec.Connection.Name, v1.GetOptions{})
 		if err != nil {
 			logger.Error("retrieving connection", "error", err)
-			return err
+			return repoType, err
 		}
 
 		token, tokenOps, err := rc.generateRepositoryToken(ctx, obj, c)
 		if err != nil {
 			logger.Error("generating token for repository", "error", err)
-			return err
+			return repoType, err
 		}
 
 		if len(tokenOps) > 0 {
@@ -935,7 +943,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 			if tokenRecentlyCreated(time.UnixMilli(obj.Status.Token.LastUpdated)) {
 				logger.Info("repository token secret not yet readable after recent write; will retry", "error", err)
 				rc.queue.AddAfter(key, tokenWriteRetryDelay)
-				return nil
+				return repoType, nil
 			}
 
 			logger.Warn("repository token secret could not be decrypted, regenerating from connection",
@@ -943,12 +951,12 @@ func (rc *RepositoryController) process(key string) (err error) {
 
 			c, cerr := rc.client.Connections(obj.Namespace).Get(ctx, obj.Spec.Connection.Name, v1.GetOptions{})
 			if cerr != nil {
-				return fmt.Errorf("retrieving connection to regenerate token: %w", cerr)
+				return repoType, fmt.Errorf("retrieving connection to regenerate token: %w", cerr)
 			}
 
 			token, tokenOps, gerr := rc.generateRepositoryToken(ctx, obj, c)
 			if gerr != nil {
-				return fmt.Errorf("regenerating repository token: %w", gerr)
+				return repoType, fmt.Errorf("regenerating repository token: %w", gerr)
 			}
 
 			if len(tokenOps) > 0 {
@@ -962,7 +970,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 			repo, err = rc.repoFactory.Build(ctx, obj)
 		}
 		if err != nil {
-			return fmt.Errorf("unable to create repository from configuration: %w", err)
+			return repoType, fmt.Errorf("unable to create repository from configuration: %w", err)
 		}
 	}
 
@@ -975,7 +983,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 			defaultBranch, err := branchHandler.GetDefaultBranch(branchCtx)
 			branchSpan.End()
 			if err != nil {
-				return fmt.Errorf("failed to get default branch: %w", err)
+				return repoType, fmt.Errorf("failed to get default branch: %w", err)
 			}
 
 			branchHandler.SetBranch(defaultBranch)
@@ -1017,7 +1025,7 @@ func (rc *RepositoryController) process(key string) (err error) {
 	healthResult, err := rc.healthChecker.RefreshHealthWithPatchOps(healthCtx, repo)
 	healthSpan.End()
 	if err != nil {
-		return fmt.Errorf("update health status: %w", err)
+		return repoType, fmt.Errorf("update health status: %w", err)
 	}
 	testResults := healthResult.TestResults
 	healthStatus := healthResult.HealthStatus
@@ -1123,10 +1131,10 @@ func (rc *RepositoryController) process(key string) (err error) {
 		} else {
 			err = errors.Join(err, patchErr)
 		}
-		return err
+		return repoType, err
 	}
 	if err != nil {
-		return err
+		return repoType, err
 	}
 
 	// QUESTION: should we trigger the sync job after we have applied all patch operations or before?
@@ -1134,11 +1142,11 @@ func (rc *RepositoryController) process(key string) (err error) {
 	// Trigger sync job after we have applied all patch operations
 	if syncOptions != nil {
 		if err := rc.addSyncJob(ctx, obj, syncOptions); err != nil {
-			return err
+			return repoType, err
 		}
 	}
 
-	return nil
+	return repoType, nil
 }
 
 // processHooks handles hook execution with intelligent retry logic. `suppressed`

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1241,7 +1241,7 @@ func TestRepositoryController_process_RepoIDBackfillGuardsAgainstStaleURL(t *tes
 				tracer:        tracing.InitializeTracerForTest(),
 			}
 
-			err := rc.process(namespace + "/" + repoName)
+			_, err := rc.process(namespace + "/" + repoName)
 
 			if tc.wantErr {
 				require.Error(t, err)
@@ -1373,7 +1373,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 				tracer:        tracing.InitializeTracerForTest(),
 			}
 
-			err := rc.process(namespace + "/" + repoName)
+			_, err := rc.process(namespace + "/" + repoName)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectRefreshes, counterValue(t, reg, repositoryQuotaRefreshMetric))
 			assert.Equal(t, 0.0, counterValue(t, reg, repositoryQuotaRefreshErrorsMetric))
@@ -1492,7 +1492,7 @@ func TestRepositoryController_process_QuotaTimestampOnlyDoesNotForceStatusPatch(
 				tracer:        tracing.InitializeTracerForTest(),
 			}
 
-			err := rc.process("default/repo")
+			_, err := rc.process("default/repo")
 			require.NoError(t, err)
 			repoFactory.AssertNotCalled(t, "Build", mock.Anything, mock.Anything)
 			assert.Empty(t, patcher.ops)
@@ -1555,7 +1555,7 @@ func TestRepositoryController_process_ConditionsNotOverwritten(t *testing.T) {
 		tracer:        tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process("default/test-repo")
+	_, err := rc.process("default/test-repo")
 	require.NoError(t, err)
 
 	// Find the last /status/conditions patch operation — if there are multiple
@@ -1709,7 +1709,7 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 		tracer:            tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	// The token patch must be present even though the repository is currently over quota.
@@ -1814,7 +1814,7 @@ func TestRepositoryController_process_RegeneratesTokenWhenSecretNotFound(t *test
 		tracer:            tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	// Regeneration happened: a fresh token status was written and Build was retried.
@@ -2079,7 +2079,7 @@ func TestRepositoryController_process_HookFailureCooldownSuppressesRetry(t *test
 		tracer:        tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(0), stub.onUpdateCalls.Load(),
@@ -2172,7 +2172,7 @@ func TestRepositoryController_process_RotationSuppressedDuringCooldown(t *testin
 		webhookSecretRotationInterval: 30 * 24 * time.Hour,
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(0), stub.onUpdateCalls.Load(),
@@ -2211,7 +2211,7 @@ func TestRepositoryController_process_HookFailureUnauthorizedDoesNotReturnError(
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err, "an unauthorized hook failure must not surface as a controller error")
 
 	assert.Equal(t, int32(1), stub.onCreateCalls.Load(), "the hook attempt should still have run")
@@ -2254,7 +2254,7 @@ func TestRepositoryController_process_HookFailureNonAuthErrorStillReturnsError(t
 	stub := &hookRepoStub{cfg: repo} // hookErrSet is false -> hookResult() returns assert.AnError
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.Error(t, err, "a non-auth hook failure must still surface as a controller error")
 	assert.ErrorIs(t, err, assert.AnError)
 
@@ -2351,7 +2351,7 @@ func TestRepositoryController_process_UnhealthyRepositorySkipsHooks(t *testing.T
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err, "an unhealthy repository must not surface as a controller error")
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(), "the health check itself should still run")
@@ -2410,7 +2410,7 @@ func TestRepositoryController_process_BranchProtectionFailureStillRunsHooks(t *t
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(), "the health check itself should still run")
@@ -2464,7 +2464,7 @@ func TestRepositoryController_process_WritePermissionDeniedStillRunsHooks(t *tes
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(), "the health check itself should still run")
@@ -2516,7 +2516,7 @@ func TestRepositoryController_process_UnauthorizedTestResultSuppressesHooks(t *t
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(), "the health check itself should still run")
@@ -2598,7 +2598,7 @@ func TestRepositoryController_process_QuotaBlockedButReachableStillRunsHooks(t *
 		tracer:        tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), stub.onCreateCalls.Load(),
@@ -2651,7 +2651,7 @@ func TestRepositoryController_process_UnhealthyCleanupSkipDoesNotAdvanceObserved
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err, "an unhealthy repository must not surface as a controller error")
 
 	assert.Equal(t, int32(0), stub.onDeleteCalls.Load(),
@@ -2709,8 +2709,11 @@ func TestRepositoryController_process_HookFailureRecoveryAfterWorkflowsRemoved(t
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(namespace+"/"+repoName))
+	repoType, err := rc.process(namespace + "/" + repoName)
 
+	require.NoError(t, err)
+	assert.Equal(t, string(provisioning.GitHubRepositoryType), repoType,
+		"process must return the repository type so the controller can attribute failure/retry log lines")
 	assert.Equal(t, int32(1), stub.testCalls.Load(),
 		"health refresh must run after workflows are removed even during the previous cooldown")
 
@@ -2810,14 +2813,15 @@ func TestRepositoryController_process_UnreachableRepoDoesNotRewriteUnchangedStat
 	rc, patcher := newRecoveryController(t, repo, stub)
 
 	// Pass 1: the repo is unreachable for the first time and status is updated.
-	require.NoError(t, rc.process(namespace+"/"+repoName))
+	_, err := rc.process(namespace + "/" + repoName)
+	require.NoError(t, err)
 	require.NotEmpty(t, patcher.ops, "the first transition to unhealthy should record status")
 	applyCapturedPatches(t, repo, patcher.ops)
 	patcher.ops = nil
 
 	// Pass 2: same repo, same failure, nothing has changed since pass 1.
-	require.NoError(t, rc.process(namespace+"/"+repoName))
-
+	_, err = rc.process(namespace + "/" + repoName)
+	require.NoError(t, err)
 	assert.Equal(t, int32(2), stub.testCalls.Load(),
 		"Test() must still run on pass 2 -- reachability can't be safely inferred from stale status")
 	assert.Equal(t, int32(0), stub.onCreateCalls.Load(),
@@ -2869,8 +2873,9 @@ func TestRepositoryController_process_HookFailureRecoveryAfterCooldownExpires(t 
 	stub := &hookRepoStub{cfg: repo}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(namespace+"/"+repoName))
+	_, err := rc.process(namespace + "/" + repoName)
 
+	require.NoError(t, err)
 	assert.Equal(t, int32(0), stub.onCreateCalls.Load(),
 		"hooks must not run when the spec is observed and the webhook already exists")
 	assert.Equal(t, int32(0), stub.onUpdateCalls.Load(),
@@ -2981,7 +2986,7 @@ func TestRepositoryController_process_FailedFlushDoesNotDuplicatePatches(t *test
 		tracer:        tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(namespace + "/" + repoName)
+	_, err := rc.process(namespace + "/" + repoName)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status patch operations failed")
 }
@@ -3008,7 +3013,7 @@ func TestRepositoryController_DeduplicatesEnqueueWhileProcessing(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		switch processCount.Add(1) {
 		case 1:
 			close(firstProcessingStarted)
@@ -3016,7 +3021,7 @@ func TestRepositoryController_DeduplicatesEnqueueWhileProcessing(t *testing.T) {
 		case 2:
 			close(secondProcessingDone)
 		}
-		return nil
+		return "", nil
 	}
 
 	rc.queue.Add("test/repo")
@@ -3062,10 +3067,10 @@ func TestRepositoryController_DeduplicatesEnqueueBeforeProcessing(t *testing.T) 
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		processCount.Add(1)
 		close(processingDone)
-		return nil
+		return "", nil
 	}
 
 	// Enqueue the same key several times before any worker starts.
@@ -3106,11 +3111,11 @@ func TestRepositoryController_ServiceUnavailableRetriesUpToMaxAttempts(t *testin
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		if processCount.Add(1) == maxAttempts {
 			close(allAttemptsDone)
 		}
-		return apierrors.NewServiceUnavailable("test")
+		return "", apierrors.NewServiceUnavailable("test")
 	}
 
 	rc.queue.Add("test/repo")
@@ -3146,10 +3151,10 @@ func TestRepositoryController_NonRetryableErrorIsNotRetried(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		processCount.Add(1)
 		close(processingDone)
-		return errors.New("some non-retryable error")
+		return "", errors.New("some non-retryable error")
 	}
 
 	rc.queue.Add("test/repo")

--- a/pkg/registry/apis/provisioning/controller/shutdown_test.go
+++ b/pkg/registry/apis/provisioning/controller/shutdown_test.go
@@ -28,11 +28,11 @@ func TestRepositoryController_Run_DrainWaitsForInFlight(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		close(processingStarted)
 		<-processCh
 		processed.Store(true)
-		return nil
+		return "", nil
 	}
 
 	rc.queue.Add("test/repo")
@@ -85,7 +85,7 @@ func TestRepositoryController_Run_DrainTimeoutForcesShutdown(t *testing.T) {
 	}
 
 	// processFn blocks forever to simulate a stuck reconciliation
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		close(processingStarted)
 		select {}
 	}
@@ -130,10 +130,10 @@ func TestRepositoryController_Run_OnShutdownCalledBeforeDrain(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(key string) error {
+	rc.processFn = func(key string) (string, error) {
 		close(processingStarted)
 		<-processCh
-		return nil
+		return "", nil
 	}
 
 	rc.queue.Add("test/ordering")


### PR DESCRIPTION
## What

`RepositoryController.processNextWorkItem` logs the reconcile-loop outcome lines — `RepositoryController failed to process key`, `RepositoryController will not retry`, `RepositoryController failed too many times`, `RepositoryController will retry as service is unavailable` — from a logger built only from the queue key (`work_key` / `namespace` / `repository`). Those lines therefore lacked the `repositoryType` field that `process()`'s own logger already attaches to every reconcile-content line.

`process()` now returns the resolved `Spec.Type`, and the caller stamps it onto the failure/retry logger.

## Why

Measured on ops, ~18% of `provisioning-repo-operator` log lines carried a `repository` but no `repositoryType` — essentially all of them the reconcile-loop lines above. As a result, type-scoped log filters (`repositoryType="github"`, etc.) silently dropped every repository's failure/retry lines, which are exactly the lines you filter on when debugging a provider-specific problem. This also produced duplicate blank-`Type` rows on the *Grafana Git Sync / Stack Debugging* dashboard.

## How

- `process(key string)` → `process(key string) (repoType string, err error)`. The type is resolved right after the existing informer `Get`, so **no extra API read** is introduced — it flows from the reconcile's existing fetch.
- `processNextWorkItem` stamps `repositoryType` onto the failure/retry logger. The field is emitted even when empty (process failed before resolving the object, e.g. an unparsable key or a not-found repository) so filters match consistently.
- The initial `RepositoryController processing key` line is intentionally left untyped — it is logged at pickup, before the object is fetched, and adding the type there would require a second live `Get` on the hot path.

## Notes / values

`repositoryType` is one of the `RepositoryType` enum values: `local`, `github`, `githubEnterprise`, `git`, `bitbucket`, `gitlab`.

## Tests

- `go build`, `go vet`, and `go test ./pkg/registry/apis/provisioning/controller/` pass.
- Added an assertion that `process()` returns the repository type on the successful-reconcile path.
- Updated the `processFn` test seam and direct `rc.process(...)` call sites for the new signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)