### PR TITLE
Plugins: Inject plugin service account namespace as GF_PLUGIN_APP_NAMESPACE

### DIFF
--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
 
 	"github.com/grafana/grafana/pkg/plugins/config"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -81,6 +82,10 @@ type PluginInstanceCfg struct {
 	SigV4VerboseLogging bool
 
 	LiveClientQueueMaxSize int
+
+	// Namespace is the namespace of the org that plugins' external service accounts are
+	// provisioned into.
+	Namespace string
 }
 
 // ProvidePluginInstanceConfig returns a new PluginInstanceCfg.
@@ -131,6 +136,7 @@ func ProvidePluginInstanceConfig(cfg *setting.Cfg, settingProvider setting.Provi
 		SigV4AuthEnabled:                    cfg.SigV4AuthEnabled,
 		SigV4VerboseLogging:                 cfg.SigV4VerboseLogging,
 		LiveClientQueueMaxSize:              cfg.LiveClientQueueMaxSize,
+		Namespace:                           request.GetNamespaceMapper(cfg)(cfg.DefaultOrgID()),
 	}, nil
 }
 

--- a/pkg/services/pluginsintegration/pluginconfig/config_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config_test.go
@@ -48,3 +48,26 @@ func TestProvidePluginInstanceConfigMarketplaceLicenseDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cfg.MarketplaceLicenseDirectory, pluginCfg.MarketplaceLicenseDirectory)
 }
+
+func TestProvidePluginInstanceConfigNamespace(t *testing.T) {
+	t.Run("on-prem default org", func(t *testing.T) {
+		cfg := &setting.Cfg{Raw: ini.Empty()}
+		pluginCfg, err := ProvidePluginInstanceConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.Equal(t, "default", pluginCfg.Namespace)
+	})
+
+	t.Run("on-prem non-default org", func(t *testing.T) {
+		cfg := &setting.Cfg{Raw: ini.Empty(), AutoAssignOrg: true, AutoAssignOrgId: 7}
+		pluginCfg, err := ProvidePluginInstanceConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.Equal(t, "org-7", pluginCfg.Namespace)
+	})
+
+	t.Run("cloud stack", func(t *testing.T) {
+		cfg := &setting.Cfg{Raw: ini.Empty(), StackID: "6481"}
+		pluginCfg, err := ProvidePluginInstanceConfig(cfg, setting.ProvideProvider(cfg), featuremgmt.WithFeatures())
+		require.NoError(t, err)
+		require.Equal(t, "stacks-6481", pluginCfg.Namespace)
+	})
+}

--- a/pkg/services/pluginsintegration/pluginconfig/envvars.go
+++ b/pkg/services/pluginsintegration/pluginconfig/envvars.go
@@ -62,6 +62,7 @@ func (p *EnvVarsProvider) PluginEnvVars(ctx context.Context, plugin *plugins.Plu
 			p.envVar("GF_APP_URL", p.cfg.GrafanaAppURL),
 			p.envVar("GF_PLUGIN_APP_CLIENT_ID", plugin.ExternalService.ClientID),
 			p.envVar("GF_PLUGIN_APP_CLIENT_SECRET", plugin.ExternalService.ClientSecret),
+			p.envVar("GF_PLUGIN_APP_NAMESPACE", p.cfg.Namespace),
 		)
 		if plugin.ExternalService.PrivateKey != "" {
 			hostEnv = append(hostEnv, p.envVar("GF_PLUGIN_APP_PRIVATE_KEY", plugin.ExternalService.PrivateKey))

--- a/pkg/services/pluginsintegration/pluginconfig/envvars_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/envvars_test.go
@@ -782,7 +782,8 @@ func TestPluginEnvVarsProvider_authEnvVars(t *testing.T) {
 		assert.Equal(t, "GF_APP_URL=https://myorg.com/", envVars[1])
 		assert.Equal(t, "GF_PLUGIN_APP_CLIENT_ID=clientID", envVars[2])
 		assert.Equal(t, "GF_PLUGIN_APP_CLIENT_SECRET=clientSecret", envVars[3])
-		assert.Equal(t, "GF_PLUGIN_APP_PRIVATE_KEY=privatePem", envVars[4])
+		assert.Equal(t, "GF_PLUGIN_APP_NAMESPACE=default", envVars[4])
+		assert.Equal(t, "GF_PLUGIN_APP_PRIVATE_KEY=privatePem", envVars[5])
 	})
 }
 


### PR DESCRIPTION
Backend plugins with a provisioned external service account currently have
no way to learn the namespace of the org that account belongs to. This makes
it impossible to call back into basically anything useful under `/apis`.

Alternatives explored:
- The common workaround for this is for plugins to require the namespace be
  added to their settings; an extra configuration step to go wrong.
- The plugin can use `/api/frontend/settings`, but these APIs are deprecated.
