### PR TITLE
Plugins: Show the correct warning when grafana.com is unreachable

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/InstallControlsWarning.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/InstallControlsWarning.tsx
@@ -80,6 +80,19 @@ export const InstallControlsWarning = ({ plugin, pluginStatus, latestCompatibleV
     return <Alert severity="warning" title={statusToMessage(pluginStatus)} className={styles.alert} />;
   }
 
+  if (!isRemotePluginsAvailable) {
+    return (
+      <Alert
+        severity="warning"
+        title={t(
+          'plugins.install-controls-warning.title-remote-plugins-unavailable',
+          'The install controls have been disabled because the Grafana server cannot access grafana.com.'
+        )}
+        className={styles.alert}
+      />
+    );
+  }
+
   if (!plugin.isPublished) {
     return (
       <Alert severity="warning" title="" className={styles.alert}>
@@ -103,19 +116,6 @@ export const InstallControlsWarning = ({ plugin, pluginStatus, latestCompatibleV
         title={t(
           'plugins.install-controls-warning.title-plugin-doesnt-support-version-grafana',
           "This plugin doesn't support your version of Grafana."
-        )}
-        className={styles.alert}
-      />
-    );
-  }
-
-  if (!isRemotePluginsAvailable) {
-    return (
-      <Alert
-        severity="warning"
-        title={t(
-          'plugins.install-controls-warning.title-remote-plugins-unavailable',
-          'The install controls have been disabled because the Grafana server cannot access grafana.com.'
         )}
         className={styles.alert}
       />

--- a/public/app/features/plugins/admin/components/PluginSubtitle.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginSubtitle.test.tsx
@@ -105,6 +105,21 @@ describe('PluginSubtitle', () => {
       expect(screen.queryByText(/permission to uninstall/i)).not.toBeInTheDocument();
     });
   });
+
+  describe('when grafana.com is unreachable', () => {
+    beforeEach(() => {
+      jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+      jest.spyOn(runtime, 'useIsRemotePluginsAvailable').mockReturnValue(false);
+    });
+
+    it('renders the unreachable warning instead of the not published one', () => {
+      const plugin = { ...basePlugin, isInstalled: true, isPublished: false };
+      render(<PluginSubtitle plugin={plugin} />);
+      expect(screen.getByText(/cannot access grafana.com/i)).toBeInTheDocument();
+      expect(screen.queryByText(/not published/i)).not.toBeInTheDocument();
+    });
+  });
+
   it('renders plugin subtitle extensions', () => {
     const TestExtension = () => <div>Extension Content</div>;
     registerPluginSubtitleExtension(TestExtension);


### PR DESCRIPTION
**What is this feature?**

Moves the `isRemotePluginsAvailable` check above the `isPublished` one in `InstallControlsWarning`, so an offline Grafana says the server cannot reach grafana.com instead of claiming the plugin is not in the catalog.

**Why do we need this feature?**

Without internet access the remote plugin fetch fails, the plugin is built from local data only, and `mapLocalToCatalog` hardcodes `isPublished: false`. The published check ran first, so a plugin that is in the catalog was reported as not published. The same ordering also made the incompatible-version warning win over the real cause.

**Who is this feature for?**

Anyone running Grafana air-gapped or behind a proxy that blocks grafana.com.

**Which issue(s) does this PR fix?**:

Fixes #132020

**Special notes for your reviewer:**

`yarn jest public/app/features/plugins/admin/components/PluginSubtitle.test.tsx` covers it. The new case fails on main and passes here.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] Pre-GA feature toggle: not applicable.
- [x] The docs are updated: not applicable, no new configuration.
