### PR TITLE
Unified Storage: log every finished garbage collection pass

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -869,28 +869,24 @@ func (b *kvStorageBackend) garbageCollectGroupResource(ctx context.Context, grou
 		}
 	}
 
-	if totalDeleted > 0 {
-		msg := "garbage collection deleted history"
-		perNamespaceMsg := "garbage collection deleted history per namespace"
-		if b.garbageCollection.DryRun {
-			msg = "garbage collection dry run"
-			perNamespaceMsg = "garbage collection dry run per namespace"
-		}
-
-		b.log.Info(msg,
+	// Logged even when nothing was eligible. A pass that finds no trash is the normal
+	// case for most groups, and staying silent leaves no way to tell it apart from a
+	// pass that never ran or was cut short.
+	b.log.Info("garbage collection finished",
+		"group", group,
+		"resource", resourceName,
+		"rows", totalDeleted,
+		"dryRun", b.garbageCollection.DryRun,
+		"seconds", time.Since(start).Seconds(),
+	)
+	for ns, count := range deletedPerNamespace {
+		b.log.Info("garbage collection finished per namespace",
 			"group", group,
 			"resource", resourceName,
-			"rows", totalDeleted,
-			"seconds", time.Since(start).Seconds(),
+			"namespace", ns,
+			"rows", count,
+			"dryRun", b.garbageCollection.DryRun,
 		)
-		for ns, count := range deletedPerNamespace {
-			b.log.Info(perNamespaceMsg,
-				"group", group,
-				"resource", resourceName,
-				"namespace", ns,
-				"rows", count,
-			)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
The KV garbage collector only logged a finished pass if it had deleted at least one row, so most passes were silent. A pass that finds nothing is the normal case for most groups, and the silence left no way to tell it apart from a pass that never ran or was cut short. While re-enabling garbage collection across prod (grafana/deployment_tools#709390) we could not tell whether dashboards had swept the largest cell and found nothing, or had never been reached; answering it meant inferring the sweep order from neighbouring log lines and a three hour gap.

Now one line per finished pass, always. The four messages also collapse to two: `garbage collection deleted history` and `garbage collection dry run` both become `garbage collection finished`, with dry-run as a `dryRun` field instead of encoded in the message. One query now covers both modes.

Note for reviewers: this breaks saved log queries matching the old strings. Nothing in grafana or deployment_tools references them. `pkg/storage/unified/sql/backend.go` has the same gate and is left alone, since its dry-run message says "first batch only", which is a real distinction, and prod runs the KV backend.

Related: grafana/search-and-storage-team#944
