### PR TITLE
Geomap: Don't rebuild the markers layer group on every data update

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.test.ts
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.test.ts
@@ -95,6 +95,20 @@ describe('markersLayer', () => {
     expect(duplicate.get('size')).toBeUndefined();
   });
 
+  it('update() keeps the existing layers when the layer set does not change', async () => {
+    const { handler, group } = await setup();
+    const layers = group.getLayers();
+    const symbolLayer = layers.item(0);
+    const onRemove = jest.fn();
+    layers.on('remove', onRemove);
+
+    handler.update!(pointData([46], [6]));
+    handler.update!(pointData([47, 48], [7, 8]));
+
+    expect(onRemove).not.toHaveBeenCalled();
+    expect(layers.item(0)).toBe(symbolLayer);
+  });
+
   it('update() clears the features when there is no data', async () => {
     const { handler, group } = await setup();
     handler.update!(pointData([46], [6]));

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -199,16 +199,13 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
             }
           });
 
-          // Update hasVector state after processing all features
-          hasVector = hasText || hasLineString;
-
-          // Update layer visibility based on current hasVector state
-          const layersArray = layers.getLayers();
-          layersArray.clear();
-          if (hasVector) {
-            layersArray.extend(symbol ? [symbolLayer, vectorLayer] : [vectorLayer]);
-          } else {
-            layersArray.extend([symbolLayer]);
+          // Re-adding the WebGL layer drops its GPU buffers and renders empty frames until the async rebuild is done
+          const nextHasVector = hasText || hasLineString;
+          if (nextHasVector !== hasVector) {
+            hasVector = nextHasVector;
+            const layersArray = layers.getLayers();
+            layersArray.clear();
+            layersArray.extend(hasVector ? (symbol ? [symbolLayer, vectorLayer] : [vectorLayer]) : [symbolLayer]);
           }
 
           break; // Only the first frame for now!


### PR DESCRIPTION
**What is this feature?**
`markersLayer.update()` currently clears its layer group and adds the same layers back on every data update. With this change it only does that when the set of layers actually changes, i.e. when text or line strings appear or disappear.

**Why do we need this feature?**
Re-adding the WebGL points layer makes OpenLayers drop its GPU buffers. Since OpenLayers 10.7 (Grafana 12.4) the point data sits in an instance buffer that is not uploaded again after that, so the panel draws empty frames until the async rebuild is done. On an auto-refreshing dashboard the markers blink on every refresh: about 10 ms on 12.4, about a second on 13.2. 12.3 did not have this because the point data was still in the vertex buffer, which is uploaded again.

Rebuilding the group on every update was never needed, so the fix just skips it.

**Who is this feature for?**
Everyone with a markers layer on a dashboard that auto-refreshes.

**Which issue(s) does this PR fix?**
Fixes #132034

**Special notes for your reviewer**
- New test `update() keeps the existing layers when the layer set does not change`. It fails without the change.
- Checked with the repro from the issue on 12.4.10 and 13.2.1: empty draws on every refresh before, none after.
- The missing upload in OpenLayers (`afterHelperCreated()` not flushing `instanceAttributesBuffer_`) is reported there separately. A Grafana build with only that fix also stops the blinking, but this change makes sense on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
