### PR TITLE
CI: Tag release branches after patches have been merged and the changelog has been updated instead of before.

### DIFF
--- a/.github/actions/changelog/action.yml
+++ b/.github/actions/changelog/action.yml
@@ -4,6 +4,12 @@ inputs:
   target:
     description: Target tag, branch or commit hash for the changelog
     required: true
+  version:
+    description: >-
+      Semver version being released (e.g. v10.0.0), used to look up the previous release tag when
+      `previous` isn't given. Falls back to `target`, so only needed when target isn't itself a
+      semver-parseable tag.
+    required: false
   previous:
     description: Previous tag, branch or commit hash to start changelog from
     required: false

--- a/.github/actions/changelog/index.js
+++ b/.github/actions/changelog/index.js
@@ -207,7 +207,11 @@ if (!ghtoken) {
 const target = process.argv[2] || process.env.INPUT_TARGET;
 LOG(`Target tag/branch/commit: ${target}`);
 
-const previous = process.argv[3] || process.env.INPUT_PREVIOUS || (await getPreviousVersion(target));
+// getPreviousVersion needs an actual semver string to look up the prior tag; target may be a
+// branch name instead (not semver-parseable), so it isn't a safe fallback for this on its own.
+const version = process.env.INPUT_VERSION || target;
+
+const previous = process.argv[3] || process.env.INPUT_PREVIOUS || (await getPreviousVersion(version));
 
 LOG(`Previous tag/commit: ${previous}`);
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -129,7 +129,11 @@ jobs:
         with:
           previous: ${{ inputs.previous_version }}
           github_token: ${{ steps.get-github-app-token.outputs.token }}
-          target: v${{ inputs.version }}
+          # The release tag doesn't exist yet at this point; diff against the release branch instead.
+          target: release-${{ inputs.version }}
+          # target is a branch name now, not semver-parseable; give the action a real version
+          # string to look up the previous release tag from when previous_version isn't set.
+          version: v${{ inputs.version }}
           output_file: changelog_items.md
       - name: "Patch CHANGELOG.md"
         run: |

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,6 +1,20 @@
 name: Create Release Tag
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag name (e.g. v10.0.0)'
+        required: true
+        type: string
+      message:
+        description: 'Tag message (defaults to tag name if not provided)'
+        required: false
+        type: string
+      commit:
+        description: 'Commit SHA to tag'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -76,11 +76,10 @@ jobs:
           # clone/checkout (enterprise/upstream + the build checkouts). Do NOT repoint it.
           echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
 
-          # public_commit is the commit STAMPED into the binary (-X main.commit). For a mirror
-          # #patched build it's the sibling unpatched branch HEAD — a real grafana/grafana
-          # commit — so artifacts advertise a public commit instead of the mirror-only one.
-          # Everywhere else it's just the checkout HEAD. This value is only ever passed to the
-          # Makefile's COMMIT_SHA; it is never used as a checkout/clone ref.
+          # public_commit is a real, publicly-resolvable grafana/grafana commit, used wherever a
+          # downstream step needs to perform a git operation against the public repo (tag
+          # creation, npm publish, test-infra checkout). It is not used to stamp the binary
+          # (main.commit uses grafana_commit instead, below) or as a checkout/clone ref.
           if [ "$GITHUB_REPOSITORY" = "grafana/grafana-security-mirror" ] && [[ "$REF_NAME" == *'#patched' ]]; then
             sibling="${REF_NAME%\#patched}"
             public_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${sibling}" --jq '.object.sha')
@@ -262,9 +261,9 @@ jobs:
           arm: ${{ matrix.arm }}
           build-number: ${{ github.run_id }}
           build-version: ${{ needs.setup.outputs.version }}
-          # Stamp the public (non-#patched) commit while still compiling the #patched
-          # source that was checked out above. See the build invariant in the plan.
-          commit: ${{ needs.setup.outputs.public-commit }}
+          # Stamp the commit actually built, not public-commit (used elsewhere where a publicly
+          # resolvable commit is required, e.g. tag creation and npm publish).
+          commit: ${{ needs.setup.outputs.grafana-commit }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: release-backend-${{ matrix.name }}

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -151,9 +151,8 @@ jobs:
     needs:
       - setup
       - create_release_tag
-    # create_release_tag is skipped, not failed, on a workflow_dispatch run; the default `needs`
-    # condition would treat that as blocking, so check failure()/cancelled() explicitly instead.
-    if: ${{ !failure() && !cancelled() }}
+    # Run unless setup was skipped or something actually failed/cancelled — a skipped create_release_tag is fine.
+    if: ${{ !failure() && !cancelled() && needs.setup.result == 'success' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -130,11 +130,30 @@ jobs:
   #   with:
   #     version: ${{ needs.setup.outputs.version }}
   #     dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+  create_release_tag:
+    # Tags the release PR's merge commit rather than a commit that predates it. Only meaningful
+    # on the real merge event — a workflow_dispatch run has no pull_request context to take a
+    # commit from.
+    name: Create release tag
+    needs: setup
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.dry_run != 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/create-release-tag.yml
+    with:
+      tag: ${{ needs.setup.outputs.version }}
+      commit: ${{ github.event.pull_request.merge_commit_sha }}
   create_github_release:
     # a github release requires a git tag
     # The github-release action retrieves the changelog using the /repos/grafana/grafana/contents/CHANGELOG.md API
     # endpoint.
-    needs: setup
+    needs:
+      - setup
+      - create_release_tag
+    # create_release_tag is skipped, not failed, on a workflow_dispatch run; the default `needs`
+    # condition would treat that as blocking, so check failure()/cancelled() explicitly instead.
+    if: ${{ !failure() && !cancelled() }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -288,3 +288,14 @@ jobs:
             -H "${WORK_BRANCH}" \
             --title "Release: $VERSION" \
             --body "These code changes must be merged after a release is complete"
+      # Publishes the branch name so external callers don't have to reconstruct it themselves.
+      - name: Publish release PR branch name
+        run: |
+          mkdir -p .release-pr-artifact
+          printf '%s' "$WORK_BRANCH" > .release-pr-artifact/branch.txt
+      - name: Upload release PR branch artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: release-pr-branch
+          path: .release-pr-artifact/branch.txt
+          retention-days: 14

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -232,8 +232,12 @@ jobs:
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
         run: |
           yarn install
-          npm version patch --no-git-tag-version
-          yarn run lerna version patch --no-push --no-git-tag-version --force-publish --exact --yes
+          # Target VERSION explicitly and skip if already there; a relative bump isn't safe to re-run.
+          current_version=$(node -p "require('./package.json').version")
+          if [ "$current_version" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+            yarn run lerna version "$VERSION" --no-push --no-git-tag-version --force-publish --exact --yes
+          fi
           yarn install
           yarn prettier:write
       - name: make gen-cue

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -180,6 +180,9 @@ jobs:
           previous: ${{inputs.previous_version}}
           # The release tag doesn't exist yet at this point; diff against the release branch instead.
           target: ${{ env.RELEASE_BRANCH }}
+          # target is a branch name now, not semver-parseable; give the action a real version
+          # string to look up the previous release tag from when previous_version isn't set.
+          version: v${{ env.VERSION }}
           output_file: changelog_items.md
           github_token: ${{ steps.get-github-app-token.outputs.token }}
       - name: Patch CHANGELOG.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -178,7 +178,8 @@ jobs:
         uses: ./.grafana-main/.github/actions/changelog
         with:
           previous: ${{inputs.previous_version}}
-          target: v${{ env.VERSION }}
+          # The release tag doesn't exist yet at this point; diff against the release branch instead.
+          target: ${{ env.RELEASE_BRANCH }}
           output_file: changelog_items.md
           github_token: ${{ steps.get-github-app-token.outputs.token }}
       - name: Patch CHANGELOG.md


### PR DESCRIPTION
- create_release_tag can be called from other workflows now with workflow_call
- update changelog generation to look for diffs between release branches instead of tags
- create_release_tag is called after the release-pr is merged, but before the github release is created. (perhaps that's redundant?)
- embed the 'grafana-commit' (post-patch-application) in the binary instead of the public pre-patch commit.