### PR TITLE
IAM: Fix LDAP diagnostic handlers

### DIFF
--- a/pkg/services/ldap/api/service.go
+++ b/pkg/services/ldap/api/service.go
@@ -120,7 +120,7 @@ func (s *Service) ReloadLDAPCfg(c *contextmodel.ReqContext) response.Response {
 // 403: forbiddenError
 // 500: internalServerError
 func (s *Service) GetLDAPStatus(c *contextmodel.ReqContext) response.Response {
-	if !s.cfg.Enabled {
+	if !s.ldapService.Enabled() {
 		return response.Error(http.StatusBadRequest, "LDAP is not enabled", nil)
 	}
 
@@ -167,7 +167,7 @@ func (s *Service) GetLDAPStatus(c *contextmodel.ReqContext) response.Response {
 // 403: forbiddenError
 // 500: internalServerError
 func (s *Service) PostSyncUserWithLDAP(c *contextmodel.ReqContext) response.Response {
-	if !s.cfg.Enabled {
+	if !s.ldapService.Enabled() {
 		return response.Error(http.StatusBadRequest, "LDAP is not enabled", nil)
 	}
 
@@ -248,7 +248,7 @@ func (s *Service) PostSyncUserWithLDAP(c *contextmodel.ReqContext) response.Resp
 // 403: forbiddenError
 // 500: internalServerError
 func (s *Service) GetUserFromLDAP(c *contextmodel.ReqContext) response.Response {
-	if !s.cfg.Enabled {
+	if !s.ldapService.Enabled() {
 		return response.Error(http.StatusBadRequest, "LDAP is not enabled", nil)
 	}
 

--- a/pkg/services/ldap/api/service_test.go
+++ b/pkg/services/ldap/api/service_test.go
@@ -98,7 +98,8 @@ func TestGetUserFromLDAPAPIEndpoint_UserNotFound(t *testing.T) {
 			ExpectedClient: &LDAPMock{
 				UserSearchResult: nil,
 			},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -164,7 +165,8 @@ func TestGetUserFromLDAPAPIEndpoint_OrgNotfound(t *testing.T) {
 				UserSearchResult: userSearchResult,
 				UserSearchConfig: userSearchConfig,
 			},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -234,7 +236,8 @@ func TestGetUserFromLDAPAPIEndpoint(t *testing.T) {
 				UserSearchResult: userSearchResult,
 				UserSearchConfig: userSearchConfig,
 			},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -320,7 +323,8 @@ func TestGetUserFromLDAPAPIEndpoint_WithTeamHandler(t *testing.T) {
 				UserSearchResult: userSearchResult,
 				UserSearchConfig: userSearchConfig,
 			},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -374,8 +378,9 @@ func TestGetLDAPStatusAPIEndpoint(t *testing.T) {
 
 	_, server := setupAPITest(t, func(a *Service) {
 		a.ldapService = &service.LDAPFakeService{
-			ExpectedClient: &LDAPMock{},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedClient:  &LDAPMock{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -405,6 +410,61 @@ func TestGetLDAPStatusAPIEndpoint(t *testing.T) {
 	assert.JSONEq(t, expected, string(bodyBytes))
 }
 
+func TestGetLDAPStatusAPIEndpoint_EnabledOnlyViaSSOSettings(t *testing.T) {
+	pingResult = []*multildap.ServerStatus{
+		{Host: "10.0.0.3", Port: 361, Available: true, Error: nil},
+	}
+
+	_, server := setupAPITest(t, func(a *Service) {
+		a.cfg.Enabled = false
+		a.ldapService = &service.LDAPFakeService{
+			ExpectedClient:  &LDAPMock{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true, // enabled via SSO settings
+		}
+	})
+
+	req := server.NewGetRequest("/api/admin/ldap/status")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID: 1,
+		Permissions: map[int64]map[string][]string{
+			1: {"ldap.status:read": {}},
+		},
+	})
+
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestGetLDAPStatusAPIEndpoint_DisabledViaSSOSettings(t *testing.T) {
+	_, server := setupAPITest(t, func(a *Service) {
+		a.ldapService = &service.LDAPFakeService{
+			ExpectedClient:  &LDAPMock{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: false,
+		}
+	})
+
+	req := server.NewGetRequest("/api/admin/ldap/status")
+	webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+		OrgID: 1,
+		Permissions: map[int64]map[string][]string{
+			1: {"ldap.status:read": {}},
+		},
+	})
+
+	res, err := server.Send(req)
+	defer func() { require.NoError(t, res.Body.Close()) }()
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, res.StatusCode)
+	bodyBytes, _ := io.ReadAll(res.Body)
+	assert.JSONEq(t, `{"message":"LDAP is not enabled"}`, string(bodyBytes))
+}
+
 func TestPostSyncUserWithLDAPAPIEndpoint_Success(t *testing.T) {
 	userServiceMock := usertest.NewUserServiceFake()
 	userServiceMock.ExpectedUser = &user.User{Login: "ldap-daniel", ID: 34}
@@ -415,7 +475,8 @@ func TestPostSyncUserWithLDAPAPIEndpoint_Success(t *testing.T) {
 			ExpectedClient: &LDAPMock{UserSearchResult: &login.ExternalUserInfo{
 				Login: "ldap-daniel",
 			}},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -450,8 +511,9 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotFound(t *testing.T) {
 	_, server := setupAPITest(t, func(a *Service) {
 		a.userService = userServiceMock
 		a.ldapService = &service.LDAPFakeService{
-			ExpectedClient: &LDAPMock{},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedClient:  &LDAPMock{},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -487,8 +549,9 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenGrafanaAdmin(t *testing.T) {
 		a.userService = userServiceMock
 		a.adminUser = "ldap-daniel"
 		a.ldapService = &service.LDAPFakeService{
-			ExpectedClient: &LDAPMock{UserSearchError: multildap.ErrDidNotFindUser},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedClient:  &LDAPMock{UserSearchError: multildap.ErrDidNotFindUser},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -521,8 +584,9 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotInLDAP(t *testing.T) {
 		a.userService = userServiceMock
 		a.authInfoService = &authinfotest.FakeService{ExpectedExternalUser: &login.ExternalUserInfo{IsDisabled: true, UserId: 34}}
 		a.ldapService = &service.LDAPFakeService{
-			ExpectedClient: &LDAPMock{UserSearchError: multildap.ErrDidNotFindUser},
-			ExpectedConfig: &ldap.ServersConfig{},
+			ExpectedClient:  &LDAPMock{UserSearchError: multildap.ErrDidNotFindUser},
+			ExpectedConfig:  &ldap.ServersConfig{},
+			ExpectedEnabled: true,
 		}
 	})
 
@@ -658,7 +722,8 @@ search_base_dns = ["dc=grafana,dc=org"]`)
 					ExpectedClient: &LDAPMock{UserSearchResult: &login.ExternalUserInfo{
 						Login: "ldap-daniel",
 					}},
-					ExpectedConfig: &ldap.ServersConfig{},
+					ExpectedConfig:  &ldap.ServersConfig{},
+					ExpectedEnabled: true,
 				}
 			})
 			// Add minimal setup to pass handler


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The LDAP diagnostic handlers (`GetLDAPStatus`, `PostSyncUserWithLDAP` and `GetUserFromLDAP`) now check the live, SSO settings backed state instead of `s.cfg.Enabled`, a snapshot taken once at server startup from the static ini setting.

**Why do we need this feature?**

These three handlers back the `Test` and `LDAP Diagnostics` flows from the UI. On instances where LDAP is configured entirely through the UI (as is always the case on Grafana Cloud), `s.cfg.Enabled` is permanently false, since it only reflects the ini setting and is never refreshed from SSO settings. As a result, every Test/Diagnostics/Sync call returns a 400 error with `LDAP is not enabled` even when an admin has fully configured and enabled LDAP through the UI, surfaced to users as a `Not found` error. The fix makes these handlers check the same live enablement state the rest of the LDAP integration already relies on for SSO settings.

**Who is this feature for?**

all LDAP users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/24055.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
