### PR TITLE
Combobox: Support custom option rendering

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.mdx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.mdx
@@ -51,19 +51,19 @@ Combobox uses its default content for generated custom-value and select-all opti
   onChange={setValue}
   width={32}
   renderOption={(option) => (
-    <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+    <Stack direction="row" alignItems="center" justifyContent="space-between">
       <span>{option.label ?? option.value}</span>
       <Badge text="Available" color="green" />
-    </span>
+    </Stack>
   )}
 />
 ```
 
 Custom option renderers must meet these requirements:
 
-- Keep the renderer pure and free of side effects. Virtualized rows can render repeatedly.
-- Custom content can use variable heights. Combobox starts with a conservative two-line estimate, includes group-header metadata, then measures each mounted custom row together with its group header and updates the virtual layout. It does not render or measure rows outside the mounted virtual range.
-- Supply accurate string `label` and `description` metadata. Menu width is estimated from that metadata and the option icon, not from custom content. Set `width` when custom content needs more space.
+- Keep the renderer pure and free of side effects. Virtualized rows can render repeatedly, and the render function _may_ be called before an option is rendered, such as to measure layout.
+- Custom content can use variable heights. Combobox starts with a conservative two-line estimate, then measures each mounted custom row and updates the virtual layout.
+- Menu and option width is estimated from that `label` and `description` on items. It is currently not measured from the custom content, so ensure your custom content fits within the estimated width or can wrap.
 - Include the option label or equivalent accessible text in the rendered content. The plain string `label` is still used for filtering and for the selected input value.
 - Do not nest buttons, links, inputs, or other interactive controls. The option row owns focus and selection.
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.mdx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.mdx
@@ -35,6 +35,38 @@ Options can be an array of objects with seperate label and values, or an array o
 
 While Combobox can handle large sets of options, you should consider both the user experience of searching through many options, and the performance of loading many options from an API.
 
+### Custom option rendering
+
+Use `renderOption` to replace the content inside an option row. Combobox continues to own the option element, selection, highlighting, and keyboard and pointer interactions.
+
+Combobox uses its default content for generated custom-value and select-all options.
+
+```tsx
+<Combobox
+  options={[
+    { label: 'API server', value: 'api' },
+    { label: 'Database', value: 'database' },
+  ]}
+  value={value}
+  onChange={setValue}
+  width={32}
+  renderOption={(option) => (
+    <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <span>{option.label ?? option.value}</span>
+      <Badge text="Available" color="green" />
+    </span>
+  )}
+/>
+```
+
+Custom option renderers must meet these requirements:
+
+- Keep the renderer pure and free of side effects. Virtualized rows can render repeatedly.
+- Custom content can use variable heights. Combobox starts with a conservative two-line estimate, includes group-header metadata, then measures each mounted custom row together with its group header and updates the virtual layout. It does not render or measure rows outside the mounted virtual range.
+- Supply accurate string `label` and `description` metadata. Menu width is estimated from that metadata and the option icon, not from custom content. Set `width` when custom content needs more space.
+- Include the option label or equivalent accessible text in the rendered content. The plain string `label` is still used for filtering and for the selected input value.
+- Do not nest buttons, links, inputs, or other interactive controls. The option row owns focus and selection.
+
 ### Grouping
 
 Each option object may also have a `group` string property. Options with matching group names will be sorted together, as will options with undefined groups. Combobox will order these based on the first occurence of each `group` (or absence of `group`) in the `options` prop.
@@ -110,7 +142,7 @@ Some differences to note:
 - `allowCustomValue` has been renamed to `createCustomValue`.
 - When specifying `width="auto"`, `minWidth` is also required.
 - Many props used to control subtle behaviour have been removed to simplify the API and improve performance.
-  - Custom render props, or label as ReactNode is not supported at this time. Reach out if you have a hard requirement for this and we can discuss.
+- Use `renderOption` for custom option content. It does not replace the option row or its interaction behavior; follow the renderer requirements above.
 
 For all async behaviour, pass in a function that returns `Promise<ComboboxOption[]>` that will be called when the menu is opened, and on keypress.
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryFn, type StoryObj } from '@storybook/react-webpack
 import { action } from 'storybook/actions';
 import { useArgs, useState, useEffect } from 'storybook/preview-api';
 
+import { Badge } from '../Badge/Badge';
 import { Button } from '../Button/Button';
 import { Field } from '../Forms/Field';
 
@@ -109,6 +110,34 @@ export const OptionIcons: Story = {
       { label: 'Three', value: 'three', group: 'Group 2', icon: 'keyboard' },
       { label: 'Four', value: 'four', group: 'Group 2', icon: 'keyboard' },
     ],
+  },
+  render: BaseCombobox,
+};
+
+export const CustomOptionRendering: Story = {
+  args: {
+    width: 40,
+    value: undefined,
+    options: Array.from({ length: 40 }, (_, index) => ({
+      label: `Service ${index + 1}`,
+      value: `service-${index + 1}`,
+      group: index < 20 ? 'Core services' : 'Supporting services',
+    })),
+    renderOption: (option) => {
+      const optionNumber = Number(option.value.split('-').at(-1));
+
+      return (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+          <span>
+            <span>{option.label}</span>
+            {optionNumber % 2 === 0 && (
+              <span style={{ display: 'block', fontWeight: 400 }}>Receives traffic from multiple environments</span>
+            )}
+          </span>
+          <Badge text="Available" color="green" />
+        </div>
+      );
+    },
   },
   render: BaseCombobox,
 };

--- a/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.story.tsx
@@ -119,7 +119,7 @@ export const CustomOptionRendering: Story = {
     width: 40,
     value: undefined,
     options: Array.from({ length: 40 }, (_, index) => ({
-      label: `Service ${index + 1}`,
+      label: `Service ${index + 1}${index === 10 ? ' (this is a very long label to test overflow)' : ''}`,
       value: `service-${index + 1}`,
       group: index < 20 ? 'Core services' : 'Supporting services',
     })),

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -121,6 +121,63 @@ describe('Combobox', () => {
     expect(onChangeHandler).toHaveBeenCalledWith(iconOptions[1]);
   });
 
+  it('renders custom content only for a bounded set of virtualized options', async () => {
+    const largeOptions: Array<ComboboxOption<string>> = Array.from({ length: 1000 }, (_, index) => ({
+      label: `Option ${index}`,
+      value: String(index),
+    }));
+    const renderOption = jest.fn((option: ComboboxOption<string>) => <span>{option.label}</span>);
+
+    render(<Combobox options={largeOptions} value={null} onChange={onChangeHandler} renderOption={renderOption} />);
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByRole('option', { name: 'Option 0' });
+
+    const renderedValues = new Set(renderOption.mock.calls.map(([option]) => option.value));
+    expect([...renderedValues]).toContain('0');
+    expect([...renderedValues]).not.toContain('999');
+    expect(renderedValues.size).toBeLessThan(50);
+  });
+
+  it('selects the source option from a custom descendant and keeps its string label in the input', async () => {
+    render(
+      <Combobox
+        options={options}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => (
+          <span>
+            Custom content for <strong data-testid={`custom-option-${option.value}`}>{option.label}</strong>
+          </span>
+        )}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByTestId('custom-option-2'));
+
+    expect(onChangeHandler).toHaveBeenCalledTimes(1);
+    expect(onChangeHandler.mock.calls[0][0]).toBe(options[1]);
+    expect(screen.getByRole('combobox')).toHaveValue('Option 2');
+  });
+
+  it('selects an option with custom content by keyboard', async () => {
+    render(
+      <Combobox
+        options={options}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => <span>{option.label} custom</span>}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    await user.click(input);
+    await user.keyboard('{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(onChangeHandler).toHaveBeenCalledWith(options[2]);
+    expect(input).toHaveValue('Option 3');
+  });
+
   it('selects value by clicking that needs scrolling', async () => {
     render(<Combobox options={options} value={null} onChange={onChangeHandler} />);
 
@@ -428,6 +485,34 @@ describe('Combobox', () => {
       await userEvent.keyboard('{Enter}'); // Select 1 as the first option
       expect(typeof onChangeHandler.mock.calls[1][0].value === 'string').toBeFalsy();
       expect(typeof onChangeHandler.mock.calls[1][0].value === 'number').toBeTruthy();
+    });
+
+    it('uses default content for a numeric custom-value row', async () => {
+      const numericOptions: Array<ComboboxOption<number>> = [
+        { label: 'One', value: 1 },
+        { label: 'Two', value: 2 },
+      ];
+      const renderOption = jest.fn((option: ComboboxOption<number>) => <span>Number {option.value.toFixed(2)}</span>);
+
+      render(
+        <Combobox<number>
+          options={numericOptions}
+          value={null}
+          onChange={onChangeHandler}
+          createCustomValue
+          renderOption={renderOption}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      expect(await screen.findByText('Number 1.00')).toBeInTheDocument();
+
+      await user.type(input, 'custom');
+
+      expect(await screen.findByText('custom')).toBeInTheDocument();
+      expect(screen.getByText('Use custom value')).toBeInTheDocument();
+      expect(renderOption.mock.calls.map(([option]) => option.value)).toContain(1);
     });
   });
 

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -39,6 +39,57 @@ const iconOptions: Array<ComboboxOption<string>> = [
   { label: 'Option 4', value: '4', icon: 'add-user' },
 ];
 
+function trackResizeObserverTargets() {
+  const originalResizeObserver = global.ResizeObserver;
+  const observedElements = new Set<Element>();
+  const observations = new Map<Element, { callback: ResizeObserverCallback; observer: ResizeObserver }>();
+  const observerStates = new Map<Element, { disconnected: boolean }>();
+
+  global.ResizeObserver = class {
+    constructor(private callback: ResizeObserverCallback) {}
+    private state = { disconnected: false };
+
+    observe(target: Element) {
+      observedElements.add(target);
+      observerStates.set(target, this.state);
+      observations.set(target, { callback: this.callback, observer: this as unknown as ResizeObserver });
+    }
+    unobserve(target: Element) {
+      observations.delete(target);
+    }
+    disconnect() {
+      this.state.disconnected = true;
+    }
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof ResizeObserver;
+
+  return {
+    observedElements,
+    observerStates,
+    resize: (target: Element, height: number) => {
+      const observation = observations.get(target);
+      if (!observation) {
+        throw new Error('Element is not observed');
+      }
+
+      observation.callback(
+        [
+          {
+            target,
+            borderBoxSize: [{ blockSize: height, inlineSize: 120 }],
+          } as unknown as ResizeObserverEntry,
+        ],
+        observation.observer
+      );
+    },
+    restore: () => {
+      global.ResizeObserver = originalResizeObserver;
+    },
+  };
+}
+
 describe('Combobox', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
@@ -136,6 +187,252 @@ describe('Combobox', () => {
     expect([...renderedValues]).toContain('0');
     expect([...renderedValues]).not.toContain('999');
     expect(renderedValues.size).toBeLessThan(50);
+  });
+
+  it('uses measured custom row heights for following row positions and total height', async () => {
+    const rowHeights = [70, 80, 60, 100];
+    const resizeObservers = trackResizeObserverTargets();
+    const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      const height = this.hasAttribute('data-index') ? 40 : 120;
+      return {
+        width: 120,
+        height,
+        top: 0,
+        right: 120,
+        bottom: height,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+    const groupedOptions = options.map((option) => ({ ...option, group: 'Services' }));
+    const view = render(
+      <Combobox
+        options={groupedOptions}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => <span>{option.label}</span>}
+      />
+    );
+
+    try {
+      await user.click(screen.getByRole('combobox'));
+      const renderedOptions = await screen.findAllByRole('option');
+      const renderedRows = renderedOptions.map((option) => {
+        const row = option.parentElement;
+        expect(row).not.toBeNull();
+        return row!;
+      });
+
+      act(() => {
+        renderedRows.forEach((row, index) => resizeObservers.resize(row, rowHeights[index] ?? 40));
+      });
+
+      await waitFor(() => expect(renderedRows[1]).toHaveStyle({ transform: 'translateY(74px)' }));
+      expect(renderedRows[2]).toHaveStyle({ transform: 'translateY(154px)' });
+      expect(renderedRows[3]).toHaveStyle({ transform: 'translateY(214px)' });
+      expect(renderedRows[0].parentElement).toHaveStyle({ height: '318px' });
+
+      const firstRow = renderedRows[0];
+      expect(firstRow).toHaveAttribute('data-index', '0');
+      expect(firstRow).toHaveStyle({ transform: 'translateY(4px)' });
+      expect(firstRow.getAttribute('style')).not.toContain('height');
+      expect(firstRow).toContainElement(screen.getByText('Services'));
+      expect(resizeObservers.observedElements).toContain(firstRow);
+    } finally {
+      view.unmount();
+      rectSpy.mockRestore();
+      resizeObservers.restore();
+    }
+  });
+
+  it('keeps the first grouped custom option visible without scrolling on open', async () => {
+    const groupedOptions = options.map((option) => ({ ...option, group: 'Services' }));
+    const resizeObservers = trackResizeObserverTargets();
+    const scrollRequests: number[] = [];
+    const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      let height = 120;
+      if (this.hasAttribute('data-index')) {
+        height = 178;
+      } else if (this.getAttribute('tabindex') === '0') {
+        height = 99;
+      }
+      return {
+        width: 120,
+        height,
+        top: 0,
+        right: 120,
+        bottom: height,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+    const scrollHeightSpy = jest.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(4000);
+    const scrollToSpy = jest.spyOn(Element.prototype, 'scrollTo').mockImplementation(function (
+      this: Element,
+      options?: ScrollToOptions | number,
+      y?: number
+    ) {
+      const top = typeof options === 'number' ? (y ?? 0) : (options?.top ?? 0);
+      scrollRequests.push(top);
+      Object.defineProperty(this, 'scrollTop', { configurable: true, value: top, writable: true });
+    });
+    const view = render(
+      <Combobox
+        options={groupedOptions}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => <span>{option.label} custom</span>}
+      />
+    );
+
+    try {
+      await user.click(screen.getByRole('combobox'));
+      const firstOption = await screen.findByRole('option', { name: 'Option 1 custom' });
+      const scrollElement = firstOption.closest<HTMLElement>('[tabindex="0"]')!;
+
+      expect(scrollElement.scrollTop).toBe(0);
+      // The zero request is TanStack's measurement adjustment. A replayed scrollToIndex(0)
+      // would end-align the 178px row in the 99px viewport and add a 79px request.
+      expect(scrollRequests).toEqual([0]);
+      expect(firstOption.parentElement).toContainElement(screen.getByText('Services'));
+    } finally {
+      view.unmount();
+      scrollToSpy.mockRestore();
+      scrollHeightSpy.mockRestore();
+      rectSpy.mockRestore();
+      resizeObservers.restore();
+    }
+  });
+
+  it('keeps default rows fixed-height and does not register them for measurement', async () => {
+    const resizeObservers = trackResizeObserverTargets();
+    const view = render(<Combobox options={options} value={null} onChange={onChangeHandler} />);
+
+    try {
+      await user.click(screen.getByRole('combobox'));
+      const firstOption = await screen.findByRole('option', { name: 'Option 1' });
+      const firstRow = firstOption.parentElement;
+
+      expect(firstRow).not.toHaveAttribute('data-index');
+      expect(firstRow).toHaveStyle({ height: '39px', transform: 'translateY(4px)' });
+      expect(resizeObservers.observedElements).not.toContain(firstRow);
+    } finally {
+      view.unmount();
+      resizeObservers.restore();
+    }
+  });
+
+  it('resets measured row state when custom rendering is removed while open', async () => {
+    const resizeObservers = trackResizeObserverTargets();
+    const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      const height = this.hasAttribute('data-index') ? 80 : 120;
+      return {
+        width: 120,
+        height,
+        top: 0,
+        right: 120,
+        bottom: height,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+    const view = render(
+      <Combobox
+        options={options}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => <span>{option.label} custom</span>}
+      />
+    );
+
+    try {
+      await user.click(screen.getByRole('combobox'));
+      const customOption = await screen.findByRole('option', { name: 'Option 1 custom' });
+      const measuredRow = customOption.parentElement!;
+      const measuredRowObserver = resizeObservers.observerStates.get(measuredRow);
+
+      expect(measuredRow).toHaveAttribute('data-index', '0');
+      expect(measuredRow).toHaveStyle({ transform: 'translateY(4px)' });
+      expect(measuredRow.getAttribute('style')).not.toContain('height');
+      expect(measuredRowObserver?.disconnected).toBe(false);
+
+      view.rerender(<Combobox options={options} value={null} onChange={onChangeHandler} />);
+
+      const defaultOption = await screen.findByRole('option', { name: 'Option 1' });
+      const fixedRow = defaultOption.parentElement;
+      expect(fixedRow).not.toHaveAttribute('data-index');
+      expect(fixedRow).toHaveStyle({ height: '39px', transform: 'translateY(4px)' });
+      expect(resizeObservers.observedElements).not.toContain(fixedRow);
+      await waitFor(() => expect(measuredRowObserver?.disconnected).toBe(true));
+    } finally {
+      view.unmount();
+      rectSpy.mockRestore();
+      resizeObservers.restore();
+    }
+  });
+
+  it('requests measured scrolling and selects a distant option by keyboard', async () => {
+    const largeOptions: Array<ComboboxOption<string>> = Array.from({ length: 50 }, (_, index) => ({
+      label: `Option ${index}`,
+      value: String(index),
+    }));
+    const resizeObservers = trackResizeObserverTargets();
+    const scrollRequests: number[] = [];
+    const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      const height = this.hasAttribute('data-index') ? 100 : 120;
+      return {
+        width: 120,
+        height,
+        top: 0,
+        right: 120,
+        bottom: height,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+    const scrollToSpy = jest.spyOn(Element.prototype, 'scrollTo').mockImplementation(function (
+      options?: ScrollToOptions | number,
+      y?: number
+    ) {
+      const top = typeof options === 'number' ? (y ?? 0) : (options?.top ?? 0);
+      scrollRequests.push(top);
+    });
+    const view = render(
+      <Combobox
+        options={largeOptions}
+        value={null}
+        onChange={onChangeHandler}
+        renderOption={(option) => <span>{option.label} custom</span>}
+      />
+    );
+
+    try {
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      const firstOption = await screen.findByRole('option', { name: 'Option 0 custom' });
+      const scrollElement = firstOption.closest<HTMLElement>('[tabindex="0"]')!;
+      Object.defineProperty(scrollElement, 'scrollHeight', { configurable: true, value: 4000 });
+      await user.keyboard('{ArrowDown}'.repeat(30));
+
+      expect(scrollRequests[scrollRequests.length - 1]).toBeGreaterThan(1800);
+
+      await user.keyboard('{Enter}');
+      expect(onChangeHandler).toHaveBeenCalledWith(largeOptions[30]);
+      expect(input).toHaveValue('Option 30');
+    } finally {
+      view.unmount();
+      scrollToSpy.mockRestore();
+      rectSpy.mockRestore();
+      resizeObservers.restore();
+    }
   });
 
   it('selects the source option from a custom descendant and keeps its string label in the input', async () => {

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -51,6 +51,13 @@ interface ComboboxStaticProps<T extends string | number>
   options: Array<ComboboxOption<T>> | ((inputValue: string) => Promise<Array<ComboboxOption<T>>>);
 
   /**
+   * Renders custom content for each mounted option supplied through `options`.
+   * Combobox owns the option row and its interactions. Generated options use the default content.
+   * The renderer must be pure because it can run repeatedly.
+   */
+  renderOption?: (option: ComboboxOption<T>) => React.ReactNode;
+
+  /**
    * Current selected value. Most consumers should pass a scalar value (string | number). However, sometimes with Async
    * it may be better to pass in an Option with a label to display.
    */
@@ -152,6 +159,7 @@ const VIRTUAL_OVERSCAN_ITEMS = 4;
 export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => {
   const {
     options: allOptions,
+    renderOption,
     onChange,
     value: valueProp,
     placeholder: placeholderProp,
@@ -187,6 +195,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
   const {
     options: filteredOptions,
+    customValueOption,
     updateOptions,
     asyncLoading,
     asyncError,
@@ -453,6 +462,8 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
             <ComboboxList
               loading={loading}
               options={filteredOptions}
+              renderOption={renderOption}
+              customValueOption={customValueOption}
               highlightedIndex={highlightedIndex}
               showFocusRing={showFocusRing}
               selectedItems={selectedItem ? [selectedItem] : []}

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { useVirtualizer, type Range } from '@tanstack/react-virtual';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
 import React, { type ComponentProps, useCallback, useId, useMemo, useState } from 'react';
 
@@ -187,7 +187,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
   const {
     options: filteredOptions,
-    groupStartIndices,
     updateOptions,
     asyncLoading,
     asyncError,
@@ -246,29 +245,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     [onIsOpenChangeProp, updateOptions, resetSearch]
   );
 
-  // Injects the group header for the first rendered item into the range to render.
-  // Accepts the range that useVirtualizer wants to render, and then returns indexes
-  // to actually render.
-  const rangeExtractor = useCallback(
-    (range: Range) => {
-      const startIndex = Math.max(0, range.startIndex - range.overscan);
-      const endIndex = Math.min(filteredOptions.length - 1, range.endIndex + range.overscan);
-      const rangeToReturn = Array.from({ length: endIndex - startIndex + 1 }, (_, i) => startIndex + i);
-
-      // If the first item doesn't have a group, no need to find a header for it
-      const firstDisplayedOption = filteredOptions[rangeToReturn[0]];
-      if (firstDisplayedOption?.group) {
-        const groupStartIndex = groupStartIndices.get(firstDisplayedOption.group);
-        if (groupStartIndex !== undefined && groupStartIndex < rangeToReturn[0]) {
-          rangeToReturn.unshift(groupStartIndex);
-        }
-      }
-
-      return rangeToReturn;
-    },
-    [filteredOptions, groupStartIndices]
-  );
-
   const rowVirtualizer = useVirtualizer({
     count: filteredOptions.length,
     getScrollElement: () => scrollRef.current,
@@ -288,7 +264,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     },
     getItemKey: (index: number) => filteredOptions[index]?.value ?? index,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
-    rangeExtractor,
     paddingStart: MENU_PADDING,
     paddingEnd: MENU_PADDING,
   });

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,5 +1,4 @@
 import { cx } from '@emotion/css';
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
 import React, { type ComponentProps, useCallback, useId, useMemo, useState } from 'react';
 
@@ -15,16 +14,11 @@ import { Portal } from '../Portal/Portal';
 import { ComboboxList } from './ComboboxList';
 import { SuffixIcon } from './SuffixIcon';
 import { itemToString } from './filter';
-import {
-  getComboboxStyles,
-  MENU_OPTION_HEIGHT,
-  MENU_OPTION_HEIGHT_DESCRIPTION,
-  MENU_PADDING,
-} from './getComboboxStyles';
+import { getComboboxStyles } from './getComboboxStyles';
 import { type ComboboxOption } from './types';
 import { useComboboxFloat } from './useComboboxFloat';
 import { useOptions } from './useOptions';
-import { isNewGroup, isKeyboardEvent } from './utils';
+import { isKeyboardEvent } from './utils';
 
 // TODO: It would be great if ComboboxOption["label"] was more generic so that if consumers do pass it in (for async),
 // then the onChange handler emits ComboboxOption with the label as non-undefined.
@@ -147,8 +141,6 @@ export type ComboboxProps<T extends string | number> = ComboboxBaseProps<T> & Au
 
 const noop = () => {};
 
-const VIRTUAL_OVERSCAN_ITEMS = 4;
-
 /**
  * A performant and accessible combobox component that supports both synchronous and asynchronous options loading. It provides type-ahead filtering, keyboard navigation, and virtual scrolling for handling large datasets efficiently.
  * Replaces the Select component, and has better performance.
@@ -254,29 +246,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     [onIsOpenChangeProp, updateOptions, resetSearch]
   );
 
-  const rowVirtualizer = useVirtualizer({
-    count: filteredOptions.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: (index: number) => {
-      const firstGroupItem = isNewGroup(filteredOptions[index], index > 0 ? filteredOptions[index - 1] : undefined);
-      const hasDescription = 'description' in filteredOptions[index];
-      const hasGroup = 'group' in filteredOptions[index];
-
-      let itemHeight = MENU_OPTION_HEIGHT;
-      if (hasDescription) {
-        itemHeight = MENU_OPTION_HEIGHT_DESCRIPTION;
-      }
-      if (firstGroupItem && hasGroup) {
-        itemHeight += MENU_OPTION_HEIGHT;
-      }
-      return itemHeight;
-    },
-    getItemKey: (index: number) => filteredOptions[index]?.value ?? index,
-    overscan: VIRTUAL_OVERSCAN_ITEMS,
-    paddingStart: MENU_PADDING,
-    paddingEnd: MENU_PADDING,
-  });
-
   const {
     isOpen,
     highlightedIndex,
@@ -325,11 +294,6 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
 
     onIsOpenChange: onIsOpenChangeHandler,
 
-    onHighlightedIndexChange: ({ highlightedIndex, type }) => {
-      if (type !== useCombobox.stateChangeTypes.MenuMouseLeave) {
-        rowVirtualizer.scrollToIndex(highlightedIndex);
-      }
-    },
     onStateChange: ({ inputValue: newInputValue, type, selectedItem: newSelectedItem }) => {
       setShowFocusRing(isKeyboardEvent(type));
 

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -23,6 +23,9 @@ const VIRTUAL_OVERSCAN_ITEMS = 4;
 
 interface ComboboxListProps<T extends string | number> {
   options: Array<ComboboxOption<T>>;
+  renderOption?: (option: ComboboxOption<T>) => React.ReactNode;
+  customValueOption?: ComboboxOption<T>;
+  allOption?: ComboboxOption<T>;
   highlightedIndex: number | null;
   /** Whether the highlighted option should show a focus ring, rather than just the muted highlight */
   showFocusRing?: boolean;
@@ -38,6 +41,9 @@ interface ComboboxListProps<T extends string | number> {
 
 export const ComboboxList = <T extends string | number>({
   options,
+  renderOption,
+  customValueOption,
+  allOption,
   highlightedIndex,
   showFocusRing = false,
   selectedItems = [],
@@ -170,12 +176,18 @@ export const ComboboxList = <T extends string | number>({
                 )}
 
                 <div className={styles.optionBody}>
-                  <Stack direction="row" alignItems="center">
-                    {item.icon && <Icon name={item.icon} />}
-                    <div className={styles.optionLabel}>{item.label ?? item.value}</div>
-                  </Stack>
+                  {renderOption && item !== customValueOption && item !== allOption ? (
+                    renderOption(item)
+                  ) : (
+                    <>
+                      <Stack direction="row" alignItems="center">
+                        {item.icon && <Icon name={item.icon} />}
+                        <div className={styles.optionLabel}>{item.label ?? item.value}</div>
+                      </Stack>
 
-                  {item.description && <div className={styles.optionDescription}>{item.description}</div>}
+                      {item.description && <div className={styles.optionDescription}>{item.description}</div>}
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -20,6 +20,8 @@ import { ALL_OPTION_VALUE, type ComboboxOption } from './types';
 import { isNewGroup } from './utils';
 
 const VIRTUAL_OVERSCAN_ITEMS = 4;
+// Leave room for a two-line custom option before its measured height is known.
+const DYNAMIC_OPTION_HEIGHT_ESTIMATE = MENU_OPTION_HEIGHT_DESCRIPTION + MENU_PADDING;
 
 interface ComboboxListProps<T extends string | number> {
   options: Array<ComboboxOption<T>>;
@@ -39,9 +41,22 @@ interface ComboboxListProps<T extends string | number> {
   loading?: boolean;
 }
 
-export const ComboboxList = <T extends string | number>({
+export const ComboboxList = <T extends string | number>(props: ComboboxListProps<T>) => {
+  const dynamicOptionHeight = props.renderOption !== undefined;
+
+  return (
+    <VirtualizedComboboxList
+      key={dynamicOptionHeight ? 'dynamic' : 'fixed'}
+      {...props}
+      dynamicOptionHeight={dynamicOptionHeight}
+    />
+  );
+};
+
+const VirtualizedComboboxList = <T extends string | number>({
   options,
   renderOption,
+  dynamicOptionHeight,
   customValueOption,
   allOption,
   highlightedIndex,
@@ -54,7 +69,7 @@ export const ComboboxList = <T extends string | number>({
   error = false,
   loading = false,
   noOptionsMessage,
-}: ComboboxListProps<T>) => {
+}: ComboboxListProps<T> & { dynamicOptionHeight: boolean }) => {
   const styles = useStyles2(getComboboxStyles);
   const groupStartIndices = useMemo(() => {
     const indices = new Map<string, number>();
@@ -71,19 +86,18 @@ export const ComboboxList = <T extends string | number>({
   const estimateSize = useCallback(
     (index: number) => {
       const firstGroupItem = isNewGroup(options[index], index > 0 ? options[index - 1] : undefined);
-      const hasDescription = 'description' in options[index];
       const hasGroup = 'group' in options[index];
 
-      let itemHeight = MENU_OPTION_HEIGHT;
-      if (hasDescription) {
-        itemHeight = MENU_OPTION_HEIGHT_DESCRIPTION;
+      if (dynamicOptionHeight) {
+        return DYNAMIC_OPTION_HEIGHT_ESTIMATE + (firstGroupItem && hasGroup ? MENU_OPTION_HEIGHT : 0);
       }
-      if (firstGroupItem && hasGroup) {
-        itemHeight += MENU_OPTION_HEIGHT;
-      }
-      return itemHeight;
+
+      return (
+        ('description' in options[index] ? MENU_OPTION_HEIGHT_DESCRIPTION : MENU_OPTION_HEIGHT) +
+        (firstGroupItem && hasGroup ? MENU_OPTION_HEIGHT : 0)
+      );
     },
-    [options]
+    [dynamicOptionHeight, options]
   );
 
   const getItemKey = useCallback((index: number) => options[index]?.value ?? index, [options]);
@@ -169,9 +183,11 @@ export const ComboboxList = <T extends string | number>({
             // It's children (header and option) should appear as flat list items.
             <div
               key={virtualRow.key}
+              ref={dynamicOptionHeight ? rowVirtualizer.measureElement : undefined}
+              data-index={dynamicOptionHeight ? virtualRow.index : undefined}
               className={styles.listItem}
               style={{
-                height: virtualRow.size,
+                height: dynamicOptionHeight ? undefined : virtualRow.size,
                 transform: `translateY(${virtualRow.start}px)`,
               }}
             >
@@ -195,6 +211,7 @@ export const ComboboxList = <T extends string | number>({
               <div
                 className={cx(
                   styles.option,
+                  dynamicOptionHeight && styles.optionDynamic,
                   !isMultiSelect && isOptionSelected(item) && styles.optionSelected,
                   isHighlighted && styles.optionFocused,
                   isHighlighted && showFocusRing && styles.optionFocusRing,
@@ -224,7 +241,7 @@ export const ComboboxList = <T extends string | number>({
                   </div>
                 )}
 
-                <div className={styles.optionBody}>
+                <div className={cx(styles.optionBody, dynamicOptionHeight && styles.optionBodyDynamic)}>
                   {renderOption && item !== customValueOption && item !== allOption ? (
                     renderOption(item)
                   ) : (

--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { useVirtualizer, type Range } from '@tanstack/react-virtual';
 import type { UseComboboxPropGetters } from 'downshift';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import { useStyles2 } from '../../themes/ThemeContext';
 import { Checkbox } from '../Forms/Checkbox';
@@ -56,6 +56,17 @@ export const ComboboxList = <T extends string | number>({
   noOptionsMessage,
 }: ComboboxListProps<T>) => {
   const styles = useStyles2(getComboboxStyles);
+  const groupStartIndices = useMemo(() => {
+    const indices = new Map<string, number>();
+
+    options.forEach((option, index) => {
+      if (option.group && isNewGroup(option, options[index - 1])) {
+        indices.set(option.group, index);
+      }
+    });
+
+    return indices;
+  }, [options]);
 
   const estimateSize = useCallback(
     (index: number) => {
@@ -75,18 +86,56 @@ export const ComboboxList = <T extends string | number>({
     [options]
   );
 
+  const getItemKey = useCallback((index: number) => options[index]?.value ?? index, [options]);
+
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const startIndex = Math.max(0, range.startIndex - range.overscan);
+      const endIndex = Math.min(options.length - 1, range.endIndex + range.overscan);
+      const rangeToReturn = Array.from({ length: endIndex - startIndex + 1 }, (_, index) => startIndex + index);
+      const firstDisplayedOption = options[rangeToReturn[0]];
+
+      if (firstDisplayedOption?.group) {
+        const groupStartIndex = groupStartIndices.get(firstDisplayedOption.group);
+        if (groupStartIndex !== undefined && groupStartIndex < rangeToReturn[0]) {
+          rangeToReturn.unshift(groupStartIndex);
+        }
+      }
+
+      return rangeToReturn;
+    },
+    [groupStartIndices, options]
+  );
+
   const rowVirtualizer = useVirtualizer({
     count: options.length,
     getScrollElement: () => scrollRef.current,
     estimateSize,
-    getItemKey: (index: number) => options[index]?.value ?? index,
+    getItemKey,
     overscan: VIRTUAL_OVERSCAN_ITEMS,
+    rangeExtractor,
     // Vertical padding belongs to the virtualizer rather than CSS so that row offsets, the total
     // size and scrollToIndex all account for it. Padding it in CSS instead would shift every row
     // down without the virtualizer knowing, and scrolling would stop short of the focus ring.
     paddingStart: MENU_PADDING,
     paddingEnd: MENU_PADDING,
   });
+  const { scrollToIndex } = rowVirtualizer;
+  const previousHighlightedIndex = useRef<number | null>(highlightedIndex === null || highlightedIndex <= 0 ? 0 : null);
+
+  useEffect(() => {
+    if (highlightedIndex === null || highlightedIndex < 0) {
+      return;
+    }
+
+    if (highlightedIndex === previousHighlightedIndex.current) {
+      return;
+    }
+
+    previousHighlightedIndex.current = highlightedIndex;
+
+    scrollToIndex(highlightedIndex, { align: 'auto' });
+  }, [highlightedIndex, scrollToIndex]);
 
   const isOptionSelected = useCallback(
     (item: ComboboxOption<T>) => selectedItems.some((opt) => opt.value === item.value),
@@ -119,7 +168,7 @@ export const ComboboxList = <T extends string | number>({
             // Wrapping div should have no styling other than virtual list positioning.
             // It's children (header and option) should appear as flat list items.
             <div
-              key={item.value}
+              key={virtualRow.key}
               className={styles.listItem}
               style={{
                 height: virtualRow.size,

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.story.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.story.tsx
@@ -3,6 +3,7 @@ import { type ComponentProps } from 'react';
 import { action } from 'storybook/actions';
 import { useArgs, useEffect, useState } from 'storybook/preview-api';
 
+import { Badge } from '../Badge/Badge';
 import { Field } from '../Forms/Field';
 
 import { MultiCombobox } from './MultiCombobox';
@@ -65,6 +66,35 @@ const BasicStory: StoryFn<typeof MultiCombobox> = (args) => {
 
 export const Basic: Story = {
   args: commonArgs,
+  render: BasicStory,
+};
+
+export const CustomOptionRendering: Story = {
+  args: {
+    width: 48,
+    value: ['service-2', 'service-5'],
+    placeholder: 'Select services...',
+    options: Array.from({ length: 40 }, (_, index) => {
+      const serviceNumber = index + 1;
+      const hasDescription = serviceNumber % 3 === 0;
+
+      return {
+        label: `Service ${serviceNumber}`,
+        value: `service-${serviceNumber}`,
+        group: serviceNumber <= 20 ? 'Core services' : 'Supporting services',
+        description: hasDescription ? 'Receives traffic from multiple environments' : undefined,
+      };
+    }),
+    renderOption: (option) => (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+          <span>{option.label}</span>
+          <Badge text="Available" color="green" />
+        </div>
+        {option.description && <span style={{ fontWeight: 400 }}>{option.description}</span>}
+      </div>
+    ),
+  },
   render: BasicStory,
 };
 

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -133,6 +133,66 @@ describe('MultiCombobox', () => {
     expect(onChange).toHaveBeenNthCalledWith(3, [{ label: 'C', value: third }]);
   });
 
+  it('keeps checkboxes and selection behavior with custom option content', async () => {
+    const options: Array<ComboboxOption<string>> = [
+      { label: 'Alpha', value: 'a' },
+      { label: 'Beta', value: 'b' },
+    ];
+    const onChange = jest.fn();
+
+    const ControlledMultiCombobox = () => {
+      const [value, setValue] = React.useState<Array<ComboboxOption<string>>>([]);
+
+      return (
+        <MultiCombobox
+          options={options}
+          value={value}
+          onChange={(selectedOptions) => {
+            setValue(selectedOptions);
+            onChange(selectedOptions);
+          }}
+          renderOption={(option) => (
+            <span>
+              Custom <strong data-testid={`custom-multi-option-${option.value}`}>{option.label}</strong>
+            </span>
+          )}
+        />
+      );
+    };
+
+    render(<ControlledMultiCombobox />);
+    await user.click(screen.getByRole('combobox'));
+
+    expect(screen.getByTestId('combobox-option-b-checkbox')).not.toBeChecked();
+    await user.click(await screen.findByTestId('custom-multi-option-b'));
+
+    expect(onChange).toHaveBeenCalledWith([options[1]]);
+    expect(screen.getByTestId('combobox-option-b-checkbox')).toBeChecked();
+  });
+
+  it('uses default content for the numeric select-all row', async () => {
+    const numericOptions: Array<ComboboxOption<number>> = [
+      { label: 'One', value: 1 },
+      { label: 'Two', value: 2 },
+    ];
+    const renderOption = jest.fn((option: ComboboxOption<number>) => <span>Number {option.value.toFixed(2)}</span>);
+
+    render(
+      <MultiCombobox<number>
+        options={numericOptions}
+        value={[]}
+        onChange={jest.fn()}
+        enableAllOption
+        renderOption={renderOption}
+      />
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    expect(await screen.findByText('Select all')).toBeInTheDocument();
+    expect(screen.getByText('Number 1.00')).toBeInTheDocument();
+    expect(renderOption.mock.calls.map(([option]) => option.value)).toContain(1);
+  });
+
   it('should allow for options to be deselected', async () => {
     // This test ensures that our fix for async options doesn't break sync options
     const options = [

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -170,6 +170,72 @@ describe('MultiCombobox', () => {
     expect(screen.getByTestId('combobox-option-b-checkbox')).toBeChecked();
   });
 
+  it('requests measured scrolling and selects a distant option by keyboard', async () => {
+    const options: Array<ComboboxOption<string>> = Array.from({ length: 50 }, (_, index) => ({
+      label: `Option ${index}`,
+      value: String(index),
+    }));
+    const onChange = jest.fn();
+    const scrollRequests: number[] = [];
+    const originalResizeObserver = global.ResizeObserver;
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return [];
+      }
+    } as unknown as typeof ResizeObserver;
+    const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(function (this: Element) {
+      const height = this.hasAttribute('data-index') ? 100 : 120;
+      return {
+        width: 120,
+        height,
+        top: 0,
+        right: 120,
+        bottom: height,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+    const scrollToSpy = jest.spyOn(Element.prototype, 'scrollTo').mockImplementation(function (
+      options?: ScrollToOptions | number,
+      y?: number
+    ) {
+      const top = typeof options === 'number' ? (y ?? 0) : (options?.top ?? 0);
+      scrollRequests.push(top);
+    });
+    const view = render(
+      <MultiCombobox
+        options={options}
+        value={[]}
+        onChange={onChange}
+        renderOption={(option) => <span>{option.label} custom</span>}
+      />
+    );
+
+    try {
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      const firstOption = await screen.findByRole('option', { name: 'Option 0 custom' });
+      const scrollElement = firstOption.closest<HTMLElement>('[tabindex="0"]')!;
+      Object.defineProperty(scrollElement, 'scrollHeight', { configurable: true, value: 4000 });
+      await user.keyboard('{ArrowDown}'.repeat(31));
+
+      expect(scrollRequests[scrollRequests.length - 1]).toBeGreaterThan(1800);
+
+      await user.keyboard('{Enter}');
+      expect(onChange).toHaveBeenCalledWith([options[30]]);
+    } finally {
+      view.unmount();
+      scrollToSpy.mockRestore();
+      rectSpy.mockRestore();
+      global.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   it('uses default content for the numeric select-all row', async () => {
     const numericOptions: Array<ComboboxOption<number>> = [
       { label: 'One', value: 1 },

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -43,6 +43,7 @@ export type MultiComboboxProps<T extends string | number> = MultiComboboxBasePro
  */
 export const MultiCombobox = <T extends string | number>(props: MultiComboboxProps<T>) => {
   const {
+    renderOption,
     placeholder,
     onChange,
     value,
@@ -76,6 +77,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
   // Handle async options and the 'All' option
   const {
     options: baseOptions,
+    customValueOption,
     updateOptions,
     asyncLoading,
     asyncError,
@@ -397,6 +399,9 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
             <ComboboxList
               loading={loading}
               options={options}
+              renderOption={renderOption}
+              customValueOption={customValueOption}
+              allOption={allOptionItem}
               highlightedIndex={highlightedIndex}
               showFocusRing={showFocusRing}
               selectedItems={selectedItems}

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -190,6 +190,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     selectedItem: null,
     defaultHighlightedIndex: 0,
     isItemDisabled: (item) => !!item?.infoOption,
+    scrollIntoView: () => {},
     stateReducer: (state, actionAndChanges) => {
       const { type } = actionAndChanges;
       let { changes } = actionAndChanges;

--- a/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
+++ b/packages/grafana-ui/src/components/Combobox/getComboboxStyles.ts
@@ -92,6 +92,10 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
         },
       },
     }),
+    optionDynamic: css({
+      whiteSpace: 'normal',
+      overflow: 'visible',
+    }),
 
     optionAccessory: css({
       label: 'combobox-option-accessory',
@@ -104,6 +108,11 @@ export const getComboboxStyles = (theme: GrafanaTheme2) => {
       flexDirection: 'column',
       flexGrow: 1,
       overflow: 'hidden',
+    }),
+    optionBodyDynamic: css({
+      minWidth: 0,
+      overflow: 'visible',
+      whiteSpace: 'normal',
     }),
 
     optionLabel: css({

--- a/packages/grafana-ui/src/components/Combobox/useOptions.ts
+++ b/packages/grafana-ui/src/components/Combobox/useOptions.ts
@@ -85,6 +85,7 @@ export function useOptions<T extends string | number>(
   const addCustomValue = useCallback(
     (opts: Array<ComboboxOption<T>>) => {
       let currentOptions: Array<ComboboxOption<T>> = opts;
+      let customValueOption: ComboboxOption<T> | undefined;
       if (createCustomValue && userTypedSearch) {
         // Since the label of a normal option does not have to match its value and a custom option has the same value and label,
         // we just focus on the value to check if the option already exists
@@ -92,14 +93,15 @@ export function useOptions<T extends string | number>(
         if (!customValueExists) {
           // Make sure to clone the array first to avoid mutating the original array!
           currentOptions = currentOptions.slice();
-          currentOptions.unshift({
+          customValueOption = {
             label: userTypedSearch,
             value: userTypedSearch as T,
             description: customValueDescription ?? t('combobox.custom-value.description', 'Use custom value'),
-          });
+          };
+          currentOptions.unshift(customValueOption);
         }
       }
-      return currentOptions;
+      return { options: currentOptions, customValueOption };
     },
     [createCustomValue, customValueDescription, userTypedSearch]
   );
@@ -129,17 +131,26 @@ export function useOptions<T extends string | number>(
     return fuzzyFind(rawOptions, stringifiedOptions, userTypedSearch);
   }, [asyncOptions, isAsync, rawOptions, stringifiedOptions, userTypedSearch]);
 
-  const [finalOptions, groupStartIndices] = useMemo(() => {
+  const finalOptions = useMemo(() => {
     const { options, groupStartIndices } = sortByGroup(filteredOptions);
+    const { options: optionsWithCustomValue, customValueOption } = addCustomValue(options);
 
-    return [addCustomValue(options), groupStartIndices];
+    return { options: optionsWithCustomValue, groupStartIndices, customValueOption };
   }, [filteredOptions, addCustomValue]);
 
   const resetSearch = useCallback(() => {
     setUserTypedSearch('');
   }, []);
 
-  return { options: finalOptions, groupStartIndices, updateOptions, asyncLoading, asyncError, resetSearch };
+  return {
+    options: finalOptions.options,
+    groupStartIndices: finalOptions.groupStartIndices,
+    customValueOption: finalOptions.customValueOption,
+    updateOptions,
+    asyncLoading,
+    asyncError,
+    resetSearch,
+  };
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Adds support for custom rendered options through a new `renderOption` prop supplied to `Combobox` and `MultiCombobox`. The components retain ownership of selection, highlighting, accessibility, and pointer and keyboard interactions, while the consumer controls all content rendered inside of it.

There's also a substantial refactor in here to de-duplicate the two list virtualisers (!!) that somehow slipped in during #102677.


- Measures each mounted custom row to support variable heights. Default rows retain the fixed-height path and skip measurement.
- **Menu width remains unchanged:** The menu will still be sized based on the width of the max label in the list
   - I'm not sure what to do about this one - for performance, we can't go ahead and measure the actual DOM width of all options ahead of time
   - It's not that bad if the menu width isn't wide enough, as variable option height means that options can safely wrap now.
   - We _could_ use the measured width of each element as they're mounted in the virtual list, but that would mean the menu width would jump around as you scrolled to larger items
   - I'm not totally sure how this would work with FloatingUI ensuring the width of items as well. If a consumer hard codes the width of an item to be larger than the viewport, then it's going to clip. 
   - Are there other ideas for what we could do?
- Keeps the default rendering for generated custom-value and select-all rows.
- Consolidates list virtualization in `ComboboxList`. PR #102677 extracted the shared list but left ownership split across two virtualizers. `ComboboxList` now owns measurement, range extraction, and scrolling because these operations need the same layout state.

**Why do we need this feature?**

The deprecated `Select` supports custom labels, but `Combobox` did not. This gap blocks migrations that render additional context, such as a label with a `Badge`.

**Who is this feature for?**

Developers who migrate customized `Select` options to `Combobox`.

**Which issue(s) does this PR fix?**:

Closes #114065

**Special notes for your reviewer:**

Focus on the `renderOption` boundary and virtual scrolling with mixed row heights.

Evidence: 102 focused Jest tests passed. Chromium Storybook checks covered interactions and layout.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
