### PR TITLE
RBAC: Add `role_id`-leading indexes to `user_role` and `team_role`

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -241,5 +241,15 @@ func AddMigration(mg *migrator.Migrator) {
 		Postgres("ALTER TABLE role ALTER COLUMN uid TYPE VARCHAR(253);").
 		Mysql("ALTER TABLE role MODIFY uid NVARCHAR(253) NOT NULL;"))
 
+	// Existing indexes bury role_id behind an unconstrained key part, so joining
+	// role -> assignees on role_id scans every assignment in the org and filters.
+	mg.AddMigration("add user_role role_id org_id index", migrator.NewAddIndexMigration(userRoleV1, &migrator.Index{
+		Cols: []string{"role_id", "org_id"},
+	}))
+
+	mg.AddMigration("add team_role role_id org_id index", migrator.NewAddIndexMigration(teamRoleV1, &migrator.Index{
+		Cols: []string{"role_id", "org_id"},
+	}))
+
 	AddDatasourceTypeMigration(mg)
 }

--- a/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
+++ b/pkg/services/sqlstore/migrations/testdata/migration_ids.txt
@@ -508,6 +508,8 @@
 "alter permission.kind to length 80"
 "add datasource_type column to permission table"
 "Expand role.uid length to 253"
+"add user_role role_id org_id index"
+"add team_role role_id org_id index"
 "populate datasource_type in permission table for uid-scoped datasource permissions"
 "create query_history table v1"
 "add index query_history.org_id-created_by-datasource_uid"


### PR DESCRIPTION
**Why**

Neither table had an index with `role_id` as the leading column, so joining role -> assignees on `role_id` could not seek. MySQL scanned every assignment in the org via `IDX_user_role_org_id` and re-checked `role_id` as a post-lookup filter, so the resource-permission listing query examined millions of rows to return hundreds. This was scaling with org size rather than with matching permissions.

Use (`role_id`, `org_id`) rather than bare (`role_id`): the join binds both by equality, so this gives a full two-column seek. `builtin_role` has had an equivalent `role_id` index since the original migration set.