### PR TITLE
[release-13.0.9] CI: Tag release branches after patches have been merged and the changelog has been updated instead of before.

### DIFF
--- a/.github/actions/changelog/action.yml
+++ b/.github/actions/changelog/action.yml
@@ -4,6 +4,12 @@ inputs:
   target:
     description: Target tag, branch or commit hash for the changelog
     required: true
+  version:
+    description: >-
+      Semver version being released (e.g. v10.0.0), used to look up the previous release tag when
+      `previous` isn't given. Falls back to `target`, so only needed when target isn't itself a
+      semver-parseable tag.
+    required: false
   previous:
     description: Previous tag, branch or commit hash to start changelog from
     required: false

--- a/.github/actions/changelog/index.js
+++ b/.github/actions/changelog/index.js
@@ -207,7 +207,11 @@ if (!ghtoken) {
 const target = process.argv[2] || process.env.INPUT_TARGET;
 LOG(`Target tag/branch/commit: ${target}`);
 
-const previous = process.argv[3] || process.env.INPUT_PREVIOUS || (await getPreviousVersion(target));
+// getPreviousVersion needs an actual semver string to look up the prior tag; target may be a
+// branch name instead (not semver-parseable), so it isn't a safe fallback for this on its own.
+const version = process.env.INPUT_VERSION || target;
+
+const previous = process.argv[3] || process.env.INPUT_PREVIOUS || (await getPreviousVersion(version));
 
 LOG(`Previous tag/commit: ${previous}`);
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -116,7 +116,11 @@ jobs:
         with:
           previous: ${{ inputs.previous_version }}
           github_token: ${{ steps.get-github-app-token.outputs.token }}
-          target: v${{ inputs.version }}
+          # The release tag doesn't exist yet at this point; diff against the release branch instead.
+          target: release-${{ inputs.version }}
+          # target is a branch name now, not semver-parseable; give the action a real version
+          # string to look up the previous release tag from when previous_version isn't set.
+          version: v${{ inputs.version }}
           output_file: changelog_items.md
       - name: "Patch CHANGELOG.md"
         run: |

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,111 @@
+name: Create Release Tag
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag name (e.g. v10.0.0)'
+        required: true
+        type: string
+      message:
+        description: 'Tag message (defaults to tag name if not provided)'
+        required: false
+        type: string
+      commit:
+        description: 'Commit SHA to tag'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name (e.g. v10.0.0)'
+        required: true
+        type: string
+      message:
+        description: 'Tag message (defaults to tag name if not provided)'
+        required: false
+        type: string
+      commit:
+        description: 'Commit SHA to tag'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-arm64-small
+    permissions:
+      id-token: write
+      contents: read
+    concurrency:
+      group: create-release-tag-${{ inputs.tag }}
+      cancel-in-progress: false
+    steps:
+      # grafana/grafana is large enough that GitHub's pre-receive workflow-file scan
+      # exceeds its server-side timeout on any ref creation here. The push/API call is
+      # then rejected with "workflows scope may be required" regardless of whether
+      # workflow files were actually touched. workflows:write tells GitHub to skip the
+      # scan. grafana-writer is the only app installed with that scope on grafana/grafana;
+      # no bot lacking it can create refs (branches or tags) in this repo.
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: grafana-writer
+      - name: Create annotated tag
+        env:
+          TAG: ${{ inputs.tag }}
+          TAG_MESSAGE: ${{ inputs.message }}
+          COMMIT_SHA: ${{ inputs.commit }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent re-runs (e.g. auto-promotion retries): if the tag ref already exists AND points
+          # at the requested commit, this is a no-op. If it exists but points elsewhere, fail loudly —
+          # don't silently accept a tag on the wrong commit.
+          ref_err=$(mktemp)
+          if existing=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" 2>"$ref_err"); then
+            rm -f "$ref_err"
+            obj_sha=$(printf '%s' "$existing" | jq -r '.object.sha')
+            obj_type=$(printf '%s' "$existing" | jq -r '.object.type')
+            # This workflow publishes an ANNOTATED tag. Only a matching annotated tag is a valid no-op;
+            # a lightweight tag (or any other ref type) is an anomaly we surface rather than accept.
+            if [ "$obj_type" != "tag" ]; then
+              echo "::error::Tag ${TAG} already exists as a non-annotated ref (type ${obj_type}); expected an annotated tag." >&2
+              exit 1
+            fi
+            # Annotated tag: dereference the tag object to the commit it points at.
+            target=$(gh api "repos/${REPO}/git/tags/${obj_sha}" --jq '.object.sha')
+            # Resolve the requested commit to its canonical 40-char SHA so a short SHA input still matches.
+            want=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}" --jq '.sha')
+            if [ "$target" = "$want" ]; then
+              echo "Annotated tag ${TAG} already exists at ${want}; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag ${TAG} already exists but points at ${target}, not ${want}." >&2
+            exit 1
+          elif ! grep -q "HTTP 404" "$ref_err"; then
+            # Only a 404 means "tag absent, go create it". Any other error (5xx, auth, rate limit) must
+            # fail loudly — otherwise we'd fall through to creation and fail on an already-existing ref,
+            # leaking an orphan tag object and hiding the real problem.
+            echo "::error::Failed to query tag ${TAG}: $(cat "$ref_err")" >&2
+            rm -f "$ref_err"
+            exit 1
+          fi
+          rm -f "$ref_err"
+
+          tag_sha=$(gh api "repos/${REPO}/git/tags" \
+            --method POST \
+            -f "tag=${TAG}" \
+            -f "message=${TAG_MESSAGE:-${TAG}}" \
+            -f "object=${COMMIT_SHA}" \
+            -f type="commit" \
+            --jq '.sha')
+
+          gh api "repos/${REPO}/git/refs" \
+            --method POST \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${tag_sha}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -76,11 +76,10 @@ jobs:
           # clone/checkout (enterprise/upstream + the build checkouts). Do NOT repoint it.
           echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
 
-          # public_commit is the commit STAMPED into the binary (-X main.commit). For a mirror
-          # #patched build it's the sibling unpatched branch HEAD — a real grafana/grafana
-          # commit — so artifacts advertise a public commit instead of the mirror-only one.
-          # Everywhere else it's just the checkout HEAD. This value is only ever passed to the
-          # Makefile's COMMIT_SHA; it is never used as a checkout/clone ref.
+          # public_commit is a real, publicly-resolvable grafana/grafana commit, used wherever a
+          # downstream step needs to perform a git operation against the public repo (tag
+          # creation, npm publish, test-infra checkout). It is not used to stamp the binary
+          # (main.commit uses grafana_commit instead, below) or as a checkout/clone ref.
           if [ "$GITHUB_REPOSITORY" = "grafana/grafana-security-mirror" ] && [[ "$REF_NAME" == *'#patched' ]]; then
             sibling="${REF_NAME%\#patched}"
             public_commit=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${sibling}" --jq '.object.sha')
@@ -262,9 +261,9 @@ jobs:
           arm: ${{ matrix.arm }}
           build-number: ${{ github.run_id }}
           build-version: ${{ needs.setup.outputs.version }}
-          # Stamp the public (non-#patched) commit while still compiling the #patched
-          # source that was checked out above. See the build invariant in the plan.
-          commit: ${{ needs.setup.outputs.public-commit }}
+          # Stamp the commit actually built, not public-commit (used elsewhere where a publicly
+          # resolvable commit is required, e.g. tag creation and npm publish).
+          commit: ${{ needs.setup.outputs.grafana-commit }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: release-backend-${{ matrix.name }}

--- a/.github/workflows/release-comms.yml
+++ b/.github/workflows/release-comms.yml
@@ -130,11 +130,29 @@ jobs:
   #   with:
   #     version: ${{ needs.setup.outputs.version }}
   #     dry_run: ${{ needs.setup.outputs.dry_run == 'true' }}
+  create_release_tag:
+    # Tags the release PR's merge commit rather than a commit that predates it. Only meaningful
+    # on the real merge event — a workflow_dispatch run has no pull_request context to take a
+    # commit from.
+    name: Create release tag
+    needs: setup
+    if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.dry_run != 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/create-release-tag.yml
+    with:
+      tag: ${{ needs.setup.outputs.version }}
+      commit: ${{ github.event.pull_request.merge_commit_sha }}
   create_github_release:
     # a github release requires a git tag
     # The github-release action retrieves the changelog using the /repos/grafana/grafana/contents/CHANGELOG.md API
     # endpoint.
-    needs: setup
+    needs:
+      - setup
+      - create_release_tag
+    # Run unless setup was skipped or something actually failed/cancelled — a skipped create_release_tag is fine.
+    if: ${{ !failure() && !cancelled() && needs.setup.result == 'success' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -46,7 +46,10 @@ permissions:
 
 jobs:
   capture-date:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      actions: read # gh run view reads the run's createdAt via the Actions API
     outputs:
       release_date: ${{ steps.set_release_date.outputs.release_date }}
     steps:
@@ -95,32 +98,52 @@ jobs:
       id-token: write
       pull-requests: write
     name: Create Release PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     if: github.repository == 'grafana/grafana'
     env:
       VERSION: ${{ inputs.version }}
       LATEST: ${{ inputs.latest }}
       DRY_RUN: ${{ inputs.dry_run }}
+      RUN_NUMBER: ${{ github.run_number }}
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
-          github_app: grafana-delivery-bot
-      - run: echo "RELEASE_BRANCH=release-${VERSION}" >> "$GITHUB_ENV"
-      - name: Checkout Grafana
+          github_app: grafana-pr-automation
+          permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release' || 'main' }}
+      # The grafana repo is large enough that GitHub's pre-receive scan for workflow-file
+      # modifications ("Restricts updates to workflow files" system rule) consistently
+      # exceeds its server-side timeout on any push -- regardless of whether the push
+      # actually touches workflow files. When the scan times out, GitHub fails closed and
+      # rejects the push with "workflows scope may be required". Granting workflows:write
+      # tells GitHub to skip the scan entirely (the caller is already authorized to modify
+      # workflow files), which is the only documented way to push to this repo from a bot.
+      # grafana-writer is the only app installed with that scope; grafana-pr-automation
+      # cannot push at all because of this.
+      - name: Get GitHub App token (writer)
+        id: get-writer-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: grafana-writer
+          permission_set: ${{ startsWith(github.ref_name, 'release-') && 'release-writer' || 'release-writer-main' }}
+      - run: |
+          {
+            echo "RELEASE_BRANCH=release-${VERSION}"
+            echo "WORK_BRANCH=release/${RUN_NUMBER}/${VERSION}"
+          } >> "$GITHUB_ENV"
+      - name: Checkout Grafana target branch #checkout the target branch to base the release branch on
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{ steps.get-writer-app-token.outputs.token }} # used only for fetching; commits go via kminehart API
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-tags: true
           fetch-depth: 0
       - name: Checkout Grafana (main)
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{ github.token }}
           ref: main
-          fetch-depth: '0'
           path: .grafana-main
 
       - name: Setup Node.js
@@ -131,27 +154,37 @@ jobs:
       # workspace (the release-branch checkout). That subtree may lag main and miss the action,
       # failing the step. Mirror cache-build:false behavior (no GOCACHE; modules via actions/cache).
       - name: Setup Go
-        uses: actions/setup-go@v6.5.0
+        uses: actions/setup-go@v7.0.0
         with:
           go-version-file: .grafana-main/go.mod
           cache: false
-      - name: Configure git user
-        run: |
-          git config --local user.name "grafana-delivery-bot[bot]"
-          git config --local user.email "grafana-delivery-bot[bot]@users.noreply.github.com"
-          git config --local --add --bool push.autoSetupRemote true
 
-      - name: Create branch
-        run: git checkout -b "release/${{ github.run_number }}/$VERSION"
+      # planetscale/ghcommit-action commits to an existing remote branch; it doesn't
+      # create the branch itself. Pre-create the ref at the release branch's HEAD via
+      # the Git Data API so subsequent commits have a target.
+      - name: Pre-create branch on remote
+        env:
+          GH_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse "origin/${RELEASE_BRANCH}")
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --method POST \
+            -f "ref=refs/heads/${WORK_BRANCH}" \
+            -f "sha=${BASE_SHA}"
+
       - name: Generate changelog
         id: changelog
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
         uses: ./.grafana-main/.github/actions/changelog
         with:
           previous: ${{inputs.previous_version}}
-          github_token: ${{ steps.get-github-app-token.outputs.token }}
-          target: v${{ env.VERSION }}
+          # The release tag doesn't exist yet at this point; diff against the release branch instead.
+          target: ${{ env.RELEASE_BRANCH }}
+          # target is a branch name now, not semver-parseable; give the action a real version
+          # string to look up the previous release tag from when previous_version isn't set.
+          version: v${{ env.VERSION }}
           output_file: changelog_items.md
+          github_token: ${{ steps.get-github-app-token.outputs.token }}
       - name: Patch CHANGELOG.md
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
         run: |
@@ -163,12 +196,18 @@ jobs:
             cat changelog_items.md
           ) > CHANGELOG.part
 
+          # Escape BRE metacharacters so versions containing '.' (and the literal '+' in
+          # '+security' builds) match the delimiters literally instead of as a regex.
+          # '+' is left unescaped on purpose: in BRE it is already a literal, and '\+'
+          # would turn it into the one-or-more operator.
+          VERSION_RE=$(printf '%s' "$VERSION" | sed 's/[][\.^$*]/\\&/g')
+
           # Check if a version exists in the changelog
-          if grep -q "<!-- $VERSION START" CHANGELOG.md ; then
+          if grep -qF "<!-- $VERSION START" CHANGELOG.md ; then
             # Replace the content between START and END delimiters
             echo "Version $VERSION is found in the CHANGELOG.md, patching contents..."
-            sed -i -e "/$VERSION START/,/$VERSION END/{//!d;}" \
-                   -e "/$VERSION START/r CHANGELOG.part" CHANGELOG.md
+            sed -i -e "/$VERSION_RE START/,/$VERSION_RE END/{//!d;}" \
+                   -e "/$VERSION_RE START/r CHANGELOG.part" CHANGELOG.md
           else
             # Prepend changelog part to the main changelog file
             echo "Version $VERSION not found in the CHANGELOG.md"
@@ -186,34 +225,57 @@ jobs:
           git diff CHANGELOG.md
       - name: "Prettify CHANGELOG.md"
         if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
-        run: npx prettier --write CHANGELOG.md
-      - name: Commit CHANGELOG.md changes
-        if: ${{ inputs.changelog == true || inputs.changelog == 'true' }}
-        run: git add CHANGELOG.md && git commit --allow-empty -m "Update changelog" CHANGELOG.md
+        run: node ./.grafana-main/.github/actions/changelog/sort.js && npx prettier --write CHANGELOG.md
+      # Remove the main checkout before lerna runs so nx doesn't see duplicate plugin
+      # package.json files across .grafana-main and the release-branch tree.
+      - name: Remove main checkout before bump
+        if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
+        run: rm -rf .grafana-main
       - name: Bump versions
         if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
         run: |
           yarn install
-          npm version patch --no-git-tag-version
-          yarn run lerna version patch --no-push --no-git-tag-version --force-publish --exact --yes
+          # Target VERSION explicitly and skip if already there; a relative bump isn't safe to re-run.
+          current_version=$(node -p "require('./package.json').version")
+          if [ "$current_version" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+            yarn run lerna version "$VERSION" --no-push --no-git-tag-version --force-publish --exact --yes
+          fi
           yarn install
           yarn prettier:write
-
       - name: make gen-cue
         if: ${{ !contains(inputs.version, '+security') }}
         shell: bash
         run: make gen-cue
-      - name: Add package.json changes
-        if: ${{ (inputs.bump == true || inputs.bump == 'true') && !contains(inputs.version, '+security') }}
-        run: |
-          git add package.json lerna.json yarn.lock packages public
-          test -e e2e-playwright/test-plugins && git add e2e-playwright/test-plugins
-          git commit -m "Update version to $VERSION"
 
-      - name: Git push
-        run: git push
+      # Single commit for all release-PR file changes (changelog + version bumps +
+      # yarn.lock refresh + regenerated CUE schemas). ghcommit-action uses the Git Data
+      # API, which gives us two things in one shot:
+      #   1. Commits made via the API with a GitHub App installation token are auto-signed
+      #      by GitHub under grafana-writer[bot]'s identity (Verified signature),
+      #      satisfying upcoming required_signatures rules.
+      #   2. The grafana-writer token's workflows:write skips the pre-receive workflow-file
+      #      scan that otherwise times out on grafana/grafana (the repo is too large for
+      #      the scan to finish in time, causing pushes to be rejected regardless of
+      #      whether workflow files were touched).
+      # Doing it as a single commit also avoids the parent-SHA mismatch ghcommit-action
+      # hits when multiple sequential API commits are made on the same branch (each
+      # commit advances the remote ref while local HEAD doesn't).
+      - name: Commit release-PR changes
+        uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+        with:
+          commit_message: "Release: ${{ env.VERSION }}"
+          repo: ${{ github.repository }}
+          branch: ${{ env.WORK_BRANCH }}
+          empty: "true"
+          file_pattern: "**"
+        env:
+          GITHUB_TOKEN: ${{ steps.get-writer-app-token.outputs.token }}
       - name: Create PR
         env:
+          # grafana-pr-automation token (reader permission-set, now with pull_requests:write)
+          # is used here instead of the default GITHUB_TOKEN so the PR is created under the
+          # grafana-pr-automation[bot] identity.
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
@@ -226,5 +288,17 @@ jobs:
             -l "no-changelog" \
             --dry-run="$DRY_RUN" \
             -B "${RELEASE_BRANCH}" \
+            -H "${WORK_BRANCH}" \
             --title "Release: $VERSION" \
             --body "These code changes must be merged after a release is complete"
+      # Publishes the branch name so external callers don't have to reconstruct it themselves.
+      - name: Publish release PR branch name
+        run: |
+          mkdir -p .release-pr-artifact
+          printf '%s' "$WORK_BRANCH" > .release-pr-artifact/branch.txt
+      - name: Upload release PR branch artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: release-pr-branch
+          path: .release-pr-artifact/branch.txt
+          retention-days: 14


### PR DESCRIPTION
Backport 6d5e6a360e709b0c1f51b479d68c82c316a942e9 from #132040

---

Manual backport: `create-release-tag.yml` did not exist on this branch (predates #125708), added fresh. `release-pr.yml` replaced wholesale with main's current version rather than merged — it is never executed from a release branch's own copy (release-cd always dispatches it with `ref: main`), so this only avoids carrying a stale, diverged copy.

- create_release_tag can be called from other workflows now with workflow_call
- update changelog generation to look for diffs between release branches instead of tags
- create_release_tag is called after the release-pr is merged, but before the github release is created.
- embed the 'grafana-commit' (post-patch-application) in the binary instead of the public pre-patch commit.