### PR TITLE
fix: Fix date pickers appearing below the mega menu

### DIFF
--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx
@@ -256,7 +256,9 @@ function getStyles(theme: GrafanaTheme2) {
       flexDirection: 'column',
       flexGrow: 1,
       position: 'relative',
-      zIndex: 1, // creates stacking context below header (1000)
+      // creates a stacking context above the mega menu (z-index=2, so the date pickers appear on top) and
+      // below the app top bar (z-index=1000, so the popovers appears below)
+      zIndex: 3,
     }),
     bodyWrapper: css({
       label: 'body-wrapper',


### PR DESCRIPTION
This PR fixes an issue where the floating date picker appears below the mega menu:

<img width="2026" height="1158" alt="image" src="https://github.com/user-attachments/assets/818a205a-7f03-4f9b-97a8-f3ef3c2ba0fd" />


(caused by https://github.com/grafana/grafana/pull/130774/changes#diff-f20919e8b68bca2db9cf5febbb3bcea6af0633a9e820fee3c37e595e00825bc6R259)