### PR TITLE
Unified storage: make the embeddings reconciler resilient to lost watch events

### DIFF
--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -32,15 +32,14 @@ type fakeStorage struct {
 	itemErr  error // returned from the iterator partway through
 	itemErrI int   // index after which to inject itemErr
 
-	// latestRvOverride pins the RV ListModifiedSince reports as its
-	// snapshot ceiling. Set it below an RV in changes to stand in for a
-	// write that commits after the snapshot is taken but is still yielded
-	// by the iterator.
-	latestRvOverride int64
+	latestRvOverride int64 // RV reported as the snapshot ceiling, instead of the highest in changes
+	lookback         int64 // widens the listing floor to sinceRv-lookback, like the backend's searchLookback
 
 	// onYield, if set, fires once per resource the ListModifiedSince
 	// iterator yields — lets tests observe iterator progress at each flush.
 	onYield func()
+
+	lastCalledWith []*time.Time // the lastCalledWithSinceRv argument of every ListModifiedSince call
 
 	// folders backs ReadResource for FolderTitleResolver: namespace+"/"+uid
 	// -> title. An unset entry reads as NotFound.
@@ -148,9 +147,10 @@ func (f *fakeStorage) GetResourceStats(_ context.Context, nsr resource.Namespace
 	return out, nil
 }
 
-func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.NamespacedResource, sinceRv int64, _ *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
+func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.NamespacedResource, sinceRv int64, lastCalledWithSinceRv *time.Time) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.lastCalledWith = append(f.lastCalledWith, lastCalledWithSinceRv)
 	if f.listErr != nil {
 		err := f.listErr
 		return 0, func(yield func(*resource.ModifiedResource, error) bool) {
@@ -176,7 +176,13 @@ func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.Namespac
 		if key.Namespace != "" && c.Key.Namespace != key.Namespace {
 			continue
 		}
-		if c.ResourceVersion <= sinceRv {
+		// A non-nil lastCalledWithSinceRv makes the real backend skip its
+		// lookback window, so mirror that here.
+		floor := sinceRv
+		if lastCalledWithSinceRv == nil {
+			floor -= f.lookback
+		}
+		if c.ResourceVersion <= floor {
 			continue
 		}
 		matches = append(matches, c)
@@ -347,6 +353,15 @@ func (f *fakeVector) DeleteRows(_ context.Context, ns, model, res string, sel ve
 	}
 	return int64(len(sel.UIDs)), false, nil
 }
+
+// storedContentFor returns the subresource content currently indexed for
+// a UID, so tests can assert a replay left it alone.
+func (f *fakeVector) storedContentFor(ns, res, uid string) map[string]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return maps.Clone(f.storedSubs[subsKey(ns, testModel, res, uid)])
+}
+
 func (f *fakeVector) DeleteSubresources(_ context.Context, ns, model, res, uid string, subs []string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/storage/unified/search/embed/reconciler/fakes_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/fakes_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/search/embed"
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector/filter"
@@ -30,6 +31,12 @@ type fakeStorage struct {
 	watchCh  chan *resource.WrittenEvent
 	itemErr  error // returned from the iterator partway through
 	itemErrI int   // index after which to inject itemErr
+
+	// latestRvOverride pins the RV ListModifiedSince reports as its
+	// snapshot ceiling. Set it below an RV in changes to stand in for a
+	// write that commits after the snapshot is taken but is still yielded
+	// by the iterator.
+	latestRvOverride int64
 
 	// onYield, if set, fires once per resource the ListModifiedSince
 	// iterator yields — lets tests observe iterator progress at each flush.
@@ -157,22 +164,25 @@ func (f *fakeStorage) ListModifiedSince(_ context.Context, key resource.Namespac
 	matches := make([]*resource.ModifiedResource, 0, len(f.changes))
 	var latestRv int64
 	for _, c := range f.changes {
+		// latestRv mirrors the KV backend: the latest event RV in the
+		// store, across every resource and independent of both the
+		// group/resource filter and the sinceRv cutoff below.
+		if c.ResourceVersion > latestRv {
+			latestRv = c.ResourceVersion
+		}
 		if c.Key.Group != key.Group || c.Key.Resource != key.Resource {
 			continue
 		}
 		if key.Namespace != "" && c.Key.Namespace != key.Namespace {
 			continue
 		}
-		// latestRv mirrors the real backend's behavior: it's the
-		// absolute latest event RV for this resource, independent
-		// of the sinceRv cutoff applied to the iterator.
-		if c.ResourceVersion > latestRv {
-			latestRv = c.ResourceVersion
-		}
 		if c.ResourceVersion <= sinceRv {
 			continue
 		}
 		matches = append(matches, c)
+	}
+	if f.latestRvOverride != 0 {
+		latestRv = f.latestRvOverride
 	}
 	itemErr := f.itemErr
 	itemErrI := f.itemErrI
@@ -558,4 +568,45 @@ func (b *fakeBroadcaster) Unsubscribe(ch <-chan *resource.WrittenEvent) {
 
 func (b *fakeBroadcaster) emit(ev *resource.WrittenEvent) {
 	b.ch <- ev
+}
+
+// fakeBuilder is a second embed.Builder, for the cross-builder cursor
+// behavior the single real builder can't reach.
+type fakeBuilder struct {
+	group    string
+	resource string
+}
+
+func (b fakeBuilder) Group() string            { return b.group }
+func (b fakeBuilder) Resource() string         { return b.resource }
+func (b fakeBuilder) MaxItemsPerResource() int { return 0 }
+func (b fakeBuilder) Version() int             { return 1 }
+
+func (b fakeBuilder) Extract(_ context.Context, key *resourcepb.ResourceKey, value []byte, _ string) ([]embed.Item, error) {
+	if len(value) == 0 {
+		return nil, nil
+	}
+	if string(value) == "boom" {
+		return nil, errBoom
+	}
+	return []embed.Item{{
+		UID:     key.Name,
+		Title:   key.Name,
+		Content: string(value),
+	}}, nil
+}
+
+// hasUpsertFor reports whether any upsert wrote a vector for this
+// resource, for tests that care that a document was embedded at all.
+func (f *fakeVector) hasUpsertFor(namespace, resource, uid string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, batch := range f.upserts {
+		for _, v := range batch {
+			if v.Namespace == namespace && v.Resource == resource && v.UID == uid {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -410,7 +410,7 @@ func (s *Reconciler) checkpointRV(ctx context.Context) (int64, error) {
 	return resource.ToSnowflakeRV(rv), nil
 }
 
-// startupReconcile enqueues changes since the last processed RV.
+// startupReconcile embeds everything written since the last processed RV.
 func (s *Reconciler) startupReconcile(ctx context.Context) {
 	sinceRv, err := s.checkpointRV(ctx)
 	if err != nil {
@@ -423,60 +423,70 @@ func (s *Reconciler) startupReconcile(ctx context.Context) {
 	}
 	s.log.Info("reconciler: startupReconcile starting", "since_rv", sinceRv)
 
+	// One cursor for every builder, so it can only move to the lowest RV
+	// all of them proved.
+	target := int64(math.MaxInt64)
 	for _, b := range s.builders {
 		if ctx.Err() != nil {
 			return
 		}
-		s.reconcileSince(ctx, b, sinceRv)
+		proven, complete := s.reconcileSince(ctx, b, sinceRv)
+		if !complete {
+			return
+		}
+		if proven < target {
+			target = proven
+		}
 	}
-	s.log.Info("reconciler: startupReconcile complete")
+	if target > sinceRv {
+		if err := s.vectorBackend.SetLatestRV(ctx, target); err != nil {
+			s.log.Error("reconciler: startupReconcile advance checkpoint",
+				"err", err, "sinceRV", sinceRv, "target", target)
+			return
+		}
+	}
+	s.log.Info("reconciler: startupReconcile complete", "from", sinceRv, "to", target)
 }
 
-// reconcileSince walks ListModifiedSince and processes events in
-// startup-sized batches. Bootstrap deliberately bypasses the shared
-// pending map: a watch event with a higher RV landing mid-iteration
-// would otherwise advance the cursor past iter events not yet yielded,
-// which would then be filtered out as "already processed" — leaving
-// those dashboards without their initial embedding.
+// reconcileSince walks ListModifiedSince in batches and returns the RV
+// it proved complete; complete is false if the walk was interrupted.
 //
-// The cursor is pinned to the value read at startupReconcile and
-// advanced once after all batches drain. Advancing per-batch would
-// drop events on the real SQL backend: rows come back ORDER BY
-// resource_version DESC, so the first batch holds the highest RVs,
-// and advancing after it would push every later (lower-RV) batch
-// below the freshly-bumped cursor — silently losing those resources.
-//
-// Watch events accumulate in the shared pending map while bootstrap
-// runs and are picked up by the first processPending cycle in Run.
-func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, sinceRv int64) {
+// sinceRv stays pinned and the caller advances the cursor only once the
+// walk finishes. Listing is not RV-ascending, so a bump partway through
+// buries whatever has not been yielded yet.
+func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, sinceRv int64) (int64, bool) {
 	logger := s.log.FromContext(ctx)
 	key := resource.NamespacedResource{
 		Group:    builder.Group(),
 		Resource: builder.Resource(),
 		// Empty namespace → cross-namespace listing.
 	}
-	_, seq := s.storage.ListModifiedSince(ctx, key, sinceRv, nil)
+	// The listing snapshot: the store's latest RV, read before the walk
+	// and covered by it. It is a ceiling, not a floor — the walk may yield
+	// a write that landed after the snapshot while a lower-RV write is
+	// still in flight, so proving anything above it would jump the
+	// in-flight one. Without a snapshot at all, an idle resource freezes
+	// the cursor until it ages off the event store and listing falls back
+	// to a full scan.
+	latestRv, seq := s.storage.ListModifiedSince(ctx, key, sinceRv, nil)
+	ceiling := resource.ToSnowflakeRV(latestRv)
 
 	var (
 		failed         []*pendingEvent
-		successes      []*pendingEvent
-		maxRv          = sinceRv
+		succeeded      int
 		lowestFailedRv = int64(math.MaxInt64)
 	)
 
 	flush := func(batch []*pendingEvent) bool {
-		batchMax, batchLowestFailed, batchFailed, batchSuccess, abort := s.processEvents(ctx, sinceRv, batch)
+		_, batchLowestFailed, batchFailed, batchSuccess, abort := s.processEvents(ctx, sinceRv, batch)
 		if abort {
 			return false
-		}
-		if batchMax > maxRv {
-			maxRv = batchMax
 		}
 		if batchLowestFailed < lowestFailedRv {
 			lowestFailedRv = batchLowestFailed
 		}
 		failed = append(failed, batchFailed...)
-		successes = append(successes, batchSuccess...)
+		succeeded += len(batchSuccess)
 		return true
 	}
 
@@ -484,12 +494,12 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 	var batchBytes int
 	for mr, err := range seq {
 		if ctx.Err() != nil {
-			return
+			return sinceRv, false
 		}
 		if err != nil {
-			logger.Warn("reconciler: startupReconcile iterator error",
+			logger.Warn("reconciler: reconcileSince iterator error",
 				"group", builder.Group(), "resource", builder.Resource(), "err", err)
-			return
+			return sinceRv, false
 		}
 		if mr == nil {
 			continue
@@ -504,16 +514,16 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 			rv:        resource.ToSnowflakeRV(mr.ResourceVersion),
 		}
 		// Skip iter events that watch has already superseded with a
-		// newer write — re-embedding the older copy would just be
+		// newer write - re-embedding the older copy would just be
 		// overwritten by the watch event the next cycle.
-		if s.supersedesPending(ev) {
+		if s.supersedesPending(ev, ceiling) {
 			continue
 		}
 		batch = append(batch, ev)
 		batchBytes += len(ev.value)
 		if len(batch) >= startupBatchSize || batchBytes >= maxStartupBatchBytes {
 			if !flush(batch) {
-				return
+				return sinceRv, false
 			}
 			batch = batch[:0]
 			batchBytes = 0
@@ -521,48 +531,31 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 	}
 	if len(batch) > 0 {
 		if !flush(batch) {
-			return
+			return sinceRv, false
 		}
 	}
 
-	target := pickLatestRV(sinceRv, maxRv, lowestFailedRv)
-	if target > sinceRv {
-		if err := s.vectorBackend.SetLatestRV(ctx, target); err != nil {
-			logger.Error("reconciler: startupReconcile advance checkpoint",
-				"err", err, "sinceRV", sinceRv, "target", target)
-			// Cursor write failed: re-enqueue everything we touched so
-			// the steady-state loop retries the advance with fresh
-			// state. Without this the cursor stays stale until a new
-			// write happens to arrive (forcing another full catch-up
-			// on the next restart). Re-enqueue of already-embedded
-			// events is idempotent — UpsertReplaceSubresources just
-			// rewrites the same rows.
-			for _, ev := range successes {
-				s.enqueue(ev)
-			}
-			for _, ev := range failed {
-				s.enqueue(ev)
-			}
-			return
-		}
-	}
+	target := pickLatestRV(sinceRv, resource.ToSnowflakeRV(latestRv), lowestFailedRv)
 	for _, ev := range failed {
 		s.enqueue(ev)
 	}
-	logger.Info("reconciler: startupReconcile builder complete",
+	logger.Info("reconciler: reconcileSince builder complete",
 		"group", builder.Group(), "resource", builder.Resource(),
-		"events", len(successes), "failed", len(failed),
+		"events", succeeded, "failed", len(failed),
 		"from", sinceRv, "to", target)
+	return target, true
 }
 
-// supersedesPending returns true if the shared pending map has an event for the
-// same resource at a higher-or-equal RV. Used by reconcileSince so it
-// doesn't waste work on iter events that watch has overtaken.
-func (s *Reconciler) supersedesPending(ev *pendingEvent) bool {
+// supersedesPending reports whether the pending map holds a newer event
+// for the same resource that the cursor cannot reach, letting the walk
+// skip work watch has overtaken. Both conditions matter: at an equal RV,
+// or at any RV the cursor is about to pass, the queued copy is dropped as
+// already processed, so the walk has to embed it itself.
+func (s *Reconciler) supersedesPending(ev *pendingEvent, ceiling int64) bool {
 	s.pendingMu.Lock()
 	defer s.pendingMu.Unlock()
 	existing, ok := s.pending[pendingKey(ev.group, ev.resource, ev.namespace, ev.name)]
-	return ok && existing.rv >= ev.rv
+	return ok && existing.rv > ev.rv && existing.rv > ceiling
 }
 
 // processPending drains the in-memory pending map (watch-sourced events

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -1,9 +1,13 @@
 // Package reconciler keeps the vector index in sync with ongoing
-// dashboard writes via a periodic reconciler that drains an in-memory
-// dedup map keyed by (group, resource, namespace, name). Watch events
-// and startupReconcile-listed events both feed the map; enqueue keeps
-// only the highest RV per resource so a replayed older event can't
-// overwrite a newer one before it's processed.
+// dashboard writes. Each cycle drains an in-memory dedup map of watch
+// events keyed by (group, resource, namespace, name) — enqueue keeps only
+// the highest RV per resource, so a replayed older event can't overwrite
+// a newer one before it's processed — and then sweeps everything written
+// since the checkpoint.
+//
+// Only the sweep advances the checkpoint. Watch delivery is at-most-once
+// on some notifiers, so the events that arrived can't show that nothing
+// between them was missed; a completed listing from the cursor can.
 package reconciler
 
 import (
@@ -50,7 +54,7 @@ const maxEventAttempts = 5
 const defaultLockRetryInterval = 10 * time.Second
 
 // startupBatchSize bounds the per-flush batch size during
-// startupReconcile. When the listing iterator fills a batch to this
+// a sweep. When the listing iterator fills a batch to this
 // cap, we flush it through processEvents, then resume listing. Keeps
 // memory bounded over large catch-up windows. Package-level so tests
 // can override.
@@ -105,7 +109,7 @@ type Options struct {
 
 // Reconciler keeps the vector index in sync with ongoing writes. The
 // advisory lock is held for the pod's lifetime (acquired in Run), so
-// only one replica processes the pending map at a time and bootstrap
+// only one replica processes the pending map at a time and listing
 // pagination doesn't ping-pong across replicas. Connection-bound pg
 // session locks release naturally if the pod crashes.
 type Reconciler struct {
@@ -129,13 +133,27 @@ type Reconciler struct {
 	pendingMu sync.Mutex
 	pending   map[string]*pendingEvent
 
+	// Only ever touched from the sweep, which runs on Run's goroutine.
+	lastSweepSinceRv int64
+	lastSweepAt      time.Time
+
+	// exhausted records the highest RV per resource whose retry budget
+	// ran out, so a sweep re-listing it from storage doesn't hand it a
+	// fresh one and pin the cursor below it forever. Bounded by the
+	// number of permanently broken resources; an entry is dropped once
+	// the resource is written again or sweeps stop listing it.
+	exhaustedMu sync.Mutex
+	exhausted   map[string]exhaustedEvent
+
 	// ensuredResources tracks provisioned resources (have partition leaf and backfill job)
 	ensuredResources map[string]struct{}
 }
 
 // New constructs the embedding reconciler.
 // The caller is expected to attach a broadcaster via Reconciler.UseBroadcaster
-// before calling Run; without one the reconciler runs in poll-only mode.
+// before calling Run. Without one the reconciler can only sweep, and a fleet
+// that has never checkpointed stays inert: the cursor is seeded from the first
+// delivered write, and the sweep does nothing until it is.
 func New(opts Options) (*Reconciler, error) {
 	builders := make(map[string]embed.Builder, len(opts.Builders))
 	if len(opts.Builders) == 0 {
@@ -166,6 +184,7 @@ func New(opts Options) (*Reconciler, error) {
 		log:                    log.New("embeddings_reconciler"),
 		metrics:                opts.Metrics,
 		pending:                make(map[string]*pendingEvent),
+		exhausted:              make(map[string]exhaustedEvent),
 		ensuredResources:       make(map[string]struct{}),
 		folderTitleResolver:    foldertitle.NewResolver(opts.Storage),
 	}, nil
@@ -256,9 +275,8 @@ func (s *Reconciler) Run(ctx context.Context) error {
 		go s.runEmbeddingCounts(ctx)
 	}
 
-	// Subscribe before startupReconcile so events between the
-	// startupReconcile snapshot and the subscription join can't slip through;
-	// the broadcaster's replay buffer covers the brief overlap.
+	// Not load-bearing for correctness: the sweep lists everything past
+	// the cursor whether or not an event was delivered.
 	if s.broadcaster != nil {
 		ch, err := s.broadcaster.Subscribe(ctx, "embeddings-reconciler", "embeddings-reconciler")
 		if err != nil {
@@ -277,23 +295,31 @@ func (s *Reconciler) Run(ctx context.Context) error {
 		}
 	}
 
-	s.startupReconcile(ctx)
-
 	t := time.NewTicker(s.interval)
 	defer t.Stop()
 
-	// First cycle runs immediately so a freshly-started replica picks up
-	// startupReconcile work without waiting a full poll interval.
-	s.processPending(ctx)
+	// First cycle runs immediately, so a freshly-started replica catches
+	// up on whatever it missed while it was down without waiting an
+	// interval.
+	s.reconcileCycle(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			s.log.Info("reconciler: stopping", "reason", ctx.Err())
 			return ctx.Err()
 		case <-t.C:
-			s.processPending(ctx)
+			s.reconcileCycle(ctx)
 		}
 	}
+}
+
+// reconcileCycle drains the pending map, then sweeps. Both run on the
+// same ticker, so draining first is not a latency win today: it is the
+// only path that retries a failed event, and the only thing that seeds
+// the cursor on a fleet that has never checkpointed.
+func (s *Reconciler) reconcileCycle(ctx context.Context) {
+	s.processPending(ctx)
+	s.sweep(ctx)
 }
 
 // acquireLockBlocking retries TryAcquireReconcilerLock at lockRetryInterval
@@ -410,18 +436,32 @@ func (s *Reconciler) checkpointRV(ctx context.Context) (int64, error) {
 	return resource.ToSnowflakeRV(rv), nil
 }
 
-// startupReconcile embeds everything written since the last processed RV.
-func (s *Reconciler) startupReconcile(ctx context.Context) {
+// sweep embeds everything written since the checkpoint. It is the only
+// writer of the checkpoint: a completed walk from the cursor is the only
+// thing that shows nothing below the new value was missed.
+func (s *Reconciler) sweep(ctx context.Context) {
 	sinceRv, err := s.checkpointRV(ctx)
 	if err != nil {
-		s.log.Error("reconciler: startupReconcile read checkpoint", "err", err)
+		s.log.Error("reconciler: sweep read checkpoint", "err", err)
 		return
 	}
 	if sinceRv == 0 {
-		s.log.Info("reconciler: startupReconcile skipped; cursor at 0, nothing to process")
+		// Seeded by the first live batch; ListModifiedSince rejects 0.
+		if s.broadcaster == nil {
+			s.log.Warn("reconciler: cursor at 0 and no write event broadcaster; nothing will be embedded")
+			return
+		}
+		s.log.Debug("reconciler: sweep skipped; cursor at 0, nothing to process")
 		return
 	}
-	s.log.Info("reconciler: startupReconcile starting", "since_rv", sinceRv)
+
+	// A repeat sweep at an unchanged cursor lets the backend skip its
+	// lookback window: writes in flight at sinceRv have committed by now.
+	var calledAt *time.Time
+	if s.lastSweepSinceRv == sinceRv && !s.lastSweepAt.IsZero() {
+		calledAt = new(s.lastSweepAt)
+	}
+	startedAt := time.Now()
 
 	// One cursor for every builder, so it can only move to the lowest RV
 	// all of them proved.
@@ -430,7 +470,7 @@ func (s *Reconciler) startupReconcile(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		proven, complete := s.reconcileSince(ctx, b, sinceRv)
+		proven, complete := s.reconcileSince(ctx, b, sinceRv, calledAt)
 		if !complete {
 			return
 		}
@@ -438,23 +478,29 @@ func (s *Reconciler) startupReconcile(ctx context.Context) {
 			target = proven
 		}
 	}
+	s.lastSweepSinceRv = sinceRv
+	s.lastSweepAt = startedAt
 	if target > sinceRv {
 		if err := s.vectorBackend.SetLatestRV(ctx, target); err != nil {
-			s.log.Error("reconciler: startupReconcile advance checkpoint",
+			s.log.Error("reconciler: sweep advance checkpoint",
 				"err", err, "sinceRV", sinceRv, "target", target)
 			return
 		}
+		s.forgetExhaustedBelow(target)
 	}
-	s.log.Info("reconciler: startupReconcile complete", "from", sinceRv, "to", target)
+	s.log.Debug("reconciler: sweep complete", "from", sinceRv, "to", target)
 }
 
 // reconcileSince walks ListModifiedSince in batches and returns the RV
 // it proved complete; complete is false if the walk was interrupted.
 //
-// sinceRv stays pinned and the caller advances the cursor only once the
-// walk finishes. Listing is not RV-ascending, so a bump partway through
-// buries whatever has not been yielded yet.
-func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, sinceRv int64) (int64, bool) {
+// sinceRv stays pinned; the caller advances the cursor only after the
+// walk finishes. Listing is RV-descending on the event store and
+// key-ordered on the data store, so rows yielded later can carry lower
+// RVs than rows already seen: advancing to the highest RV seen so far
+// would claim rows the walk has not reached, and an interrupted walk
+// would leave them un-embedded with the cursor already past them.
+func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, sinceRv int64, lastCalledAt *time.Time) (int64, bool) {
 	logger := s.log.FromContext(ctx)
 	key := resource.NamespacedResource{
 		Group:    builder.Group(),
@@ -462,13 +508,13 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 		// Empty namespace → cross-namespace listing.
 	}
 	// The listing snapshot: the store's latest RV, read before the walk
-	// and covered by it. It is a ceiling, not a floor — the walk may yield
+	// and covered by it. It is a ceiling, not a floor: the walk may yield
 	// a write that landed after the snapshot while a lower-RV write is
 	// still in flight, so proving anything above it would jump the
 	// in-flight one. Without a snapshot at all, an idle resource freezes
 	// the cursor until it ages off the event store and listing falls back
 	// to a full scan.
-	latestRv, seq := s.storage.ListModifiedSince(ctx, key, sinceRv, nil)
+	latestRv, seq := s.storage.ListModifiedSince(ctx, key, sinceRv, lastCalledAt)
 	ceiling := resource.ToSnowflakeRV(latestRv)
 
 	var (
@@ -478,7 +524,7 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 	)
 
 	flush := func(batch []*pendingEvent) bool {
-		_, batchLowestFailed, batchFailed, batchSuccess, abort := s.processEvents(ctx, sinceRv, batch)
+		batchLowestFailed, batchFailed, batchSuccess, abort := s.processEvents(ctx, batch)
 		if abort {
 			return false
 		}
@@ -516,7 +562,7 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 		// Skip iter events that watch has already superseded with a
 		// newer write - re-embedding the older copy would just be
 		// overwritten by the watch event the next cycle.
-		if s.supersedesPending(ev, ceiling) {
+		if s.supersedesPending(ev, ceiling) || s.isExhausted(ev) {
 			continue
 		}
 		batch = append(batch, ev)
@@ -558,17 +604,35 @@ func (s *Reconciler) supersedesPending(ev *pendingEvent, ceiling int64) bool {
 	return ok && existing.rv > ev.rv && existing.rv > ceiling
 }
 
-// processPending drains the in-memory pending map (watch-sourced events
-// in steady state, plus failed retries) and runs the batch through
-// processBatch.
+// dropPendingUpTo discards a queued event for the same resource at or
+// below the RV just embedded. The walk bypasses the pending map, so a
+// copy queued by an earlier failure would otherwise be retried over the
+// newer revision the walk just stored, deleting the subresources that
+// revision added.
+func (s *Reconciler) dropPendingUpTo(ev *pendingEvent) {
+	k := pendingKey(ev.group, ev.resource, ev.namespace, ev.name)
+	s.pendingMu.Lock()
+	defer s.pendingMu.Unlock()
+	existing, ok := s.pending[k]
+	if !ok || existing.rv > ev.rv {
+		return
+	}
+	delete(s.pending, k)
+	if s.metrics != nil {
+		s.metrics.ReconcilerPendingEvents.Set(float64(len(s.pending)))
+	}
+}
+
+// processPending drains the in-memory pending map (watch-sourced events,
+// plus failed retries) and runs the batch through processBatch.
 func (s *Reconciler) processPending(ctx context.Context) {
 	s.processBatch(ctx, s.drainPending())
 }
 
 // processBatch runs the embed/upsert pipeline over a batch of pending
-// events and advances the cursor. Used by processPending (steady state).
-// reconcileSince calls processEvents directly so the cursor advances
-// once after every startup batch, not per batch.
+// events. It does not advance the cursor: the batch that arrived says
+// nothing about the events that did not, so writing the cursor to the
+// batch maximum would jump over an undelivered write for good.
 func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 	if len(batch) == 0 {
 		return
@@ -582,19 +646,30 @@ func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 		return
 	}
 
-	maxRv, lowestFailedRv, failed, successes, abort := s.processEvents(ctx, sinceRv, batch)
+	// A watch event at or below the cursor was covered by the walk that
+	// moved the cursor there, and re-embedding it would overwrite the
+	// newer content that walk already indexed. A failed event is exempt:
+	// it is this reconciler's own retry, and the lookback window hands
+	// back writes the cursor has already passed.
+	live := make([]*pendingEvent, 0, len(batch))
+	for _, ev := range batch {
+		if ev.rv > sinceRv || ev.attempts > 0 {
+			live = append(live, ev)
+		}
+	}
+	batch = live
+
+	_, failed, successes, abort := s.processEvents(ctx, batch)
 	if abort {
 		s.requeue(batch)
 		return
 	}
 
-	selectedRV := pickLatestRV(sinceRv, maxRv, lowestFailedRv)
-	if selectedRV > sinceRv {
-		if err := s.vectorBackend.SetLatestRV(ctx, selectedRV); err != nil {
-			logger.Error("reconciler: advance checkpoint", "err", err, "sinceRV", sinceRv, "selectedRV", selectedRV)
-			s.requeue(batch)
-			return
-		}
+	// A cursor of 0 keeps the sweep switched off entirely, so hold the
+	// batch until the seed lands instead of waiting for another write.
+	if sinceRv == 0 && !s.seedCheckpoint(ctx, batch) {
+		s.requeue(batch)
+		return
 	}
 
 	for _, ev := range failed {
@@ -604,37 +679,47 @@ func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 	switch {
 	case len(successes) == 0 && len(failed) == 0:
 	case len(failed) == 0:
-		logger.Info("reconciler: cycle processed",
-			"events", len(successes),
-			"from", sinceRv, "to", selectedRV)
+		logger.Info("reconciler: cycle processed", "events", len(successes))
 	default:
 		logger.Info("reconciler: cycle processed (partial)",
 			"events", len(successes),
-			"failed", len(failed),
-			"from", sinceRv, "to", selectedRV)
+			"failed", len(failed))
 	}
 }
 
+// seedCheckpoint gives the sweep somewhere to start on a fleet that has
+// never checkpointed, since ListModifiedSince rejects 0. The seed sits
+// below every RV in the batch, so the first sweep re-lists even these
+// events; anything older belongs to the backfiller.
+func (s *Reconciler) seedCheckpoint(ctx context.Context, batch []*pendingEvent) bool {
+	seed := int64(math.MaxInt64)
+	for _, ev := range batch {
+		if ev.rv > 0 && ev.rv < seed {
+			seed = ev.rv
+		}
+	}
+	if seed == math.MaxInt64 {
+		return true
+	}
+	if err := s.vectorBackend.SetLatestRV(ctx, seed-1); err != nil {
+		s.log.FromContext(ctx).Error("reconciler: seed checkpoint", "err", err, "seed", seed-1)
+		return false
+	}
+	s.log.FromContext(ctx).Info("reconciler: checkpoint seeded", "seed", seed-1)
+	return true
+}
+
 // processEvents runs the embed/upsert loop without advancing the
-// cursor — the caller decides when to commit progress. sinceRv is the
-// floor for the "already processed" filter; it stays pinned across
-// calls so callers (like reconcileSince) that flush multiple batches
-// don't accidentally filter out lower-RV events after an earlier batch
-// would have bumped the checkpoint. abort is true if ctx was cancelled
-// mid-loop; the caller should treat all events as un-processed.
+// cursor — the caller decides when to commit progress. abort is true if
+// ctx was cancelled mid-loop; the caller should treat all events as
+// un-processed.
 // For new resources, it ensures a partition and backfill job is created
-func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*pendingEvent) (maxRv, lowestFailedRv int64, failed, successes []*pendingEvent, abort bool) {
+func (s *Reconciler) processEvents(ctx context.Context, batch []*pendingEvent) (lowestFailedRv int64, failed, successes []*pendingEvent, abort bool) {
 	logger := s.log.FromContext(ctx)
-	maxRv = sinceRv
 	lowestFailedRv = math.MaxInt64
 	for _, ev := range batch {
 		if ctx.Err() != nil {
-			return maxRv, lowestFailedRv, nil, nil, true
-		}
-		// Replayed history past the cursor was already processed; skip
-		// it without spending an attempt.
-		if ev.rv <= sinceRv {
-			continue
+			return lowestFailedRv, nil, nil, true
 		}
 		builder, ok := s.builders[builderKey(ev.group, ev.resource)]
 		if !ok {
@@ -666,12 +751,10 @@ func (s *Reconciler) processEvents(ctx context.Context, sinceRv int64, batch []*
 		// it afterwards — re-enqueue on checkpoint failure is a no-op for an
 		// already-embedded resource.
 		ev.value = nil
+		s.dropPendingUpTo(ev)
 		successes = append(successes, ev)
-		if ev.rv > maxRv {
-			maxRv = ev.rv
-		}
 	}
-	return maxRv, lowestFailedRv, failed, successes, false
+	return lowestFailedRv, failed, successes, false
 }
 
 // processEvent dispatches on the event action and runs the per-event
@@ -855,6 +938,7 @@ func (s *Reconciler) recordFailure(ev *pendingEvent, failed *[]*pendingEvent, lo
 				WithLabelValues(ev.group, ev.resource, "retries_exhausted").
 				Inc()
 		}
+		s.markExhausted(ev)
 		return lowestFailedRv
 	}
 	*failed = append(*failed, ev)
@@ -862,6 +946,63 @@ func (s *Reconciler) recordFailure(ev *pendingEvent, failed *[]*pendingEvent, lo
 		return ev.rv
 	}
 	return lowestFailedRv
+}
+
+// exhaustedEvent is the RV a resource gave up at, plus whether listing
+// has handed that RV back since the last cursor advance.
+type exhaustedEvent struct {
+	rv       int64
+	relisted bool
+}
+
+// markExhausted remembers that this resource gave up at this RV.
+func (s *Reconciler) markExhausted(ev *pendingEvent) {
+	k := pendingKey(ev.group, ev.resource, ev.namespace, ev.name)
+	s.exhaustedMu.Lock()
+	defer s.exhaustedMu.Unlock()
+	if s.exhausted[k].rv < ev.rv {
+		s.exhausted[k] = exhaustedEvent{rv: ev.rv, relisted: true}
+	}
+}
+
+// isExhausted reports whether this event already used up its retries. A
+// newer RV for the same resource is a fresh write, so it drops the
+// record and gets a full budget.
+func (s *Reconciler) isExhausted(ev *pendingEvent) bool {
+	k := pendingKey(ev.group, ev.resource, ev.namespace, ev.name)
+	s.exhaustedMu.Lock()
+	defer s.exhaustedMu.Unlock()
+	at, ok := s.exhausted[k]
+	if !ok {
+		return false
+	}
+	if ev.rv > at.rv {
+		delete(s.exhausted, k)
+		return false
+	}
+	at.relisted = true
+	s.exhausted[k] = at
+	return true
+}
+
+// forgetExhaustedBelow drops records below the cursor that the last
+// sweep did not list. Passing the cursor is not enough on its own: the
+// backend lists from a lookback window behind the cursor, so a record
+// still being handed back has to stay or the resource gets a fresh
+// budget every advance.
+func (s *Reconciler) forgetExhaustedBelow(rv int64) {
+	s.exhaustedMu.Lock()
+	defer s.exhaustedMu.Unlock()
+	for k, at := range s.exhausted {
+		switch {
+		case at.rv > rv:
+		case at.relisted:
+			at.relisted = false
+			s.exhausted[k] = at
+		default:
+			delete(s.exhausted, k)
+		}
+	}
 }
 
 // pickLatestRV keeps the cursor strictly below any unhandled failure so

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -56,9 +56,9 @@ func multiPanelDashboard(uid, title string, n int) []byte {
 	return body
 }
 
-// newReconciler builds a Reconciler without running startupReconcile. Tests that
-// want startupReconcile should set vec.latestRV first (so startupReconcile doesn't
-// short-circuit on RV=0) and call s.startupReconcile(ctx) explicitly.
+// newReconciler builds a Reconciler without running a cycle. Tests that
+// want the sweep should set vec.latestRV first (so the sweep doesn't
+// short-circuit on RV=0) and call s.sweep(ctx) explicitly.
 func newReconciler(t *testing.T, st *fakeStorage, vec *fakeVector) (*Reconciler, *fakeText) {
 	t.Helper()
 	text := &fakeText{dim: 4}
@@ -230,7 +230,6 @@ func TestReconciler_HappyPath_PerDashboardEmbed(t *testing.T) {
 
 	assert.Equal(t, 2, text.calls, "one EmbedText call per dashboard")
 	require.Len(t, vec.upserts, 2, "one Upsert per dashboard")
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 func TestReconciler_HappyPath_StampsBuilderVersion(t *testing.T) {
@@ -272,39 +271,7 @@ func TestReconciler_DeleteEvent_CallsVectorDelete(t *testing.T) {
 
 	require.Len(t, vec.deletes, 1)
 	assert.Equal(t, deleteCall{Namespace: "ns", Model: testModel, Resource: dashRes, UID: "dash-x"}, vec.deletes[0])
-	assert.Equal(t, int64(50), vec.latestRV)
 	assert.Equal(t, 0, text.calls, "delete does not call the embedder")
-}
-
-func TestReconciler_PerEventFailure_BlocksAdvanceAtFailureRV(t *testing.T) {
-	// Three dashboards: two succeed at RVs 100 and 300, one fails at 200.
-	// Cursor advances to 199 so the failure is retried next cycle and
-	// the unrelated successes don't get rolled back.
-	vec := newFakeVector()
-	vec.upsertErrFn = func(vs []vector.Vector) error {
-		for _, v := range vs {
-			if v.UID == "boom" {
-				return errBoom
-			}
-		}
-		return nil
-	}
-	s, _ := newReconciler(t, &fakeStorage{}, vec)
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "ok-a", 100, minimalDashboard("ok-a", "OK A")))
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "boom", 200, minimalDashboard("boom", "Boom")))
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "ok-b", 300, minimalDashboard("ok-b", "OK B")))
-
-	s.processPending(context.Background())
-
-	// ok-a and ok-b succeeded; boom failed and is re-queued.
-	require.Len(t, vec.upserts, 2)
-	assert.Equal(t, int64(199), vec.latestRV)
-
-	// boom should be back in the queue.
-	s.pendingMu.Lock()
-	defer s.pendingMu.Unlock()
-	_, hasBoom := s.pending[pendingKey(dashGroup, dashRes, "ns", "boom")]
-	assert.True(t, hasBoom)
 }
 
 func TestReconciler_StaleSubresources_AreDeletedBeforeUpsert(t *testing.T) {
@@ -360,7 +327,6 @@ func TestReconciler_PartialReembed_OnlyChangedPanel(t *testing.T) {
 	assert.Equal(t, 2, text.calls)
 	assert.Equal(t, []int{1}, text.textSets[1], "embedder called with exactly one text")
 	assert.Empty(t, vec.delsubs, "nothing deleted; every panel is still desired")
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 // Re-processing identical content writes nothing but still advances the checkpoint.
@@ -380,7 +346,6 @@ func TestReconciler_PartialReembed_NoChangeSkipsWrite(t *testing.T) {
 	require.Len(t, vec.upserts, 1, "no re-embed when content is unchanged")
 	assert.Equal(t, 1, text.calls, "embedder not called again")
 	assert.Empty(t, vec.delsubs, "nothing deleted")
-	assert.Equal(t, int64(200), vec.latestRV, "cursor still advances on a no-op write")
 }
 
 // dashboardInFolder sets the folder UID via the grafana.app/folder annotation.
@@ -481,7 +446,6 @@ func TestReconciler_PartialReembed_DeleteOnly(t *testing.T) {
 	assert.Equal(t, 1, text.calls, "no embed; surviving panels unchanged")
 	require.Len(t, vec.delsubs, 1, "the removed panel is deleted")
 	assert.ElementsMatch(t, []string{"panel/3"}, vec.delsubs[0].Subresources)
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 // Two panels can map to the same subresource (explicit id N and an
@@ -514,21 +478,21 @@ func TestReconciler_PartialReembed_SubresourceCollision_DeletesStale(t *testing.
 	assert.ElementsMatch(t, []string{"panel/9"}, vec.delsubs[0].Subresources)
 }
 
-func TestReconciler_MonotonicCheckpoint(t *testing.T) {
+// The same resource written again at a higher RV re-embeds on the next
+// cycle; dedup keeps the newer copy rather than the one already queued.
+func TestReconciler_SameResourceHigherRV_ReembedsNextCycle(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)
 
 	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, minimalDashboard("dash-1", "Dash 1")))
 	s.processPending(context.Background())
 	require.Len(t, vec.upserts, 1)
-	require.Equal(t, int64(100), vec.latestRV)
 	require.Equal(t, 1, text.calls)
 
 	// Same dashboard at a higher RV: dedup keeps the new one.
 	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "dash-1", 200, minimalDashboard("dash-1", "Dash 1 v2")))
 	s.processPending(context.Background())
 	require.Len(t, vec.upserts, 2)
-	require.Equal(t, int64(200), vec.latestRV)
 	require.Equal(t, 2, text.calls)
 }
 
@@ -551,9 +515,9 @@ func TestReconciler_UnknownAction_BlocksAdvance(t *testing.T) {
 	assert.Equal(t, int64(49), vec.latestRV, "checkpoint stops at (failed - 1)")
 }
 
-// ---------- Bootstrap ----------
+// ---------- Sweep ----------
 
-func TestReconciler_Bootstrap_SkipsWhenCursorIsZero(t *testing.T) {
+func TestReconciler_Sweep_SkipsWhenCursorIsZero(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", 100, minimalDashboard("dash-1", "Dash 1")),
@@ -561,15 +525,15 @@ func TestReconciler_Bootstrap_SkipsWhenCursorIsZero(t *testing.T) {
 	vec := newFakeVector() // latestRV stays 0
 	s, text := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 	s.processPending(context.Background())
 
-	assert.Empty(t, vec.upserts, "startupReconcile is a no-op when cursor is 0")
+	assert.Empty(t, vec.upserts, "the sweep is a no-op when cursor is 0")
 	assert.Equal(t, 0, text.calls)
 }
 
-func TestReconciler_Bootstrap_PullsCrossNamespaceEvents(t *testing.T) {
-	// Cursor non-zero → startupReconcile walks every namespace in one pass via
+func TestReconciler_Sweep_PullsCrossNamespaceEvents(t *testing.T) {
+	// Cursor non-zero → the sweep walks every namespace in one pass via
 	// cross-namespace ListModifiedSince, enqueues each event, processes
 	// them per-dashboard.
 	st := &fakeStorage{}
@@ -581,7 +545,7 @@ func TestReconciler_Bootstrap_PullsCrossNamespaceEvents(t *testing.T) {
 	vec.latestRV = snowflakeRV(50) // anything below the change RVs
 	s, text := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 	s.processPending(context.Background())
 
 	require.Len(t, vec.upserts, 2)
@@ -589,7 +553,7 @@ func TestReconciler_Bootstrap_PullsCrossNamespaceEvents(t *testing.T) {
 	assert.Equal(t, snowflakeRV(200), vec.latestRV)
 }
 
-func TestReconciler_Bootstrap_FiltersBelowCursor(t *testing.T) {
+func TestReconciler_Sweep_FiltersBelowCursor(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "old", snowflakeRV(100), minimalDashboard("old", "Old")),
@@ -599,12 +563,11 @@ func TestReconciler_Bootstrap_FiltersBelowCursor(t *testing.T) {
 	vec.latestRV = snowflakeRV(150)
 	s, _ := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 	s.processPending(context.Background())
 
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, "new", vec.upserts[0][0].UID)
-	assert.Equal(t, snowflakeRV(200), vec.latestRV)
 }
 
 // ---------- Watch path ----------
@@ -623,7 +586,6 @@ func TestReconciler_WatchEvent_DrivesNextCycle(t *testing.T) {
 
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, 1, text.calls)
-	assert.Equal(t, int64(100), vec.latestRV)
 }
 
 func TestReconciler_WatchConsumer_IgnoresUnrelatedResources(t *testing.T) {
@@ -680,7 +642,6 @@ func TestReconciler_EnqueueDedup_KeepsHighestRV(t *testing.T) {
 	require.Len(t, vec.upserts, 1)
 	require.Len(t, vec.upserts[0], 1)
 	assert.Equal(t, int64(200), vec.upserts[0][0].ResourceVersion)
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 func TestReconciler_EnqueueDedup_DeleteOverridesOlderUpsert(t *testing.T) {
@@ -695,11 +656,12 @@ func TestReconciler_EnqueueDedup_DeleteOverridesOlderUpsert(t *testing.T) {
 	assert.Empty(t, vec.upserts, "older upsert overridden by newer delete")
 	require.Len(t, vec.deletes, 1)
 	assert.Equal(t, "dash", vec.deletes[0].UID)
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
-// Events at or below the cursor were already processed; they're filtered
-// out and only newer ones embed. The cursor advances to the max.
+// Events at or below the cursor were covered by the walk that moved the
+// cursor there, so the live path filters them out: they cost an embed
+// call, and a late copy would overwrite the newer content that walk
+// already indexed.
 func TestReconciler_FiltersEventsAtOrBelowCursor(t *testing.T) {
 	vec := newFakeVector()
 	vec.latestRV = snowflakeRV(150)
@@ -708,12 +670,20 @@ func TestReconciler_FiltersEventsAtOrBelowCursor(t *testing.T) {
 	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "old", snowflakeRV(100), minimalDashboard("old", "Old")))
 	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "new", snowflakeRV(200), minimalDashboard("new", "New")))
 
-	s.processPending(context.Background())
+	s.processPending(t.Context())
 
 	assert.Equal(t, 1, text.calls)
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, "new", vec.upserts[0][0].UID)
-	assert.Equal(t, snowflakeRV(200), vec.latestRV)
+
+	// A late copy of "new" from below the cursor must not replace what is
+	// already indexed for it.
+	indexed := vec.storedContentFor("ns", dashRes, "new")
+	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "new", snowflakeRV(140), minimalDashboard("new", "Stale")))
+	s.processPending(t.Context())
+
+	assert.Len(t, vec.upserts, 1, "the stale copy is not embedded")
+	assert.Equal(t, indexed, vec.storedContentFor("ns", dashRes, "new"), "indexed content untouched")
 }
 
 // ---------- Retry cap ----------
@@ -730,19 +700,12 @@ func TestReconciler_RetryCap_DropsEventAfterMaxAttempts(t *testing.T) {
 
 	require.Equal(t, 0, s.pendingLen(), "event dropped after max attempts")
 	assert.Empty(t, vec.upserts)
-	// First failure pinned the cursor at lowestFailedRv-1 (= 99). On
-	// the give-up cycle the failure no longer pins it, but no successful
-	// event has a higher RV, so the cursor stays at 99 until something
-	// past it succeeds.
-	assert.Equal(t, int64(99), vec.latestRV)
 
-	// A subsequent healthy event proves the reconciler is unblocked and
-	// advances the cursor.
+	// A subsequent healthy event proves the reconciler is unblocked.
 	vec.upsertErr = nil
 	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns-other", "ok", 200, minimalDashboard("ok", "OK")))
 	s.processPending(context.Background())
 	require.Len(t, vec.upserts, 1)
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 func TestReconciler_RetryCap_FreshHigherRVResetsBudget(t *testing.T) {
@@ -759,7 +722,6 @@ func TestReconciler_RetryCap_FreshHigherRVResetsBudget(t *testing.T) {
 
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, int64(200), vec.upserts[0][0].ResourceVersion)
-	assert.Equal(t, int64(200), vec.latestRV)
 }
 
 func TestReconciler_RetryCap_ReEnqueuePreservesAttempts(t *testing.T) {
@@ -839,13 +801,13 @@ func TestReconciler_AcquireLockBlocking_RespectsContextCancel(t *testing.T) {
 
 // ---------- Startup pagination ----------
 
-// TestReconciler_StartupReconcile_FlushesAtBatchSize verifies that
-// startupReconcile drains the listing iterator in startupBatchSize-sized
+// TestReconciler_Sweep_FlushesAtBatchSize verifies that
+// the sweep drains the listing iterator in startupBatchSize-sized
 // chunks (so memory stays bounded) but advances the cursor exactly once
 // at the end. Advancing per batch would lose events: the event store
 // yields RV-descending, so the first (highest-RV) batch would bump the
 // cursor past every later, lower-RV batch.
-func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
+func TestReconciler_Sweep_FlushesAtBatchSize(t *testing.T) {
 	prev := startupBatchSize
 	startupBatchSize = 3
 	t.Cleanup(func() { startupBatchSize = prev })
@@ -863,7 +825,7 @@ func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
 	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 
 	require.Len(t, vec.upserts, 7, "every event must be processed across batched flushes")
 	assert.Equal(t, snowflakeRV(160), vec.latestRV, "cursor advances to highest RV")
@@ -871,13 +833,13 @@ func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
 	assert.Equal(t, 1, vec.setLatestRVCalls, "cursor advances exactly once at end of startup")
 }
 
-// TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents is the
-// regression test for the bug where startupReconcile flushed each
+// TestReconciler_Sweep_DescOrderDoesNotDropEvents is the regression
+// test for the bug where the sweep flushed each
 // batch via processBatch (which advances the cursor) while the event
 // store yields RV-descending. The first batch held the highest RVs, the
 // cursor jumped past every subsequent (lower-RV) batch's events, and
 // they were silently filtered out by the "ev.rv <= sinceRv" guard.
-func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
+func TestReconciler_Sweep_DescOrderDoesNotDropEvents(t *testing.T) {
 	prev := startupBatchSize
 	startupBatchSize = 2
 	t.Cleanup(func() { startupBatchSize = prev })
@@ -895,7 +857,7 @@ func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
 	vec.latestRV = snowflakeRV(50)
 	s, _ := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 
 	assert.Len(t, vec.upserts, 6, "every event embedded even though batches arrive in DESC order")
 	assert.Equal(t, snowflakeRV(150), vec.latestRV)
@@ -905,7 +867,7 @@ func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
 // observe it via the lazily-pulled iterator: yields-at-each-upsert is
 // [1,2,..] when flushing per event, [N,N,..] for one terminal flush. The
 // end-state invariants alone can't see the byte branch.
-func TestReconciler_StartupReconcile_FlushesAtByteBudget(t *testing.T) {
+func TestReconciler_Sweep_FlushesAtByteBudget(t *testing.T) {
 	// run returns the iterator-yield count observed at each upsert.
 	run := func(t *testing.T, capBytes int) []int {
 		prevCount, prevBytes := startupBatchSize, maxStartupBatchBytes
@@ -932,7 +894,7 @@ func TestReconciler_StartupReconcile_FlushesAtByteBudget(t *testing.T) {
 		vec.onUpsert = func() { atUpsert = append(atUpsert, yielded) }
 
 		s, _ := newReconciler(t, st, vec)
-		s.startupReconcile(context.Background())
+		s.sweep(context.Background())
 
 		require.Len(t, vec.upserts, 6, "every event embedded")
 		assert.Equal(t, snowflakeRV(150), vec.latestRV, "cursor advances to highest RV")
@@ -952,9 +914,9 @@ func TestReconciler_StartupReconcile_FlushesAtByteBudget(t *testing.T) {
 }
 
 // When SetLatestRV fails after the embeds succeeded, the cursor stays
-// put and the next run re-lists from it. Nothing is re-enqueued: only a
-// re-walk can prove the RV again.
-func TestReconciler_StartupReconcile_CheckpointWriteFailure_RetriesNextRun(t *testing.T) {
+// put and the next sweep re-lists from it. Nothing is re-enqueued: only
+// a re-walk can prove the RV again.
+func TestReconciler_Sweep_CheckpointWriteFailure_RetriesNextRun(t *testing.T) {
 	st := &fakeStorage{changes: []*resource.ModifiedResource{
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
 	}}
@@ -963,16 +925,16 @@ func TestReconciler_StartupReconcile_CheckpointWriteFailure_RetriesNextRun(t *te
 	vec.setLatestRVErr = errBoom
 	s, _ := newReconciler(t, st, vec)
 
-	s.startupReconcile(t.Context())
+	s.sweep(t.Context())
 
 	require.Len(t, vec.upserts, 1, "embeds succeeded even though the cursor write failed")
 	assert.Equal(t, snowflakeRV(50), vec.latestRV, "cursor stays at old value when SetLatestRV errors")
 	assert.Zero(t, s.pendingLen(), "nothing queued; the next walk re-proves the RV")
 
 	vec.setLatestRVErr = nil
-	s.startupReconcile(t.Context())
+	s.sweep(t.Context())
 
-	assert.Equal(t, snowflakeRV(100), vec.latestRV, "the next run advances the cursor")
+	assert.Equal(t, snowflakeRV(100), vec.latestRV, "the next sweep advances the cursor")
 }
 
 // A successful embed releases the event's value, so a caller
@@ -984,7 +946,7 @@ func TestReconciler_EmbeddedValueReleasedAndReplaysAsNoOp(t *testing.T) {
 	s, text := newReconciler(t, &fakeStorage{}, vec)
 	ev := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-0", snowflakeRV(100), minimalDashboard("dash-0", "Dash 0"))
 
-	_, _, failed, successes, abort := s.processEvents(t.Context(), snowflakeRV(50), []*pendingEvent{ev})
+	_, failed, successes, abort := s.processEvents(t.Context(), []*pendingEvent{ev})
 	require.False(t, abort)
 	require.Empty(t, failed)
 	require.Len(t, successes, 1)
@@ -999,12 +961,12 @@ func TestReconciler_EmbeddedValueReleasedAndReplaysAsNoOp(t *testing.T) {
 	assert.Empty(t, vec.deletes, "replay does not delete")
 }
 
-// TestReconciler_StartupReconcile_DoesNotProcessWatchEvents verifies
-// that a watch event queued while bootstrap is iterating is left in the
+// TestReconciler_Sweep_DoesNotProcessWatchEvents verifies
+// that a watch event queued while the sweep is iterating is left in the
 // global queue and is NOT processed mid-batch. If it were, its higher
 // RV would advance the cursor past iter events not yet yielded, which
 // would then be filtered out and never embedded.
-func TestReconciler_StartupReconcile_DoesNotProcessWatchEvents(t *testing.T) {
+func TestReconciler_Sweep_DoesNotProcessWatchEvents(t *testing.T) {
 	prev := startupBatchSize
 	startupBatchSize = 2
 	t.Cleanup(func() { startupBatchSize = prev })
@@ -1022,35 +984,36 @@ func TestReconciler_StartupReconcile_DoesNotProcessWatchEvents(t *testing.T) {
 	s, _ := newReconciler(t, st, vec)
 
 	// Pre-seed the global queue with a watch event at a much higher RV
-	// for an unrelated dashboard. If bootstrap incorrectly drained the
+	// for an unrelated dashboard. If the sweep incorrectly drained the
 	// global queue, this RV (9999) would become the new cursor and the
 	// remaining iter events would be filtered out.
 	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "watch-only", snowflakeRV(9999),
 		minimalDashboard("watch-only", "Watch Only")))
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 
 	// All 4 iter events embedded, watch event still queued.
-	require.Len(t, vec.upserts, 4, "all iter events processed during bootstrap")
+	require.Len(t, vec.upserts, 4, "all iter events processed by the sweep")
 	for _, batch := range vec.upserts {
 		require.NotEmpty(t, batch)
-		assert.NotEqual(t, "watch-only", batch[0].UID, "watch event must not be processed during bootstrap")
+		assert.NotEqual(t, "watch-only", batch[0].UID, "watch event must not be processed by the sweep")
 	}
-	assert.Equal(t, snowflakeRV(130), vec.latestRV, "cursor stays within iter range during bootstrap")
+	assert.Equal(t, snowflakeRV(130), vec.latestRV, "cursor stays within the swept range")
 	assert.Equal(t, 1, s.pendingLen(), "watch event remains in global queue for the next cycle")
 
-	// A subsequent processPending (Run's first cycle) drains the watch event.
+	// A subsequent processPending drains the watch event.
 	s.processPending(context.Background())
 	require.Len(t, vec.upserts, 5)
 	assert.Equal(t, "watch-only", vec.upserts[4][0].UID)
-	assert.Equal(t, snowflakeRV(9999), vec.latestRV)
+	assert.Equal(t, snowflakeRV(130), vec.latestRV,
+		"draining live events does not move the cursor past the swept window")
 }
 
-// TestReconciler_StartupReconcile_SkipsIterEventsSupersededByWatch
+// TestReconciler_Sweep_SkipsIterEventsSupersededByWatch
 // verifies the iter-side dedup: when watch has already queued a newer
 // event for a dashboard, the iter's older copy is dropped before
 // processing rather than wasting an embed call.
-func TestReconciler_StartupReconcile_SkipsIterEventsSupersededByWatch(t *testing.T) {
+func TestReconciler_Sweep_SkipsIterEventsSupersededByWatch(t *testing.T) {
 	st := &fakeStorage{}
 	st.changes = []*resource.ModifiedResource{
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "shared", snowflakeRV(100), minimalDashboard("shared", "v1")),
@@ -1064,9 +1027,9 @@ func TestReconciler_StartupReconcile_SkipsIterEventsSupersededByWatch(t *testing
 	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "shared", snowflakeRV(500),
 		minimalDashboard("shared", "v2")))
 
-	s.startupReconcile(context.Background())
+	s.sweep(context.Background())
 
-	// "other" is processed by bootstrap; "shared" is skipped because
+	// "other" is processed by the sweep; "shared" is skipped because
 	// watch's @500 supersedes iter's @100.
 	require.Len(t, vec.upserts, 1)
 	assert.Equal(t, "other", vec.upserts[0][0].UID)
@@ -1221,7 +1184,7 @@ func TestReconciler_Run_ContextCancelDuringLockWait(t *testing.T) {
 }
 
 // TestReconciler_Run_RunsStartupAndCycles asserts the end-to-end
-// behavior: Run executes startupReconcile (embedding the pre-existing
+// behavior: Run sweeps immediately (embedding the pre-existing
 // changes) and then ticks the queue (embedding watch-style events
 // pushed onto the queue). Both must land in vec.upserts before ctx
 // is cancelled.
@@ -1231,7 +1194,7 @@ func TestReconciler_Run_RunsStartupAndCycles(t *testing.T) {
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "startup-1", snowflakeRV(100), minimalDashboard("startup-1", "Startup 1")),
 	}
 	vec := newFakeVector()
-	vec.latestRV = snowflakeRV(50) // > 0 so startupReconcile actually runs
+	vec.latestRV = snowflakeRV(50) // > 0 so the sweep actually runs
 	s, _ := newRunnable(t, st, vec)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1244,7 +1207,7 @@ func TestReconciler_Run_RunsStartupAndCycles(t *testing.T) {
 		vec.mu.Lock()
 		defer vec.mu.Unlock()
 		return len(vec.upserts) >= 1
-	}, time.Second, time.Millisecond, "startupReconcile should run before the first tick")
+	}, time.Second, time.Millisecond, "the first sweep should run before the first tick")
 
 	// Now enqueue a tick-driven event and wait for the next cycle.
 	s.enqueue(dashEvent(resourcepb.WatchEvent_MODIFIED, "ns", "live-1", snowflakeRV(200), minimalDashboard("live-1", "Live 1")))
@@ -1283,26 +1246,6 @@ func TestReconciler_ProcessBatch_RequeuesOnGetLatestRVFailure(t *testing.T) {
 	assert.Equal(t, 2, s.pendingLen(), "both events re-enqueued for the next cycle")
 }
 
-// TestReconciler_ProcessBatch_RequeuesOnSetLatestRVFailure: in steady
-// state we already embedded the events; failing to advance the cursor
-// means we can't trust the checkpoint, so the whole batch goes back
-// on the queue (idempotent re-embed via UpsertReplaceSubresources).
-func TestReconciler_ProcessBatch_RequeuesOnSetLatestRVFailure(t *testing.T) {
-	vec := newFakeVector()
-	vec.latestRV = 50
-	vec.setLatestRVErr = fmt.Errorf("transient checkpoint write failure")
-	s, _ := newReconciler(t, &fakeStorage{}, vec)
-
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "a", 100, minimalDashboard("a", "A")))
-	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "b", 110, minimalDashboard("b", "B")))
-
-	s.processPending(context.Background())
-
-	assert.Len(t, vec.upserts, 2, "embeds happen even when SetLatestRV errors")
-	assert.Equal(t, int64(50), vec.latestRV, "cursor stays put on SetLatestRV failure")
-	assert.Equal(t, 2, s.pendingLen(), "both events re-enqueued so the next cycle retries the advance")
-}
-
 func labeledDashboard(uid, title string) []byte {
 	body, _ := json.Marshal(map[string]any{
 		"metadata": map[string]any{
@@ -1314,7 +1257,7 @@ func labeledDashboard(uid, title string) []byte {
 	return body
 }
 
-func TestReconciler_PendingDeleteLabel_SkipsUpsertAndAdvancesCursor(t *testing.T) {
+func TestReconciler_PendingDeleteLabel_SkipsUpsert(t *testing.T) {
 	vec := newFakeVector()
 	s, text := newReconciler(t, &fakeStorage{}, vec)
 
@@ -1325,7 +1268,6 @@ func TestReconciler_PendingDeleteLabel_SkipsUpsertAndAdvancesCursor(t *testing.T
 
 	require.Len(t, vec.upserts, 1, "only the unlabeled resource should be embedded")
 	assert.Equal(t, 1, text.calls, "skipped event must not call the embedder")
-	assert.Equal(t, int64(200), vec.latestRV, "skips count as processed so the cursor advances")
 	assert.Equal(t, 0, s.pendingLen(), "skipped events are not retried")
 }
 
@@ -1512,7 +1454,7 @@ func TestReconciler_EnsureResourceInitialized_CreateError(t *testing.T) {
 // it must move even when this builder saw nothing, or it ages off the
 // event store and every later listing falls onto the full data-store
 // scan.
-func TestReconciler_StartupReconcile_AdvancesCursor(t *testing.T) {
+func TestReconciler_Sweep_AdvancesCursor(t *testing.T) {
 	widgets := fakeBuilder{group: "test.grafana.app", resource: "widgets"}
 	dashAt := func(rv int64, name string) *resource.ModifiedResource {
 		return dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name))
@@ -1581,7 +1523,7 @@ func TestReconciler_StartupReconcile_AdvancesCursor(t *testing.T) {
 			}
 			s := newReconcilerWithBuilders(t, st, vec, builders...)
 
-			s.startupReconcile(t.Context())
+			s.sweep(t.Context())
 
 			assert.Equal(t, tc.wantCursor, vec.latestRV, "cursor")
 			assert.Len(t, vec.upserts, tc.wantUpserts, "upserts")
@@ -1593,7 +1535,7 @@ func TestReconciler_StartupReconcile_AdvancesCursor(t *testing.T) {
 // A watch copy that is newer than the listed one but still below the
 // ceiling gets dropped by the live path once the cursor reaches that
 // ceiling, so the walk cannot defer to it.
-func TestReconciler_StartupReconcile_EmbedsEventQueuedBelowTheCeiling(t *testing.T) {
+func TestReconciler_Sweep_EmbedsEventQueuedBelowTheCeiling(t *testing.T) {
 	st := &fakeStorage{
 		changes: []*resource.ModifiedResource{
 			dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(90), minimalDashboard("dash-1", "Dash 1")),
@@ -1608,16 +1550,84 @@ func TestReconciler_StartupReconcile_EmbedsEventQueuedBelowTheCeiling(t *testing
 		s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(95), minimalDashboard("dash-1", "Dash 1")))
 	}
 
-	s.startupReconcile(t.Context())
+	s.sweep(t.Context())
 
 	assert.Equal(t, snowflakeRV(100), vec.latestRV)
 	assert.True(t, vec.hasUpsertFor("ns", dashRes, "dash-1"), "the walk must embed what the cursor is about to pass")
 }
 
+// A write in flight when the walk read its ceiling shows up below the
+// cursor on the next sweep, inside the backend's lookback window. The
+// walk has to embed it: nothing else ever will.
+func TestReconciler_Sweep_EmbedsWriteRecoveredByLookback(t *testing.T) {
+	st := &fakeStorage{
+		changes:  []*resource.ModifiedResource{dashChange(resourcepb.WatchEvent_ADDED, "ns", "late", snowflakeRV(95), minimalDashboard("late", "Late"))},
+		lookback: 10,
+	}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(100)
+	s, _ := newReconciler(t, st, vec)
+
+	s.sweep(t.Context())
+
+	require.Len(t, vec.upserts, 1)
+	assert.Equal(t, "late", vec.upserts[0][0].UID)
+}
+
+// A lookback-recovered write that fails on the first attempt keeps its
+// retry budget. The next sweep skips the lookback window, so if the live
+// path also discarded it for sitting below the cursor, nothing would ever
+// embed it.
+func TestReconciler_Sweep_RetriesFailedLookbackWrite(t *testing.T) {
+	st := &fakeStorage{
+		changes:  []*resource.ModifiedResource{dashChange(resourcepb.WatchEvent_ADDED, "ns", "late", snowflakeRV(95), minimalDashboard("late", "Late"))},
+		lookback: 10,
+	}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(100)
+	vec.upsertErr = errBoom
+	s, _ := newReconciler(t, st, vec)
+
+	s.reconcileCycle(t.Context())
+	require.Equal(t, 1, s.pendingLen(), "the failed write is queued for retry")
+
+	vec.upsertErr = nil
+	s.reconcileCycle(t.Context())
+
+	assert.True(t, vec.hasUpsertFor("ns", dashRes, "late"), "the retry must embed it")
+	assert.Zero(t, s.pendingLen())
+}
+
+// A queued event that failed earlier must not be replayed over a newer
+// revision the sweep has since indexed: the walk bypasses the pending
+// map, so nothing else drops the stale copy.
+func TestReconciler_StaleQueuedRetry_DoesNotOverwriteNewerEmbedding(t *testing.T) {
+	st := &fakeStorage{
+		changes:  []*resource.ModifiedResource{dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(150), multiPanelDashboard("dash-1", "New", 2))},
+		lookback: 10,
+	}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(100)
+	s, _ := newReconciler(t, st, vec)
+
+	// A lookback-recovered revision that failed on an earlier cycle.
+	stale := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(95), minimalDashboard("dash-1", "Old"))
+	stale.attempts = 1
+	s.enqueue(stale)
+
+	s.sweep(t.Context())
+	indexed := vec.storedContentFor("ns", dashRes, "dash-1")
+	require.NotEmpty(t, indexed, "the sweep indexed the newer revision")
+
+	s.processPending(t.Context())
+
+	assert.Equal(t, indexed, vec.storedContentFor("ns", dashRes, "dash-1"), "the newer revision survives")
+}
+
 // A write can reach the watch and the walk at the same RV. The walk must
 // still embed it, because the cursor is about to move past that RV and
 // the queued copy is discarded once it does.
-func TestReconciler_StartupReconcile_EmbedsEventAlreadyQueuedFromWatch(t *testing.T) {
+func TestReconciler_Sweep_EmbedsEventAlreadyQueuedFromWatch(t *testing.T) {
 	st := &fakeStorage{changes: []*resource.ModifiedResource{
 		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
 	}}
@@ -1627,10 +1637,196 @@ func TestReconciler_StartupReconcile_EmbedsEventAlreadyQueuedFromWatch(t *testin
 
 	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")))
 
-	s.startupReconcile(t.Context())
+	s.sweep(t.Context())
 	require.True(t, vec.hasUpsertFor("ns", dashRes, "dash-1"), "the walk must embed what the cursor is about to pass")
 	require.Equal(t, snowflakeRV(100), vec.latestRV)
 
+	assert.Zero(t, s.pendingLen(), "the queued copy is superseded by what the walk wrote")
 	s.processPending(t.Context())
-	assert.Len(t, vec.upserts, 1, "the queued copy replays as a no-op")
+	assert.Len(t, vec.upserts, 1, "and is not written a second time")
+}
+
+// Delivery is at-most-once on the NATS notifier, so a write can never
+// arrive. If the cursor moves on the strength of the events that did
+// arrive, the missing one is jumped over and never looked at again.
+func TestReconciler_Sweep_EmbedsEventWithheldFromWatch(t *testing.T) {
+	st := &fakeStorage{}
+	for i, name := range []string{"dash-100", "dash-101", "dash-102"} {
+		st.changes = append(st.changes, dashChange(resourcepb.WatchEvent_ADDED, "ns", name,
+			snowflakeRV(int64(100+i)), minimalDashboard(name, name)))
+	}
+
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(99)
+	s, _ := newReconciler(t, st, vec)
+
+	// dash-101's event is dropped in transit; the other two arrive.
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-100", snowflakeRV(100), minimalDashboard("dash-100", "dash-100")))
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-102", snowflakeRV(102), minimalDashboard("dash-102", "dash-102")))
+
+	s.reconcileCycle(t.Context())
+
+	assert.True(t, vec.hasUpsertFor("ns", dashRes, "dash-101"),
+		"the withheld write must be embedded by the sweep")
+	assert.Equal(t, snowflakeRV(102), vec.latestRV, "cursor advances only once the sweep has covered the window")
+}
+
+// Draining live events must not move the cursor: the batch that arrived
+// says nothing about the writes that did not. The one exception is a
+// fleet that has never checkpointed, where the sweep needs a non-zero
+// cursor to start from and gets one below the batch's lowest RV.
+func TestReconciler_LiveBatch_CursorAdvance(t *testing.T) {
+	tests := []struct {
+		name       string
+		cursor     int64
+		wantCursor int64
+	}{
+		{name: "an established cursor is left alone", cursor: snowflakeRV(50), wantCursor: snowflakeRV(50)},
+		{name: "a cursor of 0 is seeded below the batch", cursor: 0, wantCursor: snowflakeRV(100) - 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vec := newFakeVector()
+			vec.latestRV = tc.cursor
+			s, _ := newReconciler(t, &fakeStorage{}, vec)
+
+			s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")))
+			s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-2", snowflakeRV(110), minimalDashboard("dash-2", "Dash 2")))
+			s.processPending(t.Context())
+
+			require.Len(t, vec.upserts, 2, "live events are still embedded promptly")
+			assert.Equal(t, tc.wantCursor, vec.latestRV)
+		})
+	}
+}
+
+// A seeded cursor sits below the events that seeded it, so the sweep
+// re-lists them rather than trusting the live path with them. Re-listing
+// is free: same content, so the diff writes nothing.
+func TestReconciler_Sweep_RelistsTheSeededBatch(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-a", snowflakeRV(100), minimalDashboard("dash-a", "dash-a")),
+	}}
+	vec := newFakeVector() // latestRV stays 0
+	s, _ := newReconciler(t, st, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-a", snowflakeRV(100), minimalDashboard("dash-a", "dash-a")))
+	s.processPending(t.Context())
+	require.Equal(t, snowflakeRV(100)-1, vec.latestRV, "seeded below the batch")
+
+	yielded := 0
+	st.onYield = func() { yielded++ }
+	s.sweep(t.Context())
+
+	assert.Equal(t, 1, yielded, "the sweep re-lists the seeded event")
+	assert.Len(t, vec.upserts, 1, "unchanged content is not re-embedded")
+	assert.Equal(t, snowflakeRV(100), vec.latestRV)
+}
+
+// A repeat sweep at an unchanged cursor passes the previous call's
+// timestamp, so the backend can skip its lookback window.
+func TestReconciler_Sweep_SkipsLookbackOnRepeatSinceRv(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
+	}}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(100) // already at the store's latest: the cursor won't move
+	s, _ := newReconciler(t, st, vec)
+
+	s.sweep(t.Context())
+	s.sweep(t.Context())
+
+	require.Len(t, st.lastCalledWith, 2)
+	assert.Nil(t, st.lastCalledWith[0], "first sweep at this cursor needs the lookback")
+	assert.NotNil(t, st.lastCalledWith[1], "repeat sweep at the same cursor can skip it")
+}
+
+// A failed seed leaves the cursor at 0, where the sweep cannot run at
+// all, so the batch is kept and the seed retried on the next cycle
+// rather than waiting for another write to arrive.
+func TestReconciler_LiveBatch_RetriesFailedSeed(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
+	}}
+	vec := newFakeVector() // latestRV stays 0
+	vec.setLatestRVErr = errBoom
+	s, _ := newReconciler(t, st, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")))
+	s.reconcileCycle(t.Context())
+
+	require.Zero(t, vec.latestRV, "the seed write failed")
+	require.Equal(t, 1, s.pendingLen(), "the batch is kept so the seed can be retried")
+
+	vec.setLatestRVErr = nil
+	s.reconcileCycle(t.Context())
+
+	assert.Equal(t, snowflakeRV(100), vec.latestRV, "the retried seed lets the sweep run and advance")
+}
+
+// The retry cap exists so a permanently broken resource can't wedge the
+// cursor. The sweep re-lists that resource from storage every interval,
+// so it must not hand it a fresh retry budget each time.
+func TestReconciler_Sweep_DoesNotResetExhaustedRetries(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "boom", snowflakeRV(100), minimalDashboard("boom", "Boom")),
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "ok", snowflakeRV(200), minimalDashboard("ok", "OK")),
+	}}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(50)
+	vec.upsertErrFn = func(vs []vector.Vector) error {
+		for _, v := range vs {
+			if v.UID == "boom" {
+				return errBoom
+			}
+		}
+		return nil
+	}
+	s, _ := newReconciler(t, st, vec)
+
+	// Well past the budget: every cycle retries the queued copy and
+	// re-lists the stored one.
+	for range maxEventAttempts + 3 {
+		s.reconcileCycle(t.Context())
+	}
+
+	assert.True(t, vec.hasUpsertFor("ns", dashRes, "ok"), "the healthy resource is embedded")
+	assert.Equal(t, snowflakeRV(200), vec.latestRV, "cursor moves past the resource that exhausted its retries")
+	assert.Zero(t, s.pendingLen(), "the broken resource is not queued again")
+}
+
+// The exhausted record is per (resource, RV): a newer write clears it so
+// a resource that starts embedding again is not skipped forever.
+func TestReconciler_ExhaustedRecord_ClearedByNewerRV(t *testing.T) {
+	s, _ := newReconciler(t, &fakeStorage{}, newFakeVector())
+	broken := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), nil)
+
+	s.markExhausted(broken)
+	assert.True(t, s.isExhausted(broken), "same RV stays exhausted")
+
+	rewritten := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(200), nil)
+	assert.False(t, s.isExhausted(rewritten), "a newer write gets a fresh budget")
+	assert.False(t, s.isExhausted(broken), "and clears the record")
+}
+
+// The cursor moving past an exhausted RV is not enough to forget it: the
+// backend lists from a lookback window behind the cursor, so the next
+// sweep can hand the same event back and would give it a fresh budget.
+// The record is dropped only once a sweep stops re-listing it.
+func TestReconciler_ExhaustedRecord_SurvivesLookbackRelist(t *testing.T) {
+	s, _ := newReconciler(t, &fakeStorage{}, newFakeVector())
+	broken := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), nil)
+	past := snowflakeRV(200)
+
+	s.markExhausted(broken)
+
+	s.forgetExhaustedBelow(past)
+	assert.True(t, s.isExhausted(broken), "still skipped when the lookback re-lists it")
+
+	s.forgetExhaustedBelow(past)
+	assert.Len(t, s.exhausted, 1, "kept while sweeps keep re-listing it")
+
+	s.forgetExhaustedBelow(past)
+	assert.Empty(t, s.exhausted, "dropped once a sweep no longer lists it")
 }

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -73,6 +73,20 @@ func newReconciler(t *testing.T, st *fakeStorage, vec *fakeVector) (*Reconciler,
 	return s, text
 }
 
+// newReconcilerWithBuilders is newReconciler with an explicit builder set.
+func newReconcilerWithBuilders(t *testing.T, st *fakeStorage, vec *fakeVector, builders ...embed.Builder) *Reconciler {
+	t.Helper()
+	s, err := New(Options{
+		Storage:       st,
+		VectorBackend: vec,
+		BatchEmbedder: embedder.NewBatchEmbedder(*newFakeEmbedder(&fakeText{dim: 4})),
+		Builders:      builders,
+		Interval:      time.Hour,
+	})
+	require.NoError(t, err)
+	return s
+}
+
 // dashEvent builds a pendingEvent with the dashboard group/resource pre-filled.
 func dashEvent(action resourcepb.WatchEvent_Type, ns, name string, rv int64, value []byte) *pendingEvent {
 	return &pendingEvent{
@@ -92,6 +106,17 @@ func dashChange(action resourcepb.WatchEvent_Type, ns, name string, rv int64, va
 		Key: resourcepb.ResourceKey{
 			Group: dashGroup, Resource: dashRes, Namespace: ns, Name: name,
 		},
+		ResourceVersion: rv,
+		Value:           value,
+	}
+}
+
+// change builds a ModifiedResource for a group/resource without a
+// dedicated helper.
+func change(group, res, ns, name string, rv int64, value []byte) *resource.ModifiedResource {
+	return &resource.ModifiedResource{
+		Action:          resourcepb.WatchEvent_ADDED,
+		Key:             resourcepb.ResourceKey{Group: group, Resource: res, Namespace: ns, Name: name},
 		ResourceVersion: rv,
 		Value:           value,
 	}
@@ -817,17 +842,16 @@ func TestReconciler_AcquireLockBlocking_RespectsContextCancel(t *testing.T) {
 // TestReconciler_StartupReconcile_FlushesAtBatchSize verifies that
 // startupReconcile drains the listing iterator in startupBatchSize-sized
 // chunks (so memory stays bounded) but advances the cursor exactly once
-// at the end. Advancing per batch would lose events on real SQL where
-// the rows come back ORDER BY resource_version DESC: the first
-// (highest-RV) batch would bump the cursor past every later, lower-RV
-// batch, silently dropping them.
+// at the end. Advancing per batch would lose events: the event store
+// yields RV-descending, so the first (highest-RV) batch would bump the
+// cursor past every later, lower-RV batch.
 func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
 	prev := startupBatchSize
 	startupBatchSize = 3
 	t.Cleanup(func() { startupBatchSize = prev })
 
 	st := &fakeStorage{}
-	// Emit in DESC order to mirror the real SQL backend.
+	// Emit in DESC order, as the event store does.
 	for i := 6; i >= 0; i-- {
 		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("dash-%d", i)
@@ -849,18 +873,17 @@ func TestReconciler_StartupReconcile_FlushesAtBatchSize(t *testing.T) {
 
 // TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents is the
 // regression test for the bug where startupReconcile flushed each
-// batch via processBatch (which advances the cursor) while the real
-// SQL backend yields ORDER BY resource_version DESC. The first batch
-// held the highest RVs, the cursor jumped past every subsequent
-// (lower-RV) batch's events, and they were silently filtered out by
-// the "ev.rv <= sinceRv" guard.
+// batch via processBatch (which advances the cursor) while the event
+// store yields RV-descending. The first batch held the highest RVs, the
+// cursor jumped past every subsequent (lower-RV) batch's events, and
+// they were silently filtered out by the "ev.rv <= sinceRv" guard.
 func TestReconciler_StartupReconcile_DescOrderDoesNotDropEvents(t *testing.T) {
 	prev := startupBatchSize
 	startupBatchSize = 2
 	t.Cleanup(func() { startupBatchSize = prev })
 
 	st := &fakeStorage{}
-	// Strictly descending RV order, mirroring the real SQL backend.
+	// Strictly descending RV order, as the event store yields.
 	for i := 5; i >= 0; i-- {
 		rv := snowflakeRV(int64(100 + i*10))
 		name := fmt.Sprintf("dash-%d", i)
@@ -928,93 +951,52 @@ func TestReconciler_StartupReconcile_FlushesAtByteBudget(t *testing.T) {
 	})
 }
 
-// TestReconciler_StartupReconcile_RequeuesOnCheckpointWriteFailure
-// pins the recovery behavior when SetLatestRV fails after embeds
-// succeed. Without re-enqueueing the embedded events the cursor stays
-// stale (no advance happened) and the queue is empty, so the next
-// steady-state cycle has nothing to retry — the cursor sits behind
-// real progress until a new write arrives.
-func TestReconciler_StartupReconcile_RequeuesOnCheckpointWriteFailure(t *testing.T) {
-	st := &fakeStorage{}
-	for i := range 3 {
-		rv := snowflakeRV(int64(100 + i*10))
-		name := fmt.Sprintf("dash-%d", i)
-		st.changes = append(st.changes,
-			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
-	}
-
+// When SetLatestRV fails after the embeds succeeded, the cursor stays
+// put and the next run re-lists from it. Nothing is re-enqueued: only a
+// re-walk can prove the RV again.
+func TestReconciler_StartupReconcile_CheckpointWriteFailure_RetriesNextRun(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
+	}}
 	vec := newFakeVector()
 	vec.latestRV = snowflakeRV(50)
-	vec.setLatestRVErr = fmt.Errorf("transient checkpoint write failure")
+	vec.setLatestRVErr = errBoom
 	s, _ := newReconciler(t, st, vec)
 
-	s.startupReconcile(context.Background())
+	s.startupReconcile(t.Context())
 
-	assert.Len(t, vec.upserts, 3, "embeds succeeded even though the cursor write failed")
+	require.Len(t, vec.upserts, 1, "embeds succeeded even though the cursor write failed")
 	assert.Equal(t, snowflakeRV(50), vec.latestRV, "cursor stays at old value when SetLatestRV errors")
-	assert.Equal(t, 3, s.pendingLen(), "all processed events re-enqueued for the next cycle to retry the advance")
-}
+	assert.Zero(t, s.pendingLen(), "nothing queued; the next walk re-proves the RV")
 
-// TestReconciler_StartupReconcile_FreesEmbeddedValues verifies an
-// embedded event releases its value, so the successes slice doesn't grow
-// unbounded over the backlog. Observed via the checkpoint-write-failure
-// path, which re-enqueues every embedded event.
-func TestReconciler_StartupReconcile_FreesEmbeddedValues(t *testing.T) {
-	st := &fakeStorage{}
-	for i := range 3 {
-		rv := snowflakeRV(int64(100 + i*10))
-		name := fmt.Sprintf("dash-%d", i)
-		st.changes = append(st.changes,
-			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
-	}
-
-	vec := newFakeVector()
-	vec.latestRV = snowflakeRV(50)
-	vec.setLatestRVErr = errBoom // fail the checkpoint so successes are re-enqueued
-	s, _ := newReconciler(t, st, vec)
-
-	s.startupReconcile(context.Background())
-
-	pending := s.drainPending()
-	require.Len(t, pending, 3, "all embedded events re-enqueued after the checkpoint write failed")
-	for _, ev := range pending {
-		assert.Nil(t, ev.value, "embedded value released before re-enqueue")
-	}
-}
-
-// After a checkpoint write fails, the re-enqueued value-less events must
-// replay as no-ops (no re-embed, no delete) while still advancing the
-// cursor. Distinct from FreesEmbeddedValues, which pins the release itself.
-func TestReconciler_StartupReconcile_ReleasedValuesReplayAsNoOps(t *testing.T) {
-	st := &fakeStorage{}
-	for i := range 3 {
-		rv := snowflakeRV(int64(100 + i*10))
-		name := fmt.Sprintf("dash-%d", i)
-		st.changes = append(st.changes,
-			dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name)))
-	}
-
-	vec := newFakeVector()
-	vec.latestRV = snowflakeRV(50)
-	vec.setLatestRVErr = errBoom // fail the checkpoint so the embedded events re-enqueue
-	s, text := newReconciler(t, st, vec)
-
-	s.startupReconcile(context.Background())
-	require.Len(t, vec.upserts, 3, "startup embedded all three")
-	require.Equal(t, 3, s.pendingLen(), "all re-enqueued after the checkpoint write failed")
-
-	embedCalls := text.calls
-	upserts := len(vec.upserts)
-
-	// Recover: checkpoint writes succeed; pending value-less events replay.
 	vec.setLatestRVErr = nil
-	s.processPending(context.Background())
+	s.startupReconcile(t.Context())
 
-	assert.Equal(t, embedCalls, text.calls, "replay does not re-embed released values")
-	assert.Equal(t, upserts, len(vec.upserts), "replay does not upsert")
+	assert.Equal(t, snowflakeRV(100), vec.latestRV, "the next run advances the cursor")
+}
+
+// A successful embed releases the event's value, so a caller
+// accumulating successes over a long backlog doesn't retain every
+// dashboard body. Replaying a released event must then be a no-op, and
+// above all must not delete the vectors it already wrote.
+func TestReconciler_EmbeddedValueReleasedAndReplaysAsNoOp(t *testing.T) {
+	vec := newFakeVector()
+	s, text := newReconciler(t, &fakeStorage{}, vec)
+	ev := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-0", snowflakeRV(100), minimalDashboard("dash-0", "Dash 0"))
+
+	_, _, failed, successes, abort := s.processEvents(t.Context(), snowflakeRV(50), []*pendingEvent{ev})
+	require.False(t, abort)
+	require.Empty(t, failed)
+	require.Len(t, successes, 1)
+	require.Nil(t, ev.value, "value released after a successful embed")
+
+	ev.rv = snowflakeRV(110)
+	s.enqueue(ev)
+	s.processPending(t.Context())
+
+	assert.Equal(t, 1, text.calls, "replay does not re-embed")
+	assert.Len(t, vec.upserts, 1, "replay does not upsert")
 	assert.Empty(t, vec.deletes, "replay does not delete")
-	assert.Equal(t, snowflakeRV(120), vec.latestRV, "cursor advances to highest RV on replay")
-	assert.Equal(t, 0, s.pendingLen(), "queue drained after replay")
 }
 
 // TestReconciler_StartupReconcile_DoesNotProcessWatchEvents verifies
@@ -1524,4 +1506,131 @@ func TestReconciler_EnsureResourceInitialized_CreateError(t *testing.T) {
 	err := s.ensureResourceInitialized(context.Background(), dashboard.New(), snowflakeRV(1))
 	require.Error(t, err)
 	assert.Empty(t, vec.backfillJobs)
+}
+
+// The cursor may only move to an RV every builder proved complete, and
+// it must move even when this builder saw nothing, or it ages off the
+// event store and every later listing falls onto the full data-store
+// scan.
+func TestReconciler_StartupReconcile_AdvancesCursor(t *testing.T) {
+	widgets := fakeBuilder{group: "test.grafana.app", resource: "widgets"}
+	dashAt := func(rv int64, name string) *resource.ModifiedResource {
+		return dashChange(resourcepb.WatchEvent_ADDED, "ns", name, rv, minimalDashboard(name, name))
+	}
+
+	tests := []struct {
+		name        string
+		builders    []embed.Builder
+		changes     []*resource.ModifiedResource
+		itemErr     error
+		snapshotRv  int64
+		cursor      int64
+		wantCursor  int64
+		wantUpserts int
+		wantPending int
+	}{
+		{
+			name: "a write landing mid-walk does not lift the listing ceiling",
+			changes: []*resource.ModifiedResource{
+				dashAt(snowflakeRV(200), "dash-1"),
+				dashAt(snowflakeRV(300), "dash-2"),
+			},
+			snapshotRv:  snowflakeRV(200),
+			cursor:      snowflakeRV(50),
+			wantCursor:  snowflakeRV(200),
+			wantUpserts: 2,
+		},
+		{
+			name: "no changes for this builder still rides the store's latest RV",
+			changes: []*resource.ModifiedResource{
+				dashAt(snowflakeRV(100), "dash-1"), // at the cursor, so skipped
+				change("other.grafana.app", "others", "ns", "other-1", snowflakeRV(300), nil),
+			},
+			cursor:     snowflakeRV(100),
+			wantCursor: snowflakeRV(300),
+		},
+		{
+			name:       "interrupted walk proves nothing",
+			changes:    []*resource.ModifiedResource{dashAt(snowflakeRV(100), "dash-1"), dashAt(snowflakeRV(200), "dash-2")},
+			itemErr:    errBoom,
+			cursor:     snowflakeRV(50),
+			wantCursor: snowflakeRV(50),
+		},
+		{
+			name:     "one builder's failure holds the cursor for all of them",
+			builders: []embed.Builder{dashboard.New(), widgets},
+			changes: []*resource.ModifiedResource{
+				dashAt(snowflakeRV(200), "dash-1"),
+				change(widgets.group, widgets.resource, "ns", "widget-1", snowflakeRV(150), []byte("boom")),
+			},
+			cursor:      snowflakeRV(50),
+			wantCursor:  snowflakeRV(150) - 1,
+			wantUpserts: 1,
+			wantPending: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &fakeStorage{changes: tc.changes, itemErr: tc.itemErr, itemErrI: 1, latestRvOverride: tc.snapshotRv}
+			vec := newFakeVector()
+			vec.latestRV = tc.cursor
+			builders := tc.builders
+			if builders == nil {
+				builders = []embed.Builder{dashboard.New()}
+			}
+			s := newReconcilerWithBuilders(t, st, vec, builders...)
+
+			s.startupReconcile(t.Context())
+
+			assert.Equal(t, tc.wantCursor, vec.latestRV, "cursor")
+			assert.Len(t, vec.upserts, tc.wantUpserts, "upserts")
+			assert.Equal(t, tc.wantPending, s.pendingLen(), "queued for retry")
+		})
+	}
+}
+
+// A watch copy that is newer than the listed one but still below the
+// ceiling gets dropped by the live path once the cursor reaches that
+// ceiling, so the walk cannot defer to it.
+func TestReconciler_StartupReconcile_EmbedsEventQueuedBelowTheCeiling(t *testing.T) {
+	st := &fakeStorage{
+		changes: []*resource.ModifiedResource{
+			dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(90), minimalDashboard("dash-1", "Dash 1")),
+		},
+		latestRvOverride: snowflakeRV(100),
+	}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(50)
+	s, _ := newReconciler(t, st, vec)
+	// Watch delivers a newer copy while the walk is running.
+	st.onYield = func() {
+		s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(95), minimalDashboard("dash-1", "Dash 1")))
+	}
+
+	s.startupReconcile(t.Context())
+
+	assert.Equal(t, snowflakeRV(100), vec.latestRV)
+	assert.True(t, vec.hasUpsertFor("ns", dashRes, "dash-1"), "the walk must embed what the cursor is about to pass")
+}
+
+// A write can reach the watch and the walk at the same RV. The walk must
+// still embed it, because the cursor is about to move past that RV and
+// the queued copy is discarded once it does.
+func TestReconciler_StartupReconcile_EmbedsEventAlreadyQueuedFromWatch(t *testing.T) {
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")),
+	}}
+	vec := newFakeVector()
+	vec.latestRV = snowflakeRV(99)
+	s, _ := newReconciler(t, st, vec)
+
+	s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash-1", snowflakeRV(100), minimalDashboard("dash-1", "Dash 1")))
+
+	s.startupReconcile(t.Context())
+	require.True(t, vec.hasUpsertFor("ns", dashRes, "dash-1"), "the walk must embed what the cursor is about to pass")
+	require.Equal(t, snowflakeRV(100), vec.latestRV)
+
+	s.processPending(t.Context())
+	assert.Len(t, vec.upserts, 1, "the queued copy replays as a no-op")
 }


### PR DESCRIPTION
Two commits: the checkpoint refactor that makes the fix possible, then the fix. They ship together - see the last section.

## The bug

`processBatch` wrote `SetLatestRV(pickLatestRV(sinceRv, maxRv, ...))` where `maxRv` is the highest RV in the batch **that arrived**. That asserts everything at or below `maxRv` is embedded; nothing established it.

The pending map is fed only by watch, and watch delivery is at-most-once - core NATS, no JetStream, and `notifier_nats.go` says "recovery relies on consumers relisting". This consumer relisted exactly once, at startup, from the same checkpoint. RVs 100/101/102 with 101 dropped gives cursor 102 and RV 101 never embedded, never looked at again.

Same design also silently dropped late lower-RV events via the `ev.rv <= sinceRv` filter, and `New` documented a "poll-only mode" that did not exist.

## Commit 1: `reconcileSince` reports its proven RV

It now returns the RV its walk proved plus whether the walk finished; the caller advances once, after every builder, to the lowest RV all of them proved. The checkpoint is shared, so no single builder's walk can speak for it.

The proven RV is the store's own latest RV from `ListModifiedSince`, and nothing higher:

- Without it, a resource that stops being written freezes the cursor, and once the cursor ages past event retention every listing falls onto the full data-store scan - the path that OOM'd `storage-api`.
- Above it there is no proof. KV reads its ceiling before the iterator runs, and `WriteEvent` assigns the RV before the data commit, so a mid-walk write can be yielded while an earlier-RV write is still in flight. That write is just relisted next walk, where unchanged content is a no-op.

Because the cursor can now pass an RV the walk did not embed, the walk defers to a queued watch copy only when it is newer **and above the ceiling** - anything at or below is dropped by the live path once the cursor gets there.

## Commit 2: sweep every cycle, and only advance the cursor there

Each cycle drains pending for latency, then sweeps `ListModifiedSince` from the checkpoint. The sweep is the only writer: a completed walk from the cursor is the only thing that establishes nothing below the new value was missed. Lost, late and out-of-order events are picked up by the next sweep, as is a failed cursor write.

Startup is no longer a special phase, just the first cycle. The live path writes the cursor only to seed it from 0 (`ListModifiedSince` rejects 0), and a failed seed keeps its batch queued, since a 0 cursor leaves the sweep switched off.

Two subtleties:

- **The "already processed" filter moves to the live path.** The backend lists from a lookback window behind the cursor precisely so an in-flight write still shows up; filtering it out made that recovery unreachable. It stays on the live path, where such an event was covered by the walk that moved the cursor and re-embedding would overwrite newer content. Listing only yields a resource's latest revision, so the sweep has no such hazard.
- **Retry exhaustion is remembered.** Re-listing would otherwise hand a failing event a fresh attempt count every interval, undoing `maxEventAttempts` and pinning the cursor below a broken resource for good. Give-ups are recorded per resource and RV; a newer RV gets a full budget; a record survives a cursor advance (the lookback would hand the same RV back) and is dropped once a sweep stops listing it.

## Why this is safe

An earlier incremental-checkpoint attempt was dropped as unsafe because it advanced mid-scan, and neither KV listing path is RV-ascending (event store RV-DESC, data store key-ordered). This does not touch that rule: the advance stays end-of-walk only. It changes *who* may advance, never *when within a walk*.

`TryAcquireReconcilerLock` still gates all of `Run`, and the sweep runs inline on `Run`'s goroutine, so there is still exactly one writer.

## Tests

`TestReconciler_Sweep_EmbedsEventWithheldFromWatch` is the proof: withhold one RV from the broadcaster, assert the sweep embeds it and that the cursor never passed it while un-embedded. Fails on today's code.

Around it, table-driven cursor rules plus cases for a mid-walk write not lifting the ceiling, a write recovered by the lookback, a queued copy below the ceiling, an equal-RV queued copy, an idle builder still riding the cursor, an interrupted walk, one builder's failure holding the cursor, a retried seed, skipped lookback on a repeat `sinceRv`, and exhausted retries surviving both a cursor advance and a relist. `fakeStorage` gained `latestRvOverride` and `lookback` knobs mirroring the real backend.

## Why one PR

Commit 1 alone is not neutral: it moves the cursor to a store-wide latest RV while the live path still drops events at or below the cursor, so the filter discards more late events with no sweep yet to recover them. Unified storage deploys continuously, so that interval is real. Commit 2 is what makes commit 1 correct.

Two follow-ups stay separate: a `source`-labelled write counter measuring how often delivery loses events, and a supervising resubscribe loop so a dropped subscriber recovers prompt embedding instead of degrading to sweep latency until restart.
