### PR TITLE
docs: note GitLab token needs project scope for Git Sync

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -155,7 +155,7 @@ After creating the token, return to Grafana and fill in the following fields:
 
 {{< admonition type="note" >}}
 
-If the token loses access to the project, or was never scoped to it, Git Sync can't resolve the project ID and the connection fails with a `create gitlab client: permission denied` error. Make sure the token has project-level access, then reconnect the repository.
+If the token loses access to the project, or was never scoped to it, Git Sync can't resolve the project ID and the connection fails with a permission denied error. Make sure the token has project-level access, then reconnect the repository.
 
 {{< /admonition >}}
 

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -146,10 +146,18 @@ If you want to configure Git Sync for GitLab, you need a GitLab Personal Access 
 
 If you're using a token from a **service account**, you need to add the service account to the GitLab project as a member to avoid authentication issues.
 
+The token must have access to the specific project you're connecting. Git Sync resolves your repository's numeric project ID before it can sync, and this resolution fails if the token isn't scoped to the project.
+
 After creating the token, return to Grafana and fill in the following fields:
 
 1. Paste the token into the **Project Access Token** text box.
 1. Paste the **Repository URL** for your GitLab repository into the text box.
+
+{{< admonition type="note" >}}
+
+If the token loses access to the project, or was never scoped to it, Git Sync can't resolve the project ID and the connection fails with a `create gitlab client: permission denied` error. Make sure the token has project-level access, then reconnect the repository.
+
+{{< /admonition >}}
 
 Select **Configure repository** to set up your provisioning folder.
 


### PR DESCRIPTION
## What

Updates the Git Sync GitLab setup docs to explain that the Personal Access Token must be scoped to the specific project you're connecting, and documents the `create gitlab client: permission denied` error users see when it isn't.

## Why

Git Sync resolves a GitLab repository's numeric **project ID** (via `GET /projects/:id`) before it can sync. When the token has lost — or never had — project-level scope, that call 403s and the connection fails with `create gitlab client: permission denied`, with no docs explaining the cause or fix.

Related:
- grafana/git-ui-sync-project#1346 — investigation of the `create gitlab client: permission denied` error
- grafana/grafana-enterprise#13376 — enterprise-side error classification (surfaces the 403 as `repository.ErrPermissionDenied`)

## How

Adds to the **Configure with GitLab** section of `git-sync-setup/_index.md`:
- A sentence explaining the project-ID resolution step and why the token must be scoped to the project.
- A `note` admonition naming the exact error symptom and the fix (ensure project-level access, then reconnect).

Docs-only change; no code changes.

## Testing

- Docs-only. Reviewed rendered admonition/shortcode syntax against surrounding sections.

## Checklist
- [ ] Tests added/updated (n/a — docs only)
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with Claude Code