### PR TITLE
Zanzana: Persist MT reconciler state so namespaces are not skipped

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/modules"
 	"github.com/grafana/grafana/pkg/services/apiserver/standalone"
 	"github.com/grafana/grafana/pkg/services/authz"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	zStore "github.com/grafana/grafana/pkg/services/authz/zanzana/store"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/frontend"
@@ -73,8 +74,9 @@ func NewModule(opts Options,
 	hooksService *hooks.HooksService,
 	storeProvider zStore.StoreProvider,
 	reconcileCRDs []schema.GroupVersionResource,
+	reconcilerState reconciler.StateStore,
 ) (*ModuleServer, error) {
-	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, vectorMetrics, reg, promGatherer, tracer, license, moduleRegisterer, kvStore, experimentalKV, hooksService, storeProvider, reconcileCRDs)
+	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, vectorMetrics, reg, promGatherer, tracer, license, moduleRegisterer, kvStore, experimentalKV, hooksService, storeProvider, reconcileCRDs, reconcilerState)
 	if err != nil {
 		return nil, err
 	}
@@ -103,6 +105,7 @@ func newModuleServer(opts Options,
 	hooksService *hooks.HooksService,
 	storeProvider zStore.StoreProvider,
 	reconcileCRDs []schema.GroupVersionResource,
+	reconcilerState reconciler.StateStore,
 ) (*ModuleServer, error) {
 	rootCtx, shutdownFn := context.WithCancel(context.Background())
 
@@ -140,6 +143,7 @@ func newModuleServer(opts Options,
 		healthNotifier:   NewHealthNotifier(),
 		storeProvider:    storeProvider,
 		reconcileCRDs:    reconcileCRDs,
+		reconcilerState:  reconcilerState,
 	}
 
 	return s, nil
@@ -202,6 +206,10 @@ type ModuleServer struct {
 	// reconcileCRDs is the list of namespaced CRDs the MT reconciler translates
 	// into Zanzana tuples when running as a standalone zanzana-server module.
 	reconcileCRDs []schema.GroupVersionResource
+
+	// reconcilerState is where the MT reconciler records which namespaces it
+	// has reconciled. Nil in OSS builds, which have no SQL store to record to.
+	reconcilerState reconciler.StateStore
 
 	// healthNotifier is shared between the InstrumentationServer and the OperatorServer
 	// so that operators can signal readiness to the /readyz endpoint.
@@ -303,7 +311,7 @@ func (s *ModuleServer) Run() error {
 	m.RegisterModule(modules.SearchServer, s.initSearchServerModule)
 
 	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {
-		return authz.ProvideZanzanaService(s.cfg, s.features, s.registerer, s.storeProvider, s.reconcileCRDs)
+		return authz.ProvideZanzanaService(s.cfg, s.features, s.registerer, s.storeProvider, s.reconcileCRDs, s.reconcilerState)
 	})
 
 	m.RegisterModule(modules.FrontendServer, func() (services.Service, error) {

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -310,9 +310,7 @@ func (s *ModuleServer) Run() error {
 
 	m.RegisterModule(modules.SearchServer, s.initSearchServerModule)
 
-	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {
-		return authz.ProvideZanzanaService(s.cfg, s.features, s.registerer, s.storeProvider, s.reconcileCRDs, s.reconcilerState)
-	})
+	m.RegisterModule(modules.ZanzanaServer, s.initZanzanaServerModule)
 
 	m.RegisterModule(modules.FrontendServer, func() (services.Service, error) {
 		return frontend.ProvideFrontendService(s.cfg, s.features, s.promGatherer, s.registerer, s.license, s.hooksService)
@@ -452,6 +450,22 @@ func (s *ModuleServer) initStorageServerModule() (services.Service, error) {
 		resourcepb.Quotas_ServiceDesc.ServiceName,
 	)
 	return svc, nil
+}
+
+func (s *ModuleServer) initZanzanaServerModule() (services.Service, error) {
+	reconcilerState := s.reconcilerState
+	if reconcilerState == nil {
+		// Builds are free not to put a SQL store in the module server graph, so
+		// that targets which don't need a database don't open one. Zanzana does
+		// need one, so build it here, where only this target pays for it.
+		var err error
+		reconcilerState, err = InitializeZanzanaReconcilerState(s.cfg, s.features, s.tracer)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return authz.ProvideZanzanaService(s.cfg, s.features, s.registerer, s.storeProvider, s.reconcileCRDs, reconcilerState)
 }
 
 func (s *ModuleServer) initSearchServerModule() (services.Service, error) {

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -367,7 +367,7 @@ func initModuleServerForTest(
 	tracer := tracing.InitializeTracerForTest()
 	hooksService := hooks.ProvideService()
 	license := &licensing.OSSLicensingService{}
-	ms, err := NewModule(opts, apiOpts, featuremgmt.WithFeatures(), cfg, nil, nil, nil, prometheus.NewRegistry(), prometheus.DefaultGatherer, tracer, license, ProvideNoopModuleRegisterer(), nil, nil, hooksService, zStore.ProvideDefaultStoreProvider(), nil)
+	ms, err := NewModule(opts, apiOpts, featuremgmt.WithFeatures(), cfg, nil, nil, nil, prometheus.NewRegistry(), prometheus.DefaultGatherer, tracer, license, ProvideNoopModuleRegisterer(), nil, nil, hooksService, zStore.ProvideDefaultStoreProvider(), nil, nil)
 	require.NoError(t, err)
 
 	conn, err := grpc.NewClient(cfg.GRPCServer.Address,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/router"
 	"github.com/grafana/grafana/pkg/services/apiserver/standalone"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
@@ -67,6 +68,14 @@ func InitializeAPIServerFactory() (standalone.APIServerFactory, error) {
 func InitializeRouterFactory() (router.RouterFactory, error) {
 	wire.Build(wireExtsRouterFactorySet)
 	return &router.NoOpRouterFactory{}, nil // Wire will replace this with a real interface
+}
+
+// InitializeZanzanaReconcilerState builds the MT reconciler's state store for
+// the zanzana-server target, which runs without the SQL store the full server
+// graph provides.
+func InitializeZanzanaReconcilerState(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (reconciler.StateStore, error) {
+	wire.Build(wireExtsZanzanaReconcilerStateSet)
+	return nil, nil
 }
 
 // InitializeSearchSupport builds the document builders together with the

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -11,10 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/authz"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/store"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/hooks"
@@ -69,12 +71,27 @@ func InitializeModuleServer(cfg *setting.Cfg, opts Options, apiOpts api.ServerOp
 	}
 	storeProvider := store.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	stateStore := authz.ProvideNoopZanzanaReconcilerState()
+	stateStore := authz.ProvideDeferredZanzanaReconcilerState()
 	moduleServer, err := NewModule(opts, apiOpts, featureToggles, cfg, storageMetrics, bleveIndexMetrics, vectorMetrics, registerer, gatherer, tracingService, ossLicensingService, moduleRegisterer, kv, experimentalKVOptions, hooksService, storeProvider, v, stateStore)
 	if err != nil {
 		return nil, err
 	}
 	return moduleServer, nil
+}
+
+// InitializeZanzanaReconcilerState builds the MT reconciler's state store for
+// the zanzana-server target, which runs without the SQL store the full server
+// graph provides.
+func InitializeZanzanaReconcilerState(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (reconciler.StateStore, error) {
+	ossMigrations := migrations.ProvideOSSMigrations(features)
+	inProcBus := bus.ProvideBus(tracer)
+	sqlStore, err := sqlstore.ProvideService(cfg, features, ossMigrations, inProcBus, tracer)
+	if err != nil {
+		return nil, err
+	}
+	kvStore := kvstore.ProvideService(sqlStore)
+	stateStore := authz.ProvideZanzanaReconcilerState(kvStore)
+	return stateStore, nil
 }
 
 // InitializeSearchSupport builds the document builders together with the
@@ -115,10 +132,15 @@ var ossBaseCLISet = wire.NewSet(
 
 var moduleServerSet = wire.NewSet(
 	NewModule,
-	ossBaseCLISet, tracing.ProvideTracingConfig, tracing.ProvideService, wire.Bind(new(tracing.Tracer), new(*tracing.TracingService)), resource.ProvideStorageMetrics, resource.ProvideIndexMetrics, resource.ProvideVectorMetrics, ProvideNoopModuleRegisterer, sql.ProvideModuleServerKV, sql.ProvideExperimentalKV, store.ProvideDefaultStoreProvider, authz.ProvideReconcileCRDs, authz.ProvideNoopZanzanaReconcilerState,
+	ossBaseCLISet, tracing.ProvideTracingConfig, tracing.ProvideService, wire.Bind(new(tracing.Tracer), new(*tracing.TracingService)), resource.ProvideStorageMetrics, resource.ProvideIndexMetrics, resource.ProvideVectorMetrics, ProvideNoopModuleRegisterer, sql.ProvideModuleServerKV, sql.ProvideExperimentalKV, store.ProvideDefaultStoreProvider, authz.ProvideReconcileCRDs, authz.ProvideDeferredZanzanaReconcilerState,
 )
 
 var dashboardStatsSet = wire.NewSet(builders.ProvideDashboardStats, wire.Bind(new(builders.DashboardStats), new(*builders.OssDashboardStats)))
+
+// zanzanaReconcilerStateSet builds the reconciler's state store from its own
+// SQL store, so the zanzana-server target gets one without the base module
+// graph — and therefore every other module target — opening a database.
+var zanzanaReconcilerStateSet = wire.NewSet(migrations.ProvideOSSMigrations, wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)), bus.ProvideBus, wire.Bind(new(bus.Bus), new(*bus.InProcBus)), sqlstore.ProvideService, wire.Bind(new(db.DB), new(*sqlstore.SQLStore)), kvstore.ProvideService, authz.ProvideZanzanaReconcilerState)
 
 var searchSupportSet = wire.NewSet(
 	dashboardStatsSet, migrations.ProvideOSSMigrations, wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)), bus.ProvideBus, wire.Bind(new(bus.Bus), new(*bus.InProcBus)), sqlstore.ProvideService, wire.Bind(new(db.DB), new(*sqlstore.SQLStore)), search.ProvideDocumentBuilders,

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -69,7 +69,8 @@ func InitializeModuleServer(cfg *setting.Cfg, opts Options, apiOpts api.ServerOp
 	}
 	storeProvider := store.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	moduleServer, err := NewModule(opts, apiOpts, featureToggles, cfg, storageMetrics, bleveIndexMetrics, vectorMetrics, registerer, gatherer, tracingService, ossLicensingService, moduleRegisterer, kv, experimentalKVOptions, hooksService, storeProvider, v)
+	stateStore := authz.ProvideNoopZanzanaReconcilerState()
+	moduleServer, err := NewModule(opts, apiOpts, featureToggles, cfg, storageMetrics, bleveIndexMetrics, vectorMetrics, registerer, gatherer, tracingService, ossLicensingService, moduleRegisterer, kv, experimentalKVOptions, hooksService, storeProvider, v, stateStore)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ var ossBaseCLISet = wire.NewSet(
 
 var moduleServerSet = wire.NewSet(
 	NewModule,
-	ossBaseCLISet, tracing.ProvideTracingConfig, tracing.ProvideService, wire.Bind(new(tracing.Tracer), new(*tracing.TracingService)), resource.ProvideStorageMetrics, resource.ProvideIndexMetrics, resource.ProvideVectorMetrics, ProvideNoopModuleRegisterer, sql.ProvideModuleServerKV, sql.ProvideExperimentalKV, store.ProvideDefaultStoreProvider, authz.ProvideReconcileCRDs,
+	ossBaseCLISet, tracing.ProvideTracingConfig, tracing.ProvideService, wire.Bind(new(tracing.Tracer), new(*tracing.TracingService)), resource.ProvideStorageMetrics, resource.ProvideIndexMetrics, resource.ProvideVectorMetrics, ProvideNoopModuleRegisterer, sql.ProvideModuleServerKV, sql.ProvideExperimentalKV, store.ProvideDefaultStoreProvider, authz.ProvideReconcileCRDs, authz.ProvideNoopZanzanaReconcilerState,
 )
 
 var dashboardStatsSet = wire.NewSet(builders.ProvideDashboardStats, wire.Bind(new(builders.DashboardStats), new(*builders.OssDashboardStats)))

--- a/pkg/server/wire_subinject_oss.go
+++ b/pkg/server/wire_subinject_oss.go
@@ -11,10 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/authz"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	zStore "github.com/grafana/grafana/pkg/services/authz/zanzana/store"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/hooks"
@@ -53,12 +55,26 @@ var moduleServerSet = wire.NewSet(
 	sql.ProvideExperimentalKV,
 	zStore.ProvideDefaultStoreProvider,
 	authz.ProvideReconcileCRDs,
-	authz.ProvideNoopZanzanaReconcilerState,
+	authz.ProvideDeferredZanzanaReconcilerState,
 )
 
 var dashboardStatsSet = wire.NewSet(
 	builders.ProvideDashboardStats,
 	wire.Bind(new(builders.DashboardStats), new(*builders.OssDashboardStats)),
+)
+
+// zanzanaReconcilerStateSet builds the reconciler's state store from its own
+// SQL store, so the zanzana-server target gets one without the base module
+// graph — and therefore every other module target — opening a database.
+var zanzanaReconcilerStateSet = wire.NewSet(
+	migrations.ProvideOSSMigrations,
+	wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)),
+	bus.ProvideBus,
+	wire.Bind(new(bus.Bus), new(*bus.InProcBus)),
+	sqlstore.ProvideService,
+	wire.Bind(new(db.DB), new(*sqlstore.SQLStore)),
+	kvstore.ProvideService,
+	authz.ProvideZanzanaReconcilerState,
 )
 
 var searchSupportSet = wire.NewSet(
@@ -77,6 +93,14 @@ var searchSupportSet = wire.NewSet(
 func InitializeModuleServer(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*ModuleServer, error) {
 	wire.Build(moduleServerSet)
 	return &ModuleServer{}, nil
+}
+
+// InitializeZanzanaReconcilerState builds the MT reconciler's state store for
+// the zanzana-server target, which runs without the SQL store the full server
+// graph provides.
+func InitializeZanzanaReconcilerState(cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer tracing.Tracer) (reconciler.StateStore, error) {
+	wire.Build(zanzanaReconcilerStateSet)
+	return nil, nil
 }
 
 // InitializeSearchSupport builds the document builders together with the

--- a/pkg/server/wire_subinject_oss.go
+++ b/pkg/server/wire_subinject_oss.go
@@ -53,6 +53,7 @@ var moduleServerSet = wire.NewSet(
 	sql.ProvideExperimentalKV,
 	zStore.ProvideDefaultStoreProvider,
 	authz.ProvideReconcileCRDs,
+	authz.ProvideNoopZanzanaReconcilerState,
 )
 
 var dashboardStatsSet = wire.NewSet(

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -137,9 +137,11 @@ func ProvideZanzanaReconcilerState(kvStore kvstore.KVStore) reconciler.StateStor
 	return newReconcilerState(kvStore)
 }
 
-// ProvideNoopZanzanaReconcilerState is the OSS module server's stand-in: that
-// build has no SQL store, and therefore no kv_store table to record into.
-func ProvideNoopZanzanaReconcilerState() reconciler.StateStore {
+// ProvideDeferredZanzanaReconcilerState leaves the state store to the OSS
+// module server, whose graph has no SQL store: it builds one from its own
+// injector when the zanzana module starts, so that targets which need no
+// database don't open one.
+func ProvideDeferredZanzanaReconcilerState() reconciler.StateStore {
 	return nil
 }
 

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -116,7 +116,7 @@ func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tra
 	}
 
 	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs, elector,
-		zServer.WithReconcilerState(newReconcilerState(kvstore.ProvideService(db))))
+		newReconcilerState(kvstore.ProvideService(db)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
@@ -471,7 +471,7 @@ func (z *Zanzana) start(ctx context.Context) error {
 	}
 
 	zanzanaServer, err := zServer.NewZanzanaServer(z.cfg, store, z.logger, z.tracer, z.reg, z.reconcileCRDs, elector,
-		zServer.WithReconcilerState(z.reconcilerState))
+		z.reconcilerState)
 	if err != nil {
 		return fmt.Errorf("failed to start zanzana: %w", err)
 	}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/leaderelection"
 	"github.com/grafana/grafana/pkg/infra/leaderelection/kvlease"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -114,12 +115,32 @@ func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tra
 		return nil, fmt.Errorf("failed to create zanzana store: %w", err)
 	}
 
-	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs, elector)
+	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs, elector,
+		zServer.WithReconcilerState(newReconcilerState(kvstore.ProvideService(db))))
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
 	return srv, nil
+}
+
+// newReconcilerState points the MT reconciler at Grafana's kv_store table, so
+// the record of what it has reconciled outlives the process and survives a
+// rebuild of the Zanzana store.
+func newReconcilerState(kvStore kvstore.KVStore) reconciler.StateStore {
+	return kvstore.WithNamespace(kvStore, reconciler.StateKVOrgID, reconciler.StateKVNamespace)
+}
+
+// ProvideZanzanaReconcilerState supplies the standalone zanzana module with the
+// same reconciliation records the embedded server keeps.
+func ProvideZanzanaReconcilerState(kvStore kvstore.KVStore) reconciler.StateStore {
+	return newReconcilerState(kvStore)
+}
+
+// ProvideNoopZanzanaReconcilerState is the OSS module server's stand-in: that
+// build has no SQL store, and therefore no kv_store table to record into.
+func ProvideNoopZanzanaReconcilerState() reconciler.StateStore {
+	return nil
 }
 
 // ProvideEmbeddedZanzanaElector builds the leader-election Elector for the
@@ -390,7 +411,7 @@ type ZanzanaService interface {
 var _ ZanzanaService = (*Zanzana)(nil)
 
 // ProvideZanzanaService is used to register zanzana as a module so we can run it separately from grafana.
-func ProvideZanzanaService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, reg prometheus.Registerer, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource) (*Zanzana, error) {
+func ProvideZanzanaService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, reg prometheus.Registerer, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource, reconcilerState reconciler.StateStore) (*Zanzana, error) {
 	cfgProvider, err := configprovider.ProvideService(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to provide config: %w", err)
@@ -408,12 +429,13 @@ func ProvideZanzanaService(cfg *setting.Cfg, features featuremgmt.FeatureToggles
 	}
 
 	s := &Zanzana{
-		cfg:           cfg,
-		logger:        log.New("zanzana.server"),
-		reg:           reg,
-		tracer:        tracer,
-		storeProvider: storeProvider,
-		reconcileCRDs: reconcileCRDs,
+		cfg:             cfg,
+		logger:          log.New("zanzana.server"),
+		reg:             reg,
+		tracer:          tracer,
+		storeProvider:   storeProvider,
+		reconcileCRDs:   reconcileCRDs,
+		reconcilerState: reconcilerState,
 	}
 
 	s.BasicService = services.NewBasicService(s.start, s.running, s.stopping).WithName("zanzana")
@@ -424,14 +446,15 @@ func ProvideZanzanaService(cfg *setting.Cfg, features featuremgmt.FeatureToggles
 type Zanzana struct {
 	*services.BasicService
 
-	cfg           *setting.Cfg
-	zanzanaServer zanzana.ServerInternal
-	logger        log.Logger
-	tracer        tracing.Tracer
-	handle        grpcserver.Provider
-	reg           prometheus.Registerer
-	storeProvider zStore.StoreProvider
-	reconcileCRDs []schema.GroupVersionResource
+	cfg             *setting.Cfg
+	zanzanaServer   zanzana.ServerInternal
+	logger          log.Logger
+	tracer          tracing.Tracer
+	handle          grpcserver.Provider
+	reg             prometheus.Registerer
+	storeProvider   zStore.StoreProvider
+	reconcileCRDs   []schema.GroupVersionResource
+	reconcilerState reconciler.StateStore
 }
 
 func (z *Zanzana) start(ctx context.Context) error {
@@ -445,7 +468,8 @@ func (z *Zanzana) start(ctx context.Context) error {
 		return err
 	}
 
-	zanzanaServer, err := zServer.NewZanzanaServer(z.cfg, store, z.logger, z.tracer, z.reg, z.reconcileCRDs, elector)
+	zanzanaServer, err := zServer.NewZanzanaServer(z.cfg, store, z.logger, z.tracer, z.reg, z.reconcileCRDs, elector,
+		zServer.WithReconcilerState(z.reconcilerState))
 	if err != nil {
 		return fmt.Errorf("failed to start zanzana: %w", err)
 	}

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -43,6 +43,12 @@ type Reconciler struct {
 	metrics       *reconcilerMetrics
 	leaderElector leaderelection.Elector
 
+	// stateStore persists which namespaces have been reconciled. It is nil when
+	// the deployment has no Grafana database to keep the records in, in which
+	// case EnsureNamespace falls back to treating an existing store as
+	// reconciled.
+	stateStore StateStore
+
 	workQueue chan string
 
 	// queuedNamespaces tracks namespaces that are currently either sitting in
@@ -53,7 +59,8 @@ type Reconciler struct {
 
 	// ensuredNamespaces caches namespaces that have been fully reconciled - the store for this namespace exists with up to date permissions - in this
 	// process lifetime so EnsureNamespace can short-circuit on subsequent calls
-	// without taking any lock or making any RPC.
+	// without taking any lock or making any RPC. stateStore carries the same
+	// knowledge across process restarts.
 	ensuredNamespaces sync.Map
 	ensureSF          singleflight.Group
 
@@ -112,6 +119,7 @@ func NewReconciler(
 	tracer tracing.Tracer,
 	reg prometheus.Registerer,
 	leaderElector leaderelection.Elector,
+	stateStore StateStore,
 ) *Reconciler {
 	return &Reconciler{
 		server:        srv,
@@ -121,6 +129,7 @@ func NewReconciler(
 		tracer:        tracer,
 		metrics:       newReconcilerMetrics(reg),
 		leaderElector: leaderElector,
+		stateStore:    stateStore,
 		workQueue:     make(chan string, cfg.queueSize()),
 	}
 }
@@ -298,7 +307,10 @@ func (r *Reconciler) runNamespaceReconciliation(ctx context.Context, namespace s
 			"workerID", workerID,
 			"duration", elapsed,
 		}
+		// A nil result means the namespace was deleted, in which case
+		// reconcileNamespace has already dropped its store and its record.
 		if result != nil {
+			r.markReconciled(ctx, namespace)
 			logFields = append(logFields,
 				"expectedTuples", result.ExpectedTuples,
 				"tuplesToAdd", result.TuplesToAdd,
@@ -328,6 +340,7 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) (
 		if apierrors.IsNotFound(err) {
 			r.logger.Warn("Namespace deleted or archived, removing store from Zanzana", "namespace", namespace)
 			r.ensuredNamespaces.Delete(namespace)
+			r.clearReconciled(ctx, namespace)
 			if delErr := r.server.DeleteStore(ctx, namespace); delErr != nil {
 				r.logger.Error("Failed to delete orphaned store", "namespace", namespace, "error", delErr)
 			}
@@ -375,9 +388,10 @@ func (r *Reconciler) reconcileNamespace(ctx context.Context, namespace string) (
 
 // EnsureNamespace is not gated by leader election: it is called inline from
 // the authorization request path and must complete before the caller can
-// proceed. It only creates stores for new namespaces. Any overlap with the
-// leader's background reconciliation loop is safe because reconcileNamespace
-// is idempotent.
+// proceed. It reconciles namespaces that have no record of a completed
+// reconciliation against their current store. Any overlap with the leader's
+// background reconciliation loop is safe because reconcileNamespace is
+// idempotent.
 func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) error {
 	if _, ok := r.ensuredNamespaces.Load(namespace); ok {
 		return nil
@@ -401,25 +415,32 @@ func (r *Reconciler) EnsureNamespace(ctx context.Context, namespace string) erro
 			return false, fmt.Errorf("failed to get store: %w", err)
 		}
 
+		if r.isReconciled(ctx, namespace, store) {
+			r.ensuredNamespaces.Store(namespace, struct{}{})
+			return false, nil
+		}
+
 		if store == nil {
 			storeCreated = true
 			if _, err = r.server.GetOrCreateStore(ctx, namespace); err != nil {
 				return false, fmt.Errorf("failed to create store: %w", err)
 			}
+		}
 
-			if _, err = r.reconcileNamespace(ctx, namespace); err != nil {
-				return false, fmt.Errorf("failed to reconcile namespace: %w", err)
-			}
+		if _, err = r.reconcileNamespace(ctx, namespace); err != nil {
+			return false, fmt.Errorf("failed to reconcile namespace: %w", err)
+		}
 
-			// Verify the store still exists — reconcileNamespace may have
-			// deleted it if the namespace was removed while we were working.
-			store, err = r.server.GetStore(ctx, namespace)
-			if err != nil || store == nil {
-				return false, fmt.Errorf("store disappeared during reconciliation for namespace %s", namespace)
-			}
+		// Verify the store still exists — reconcileNamespace may have
+		// deleted it if the namespace was removed while we were working.
+		store, err = r.server.GetStore(ctx, namespace)
+		if err != nil || store == nil {
+			return false, fmt.Errorf("store disappeared during reconciliation for namespace %s", namespace)
 		}
 
 		span.SetAttributes(attribute.Bool("ensure.store_created", storeCreated))
+
+		r.markReconciled(ctx, namespace)
 
 		r.logger.Info("EnsureNamespace reconciled namespace",
 			"namespace", namespace,

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -126,18 +126,22 @@ func TestEnsureNamespace_ShortCircuitsOnCachedNamespace(t *testing.T) {
 	assert.Equal(t, int32(0), srv.getStoreIdx.Load(), "GetStore should not be called for a cached namespace")
 }
 
-func TestEnsureNamespace_ExistingStoreIsCachedWithoutReconcile(t *testing.T) {
-	// Fallback behaviour for deployments with no state store: an existing store
-	// is the only signal available, so it is taken as reconciled and
-	// GetOrCreateStore and reconcile are skipped.
+func TestEnsureNamespace_ExistingStoreWithoutStateStoreIsReconciled(t *testing.T) {
+	// A reconciler built without a state store has no record to consult, which
+	// must mean "not reconciled" — reading an existing store as reconciled is
+	// the bug the state exists to fix.
+	//
+	// notFoundClientFactory drives reconcileNamespace into its "namespace
+	// deleted" branch, so reaching it is observable through DeleteStore.
 	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "existing-ns"}}}
 	r := newReconcilerForTest(srv, notFoundClientFactory{})
 
-	require.NoError(t, r.EnsureNamespace(context.Background(), "existing-ns"))
+	require.ErrorContains(t, r.EnsureNamespace(context.Background(), "existing-ns"), "store disappeared")
 
-	_, cached := r.ensuredNamespaces.Load("existing-ns")
-	assert.True(t, cached)
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
 	assert.Equal(t, int32(0), srv.getOrCreateCalls.Load(), "GetOrCreateStore should not be called when store already exists")
+	_, cached := r.ensuredNamespaces.Load("existing-ns")
+	assert.False(t, cached)
 }
 
 func TestReconcileNamespace_EvictsCacheOnNotFound(t *testing.T) {

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -127,8 +127,9 @@ func TestEnsureNamespace_ShortCircuitsOnCachedNamespace(t *testing.T) {
 }
 
 func TestEnsureNamespace_ExistingStoreIsCachedWithoutReconcile(t *testing.T) {
-	// Store already exists → GetOrCreateStore and reconcile must be skipped,
-	// but the namespace should still be cached.
+	// Fallback behaviour for deployments with no state store: an existing store
+	// is the only signal available, so it is taken as reconciled and
+	// GetOrCreateStore and reconcile are skipped.
 	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "existing-ns"}}}
 	r := newReconcilerForTest(srv, notFoundClientFactory{})
 

--- a/pkg/services/authz/zanzana/server/reconciler/state.go
+++ b/pkg/services/authz/zanzana/server/reconciler/state.go
@@ -61,11 +61,10 @@ func (r *Reconciler) isReconciled(ctx context.Context, namespace string, store *
 	}
 
 	if r.stateStore == nil {
-		// Without durable state, store existence is the only signal available,
-		// which is what this path relied on before. Reconciling every namespace
-		// on its first request instead would move a full reconcile onto the
-		// authorization path after every process start.
-		return true
+		// Callers that run a reconciler are required to supply one; treat its
+		// absence the way an empty record is treated rather than as evidence
+		// that the namespace is reconciled.
+		return false
 	}
 
 	state, ok, err := r.readState(ctx, namespace)

--- a/pkg/services/authz/zanzana/server/reconciler/state.go
+++ b/pkg/services/authz/zanzana/server/reconciler/state.go
@@ -46,9 +46,15 @@ type namespaceState struct {
 }
 
 // describes reports whether the record was written for the store that exists
-// now, by the current expected-tuple computation.
+// now, by an expected-tuple computation at least as new as this process's.
+//
+// A newer version counts as reconciled so that during a rolling deploy that
+// bumps stateVersion, replicas still running the old binary leave namespaces
+// the new ones have reconciled alone rather than reverting their tuples. A
+// rollback recovers on its own: the leader's periodic pass reconciles every
+// store regardless of its record and rewrites the record with its own version.
 func (s namespaceState) describes(store *zanzana.StoreInfo) bool {
-	return s.Version == stateVersion && s.StoreID != "" && s.StoreID == store.ID
+	return s.Version >= stateVersion && s.StoreID != "" && s.StoreID == store.ID
 }
 
 // isReconciled reports whether namespace can be served without reconciling it

--- a/pkg/services/authz/zanzana/server/reconciler/state.go
+++ b/pkg/services/authz/zanzana/server/reconciler/state.go
@@ -1,0 +1,142 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+const (
+	// StateKVOrgID and StateKVNamespace address the reconciler's records in
+	// Grafana's kv_store table. Reconciliation state is not org-scoped, so it
+	// uses org 0 like the unified storage dualwrite state does.
+	StateKVOrgID     int64 = 0
+	StateKVNamespace       = "zanzana.reconciler"
+
+	// stateVersion identifies the expected-tuple computation. Bump it whenever
+	// a change makes tuples written by earlier versions wrong, so that every
+	// namespace reconciles on its next authorization request instead of waiting
+	// out the reconciler interval.
+	stateVersion = 1
+)
+
+// StateStore persists which namespaces have been reconciled, keyed by
+// namespace. It is satisfied by *kvstore.NamespacedKVStore.
+type StateStore interface {
+	Get(ctx context.Context, key string) (string, bool, error)
+	Set(ctx context.Context, key string, value string) error
+	Del(ctx context.Context, key string) error
+}
+
+// namespaceState records a completed reconciliation. Its purpose is to identify
+// the store the tuples were written to: the record lives in Grafana's database
+// while the tuples live in Zanzana's, and the two can diverge — the OpenFGA
+// migrations drop and rebuild their tables when the goose schema is
+// inconsistent, on the grounds that Zanzana holds derived state.
+type namespaceState struct {
+	StoreID string `json:"store_id"`
+	// ModelID is diagnostic only. GetStore and ListAllStores leave it empty, so
+	// comparing it would force a reconcile after every process start.
+	ModelID      string `json:"model_id"`
+	ReconciledAt int64  `json:"reconciled_at"`
+	Version      int    `json:"version"`
+}
+
+// describes reports whether the record was written for the store that exists
+// now, by the current expected-tuple computation.
+func (s namespaceState) describes(store *zanzana.StoreInfo) bool {
+	return s.Version == stateVersion && s.StoreID != "" && s.StoreID == store.ID
+}
+
+// isReconciled reports whether namespace can be served without reconciling it
+// first. A store existing is not evidence of reconciliation: the user and org
+// mutation hooks write tuples through GetOrCreateStore, so a store can exist
+// for a namespace whose role bindings were never computed.
+func (r *Reconciler) isReconciled(ctx context.Context, namespace string, store *zanzana.StoreInfo) bool {
+	if store == nil {
+		return false
+	}
+
+	if r.stateStore == nil {
+		// Without durable state, store existence is the only signal available,
+		// which is what this path relied on before. Reconciling every namespace
+		// on its first request instead would move a full reconcile onto the
+		// authorization path after every process start.
+		return true
+	}
+
+	state, ok, err := r.readState(ctx, namespace)
+	if err != nil {
+		// An unreadable record is treated as absent: reconciling a namespace
+		// twice is harmless, skipping it leaves users without permissions.
+		r.logger.Warn("Failed to read reconciliation state", "namespace", namespace, "error", err)
+		r.metrics.errorsTotal.WithLabelValues("read_state").Inc()
+		return false
+	}
+
+	return ok && state.describes(store)
+}
+
+func (r *Reconciler) readState(ctx context.Context, namespace string) (namespaceState, bool, error) {
+	raw, ok, err := r.stateStore.Get(ctx, namespace)
+	if err != nil {
+		return namespaceState{}, false, err
+	}
+	if !ok {
+		return namespaceState{}, false, nil
+	}
+
+	var state namespaceState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return namespaceState{}, false, fmt.Errorf("failed to decode reconciliation state: %w", err)
+	}
+
+	return state, true, nil
+}
+
+// markReconciled records that namespace is reconciled against its current
+// store. Failing to record is logged but not fatal: the namespace stays
+// correct, it just gets reconciled again after the next process start.
+func (r *Reconciler) markReconciled(ctx context.Context, namespace string) {
+	if r.stateStore == nil {
+		return
+	}
+
+	store, err := r.server.GetStore(ctx, namespace)
+	if err != nil || store == nil {
+		r.logger.Warn("Skipping reconciliation state write, store unavailable", "namespace", namespace, "error", err)
+		return
+	}
+
+	raw, err := json.Marshal(namespaceState{
+		StoreID:      store.ID,
+		ModelID:      store.ModelID,
+		ReconciledAt: time.Now().Unix(),
+		Version:      stateVersion,
+	})
+	if err != nil {
+		r.logger.Warn("Failed to encode reconciliation state", "namespace", namespace, "error", err)
+		return
+	}
+
+	if err := r.stateStore.Set(ctx, namespace, string(raw)); err != nil {
+		r.logger.Warn("Failed to write reconciliation state", "namespace", namespace, "error", err)
+		r.metrics.errorsTotal.WithLabelValues("write_state").Inc()
+	}
+}
+
+// clearReconciled drops the record for a namespace that no longer exists, so a
+// namespace recreated under the same name reconciles from scratch.
+func (r *Reconciler) clearReconciled(ctx context.Context, namespace string) {
+	if r.stateStore == nil {
+		return
+	}
+
+	if err := r.stateStore.Del(ctx, namespace); err != nil {
+		r.logger.Warn("Failed to delete reconciliation state", "namespace", namespace, "error", err)
+		r.metrics.errorsTotal.WithLabelValues("delete_state").Inc()
+	}
+}

--- a/pkg/services/authz/zanzana/server/reconciler/state_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/state_test.go
@@ -145,6 +145,21 @@ func TestEnsureNamespace_ReconcilesOnOutdatedRecordVersion(t *testing.T) {
 	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
 }
 
+func TestEnsureNamespace_SkipsReconcileOnNewerRecordVersion(t *testing.T) {
+	// A record written by a newer binary mid-rollout must not be reverted to
+	// this one's computation.
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "ahead-ns"}}}
+	state := newFakeStateStore()
+	state.record(t, "ahead-ns", namespaceState{StoreID: "store-1", Version: stateVersion + 1})
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.NoError(t, r.EnsureNamespace(context.Background(), "ahead-ns"))
+
+	assert.Equal(t, int32(0), srv.deleteStoreCalls.Load())
+	assert.Equal(t, namespaceState{StoreID: "store-1", Version: stateVersion + 1}, state.state(t, "ahead-ns"),
+		"the newer record should be left as it is")
+}
+
 func TestEnsureNamespace_ReconcilesWhenStateStoreFails(t *testing.T) {
 	// An unreadable record must not be read as "already reconciled".
 	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "broken-ns"}}}

--- a/pkg/services/authz/zanzana/server/reconciler/state_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/state_test.go
@@ -1,0 +1,207 @@
+package reconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+// fakeStateStore is an in-memory StateStore with optional error injection.
+type fakeStateStore struct {
+	mu     sync.Mutex
+	values map[string]string
+	getErr error
+	setErr error
+	delErr error
+}
+
+func newFakeStateStore() *fakeStateStore {
+	return &fakeStateStore{values: map[string]string{}}
+}
+
+func (f *fakeStateStore) Get(_ context.Context, key string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return "", false, f.getErr
+	}
+	v, ok := f.values[key]
+	return v, ok, nil
+}
+
+func (f *fakeStateStore) Set(_ context.Context, key string, value string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.values[key] = value
+	return nil
+}
+
+func (f *fakeStateStore) Del(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.delErr != nil {
+		return f.delErr
+	}
+	delete(f.values, key)
+	return nil
+}
+
+func (f *fakeStateStore) has(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.values[key]
+	return ok
+}
+
+func (f *fakeStateStore) state(t *testing.T, key string) namespaceState {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	raw, ok := f.values[key]
+	require.True(t, ok, "no reconciliation state recorded for %s", key)
+	var state namespaceState
+	require.NoError(t, json.Unmarshal([]byte(raw), &state))
+	return state
+}
+
+func (f *fakeStateStore) record(t *testing.T, key string, state namespaceState) {
+	t.Helper()
+	raw, err := json.Marshal(state)
+	require.NoError(t, err)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[key] = string(raw)
+}
+
+func newReconcilerWithState(srv *stubServer, cf resources.ClientFactory, ss StateStore) *Reconciler {
+	r := newReconcilerForTest(srv, cf)
+	r.stateStore = ss
+	return r
+}
+
+func TestEnsureNamespace_ReconcilesStoreWithoutRecord(t *testing.T) {
+	// The regression this state exists for: the user and org mutation hooks
+	// create a store on first login, so a store can exist for a namespace whose
+	// role bindings were never computed. With no record, EnsureNamespace must
+	// reconcile rather than trust the store's existence.
+	//
+	// notFoundClientFactory drives reconcileNamespace into its "namespace
+	// deleted" branch, so reaching it is observable through DeleteStore.
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "hooked-ns"}}}
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, newFakeStateStore())
+
+	err := r.EnsureNamespace(context.Background(), "hooked-ns")
+	require.ErrorContains(t, err, "store disappeared during reconciliation")
+
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load(), "namespace with no record should be reconciled")
+	_, cached := r.ensuredNamespaces.Load("hooked-ns")
+	assert.False(t, cached)
+}
+
+func TestEnsureNamespace_SkipsReconcileOnMatchingRecord(t *testing.T) {
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "done-ns"}}}
+	state := newFakeStateStore()
+	state.record(t, "done-ns", namespaceState{StoreID: "store-1", Version: stateVersion})
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.NoError(t, r.EnsureNamespace(context.Background(), "done-ns"))
+
+	assert.Equal(t, int32(0), srv.deleteStoreCalls.Load(), "reconciled namespace should not be reconciled again")
+	_, cached := r.ensuredNamespaces.Load("done-ns")
+	assert.True(t, cached)
+}
+
+func TestEnsureNamespace_ReconcilesWhenRecordNamesAnotherStore(t *testing.T) {
+	// The record lives in Grafana's database and the tuples in Zanzana's, so a
+	// rebuilt Zanzana store leaves a record naming a store that no longer
+	// exists. The store ID mismatch has to invalidate it.
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-2", Name: "rebuilt-ns"}}}
+	state := newFakeStateStore()
+	state.record(t, "rebuilt-ns", namespaceState{StoreID: "store-1", Version: stateVersion})
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.ErrorContains(t, r.EnsureNamespace(context.Background(), "rebuilt-ns"), "store disappeared")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
+}
+
+func TestEnsureNamespace_ReconcilesOnOutdatedRecordVersion(t *testing.T) {
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "old-ns"}}}
+	state := newFakeStateStore()
+	state.record(t, "old-ns", namespaceState{StoreID: "store-1", Version: stateVersion - 1})
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.ErrorContains(t, r.EnsureNamespace(context.Background(), "old-ns"), "store disappeared")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
+}
+
+func TestEnsureNamespace_ReconcilesWhenStateStoreFails(t *testing.T) {
+	// An unreadable record must not be read as "already reconciled".
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "broken-ns"}}}
+	state := newFakeStateStore()
+	state.getErr = errors.New("kv unavailable")
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.ErrorContains(t, r.EnsureNamespace(context.Background(), "broken-ns"), "store disappeared")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
+}
+
+func TestEnsureNamespace_ReconcilesOnUndecodableRecord(t *testing.T) {
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "garbage-ns"}}}
+	state := newFakeStateStore()
+	require.NoError(t, state.Set(context.Background(), "garbage-ns", "not json"))
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	require.ErrorContains(t, r.EnsureNamespace(context.Background(), "garbage-ns"), "store disappeared")
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
+}
+
+func TestMarkReconciled_RecordsCurrentStore(t *testing.T) {
+	srv := &stubServer{getStoreResults: []*zanzana.StoreInfo{{ID: "store-1", Name: "ns-1", ModelID: "model-1"}}}
+	state := newFakeStateStore()
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	r.markReconciled(context.Background(), "ns-1")
+
+	recorded := state.state(t, "ns-1")
+	assert.Equal(t, "store-1", recorded.StoreID)
+	assert.Equal(t, "model-1", recorded.ModelID)
+	assert.Equal(t, stateVersion, recorded.Version)
+	assert.NotZero(t, recorded.ReconciledAt)
+}
+
+func TestMarkReconciled_SkipsWhenStoreIsGone(t *testing.T) {
+	srv := &stubServer{}
+	state := newFakeStateStore()
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	r.markReconciled(context.Background(), "missing-ns")
+
+	assert.False(t, state.has("missing-ns"), "no record should be written without a store to name")
+}
+
+func TestReconcileNamespace_ClearsRecordOnNotFound(t *testing.T) {
+	// A namespace that disappears has its store deleted, so its record must go
+	// too — otherwise a namespace recreated under the same name would inherit a
+	// record for tuples that no longer exist.
+	srv := &stubServer{}
+	state := newFakeStateStore()
+	state.record(t, "gone-ns", namespaceState{StoreID: "store-1", Version: stateVersion})
+	r := newReconcilerWithState(srv, notFoundClientFactory{}, state)
+
+	_, err := r.reconcileNamespace(context.Background(), "gone-ns")
+	require.NoError(t, err)
+
+	assert.False(t, state.has("gone-ns"))
+	assert.Equal(t, int32(1), srv.deleteStoreCalls.Load())
+}

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -75,52 +75,29 @@ type Server struct {
 	nsLimiterSize     int64
 }
 
-// Option configures optional server dependencies.
-type Option func(*options)
-
-type options struct {
-	reconcilerState reconciler.StateStore
-}
-
-// WithReconcilerState gives the MT reconciler somewhere to record which
-// namespaces it has reconciled, so the knowledge survives a restart. Without
-// it the reconciler can only tell that a namespace has a store, which the
-// mutation hooks create without reconciling anything.
-func WithReconcilerState(store reconciler.StateStore) Option {
-	return func(o *options) {
-		o.reconcilerState = store
-	}
-}
-
-func newOptions(opts []Option) options {
-	var o options
-	for _, apply := range opts {
-		apply(&o)
-	}
-	return o
-}
-
-func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
+// reconcilerState gives the MT reconciler somewhere to record which namespaces
+// it has reconciled, so the knowledge survives a restart. It is required in MT
+// reconciler mode: without it the reconciler can only tell that a namespace has
+// a store, which the mutation hooks create without reconciling anything.
+func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, reconcilerState reconciler.StateStore) (*Server, error) {
 	openfga, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, elector, opts...)
+	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, elector, reconcilerState)
 }
 
-func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
+func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, reconcilerState reconciler.StateStore) (*Server, error) {
 	openfgaServer, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, elector, opts...)
+	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, elector, reconcilerState)
 }
 
-func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
-	serverOpts := newOptions(opts)
-
+func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, reconcilerState reconciler.StateStore) (*Server, error) {
 	channel := &inprocgrpc.Channel{}
 	openfgav1.RegisterOpenFGAServiceServer(channel, openfga)
 	openFGAClient := openfgav1.NewOpenFGAServiceClient(channel)
@@ -216,7 +193,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 
 	var mtReconciler zanzana.MTReconciler
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
-		if serverOpts.reconcilerState == nil {
+		if reconcilerState == nil {
 			// Without it every namespace reconciles inline on its first
 			// authorization request after each restart, which is a large enough
 			// regression to be worth refusing to start over.
@@ -239,7 +216,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 			tracer,
 			reg,
 			elector,
-			serverOpts.reconcilerState,
+			reconcilerState,
 		)
 	} else {
 		mtReconciler = reconciler.NewNoopReconciler()

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -216,9 +217,10 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	var mtReconciler zanzana.MTReconciler
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
 		if serverOpts.reconcilerState == nil {
-			logger.Warn("Reconciliation state will not be persisted; namespaces with an existing store " +
-				"are assumed to be reconciled, so permissions written by mutation hooks before the first " +
-				"reconciliation may be incomplete until the next reconciler interval")
+			// Without it every namespace reconciles inline on its first
+			// authorization request after each restart, which is a large enough
+			// regression to be worth refusing to start over.
+			return nil, errors.New("reconciler state store is required in MT reconciler mode")
 		}
 
 		mtReconciler = reconciler.NewReconciler(

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -74,25 +74,52 @@ type Server struct {
 	nsLimiterSize     int64
 }
 
-func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector) (*Server, error) {
+// Option configures optional server dependencies.
+type Option func(*options)
+
+type options struct {
+	reconcilerState reconciler.StateStore
+}
+
+// WithReconcilerState gives the MT reconciler somewhere to record which
+// namespaces it has reconciled, so the knowledge survives a restart. Without
+// it the reconciler can only tell that a namespace has a store, which the
+// mutation hooks create without reconciling anything.
+func WithReconcilerState(store reconciler.StateStore) Option {
+	return func(o *options) {
+		o.reconcilerState = store
+	}
+}
+
+func newOptions(opts []Option) options {
+	var o options
+	for _, apply := range opts {
+		apply(&o)
+	}
+	return o
+}
+
+func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
 	openfga, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, elector)
+	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, elector, opts...)
 }
 
-func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector) (*Server, error) {
+func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
 	openfgaServer, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, elector)
+	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, elector, opts...)
 }
 
-func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector) (*Server, error) {
+func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, elector leaderelection.Elector, opts ...Option) (*Server, error) {
+	serverOpts := newOptions(opts)
+
 	channel := &inprocgrpc.Channel{}
 	openfgav1.RegisterOpenFGAServiceServer(channel, openfga)
 	openFGAClient := openfgav1.NewOpenFGAServiceClient(channel)
@@ -188,6 +215,12 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 
 	var mtReconciler zanzana.MTReconciler
 	if cfg.ZanzanaReconciler.Mode == setting.ZanzanaReconcilerModeMT {
+		if serverOpts.reconcilerState == nil {
+			logger.Warn("Reconciliation state will not be persisted; namespaces with an existing store " +
+				"are assumed to be reconciled, so permissions written by mutation hooks before the first " +
+				"reconciliation may be incomplete until the next reconciler interval")
+		}
+
 		mtReconciler = reconciler.NewReconciler(
 			s,
 			clientFactory,
@@ -204,6 +237,7 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 			tracer,
 			reg,
 			elector,
+			serverOpts.reconcilerState,
 		)
 	} else {
 		mtReconciler = reconciler.NewNoopReconciler()

--- a/pkg/services/authz/zanzana/server/server_bench_test.go
+++ b/pkg/services/authz/zanzana/server/server_bench_test.go
@@ -357,7 +357,7 @@ func setupBenchmarkServer(b *testing.B) (*Server, *benchmarkData) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector())
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector(), nil)
 	require.NoError(b, err)
 
 	// Generate test data
@@ -457,7 +457,7 @@ func setupSubresourceDepthBenchmarkServer(b *testing.B, childrenPerLevel, depth 
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector())
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector(), nil)
 	require.NoError(b, err)
 
 	// Build only the hierarchy needed to force TTU walks.

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -569,7 +569,7 @@ func TestIntegrationServerListStreamDeadline(t *testing.T) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector())
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector(), nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -116,7 +116,7 @@ func setupOpenFGAServer(t *testing.T) *Server {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector())
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, leaderelection.NewDefaultElector(), nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
**What is this feature?**

The MT reconciler now records which namespaces it has reconciled in Grafana's `kv_store` table, and `EnsureNamespace` decides whether to reconcile based on that record instead of on whether an OpenFGA store exists.

**Why do we need this feature?**

`EnsureNamespace` treated the existence of a store as proof that a namespace had been reconciled. That is not true: the user and org mutation hooks write tuples through `GetOrCreateStore`, so on a fresh database the store is created during the first login, before any reconciliation has run. The namespace was then cached as reconciled and its basic-role bindings were never computed — until the next background reconciliation, up to the reconciler interval (default 1h) later. On a fresh stack that means users have no permissions for up to an hour.

**Who is this feature for?**

Multi-tenant Grafana deployments running the Zanzana MT reconciler, both embedded and as a standalone `zanzana-server` module.

**What the record contains**

A small JSON value per namespace, stored under org 0 in the `zanzana.reconciler` namespace of `kv_store`, following the convention unified storage uses for its dualwrite state:

- `store_id` — the OpenFGA store the tuples were written to
- `model_id` — the authorization model, diagnostic only
- `reconciled_at` — unix seconds, refreshed by the background loop
- `version` — the expected-tuple computation the record was written by

The record is validated on `store_id` and `version`. The store ID matters because the record lives in Grafana's database while the tuples live in Zanzana's: if the Zanzana store is rebuilt — which the OpenFGA migrations do by dropping and recreating their tables when the goose schema is inconsistent — the new store ID no longer matches and the namespace reconciles from scratch. The version field is there to force re-reconciliation when a change makes previously written tuples wrong; bump `stateVersion` and every namespace reconciles on its next authorization request rather than waiting out the interval.

`model_id` is recorded but not compared, because `GetStore` and `ListAllStores` leave it empty; comparing it would force a reconcile after every process start. Model changes are picked up by the periodic loop, or immediately via `version`.

**Behaviour**

- Records are written after every successful reconciliation, by both the inline `EnsureNamespace` path and the leader's background loop.
- A namespace that turns out to be deleted has its record removed along with its store, so a namespace recreated under the same name starts clean.
- Read or decode failures are treated as "no record": reconciling twice is harmless, skipping leaves users without permissions.
- The periodic loop is unchanged — it still lists OpenFGA stores and reconciles only namespaces that have one.

**Deployment modes**

The embedded server builds the state store from the `db.DB` it already receives. The standalone `zanzana-server` module gets it through wire: the enterprise module server already constructs `sqlstore` (licensing needs it, so every Grafana table is migrated at startup) and already has `kvstore.ProvideService`. Both modes therefore read and write the same rows, so moving a cell between them keeps its state.

The OSS module server builds no SQL store at all, so it has no `kv_store` to record to. It keeps the previous store-exists behaviour and logs a warning at startup; giving it real persistence would mean pulling `sqlstore.ProvideService` into the OSS module graph, making every OSS module target open a database and run all migrations.

**Rollout note**

On the first deploy no records exist, so the first authorization request per namespace performs a full inline reconcile (fetching that namespace's folders, users, teams and resource permissions). It happens once per namespace, singleflight collapses concurrent requests, and every subsequent request is a map lookup.

**Companion PR**

`NewModule` gains a parameter, so the enterprise wire graph changes alongside this: https://github.com/grafana/grafana-enterprise/pull/13392. The two must merge together.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/hyperion-planning/issues/733 (first problem in the issue)
