### PR TITLE
Datasources: Remove readOnly from DataSourceInstanceListItem

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -849,7 +849,6 @@ export interface DataSourceInstanceListItem {
   apiVersion?: string;
   name: string;
   meta: DataSourcePluginMeta;
-  readOnly: boolean;
   isDefault: boolean;
 }
 

--- a/packages/grafana-runtime/src/services/dataSource/hooks.ts
+++ b/packages/grafana-runtime/src/services/dataSource/hooks.ts
@@ -108,9 +108,8 @@ export function useDataSourceInstanceSettings(
  * changes (compared by value, so inline objects are safe).
  *
  * Prefer this over {@link useDataSourceInstanceSettings} whenever only identity or plugin
- * metadata is needed — `item` carries `uid`, `type`, `name`, `meta`, `readOnly` and
- * `isDefault`, and avoids depending on per-instance settings that will later be fetched on
- * demand.
+ * metadata is needed — `item` carries `uid`, `type`, `name`, `meta` and `isDefault`, and avoids
+ * depending on per-instance settings that will later be fetched on demand.
  *
  * Resolves **by uid only**: a ref with no usable uid — including `'default'`, `undefined` and
  * type-only refs — yields `item: undefined` rather than the default data source. Template

--- a/packages/grafana-runtime/src/services/dataSource/hooks.ts
+++ b/packages/grafana-runtime/src/services/dataSource/hooks.ts
@@ -108,8 +108,9 @@ export function useDataSourceInstanceSettings(
  * changes (compared by value, so inline objects are safe).
  *
  * Prefer this over {@link useDataSourceInstanceSettings} whenever only identity or plugin
- * metadata is needed — `item` carries `uid`, `type`, `name`, `meta` and `isDefault`, and avoids
- * depending on per-instance settings that will later be fetched on demand.
+ * metadata is needed — `item` carries `uid`, `type`, `apiVersion`, `name`, `meta` and
+ * `isDefault`, and avoids depending on per-instance settings that will later be fetched on
+ * demand.
  *
  * Resolves **by uid only**: a ref with no usable uid — including `'default'`, `undefined` and
  * type-only refs — yields `item: undefined` rather than the default data source. Template

--- a/packages/grafana-runtime/src/services/dataSource/listItem.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/listItem.test.ts
@@ -85,7 +85,6 @@ describe('getDataSourceInstanceListItem', () => {
       apiVersion: undefined,
       name: 'Alpha',
       meta: metas['test-db'],
-      readOnly: false,
       isDefault: false,
     });
   });

--- a/packages/grafana-runtime/src/services/dataSource/listItem.ts
+++ b/packages/grafana-runtime/src/services/dataSource/listItem.ts
@@ -9,9 +9,9 @@ import { lookupByUid, toListItem } from './settings';
  * the singular counterpart of `getDataSourceInstanceList`. Takes a uid string or any
  * {@link DataSourceRef} carrying one.
  *
- * Prefer it over `getDataSourceInstanceSettings` when `type`, `name`, `meta`, `readOnly` and
- * `isDefault` are all you need: the settings it leaves out (`jsonData`, `url`, `access`,
- * `apiVersion`) will eventually cost a request per uid.
+ * Prefer it over `getDataSourceInstanceSettings` when `type`, `name`, `meta` and `isDefault`
+ * are all you need: the settings it leaves out (`jsonData`, `url`, `access`, `apiVersion`) will
+ * eventually cost a request per uid.
  *
  * - **uid or nothing.** No name or numeric-id fallback, no `'default'`, no type-only refs, no
  *   `${ds}` interpolation — interpolate first. Anything else returns `undefined`.

--- a/packages/grafana-runtime/src/services/dataSource/listItem.ts
+++ b/packages/grafana-runtime/src/services/dataSource/listItem.ts
@@ -9,8 +9,8 @@ import { lookupByUid, toListItem } from './settings';
  * the singular counterpart of `getDataSourceInstanceList`. Takes a uid string or any
  * {@link DataSourceRef} carrying one.
  *
- * Prefer it over `getDataSourceInstanceSettings` when `type`, `name`, `meta` and `isDefault`
- * are all you need: the settings it leaves out (`jsonData`, `url`, `access`, `apiVersion`) will
+ * Prefer it over `getDataSourceInstanceSettings` when `type`, `apiVersion`, `name`, `meta` and
+ * `isDefault` are all you need: the settings it leaves out (`jsonData`, `url`, `access`) will
  * eventually cost a request per uid.
  *
  * - **uid or nothing.** No name or numeric-id fallback, no `'default'`, no type-only refs, no

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -1066,7 +1066,6 @@ describe('instanceSettings', () => {
             apiVersion: fixtures.Alpha.apiVersion,
             name: fixtures.Alpha.name,
             meta: fixtures.Alpha.meta,
-            readOnly: fixtures.Alpha.readOnly,
             isDefault: fixtures.Alpha.isDefault ?? false,
           },
         ]);

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -212,7 +212,6 @@ export function toListItem(settings: DataSourceInstanceSettings): DataSourceInst
     apiVersion: settings.apiVersion,
     name: settings.name,
     meta: settings.meta,
-    readOnly: settings.readOnly,
     isDefault: settings.isDefault ?? false,
   };
 }

--- a/public/app/features/actions/ConnectionPicker.test.tsx
+++ b/public/app/features/actions/ConnectionPicker.test.tsx
@@ -41,7 +41,6 @@ function createDataSource(name: string, uid: string, dsType: string): DataSource
     meta,
     isDefault: false,
     type: dsType,
-    readOnly: false,
   };
 }
 

--- a/public/app/features/home/Overview/Overview.test.tsx
+++ b/public/app/features/home/Overview/Overview.test.tsx
@@ -21,7 +21,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Datasource',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
+++ b/public/app/features/home/Recommendations/RecommendationExisting.test.tsx
@@ -25,7 +25,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Prometheus',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/home/Recommendations/Recommendations.test.tsx
+++ b/public/app/features/home/Recommendations/Recommendations.test.tsx
@@ -28,7 +28,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Prometheus',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/home/solutions/kubernetesData.test.ts
+++ b/public/app/features/home/solutions/kubernetesData.test.ts
@@ -47,7 +47,6 @@ function createPrometheusListItem(ds: { uid: string; name: string; isDefault?: b
     name: ds.name,
     type: 'prometheus',
     meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-    readOnly: false,
     isDefault: ds.isDefault ?? false,
   };
 }
@@ -384,7 +383,6 @@ describe('Kubernetes Prometheus resolution', () => {
       name: partial.name,
       type: partial.type,
       meta: { id: partial.metaId } as DataSourceInstanceListItem['meta'],
-      readOnly: false,
       isDefault: false,
     });
     // Builtin rejected by meta.id; real and alias prometheus datasources pass.

--- a/public/app/features/home/solutions/probeUtils.test.ts
+++ b/public/app/features/home/solutions/probeUtils.test.ts
@@ -31,7 +31,6 @@ function listItem(ds: { uid?: string; name: string; isDefault?: boolean }): Data
     name: ds.name,
     type: 'loki',
     meta: { id: 'loki' } as DataSourceInstanceListItem['meta'],
-    readOnly: false,
     isDefault: ds.isDefault ?? false,
   };
 }

--- a/public/app/features/home/solutions/solutionDataProbes.test.ts
+++ b/public/app/features/home/solutions/solutionDataProbes.test.ts
@@ -26,7 +26,6 @@ function datasource(type: string, name = `${type}-ds`): DataSourceInstanceListIt
     name,
     type,
     meta: { id: type } as DataSourceInstanceListItem['meta'],
-    readOnly: false,
     isDefault: false,
   };
 }

--- a/public/app/features/home/solutions/solutionState.test.ts
+++ b/public/app/features/home/solutions/solutionState.test.ts
@@ -7,7 +7,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Prometheus',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/home/solutions/spanMetricsSignal.test.ts
+++ b/public/app/features/home/solutions/spanMetricsSignal.test.ts
@@ -22,7 +22,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Prometheus',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/home/solutions/syntheticsData.test.ts
+++ b/public/app/features/home/solutions/syntheticsData.test.ts
@@ -47,7 +47,6 @@ function createPrometheusListItem(ds: { uid: string; name: string; isDefault?: b
     name: ds.name,
     type: 'prometheus',
     meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-    readOnly: false,
     isDefault: ds.isDefault ?? false,
   };
 }

--- a/public/app/features/home/useHomepageSolutions.test.ts
+++ b/public/app/features/home/useHomepageSolutions.test.ts
@@ -32,7 +32,6 @@ const datasource: DataSourceInstanceListItem = {
   name: 'Prometheus',
   type: 'prometheus',
   meta: { id: 'prometheus' } as DataSourceInstanceListItem['meta'],
-  readOnly: false,
   isDefault: true,
 };
 

--- a/public/app/features/plugins/datasource_srv.test.ts
+++ b/public/app/features/plugins/datasource_srv.test.ts
@@ -829,7 +829,6 @@ describe('getList parity: DatasourceSrv.getList vs getDataSourceInstanceList', (
           apiVersion: ds.apiVersion,
           name: ds.name,
           meta: ds.meta,
-          readOnly: ds.readOnly,
           isDefault: ds.isDefault ?? false,
         }),
     };

--- a/public/app/features/variables/datasource/actions.test.ts
+++ b/public/app/features/variables/datasource/actions.test.ts
@@ -42,7 +42,6 @@ function toListItem(name: string, meta: ReturnType<typeof getMockPlugin>): DataS
     type: settings.type,
     name: settings.name,
     meta: settings.meta,
-    readOnly: settings.readOnly,
     isDefault: settings.isDefault ?? false,
   };
 }

--- a/public/app/features/variables/datasource/reducer.test.ts
+++ b/public/app/features/variables/datasource/reducer.test.ts
@@ -20,7 +20,6 @@ function toListItems(plugins: ReturnType<typeof getMockPlugins>): DataSourceInst
       type: settings.type,
       name: settings.name,
       meta: settings.meta,
-      readOnly: settings.readOnly,
       isDefault: settings.isDefault ?? false,
     };
   });


### PR DESCRIPTION
**What is this feature?**

This change removes the `readOnly` field from `DataSourceInstanceListItem`. No code reads this field today.

**Why do we need this feature?**

`DataSourceInstanceListItem` must stay small. The `readOnly` value is not part of a data source's identity. This value stays on `DataSourceInstanceSettings` and `DataSourceSettings`.

**Who is this feature for?**

This change is for developers who use the `@grafana/runtime` data source list APIs.

**Special notes for your reviewer:**

This change breaks the public `@grafana/data` API. Levitate will flag this change. The break is safe. Every function that creates a `DataSourceInstanceListItem` object is marked `unstable`. Plugin authors cannot use these functions yet.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.