### PR TITLE
App/Plugins: Generate OpenAPI from command line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,6 +72,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4 // @grafana/identity-access-team
 	github.com/go-kit/log v0.2.1 //  @grafana/grafana-backend-group
 	github.com/go-ldap/ldap/v3 v3.4.4 // @grafana/identity-access-team
+	github.com/go-logr/logr v1.4.4 // @grafana/grafana-app-platform-squad
 	github.com/go-openapi/loads v0.25.1 // @grafana/alerting-backend
 	github.com/go-openapi/runtime v0.33.0 // @grafana/alerting-backend
 	github.com/go-openapi/strfmt v0.27.0 // @grafana/alerting-backend
@@ -441,7 +442,6 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
-	github.com/go-logr/logr v1.4.4
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.26.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -441,7 +441,7 @@ require (
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect
 	github.com/go-logfmt/logfmt v0.6.1 // indirect
-	github.com/go-logr/logr v1.4.4 // indirect
+	github.com/go-logr/logr v1.4.4
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/analysis v0.26.0 // indirect

--- a/pkg/cmd/grafana-cli/commands/README.md
+++ b/pkg/cmd/grafana-cli/commands/README.md
@@ -1,0 +1,154 @@
+# write-openapi
+
+Renders the OpenAPI v3 spec an app plugin's API server serves, without starting Grafana.
+
+It is the offline equivalent of downloading `/openapi/v3/apis/<pluginID>/<version>` from a
+running server: the same builder, the same schemas, the same routes. Use it to commit a
+spec alongside a plugin, to generate clients in a plugin's build, or to review what a
+manifest change does to the API before shipping it.
+
+```
+grafana cli write-openapi <manifest.json | pluginID[/version]> [-o <path>]
+```
+
+The CLI is a subcommand of the one `grafana` binary — `grafana cli <command>` — not a
+separate executable. Global flags such as `--homepath` belong to `cli`, so they go before
+`write-openapi`.
+
+## From a manifest file
+
+This is the form to use in a plugin's own build. It reads the manifest directly and needs
+no Grafana config, no `--homepath`, and no installed plugin:
+
+```bash
+grafana cli write-openapi ./app-sdk-manifest.json -o ./openapi
+```
+
+```
+Wrote openapi/v1alpha1.json for example.ext.grafana.app/v1alpha1
+Wrote openapi/v0alpha1.json for example.ext.grafana.app/v0alpha1
+```
+
+**`-o` is required here, and it must name a directory.** A manifest target always renders
+every served version, one `<version>.json` per file — there is no way to name a single
+version or write to stdout. That is because a plugin serves more than its manifest
+declares: `v0alpha1` carries the settings API, and it is served alongside the manifest's
+own versions whether or not the manifest mentions it. Passing `-o spec.json` is refused
+rather than silently writing one of them.
+
+### plugin.json is picked up when it is there
+
+If a `plugin.json` sits in the same directory as the manifest — which is what a built
+plugin looks like — it is loaded too, and the spec then matches what a real server serving
+that plugin returns: the plugin's id, description, version, and settings schema.
+
+Without it, the manifest's `appName` stands in for the plugin id and the settings API falls
+back to its defaults. The manifest kinds are identical either way, so a manifest on its own
+is fine for reviewing a schema change; point at a built plugin directory's manifest when
+the spec is a deliverable.
+
+If the manifest has no `appName` **and** there is no `plugin.json` to take an id from, the
+command fails rather than inventing one.
+
+## From an installed plugin
+
+Naming a plugin id looks it up the way the server does, which needs the config that says
+where plugins live. Unlike the manifest form, this one can name a single version and write
+it to stdout:
+
+```bash
+grafana cli --homepath /usr/share/grafana write-openapi my-app/v1alpha1
+```
+
+Point at a plugin that is not in the config's plugin paths — one under development — with
+`--pluginsDir`:
+
+```bash
+grafana cli --homepath $PWD --pluginsDir ./plugins write-openapi my-app/v1alpha1 -o spec.json
+```
+
+Leaving the version off writes every one of them to `-o <directory>`. Leaving off both the
+version and `-o` tells you which versions exist rather than guessing:
+
+```
+my-app serves v1alpha1, v0alpha1: pass -o <directory> to write them all, or name one version
+```
+
+## Docker
+
+The `grafana` binary is on `PATH` in every image variant, but the entrypoint is the server
+launcher, so it has to be overridden:
+
+```bash
+docker run --rm \
+  --entrypoint grafana \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD:/work" -w /work \
+  grafana/grafana:<version> \
+  cli write-openapi ./app-sdk-manifest.json -o ./openapi
+```
+
+The image's entrypoint is `/run.sh`, which starts the server and ignores anything you pass
+it, so `--entrypoint grafana` is required. Note `cli` as the first argument after the image
+name: the entrypoint is the `grafana` binary, so the subcommand path is `cli write-openapi`.
+
+Two things worth knowing:
+
+- **`--user`.** The image runs as uid `472`. On a Linux host that uid is what writes into
+  your bind mount, so the output lands owned by `472` or fails outright. Docker Desktop on
+  macOS and Windows maps ownership back to you and hides this, so the flag is harmless
+  there and necessary on Linux — pass it and the command behaves the same everywhere.
+- **Paths are container paths.** `-o ./openapi` is relative to `-w /work`, so it appears in
+  the current directory on the host. An absolute host path will not resolve.
+
+The manifest form is the one worth running in a container, because it needs nothing from
+the image but the binary. The plugin-id form needs the plugin mounted where the config
+looks for it, and **`--homepath` becomes mandatory**: it defaults to the working directory,
+and `-w /work` has just moved that away from `/usr/share/grafana`. Without it the command
+stops at `Could not find config defaults`.
+
+```bash
+docker run --rm \
+  --entrypoint grafana \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD/dist:/var/lib/grafana/plugins/my-app" \
+  -v "$PWD:/work" -w /work \
+  grafana/grafana:<version> \
+  cli --homepath /usr/share/grafana --pluginsDir /var/lib/grafana/plugins \
+  write-openapi my-app/v1alpha1 -o spec.json
+```
+
+That form loads the full server config, so it prints the usual settings and feature-toggle
+banner on the way. The spec goes to the file; the noise is on stdout. Do not pipe it into
+something that closes the stream early — `| head` will kill the process before it writes.
+
+### Which image has it
+
+`write-openapi` only exists in a Grafana build that contains it, so pin `<version>` to a
+release that has shipped the command. To try it before then, build the image from this
+repo:
+
+```bash
+make build-docker-full          # tags grafana/grafana:dev
+docker run --rm --entrypoint grafana --user "$(id -u):$(id -g)" \
+  -v "$PWD:/work" -w /work grafana/grafana:dev \
+  cli write-openapi ./app-sdk-manifest.json -o ./openapi
+```
+
+The distroless variant has no shell, which does not matter here — the command is exec'd
+directly rather than through one.
+
+## Output
+
+JSON, indented two spaces, with `<` `>` `&` left unescaped so the Kubernetes descriptions
+stay readable in a diff. Written to the file or directory `-o` names, or to stdout when a
+single version was named and `-o` was not.
+
+Rendering to stdout suppresses the console log so the spec is the only thing on it; the
+same messages still go to the log file.
+
+## See also
+
+`pkg/registry/apis/appplugin/pluginopenapi` builds the spec — the command is a thin wrapper
+over it. `pkg/registry/apis/appplugin/README.md` explains what the served API looks like and
+why.

--- a/pkg/cmd/grafana-cli/commands/README.md
+++ b/pkg/cmd/grafana-cli/commands/README.md
@@ -2,10 +2,9 @@
 
 Renders the OpenAPI v3 spec an app plugin's API server serves, without starting Grafana.
 
-It is the offline equivalent of downloading `/openapi/v3/apis/<pluginID>/<version>` from a
-running server: the same builder, the same schemas, the same routes. Use it to commit a
-spec alongside a plugin, to generate clients in a plugin's build, or to review what a
-manifest change does to the API before shipping it.
+It uses the same rendering pipeline as `/openapi/v3/apis/<group>/<version>` on a running
+server. Use it to commit a spec alongside a plugin, generate clients in a plugin's build,
+or review what a manifest change does to the API before shipping it.
 
 ```
 grafana cli write-openapi <manifest.json | pluginID[/version]> [-o <path>]
@@ -39,10 +38,10 @@ rather than silently writing one of them.
 ### plugin.json is picked up when it is there
 
 If a `plugin.json` sits in the same directory as the manifest — which is what a built
-plugin looks like — it is loaded too, and the spec then matches what a real server serving
-that plugin returns: the plugin's id, description, version, and settings schema.
+plugin looks like — it is loaded too. The rendered spec then includes the plugin's id,
+description, version, and settings schema.
 
-Without it, the manifest's `appName` stands in for the plugin id and the settings API falls
+Without it, the manifest's `appName` stands in for the plugin ID and the settings API falls
 back to its defaults. The manifest kinds are identical either way, so a manifest on its own
 is fine for reviewing a schema change; point at a built plugin directory's manifest when
 the spec is a deliverable.
@@ -143,6 +142,10 @@ directly rather than through one.
 JSON, indented two spaces, with `<` `>` `&` left unescaped so the Kubernetes descriptions
 stay readable in a diff. Written to the file or directory `-o` names, or to stdout when a
 single version was named and `-o` was not.
+
+Generated specs always enable search and trash route registration, regardless of whether
+those routes are disabled in a particular Grafana configuration. The usual per-kind
+eligibility rules still apply.
 
 Rendering to stdout suppresses the console log so the spec is the only thing on it; the
 same messages still go to the log file.

--- a/pkg/cmd/grafana-cli/commands/README.md
+++ b/pkg/cmd/grafana-cli/commands/README.md
@@ -24,16 +24,16 @@ grafana cli write-openapi ./app-sdk-manifest.json -o ./openapi
 ```
 
 ```
-Wrote openapi/v1alpha1.json for example.ext.grafana.app/v1alpha1
-Wrote openapi/v0alpha1.json for example.ext.grafana.app/v0alpha1
+Wrote openapi/example.ext.grafana.app-v1alpha1.json for example.ext.grafana.app/v1alpha1
+Wrote openapi/example.ext.grafana.app-v0alpha1.json for example.ext.grafana.app/v0alpha1
 ```
 
 **`-o` is required here, and it must name a directory.** A manifest target always renders
-every served version, one `<version>.json` per file — there is no way to name a single
-version or write to stdout. That is because a plugin serves more than its manifest
-declares: `v0alpha1` carries the settings API, and it is served alongside the manifest's
-own versions whether or not the manifest mentions it. Passing `-o spec.json` is refused
-rather than silently writing one of them.
+every served version, one `<group>-<version>.json` file per version — there is no way to
+name a single version or write to stdout. That is because a plugin serves more than its
+manifest declares: `v0alpha1` carries the settings API, and it is served alongside the
+manifest's own versions whether or not the manifest mentions it. Passing `-o spec.json` is
+refused rather than silently writing one of them.
 
 ### plugin.json is picked up when it is there
 

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -247,6 +247,26 @@ var adminCommands = []*cli.Command{
 
 var Commands = []*cli.Command{
 	{
+		Name:  "write-openapi",
+		Usage: "write-openapi <manifest.json|pluginID[/version]> -o <path>",
+		Description: "Render the OpenAPI v3 spec served by an app plugin's API server. This is the " +
+			"offline equivalent of downloading /openapi/v3/apis/<pluginID>/<version> from a running " +
+			"Grafana.\n\n" +
+			"   The target is either a path to an app-sdk manifest file, which needs no Grafana " +
+			"config and reads a plugin.json beside it when there is one, or the id of an installed " +
+			"plugin, optionally with the version to render.\n\n" +
+			"   Naming one version writes one spec, to --output or to stdout. Otherwise every served " +
+			"version is written to the --output directory as <version>.json.",
+		Action: writeOpenAPICommand,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Usage:   "File to write one version to, or directory to write every version to",
+			},
+		},
+	},
+	{
 		Name:        "plugins",
 		Usage:       "Manage plugins for grafana",
 		Subcommands: pluginCommands,

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -249,8 +249,8 @@ var Commands = []*cli.Command{
 	{
 		Name:  "write-openapi",
 		Usage: "write-openapi <manifest.json|pluginID[/version]> -o <path>",
-		Description: "Render the OpenAPI v3 spec served by an app plugin's API server. This is the " +
-			"offline equivalent of downloading /openapi/v3/apis/<pluginID>/<version> from a running " +
+		Description: "Render the OpenAPI v3 spec served by an app plugin's API server. This uses " +
+			"the same rendering pipeline as /openapi/v3/apis/<group>/<version> on a running " +
 			"Grafana.\n\n" +
 			"   The target is either a path to an app-sdk manifest file, which needs no Grafana " +
 			"config and reads a plugin.json beside it when there is one, or the id of an installed " +

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -256,7 +256,7 @@ var Commands = []*cli.Command{
 			"config and reads a plugin.json beside it when there is one, or the id of an installed " +
 			"plugin, optionally with the version to render.\n\n" +
 			"   Naming one version writes one spec, to --output or to stdout. Otherwise every served " +
-			"version is written to the --output directory as <version>.json.",
+			"version is written to the --output directory as <group>-<version>.json.",
 		Action: writeOpenAPICommand,
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command.go
@@ -1,0 +1,258 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/spec3"
+
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/definition"
+	"github.com/grafana/grafana/pkg/registry/apis/appplugin/pluginopenapi"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginconfig"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginsources"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+// writeOpenAPICommand renders the OpenAPI v3 spec an app plugin's API server
+// serves, without starting Grafana. It is the offline equivalent of
+// GET /openapi/v3/apis/{pluginID}/{version} on a running server.
+func writeOpenAPICommand(c *cli.Context) error {
+	target, output, err := writeOpenAPIArgs(c)
+	if err != nil {
+		return cli.Exit(err.Error(), 1)
+	}
+
+	// The apiserver machinery reports on the server it is building ("Authorization
+	// is disabled", "Adding GroupVersion ..."), which says nothing about the spec.
+	klog.SetLogger(logr.Discard())
+
+	plugin, version, opts, err := writeOpenAPIInput(c, target, output)
+	if err != nil {
+		return err
+	}
+
+	if version != "" {
+		oas, err := pluginopenapi.Build(plugin, version, opts)
+		if err != nil {
+			return err
+		}
+		if output == "" {
+			return writeSpecTo(os.Stdout, oas)
+		}
+		return writeSpecFile(output, oas)
+	}
+
+	versions, err := pluginopenapi.Versions(plugin, opts)
+	if err != nil {
+		return err
+	}
+	if output == "" {
+		return cli.Exit(fmt.Sprintf(
+			"%s serves %s: pass -o <directory> to write them all, or name one version",
+			plugin.JSONData.ID, strings.Join(versions, ", ")), 1)
+	}
+	if err := ensureOutputDir(output); err != nil {
+		return err
+	}
+	for _, v := range versions {
+		oas, err := pluginopenapi.Build(plugin, v, opts)
+		if err != nil {
+			return err
+		}
+		if err := writeSpecFile(filepath.Join(output, v+".json"), oas); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureOutputDir prepares the directory the per-version specs are written to.
+// A path that names a file is refused rather than turned into a directory: it
+// is a caller who meant to write one version and did not say which.
+func ensureOutputDir(path string) error {
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return cli.Exit(fmt.Sprintf("%s is a file; pass a directory to write every version", path), 1)
+	}
+	if strings.HasSuffix(path, ".json") {
+		return cli.Exit(fmt.Sprintf("%s names a file; pass a directory to write every version, or name one version", path), 1)
+	}
+	return os.MkdirAll(path, 0750)
+}
+
+// writeOpenAPIInput resolves the target into the plugin to render, the single
+// version to render (empty for all of them), and the options that make the
+// output match a server's.
+//
+// A manifest file is read on its own, with no Grafana config involved, so this
+// works in a plugin's build with no Grafana installed. A plugin id is looked up
+// the way the server looks it up, which needs the config that says where plugins
+// live.
+func writeOpenAPIInput(c *cli.Context, target, output string) (definition.PluginDefinition, string, pluginopenapi.Options, error) {
+	var empty definition.PluginDefinition
+
+	info, statErr := os.Stat(target)
+	switch {
+	case statErr == nil && !info.IsDir():
+		plugin, err := pluginopenapi.LoadManifest(c.Context, target)
+		return plugin, "", pluginopenapi.Options{BuildVersion: setting.BuildVersion}, err
+
+	// A target typed as a path is answered as a path. Falling through to the
+	// plugin lookup would report a missing plugin named after part of the path.
+	case !looksLikePath(target):
+	case statErr != nil:
+		return empty, "", pluginopenapi.Options{}, statErr
+	default:
+		return empty, "", pluginopenapi.Options{}, cli.Exit(fmt.Sprintf(
+			"%s is a directory; pass the manifest file inside it", target), 1)
+	}
+
+	pluginID, version, _ := strings.Cut(target, "/")
+
+	args := strings.Split(c.String("configOverrides"), " ")
+	if output == "" {
+		// Loading the config logs to the console, which is stdout, and that is
+		// where the spec goes when no output path was given. The file log mode
+		// is on by default, so the same messages are still recorded.
+		args = append(args, "cfg:log.mode=file")
+	}
+	cmd := &utils.ContextCommandLine{Context: c}
+	cfg, err := setting.NewCfgFromArgs(setting.CommandLineArgs{
+		Config:   cmd.ConfigFile(),
+		HomePath: cmd.HomePath(),
+		Args:     args,
+	})
+	if err != nil {
+		return definition.PluginDefinition{}, "", pluginopenapi.Options{}, err
+	}
+
+	features, err := featuremgmt.ProvideManagerService(cfg)
+	if err != nil {
+		return definition.PluginDefinition{}, "", pluginopenapi.Options{}, err
+	}
+
+	plugin, err := findAppPlugin(c, cfg, features, pluginID)
+	return plugin, version, pluginopenapi.Options{
+		BuildVersion: cfg.BuildVersion,
+		// nolint:staticcheck // not yet migrated to OpenFeature
+		RegisterProxy: features.IsEnabledGlobally(featuremgmt.FlagApppluginsHandleProxyRequests),
+	}, err
+}
+
+// looksLikePath reports whether the target was typed as a file path rather than
+// as a plugin id. A plugin id carries a slash too -- pluginID/version -- so the
+// slash alone says nothing; a leading dot or separator, or a .json name, does.
+func looksLikePath(target string) bool {
+	return strings.HasSuffix(target, ".json") ||
+		strings.HasPrefix(target, ".") ||
+		strings.HasPrefix(target, "~") ||
+		strings.HasPrefix(target, string(os.PathSeparator))
+}
+
+func writeSpecFile(path string, oas *spec3.OpenAPI) error {
+	f, err := os.Create(path) // #nosec G304 -- a path the operator typed
+	if err != nil {
+		return err
+	}
+	if err := writeSpecTo(f, oas); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	// Title is the group version the spec was rendered for.
+	logger.Infof("Wrote %s for %s\n", path, oas.Info.Title)
+	return nil
+}
+
+// writeSpecTo encodes the spec the way a file that people read and diff wants
+// it: indented, and without escaping the angle brackets that fill Kubernetes
+// descriptions.
+func writeSpecTo(w io.Writer, oas *spec3.OpenAPI) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	return enc.Encode(oas)
+}
+
+// writeOpenAPIArgs reads the target and the output path off the command line.
+// The output is also read out of the positional arguments because flag parsing
+// stops at the first one, and `write-openapi <target> -o spec.json` is the
+// natural way to type this.
+func writeOpenAPIArgs(c *cli.Context) (target string, output string, err error) {
+	output = c.String("output")
+	args := c.Args().Slice()
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-o" || arg == "--output":
+			if i+1 >= len(args) {
+				return "", "", fmt.Errorf("missing value for %s", arg)
+			}
+			output = args[i+1]
+			i++
+		case strings.HasPrefix(arg, "-o=") || strings.HasPrefix(arg, "--output="):
+			_, output, _ = strings.Cut(arg, "=")
+		case strings.HasPrefix(arg, "-"):
+			return "", "", fmt.Errorf("unknown flag %q", arg)
+		case target == "":
+			target = arg
+		default:
+			return "", "", fmt.Errorf("unexpected argument %q", arg)
+		}
+	}
+	if target == "" {
+		return "", "", fmt.Errorf("expected a manifest file or <pluginID>[/<version>] as the first argument")
+	}
+	return target, output, nil
+}
+
+// findAppPlugin discovers the plugin the same way the server does, from the
+// plugin paths in the config plus the directory the CLI was pointed at.
+func findAppPlugin(
+	c *cli.Context,
+	cfg *setting.Cfg,
+	features featuremgmt.FeatureToggles,
+	pluginID string,
+) (definition.PluginDefinition, error) {
+	var empty definition.PluginDefinition
+
+	pluginCfg, err := pluginconfig.ProvidePluginManagementConfig(cfg, setting.ProvideProvider(cfg), features)
+	if err != nil {
+		return empty, err
+	}
+	// A plugin under development is often not in the config's plugin paths.
+	if dir := c.String("pluginsDir"); dir != "" && !slices.Contains(pluginCfg.PluginsPaths, dir) {
+		pluginCfg.PluginsPaths = append(pluginCfg.PluginsPaths, dir)
+	}
+
+	defs, err := definition.LoadPluginDefinition(c.Context,
+		pluginsources.ProvideService(cfg, pluginCfg),
+		definition.Options{
+			Filter: func(json plugins.JSONData) bool {
+				return json.ID == pluginID && json.Type == plugins.TypeApp
+			},
+			Schemas:     true,
+			AppManifest: true,
+		})
+	if err != nil {
+		return empty, err
+	}
+	if len(defs) == 0 {
+		return empty, fmt.Errorf("app plugin %q was not found in %s",
+			pluginID, strings.Join(pluginCfg.PluginsPaths, ", "))
+	}
+	return defs[0], nil
+}

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command.go
@@ -26,8 +26,8 @@ import (
 )
 
 // writeOpenAPICommand renders the OpenAPI v3 spec an app plugin's API server
-// serves, without starting Grafana. It is the offline equivalent of
-// GET /openapi/v3/apis/{pluginID}/{version} on a running server.
+// serves, without starting Grafana. It uses the same rendering pipeline as
+// GET /openapi/v3/apis/{group}/{version} on a running server.
 func writeOpenAPICommand(c *cli.Context) error {
 	target, output, err := writeOpenAPIArgs(c)
 	if err != nil {
@@ -92,8 +92,8 @@ func ensureOutputDir(path string) error {
 }
 
 // writeOpenAPIInput resolves the target into the plugin to render, the single
-// version to render (empty for all of them), and the options that make the
-// output match a server's.
+// version to render (empty for all of them), and the options that affect the
+// rendered document.
 //
 // A manifest file is read on its own, with no Grafana config involved, so this
 // works in a plugin's build with no Grafana installed. A plugin id is looked up
@@ -103,28 +103,27 @@ func writeOpenAPIInput(c *cli.Context, target, output string) (definition.Plugin
 	var empty definition.PluginDefinition
 
 	info, statErr := os.Stat(target)
-	switch {
-	case statErr == nil && !info.IsDir():
+	if statErr == nil {
+		if info.IsDir() {
+			return empty, "", pluginopenapi.Options{}, cli.Exit(fmt.Sprintf(
+				"%s is a directory; pass the manifest file inside it", target), 1)
+		}
 		plugin, err := pluginopenapi.LoadManifest(c.Context, target)
 		return plugin, "", pluginopenapi.Options{BuildVersion: setting.BuildVersion}, err
+	}
 
-	// A target typed as a path is answered as a path. Falling through to the
-	// plugin lookup would report a missing plugin named after part of the path.
-	case !looksLikePath(target):
-	case statErr != nil:
+	// Preserve the filesystem error for a path. Treating it as a plugin target
+	// would report a misleading missing-plugin error instead.
+	if looksLikePath(target) {
 		return empty, "", pluginopenapi.Options{}, statErr
-	default:
-		return empty, "", pluginopenapi.Options{}, cli.Exit(fmt.Sprintf(
-			"%s is a directory; pass the manifest file inside it", target), 1)
 	}
 
 	pluginID, version, _ := strings.Cut(target, "/")
 
 	args := strings.Split(c.String("configOverrides"), " ")
 	if output == "" {
-		// Loading the config logs to the console, which is stdout, and that is
-		// where the spec goes when no output path was given. The file log mode
-		// is on by default, so the same messages are still recorded.
+		// Keep configuration logs off stdout when stdout is reserved for the
+		// rendered spec. File logging remains enabled by default.
 		args = append(args, "cfg:log.mode=file")
 	}
 	cmd := &utils.ContextCommandLine{Context: c}
@@ -172,7 +171,6 @@ func writeSpecFile(path string, oas *spec3.OpenAPI) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	// Title is the group version the spec was rendered for.
 	logger.Infof("Wrote %s for %s\n", path, oas.Info.Title)
 	return nil
 }

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command.go
@@ -71,11 +71,19 @@ func writeOpenAPICommand(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if err := writeSpecFile(filepath.Join(output, v+".json"), oas); err != nil {
+		if err := writeSpecFile(filepath.Join(output, openAPISpecFilename(plugin, v)), oas); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func openAPISpecFilename(plugin definition.PluginDefinition, version string) string {
+	group := plugin.JSONData.ID
+	if plugin.Manifest != nil {
+		group = plugin.Manifest.Group
+	}
+	return group + "-" + version + ".json"
 }
 
 // ensureOutputDir prepares the directory the per-version specs are written to.

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
@@ -1,0 +1,131 @@
+package commands
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestWriteOpenAPIArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		target  string
+		output  string
+		wantErr string
+	}{
+		{
+			name:   "flag before the target",
+			args:   []string{"-o", "spec.json", "test-app/v1alpha1"},
+			target: "test-app/v1alpha1",
+			output: "spec.json",
+		},
+		{
+			// Flag parsing stops at the first positional argument, so this form
+			// reaches the action as three plain arguments.
+			name:   "flag after the target",
+			args:   []string{"test-app/v1alpha1", "-o", "spec.json"},
+			target: "test-app/v1alpha1",
+			output: "spec.json",
+		},
+		{
+			name:   "a manifest path is a target like any other",
+			args:   []string{"./dist/app-sdk-manifest.json", "-o", "specs"},
+			target: "./dist/app-sdk-manifest.json",
+			output: "specs",
+		},
+		{
+			name:   "long flag with an equals sign",
+			args:   []string{"test-app", "--output=spec.json"},
+			target: "test-app",
+			output: "spec.json",
+		},
+		{
+			name:   "no output writes to stdout",
+			args:   []string{"test-app"},
+			target: "test-app",
+		},
+		{
+			name:    "no target",
+			args:    []string{"-o", "spec.json"},
+			wantErr: "expected a manifest file or <pluginID>[/<version>]",
+		},
+		{
+			name:    "output without a value",
+			args:    []string{"test-app", "-o"},
+			wantErr: "missing value for -o",
+		},
+		{
+			name:    "unknown flag",
+			args:    []string{"test-app", "--pretty"},
+			wantErr: `unknown flag "--pretty"`,
+		},
+		{
+			name:    "two targets",
+			args:    []string{"test-app", "other-app"},
+			wantErr: `unexpected argument "other-app"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, output, err := writeOpenAPIArgs(writeOpenAPIContext(t, tt.args))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.target, target)
+			require.Equal(t, tt.output, output)
+		})
+	}
+}
+
+// writeOpenAPIContext runs the registered command with its action replaced, so
+// the context under test is parsed by the command that ships -- flag aliases and
+// all.
+func writeOpenAPIContext(t *testing.T, args []string) *cli.Context {
+	t.Helper()
+
+	var cmd *cli.Command
+	for _, c := range Commands {
+		if c.Name == "write-openapi" {
+			copied := *c
+			cmd = &copied
+		}
+	}
+	require.NotNil(t, cmd, "the write-openapi command should be registered")
+
+	var ctx *cli.Context
+	cmd.Action = func(c *cli.Context) error {
+		ctx = c
+		return nil
+	}
+	app := &cli.App{Commands: []*cli.Command{cmd}, Writer: io.Discard}
+	require.NoError(t, app.Run(append([]string{"grafana-cli", cmd.Name}, args...)))
+	require.NotNil(t, ctx)
+	return ctx
+}
+
+// The target is a plugin id or a path, and the two overlap: pluginID/version
+// carries a slash, so a slash cannot be what tells them apart.
+func TestLooksLikePath(t *testing.T) {
+	for _, target := range []string{
+		"./dist/app-sdk-manifest.json",
+		"dist/app-sdk-manifest.json",
+		"/abs/path/manifest.json",
+		"../plugin/dist",
+		"~/plugins/app/dist/app-sdk-manifest.json",
+	} {
+		require.True(t, looksLikePath(target), target)
+	}
+
+	for _, target := range []string{
+		"grafana-app-sdk-test-app",
+		"grafana-app-sdk-test-app/v1alpha1",
+	} {
+		require.False(t, looksLikePath(target), target)
+	}
+}

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
@@ -142,7 +142,7 @@ func TestWriteOpenAPIInputRejectsDirectory(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
 
 	target := filepath.Base(dir)
-	_, _, _, err = writeOpenAPIInput(writeOpenAPIContext(t, []string{"test-app"}), target, "")
+	_, _, _, err = writeOpenAPIInput(writeOpenAPIContext(t, []string{"test-app"}), target, "") //nolint:dogsled
 	require.ErrorContains(t, err, "is a directory; pass the manifest file inside it")
 }
 

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
@@ -8,6 +8,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/definition"
 )
 
 func TestWriteOpenAPIArgs(t *testing.T) {
@@ -140,4 +144,21 @@ func TestWriteOpenAPIInputRejectsDirectory(t *testing.T) {
 	target := filepath.Base(dir)
 	_, _, _, err = writeOpenAPIInput(writeOpenAPIContext(t, []string{"test-app"}), target, "")
 	require.ErrorContains(t, err, "is a directory; pass the manifest file inside it")
+}
+
+func TestOpenAPISpecFilename(t *testing.T) {
+	t.Run("uses manifest group", func(t *testing.T) {
+		plugin := definition.PluginDefinition{
+			JSONData: plugins.JSONData{ID: "example-app"},
+			Manifest: &app.ManifestData{Group: "example.ext.grafana.app"},
+		}
+
+		require.Equal(t, "example.ext.grafana.app-v1alpha1.json", openAPISpecFilename(plugin, "v1alpha1"))
+	})
+
+	t.Run("uses plugin ID without manifest", func(t *testing.T) {
+		plugin := definition.PluginDefinition{JSONData: plugins.JSONData{ID: "example-app"}}
+
+		require.Equal(t, "example-app-v0alpha1.json", openAPISpecFilename(plugin, "v0alpha1"))
+	})
 }

--- a/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
+++ b/pkg/cmd/grafana-cli/commands/write_openapi_command_test.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -128,4 +130,14 @@ func TestLooksLikePath(t *testing.T) {
 	} {
 		require.False(t, looksLikePath(target), target)
 	}
+}
+
+func TestWriteOpenAPIInputRejectsDirectory(t *testing.T) {
+	dir, err := os.MkdirTemp(".", "write-openapi-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(dir)) })
+
+	target := filepath.Base(dir)
+	_, _, _, err = writeOpenAPIInput(writeOpenAPIContext(t, []string{"test-app"}), target, "")
+	require.ErrorContains(t, err, "is a directory; pass the manifest file inside it")
 }

--- a/pkg/registry/apis/appplugin/pluginopenapi/README.md
+++ b/pkg/registry/apis/appplugin/pluginopenapi/README.md
@@ -1,0 +1,78 @@
+# Rendering an app plugin's OpenAPI spec offline
+
+For plugin authors who want the spec their manifest produces, and for anyone changing how
+that spec is built. The short version:
+
+```sh
+grafana cli write-openapi ./dist/app-sdk-manifest.json -o ./specs
+```
+
+writes one `<version>.json` per served version into `./specs`, each identical to what a
+running Grafana serves at `/openapi/v3/apis/<group>/<version>` — without starting the
+server, opening a database, or launching the plugin backend.
+
+## What you can point it at
+
+**A manifest file.** No Grafana config is read and no plugin needs to be installed, so this
+works inside a plugin's own build. When a `plugin.json` sits in the same directory — what a
+built plugin looks like — it is loaded too, and the spec matches the server exactly. Without
+it, the manifest's `appName` stands in for the plugin id and the plugin version is absent
+from `info.x-grafana-plugin`. Everything else is the same document — the APIs are served
+under the group the manifest declares either way.
+
+**An installed plugin's id**, optionally with a version:
+
+```sh
+grafana cli --config conf/custom.ini --homepath "$PWD" \
+  write-openapi grafana-app-sdk-test-app/v1alpha1 -o spec.json
+```
+
+The plugin is found the way the server finds it — the plugin paths in the config file, plus
+the CLI's `--pluginsDir` — so point `--config` at the config the server uses.
+
+## Where it writes
+
+Naming a single version writes a single spec, to `-o <file>` or to stdout. Otherwise every
+served version is written into the `-o <directory>`, which is created if it doesn't exist.
+That set always includes the `v0alpha1` settings API, which every app plugin serves whether
+or not its manifest mentions the version.
+
+## How the spec is built
+
+`Build` in [spec.go](spec.go) assembles the same pipeline the server does, and nothing else:
+
+1. `appplugin.NewAppPluginAPIBuilder` over the loaded plugin definition, with the plugin
+   client, the plugin context, the decrypter and access control stubbed — none of them
+   contribute to the spec.
+2. `builder.SetupConfig`, which installs the OpenAPI definitions and, more importantly, the
+   post-processors: `getOpenAPIPostProcessor` (hiding the watch and all-namespace routes)
+   and the builder's own `PostProcessOpenAPI` (the settings schema, the manifest kind
+   schemas, the request examples).
+3. A `GenericAPIServer` with a no-op `RESTOptionsGetter`, so the resource handlers are
+   installed and the paths they serve exist. No request is ever routed to them.
+4. `builder3.BuildOpenAPISpecFromRoutes` over the group version's web service, which is what
+   `routes.OpenAPI.InstallV3` does for each `/openapi/v3/apis/...` endpoint.
+
+Because step 3 registers storage it never reads, the spec describes the API as unified
+storage serves it. That is the one known difference from a running server: on a deployment
+where the settings resource is still served from legacy storage, the server's `v0alpha1`
+spec carries two fewer unused component schemas (`WatchEvent` and `RawExtension`), because
+legacy storage cannot watch. No path refers to them in either spec.
+
+## Keeping it honest
+
+The value of this command is that it agrees with the server, and the only way to be sure is
+to compare. With a plugin installed and `appplugins.registerAPIServer` on:
+
+```sh
+curl -s -u admin:admin \
+  http://localhost:3000/openapi/v3/apis/<pluginID>/<version> | python3 -m json.tool --indent 2 > server.json
+grafana cli --config conf/custom.ini --homepath "$PWD" write-openapi <pluginID>/<version> -o cli.json
+diff <(python3 -m json.tool --indent 2 cli.json) server.json
+```
+
+The CLI output is indented because it is read and diffed by people; the HTTP response is
+not, so both sides need normalizing before the diff means anything.
+
+Rendering from the manifest instead (`write-openapi ./dist/app-sdk-manifest.json -o ./specs`)
+produces the same bytes, as long as the `plugin.json` is beside it.

--- a/pkg/registry/apis/appplugin/pluginopenapi/README.md
+++ b/pkg/registry/apis/appplugin/pluginopenapi/README.md
@@ -7,9 +7,9 @@ that spec is built. The short version:
 grafana cli write-openapi ./dist/app-sdk-manifest.json -o ./specs
 ```
 
-writes one `<version>.json` per served version into `./specs`, using the same OpenAPI
-builder as `/openapi/v3/apis/<group>/<version>` — without starting the server, opening a
-database, or launching the plugin backend.
+writes one `<group>-<version>.json` file per served version into `./specs`, using the same
+OpenAPI builder as `/openapi/v3/apis/<group>/<version>` — without starting the server,
+opening a database, or launching the plugin backend.
 
 ## What you can point it at
 

--- a/pkg/registry/apis/appplugin/pluginopenapi/README.md
+++ b/pkg/registry/apis/appplugin/pluginopenapi/README.md
@@ -7,18 +7,17 @@ that spec is built. The short version:
 grafana cli write-openapi ./dist/app-sdk-manifest.json -o ./specs
 ```
 
-writes one `<version>.json` per served version into `./specs`, each identical to what a
-running Grafana serves at `/openapi/v3/apis/<group>/<version>` — without starting the
-server, opening a database, or launching the plugin backend.
+writes one `<version>.json` per served version into `./specs`, using the same OpenAPI
+builder as `/openapi/v3/apis/<group>/<version>` — without starting the server, opening a
+database, or launching the plugin backend.
 
 ## What you can point it at
 
 **A manifest file.** No Grafana config is read and no plugin needs to be installed, so this
 works inside a plugin's own build. When a `plugin.json` sits in the same directory — what a
-built plugin looks like — it is loaded too, and the spec matches the server exactly. Without
-it, the manifest's `appName` stands in for the plugin id and the plugin version is absent
-from `info.x-grafana-plugin`. Everything else is the same document — the APIs are served
-under the group the manifest declares either way.
+built plugin looks like — it is loaded too. Without it, the manifest's `appName` stands in
+for the plugin ID and the plugin version is absent from `info.x-grafana-plugin`. The APIs
+are served under the group declared by the manifest either way.
 
 **An installed plugin's id**, optionally with a version:
 
@@ -29,6 +28,9 @@ grafana cli --config conf/custom.ini --homepath "$PWD" \
 
 The plugin is found the way the server finds it — the plugin paths in the config file, plus
 the CLI's `--pluginsDir` — so point `--config` at the config the server uses.
+
+The command target is the plugin ID. The HTTP endpoint is keyed by API group, which is the
+group declared in the manifest when one is present and may differ from the plugin ID.
 
 ## Where it writes
 
@@ -53,11 +55,16 @@ or not its manifest mentions the version.
 4. `builder3.BuildOpenAPISpecFromRoutes` over the group version's web service, which is what
    `routes.OpenAPI.InstallV3` does for each `/openapi/v3/apis/...` endpoint.
 
-Because step 3 registers storage it never reads, the spec describes the API as unified
-storage serves it. That is the one known difference from a running server: on a deployment
-where the settings resource is still served from legacy storage, the server's `v0alpha1`
-spec carries two fewer unused component schemas (`WatchEvent` and `RawExtension`), because
-legacy storage cannot watch. No path refers to them in either spec.
+## Deliberate rendering choices
+
+The generated contract always enables search and trash route registration. This is
+independent of the `enable_search_api` and `enable_trash_api` settings of the Grafana
+installation used to locate a plugin. The usual per-kind eligibility rules still apply.
+
+Step 3 also describes the API as unified storage serves it. On a deployment where the
+settings resource still uses legacy storage, the generated `v0alpha1` spec carries two
+additional unused component schemas (`WatchEvent` and `RawExtension`), because legacy
+storage cannot watch. No path refers to them in either spec.
 
 ## Keeping it honest
 
@@ -66,7 +73,7 @@ to compare. With a plugin installed and `appplugins.registerAPIServer` on:
 
 ```sh
 curl -s -u admin:admin \
-  http://localhost:3000/openapi/v3/apis/<pluginID>/<version> | python3 -m json.tool --indent 2 > server.json
+  http://localhost:3000/openapi/v3/apis/<group>/<version> | python3 -m json.tool --indent 2 > server.json
 grafana cli --config conf/custom.ini --homepath "$PWD" write-openapi <pluginID>/<version> -o cli.json
 diff <(python3 -m json.tool --indent 2 cli.json) server.json
 ```
@@ -74,5 +81,5 @@ diff <(python3 -m json.tool --indent 2 cli.json) server.json
 The CLI output is indented because it is read and diffed by people; the HTTP response is
 not, so both sides need normalizing before the diff means anything.
 
-Rendering from the manifest instead (`write-openapi ./dist/app-sdk-manifest.json -o ./specs`)
-produces the same bytes, as long as the `plugin.json` is beside it.
+When comparing output, account for the deliberate rendering choices above and normalize
+formatting as shown.

--- a/pkg/registry/apis/appplugin/pluginopenapi/client.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/client.go
@@ -1,0 +1,62 @@
+package pluginopenapi
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	pluginv3 "github.com/grafana/grafana-app-sdk/plugin/genproto/grafana/plugin/v3"
+	v3 "github.com/grafana/grafana/pkg/plugins/backendplugin/v3"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+var _ v3.ClientV3 = offlineClientV3{}
+
+// offlineClientV3 stands in for the plugin backend. A kind that declares
+// admission capabilities is refused a nil client, and the spec describes the
+// custom routes this client would serve, so it has to exist -- but rendering a
+// spec never starts the plugin.
+type offlineClientV3 struct{}
+
+func (offlineClientV3) AdmissionReview(context.Context, *pluginv3.AdmissionReviewRequest, ...grpc.CallOption) (*pluginv3.AdmissionReviewResponse, error) {
+	return nil, errOffline
+}
+
+func (offlineClientV3) CallRoute(context.Context, *pluginv3.CallRouteRequest, ...grpc.CallOption) (grpc.ServerStreamingClient[pluginv3.CallRouteResponse], error) {
+	return nil, errOffline
+}
+
+func (offlineClientV3) ConvertObjects(context.Context, *pluginv3.ConvertObjectsRequest, ...grpc.CallOption) (*pluginv3.ConvertObjectsResponse, error) {
+	return nil, errOffline
+}
+
+var errOffline = apierrors.NewServiceUnavailable("the plugin backend is not running")
+
+var _ resourcepb.ResourceIndexClient = offlineSearchClient{}
+
+// offlineSearchClient stands in for the search index. The kinds that serve
+// /search and /trash are described only when a plugin's API server has an index
+// client, so rendering needs one to describe them -- but nothing here is asked
+// a question.
+type offlineSearchClient struct{}
+
+func (offlineSearchClient) Search(context.Context, *resourcepb.ResourceSearchRequest, ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	return nil, errOffline
+}
+
+func (offlineSearchClient) GetStats(context.Context, *resourcepb.ResourceStatsRequest, ...grpc.CallOption) (*resourcepb.ResourceStatsResponse, error) {
+	return nil, errOffline
+}
+
+func (offlineSearchClient) RebuildIndexes(context.Context, *resourcepb.RebuildIndexesRequest, ...grpc.CallOption) (*resourcepb.RebuildIndexesResponse, error) {
+	return nil, errOffline
+}
+
+func (offlineSearchClient) VectorSearch(context.Context, *resourcepb.VectorSearchRequest, ...grpc.CallOption) (*resourcepb.VectorSearchResponse, error) {
+	return nil, errOffline
+}
+
+func (offlineSearchClient) HybridSearch(context.Context, *resourcepb.HybridSearchRequest, ...grpc.CallOption) (*resourcepb.HybridSearchResponse, error) {
+	return nil, errOffline
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/client.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/client.go
@@ -13,10 +13,8 @@ import (
 
 var _ v3.ClientV3 = offlineClientV3{}
 
-// offlineClientV3 stands in for the plugin backend. A kind that declares
-// admission capabilities is refused a nil client, and the spec describes the
-// custom routes this client would serve, so it has to exist -- but rendering a
-// spec never starts the plugin.
+// offlineClientV3 satisfies dependencies used by admission, conversion, and
+// custom routes without starting the plugin backend.
 type offlineClientV3 struct{}
 
 func (offlineClientV3) AdmissionReview(context.Context, *pluginv3.AdmissionReviewRequest, ...grpc.CallOption) (*pluginv3.AdmissionReviewResponse, error) {
@@ -35,10 +33,8 @@ var errOffline = apierrors.NewServiceUnavailable("the plugin backend is not runn
 
 var _ resourcepb.ResourceIndexClient = offlineSearchClient{}
 
-// offlineSearchClient stands in for the search index. The kinds that serve
-// /search and /trash are described only when a plugin's API server has an index
-// client, so rendering needs one to describe them -- but nothing here is asked
-// a question.
+// offlineSearchClient allows search and trash routes to be registered without
+// connecting to the search index.
 type offlineSearchClient struct{}
 
 func (offlineSearchClient) Search(context.Context, *resourcepb.ResourceSearchRequest, ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {

--- a/pkg/registry/apis/appplugin/pluginopenapi/manifest.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/manifest.go
@@ -1,0 +1,89 @@
+package pluginopenapi
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/definition"
+	"github.com/grafana/grafana/pkg/plugins/manager/sources"
+)
+
+// pluginJSONFile sits beside the manifest in a built plugin.
+const pluginJSONFile = "plugin.json"
+
+// LoadManifest reads an app-sdk manifest file into the definition the spec is
+// rendered from.
+//
+// A plugin's APIs are served under the group its manifest declares, but the
+// settings API is described by the plugin's own metadata and schema. So when a
+// plugin.json sits in the same directory -- which is what a built plugin looks
+// like -- it is loaded too, and the spec then matches what a server serving that
+// plugin would return. Without it the manifest's app name stands in for the
+// plugin id, and the settings API falls back to its defaults.
+func LoadManifest(ctx context.Context, path string) (definition.PluginDefinition, error) {
+	var plugin definition.PluginDefinition
+
+	raw, err := os.ReadFile(path) // #nosec G304 -- a path the operator typed
+	if err != nil {
+		return plugin, err
+	}
+	manifest, err := definition.ParseManifest(raw)
+	if err != nil {
+		return plugin, fmt.Errorf("%s: %w", filepath.Base(path), err)
+	}
+	if manifest == nil {
+		return plugin, fmt.Errorf("%s: no manifest found", filepath.Base(path))
+	}
+
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(filepath.Join(dir, pluginJSONFile)); err == nil {
+		plugin, err = loadPluginDir(ctx, dir)
+		if err != nil {
+			return plugin, err
+		}
+	}
+	if plugin.JSONData.ID == "" {
+		if manifest.AppName == "" {
+			return plugin, fmt.Errorf("%s: manifest has no appName, and there is no %s to take a plugin id from",
+				filepath.Base(path), pluginJSONFile)
+		}
+		plugin.JSONData = plugins.JSONData{
+			ID:   manifest.AppName,
+			Type: plugins.TypeApp,
+		}
+	}
+
+	// The file the caller named wins over the one the directory happens to hold.
+	plugin.Manifest = manifest
+	return plugin, nil
+}
+
+// loadPluginDir reads a built plugin the way the server reads it, so the
+// definition carries the same plugin.json, schemas and manifest.
+func loadPluginDir(ctx context.Context, dir string) (definition.PluginDefinition, error) {
+	found, err := definition.LoadPluginDefinition(ctx,
+		singleSource{sources.NewUnsafeLocalSource(plugins.ClassExternal, []string{dir})},
+		definition.Options{Schemas: true, AppManifest: true},
+	)
+	if err != nil {
+		return definition.PluginDefinition{}, err
+	}
+	if len(found) == 0 {
+		// The directory holds a plugin.json the loader would not take, which
+		// says more than a spec rendered from defaults would.
+		return definition.PluginDefinition{}, fmt.Errorf("%s in %s could not be loaded", pluginJSONFile, dir)
+	}
+	return found[0], nil
+}
+
+// singleSource adapts one plugin source to the registry the loader takes.
+type singleSource struct {
+	source plugins.PluginSource
+}
+
+func (s singleSource) List(_ context.Context) []plugins.PluginSource {
+	return []plugins.PluginSource{s.source}
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/manifest.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/manifest.go
@@ -11,18 +11,16 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/sources"
 )
 
-// pluginJSONFile sits beside the manifest in a built plugin.
 const pluginJSONFile = "plugin.json"
 
 // LoadManifest reads an app-sdk manifest file into the definition the spec is
 // rendered from.
 //
 // A plugin's APIs are served under the group its manifest declares, but the
-// settings API is described by the plugin's own metadata and schema. So when a
-// plugin.json sits in the same directory -- which is what a built plugin looks
-// like -- it is loaded too, and the spec then matches what a server serving that
-// plugin would return. Without it the manifest's app name stands in for the
-// plugin id, and the settings API falls back to its defaults.
+// settings API also depends on the plugin's metadata and schema. When a
+// plugin.json sits beside the manifest, LoadManifest loads the complete plugin
+// definition. Otherwise, the manifest's app name stands in for the plugin ID
+// and the settings API uses its defaults.
 func LoadManifest(ctx context.Context, path string) (definition.PluginDefinition, error) {
 	var plugin definition.PluginDefinition
 
@@ -47,7 +45,7 @@ func LoadManifest(ctx context.Context, path string) (definition.PluginDefinition
 	}
 	if plugin.JSONData.ID == "" {
 		if manifest.AppName == "" {
-			return plugin, fmt.Errorf("%s: manifest has no appName, and there is no %s to take a plugin id from",
+			return plugin, fmt.Errorf("%s: manifest has no appName, and there is no %s to take a plugin ID from",
 				filepath.Base(path), pluginJSONFile)
 		}
 		plugin.JSONData = plugins.JSONData{
@@ -61,8 +59,8 @@ func LoadManifest(ctx context.Context, path string) (definition.PluginDefinition
 	return plugin, nil
 }
 
-// loadPluginDir reads a built plugin the way the server reads it, so the
-// definition carries the same plugin.json, schemas and manifest.
+// loadPluginDir reads a built plugin the way the server reads it, including its
+// plugin.json, schemas, and conventional manifest.
 func loadPluginDir(ctx context.Context, dir string) (definition.PluginDefinition, error) {
 	found, err := definition.LoadPluginDefinition(ctx,
 		singleSource{sources.NewUnsafeLocalSource(plugins.ClassExternal, []string{dir})},
@@ -72,8 +70,8 @@ func loadPluginDir(ctx context.Context, dir string) (definition.PluginDefinition
 		return definition.PluginDefinition{}, err
 	}
 	if len(found) == 0 {
-		// The directory holds a plugin.json the loader would not take, which
-		// says more than a spec rendered from defaults would.
+		// A present but unloadable plugin.json is an error; silently falling back
+		// would omit metadata and schemas from the generated spec.
 		return definition.PluginDefinition{}, fmt.Errorf("%s in %s could not be loaded", pluginJSONFile, dir)
 	}
 	return found[0], nil

--- a/pkg/registry/apis/appplugin/pluginopenapi/manifest_test.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/manifest_test.go
@@ -1,0 +1,89 @@
+package pluginopenapi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A manifest on its own is enough to render from: the app name stands in for
+// the plugin id, and the manifest group is what the APIs are served under.
+func TestLoadManifestStandalone(t *testing.T) {
+	plugin, err := LoadManifest(context.Background(), "testdata/standalone/app-sdk-manifest.json")
+	require.NoError(t, err)
+
+	require.Equal(t, "example-app", plugin.JSONData.ID)
+	require.NotNil(t, plugin.Manifest)
+	require.Equal(t, "example-app", plugin.Manifest.AppName)
+	require.Empty(t, plugin.JSONData.Info.Version, "there is no plugin.json to take a version from")
+
+	versions, err := Versions(plugin, Options{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"v1alpha1", "v0alpha1"}, versions,
+		"the unserved manifest version is left out, and the settings version is served last")
+
+	oas, err := Build(plugin, "v1alpha1", Options{})
+	require.NoError(t, err)
+	require.Equal(t, "example.ext.grafana.app/v1alpha1", oas.Info.Title)
+	require.Contains(t, oas.Paths.Paths, "/apis/example.ext.grafana.app/v1alpha1/namespaces/{namespace}/testkinds")
+}
+
+// A built plugin has its plugin.json beside the manifest, and that is where the
+// plugin id comes from, but the APIs are still served under the manifest group.
+func TestLoadManifestBesidePluginJSON(t *testing.T) {
+	plugin, err := LoadManifest(context.Background(), "testdata/plugin/app-sdk-manifest.json")
+	require.NoError(t, err)
+
+	require.Equal(t, "grafana-example-app", plugin.JSONData.ID)
+	require.Equal(t, "4.5.6", plugin.JSONData.Info.Version)
+	require.Equal(t, "example-app", plugin.Manifest.AppName, "the manifest is still the one that was named")
+
+	oas, err := Build(plugin, "v1alpha1", Options{})
+	require.NoError(t, err)
+	require.Equal(t, "example.ext.grafana.app/v1alpha1", oas.Info.Title)
+	require.Equal(t, "An example app plugin", oas.Info.Description)
+	require.Contains(t, oas.Paths.Paths, "/apis/example.ext.grafana.app/v1alpha1/namespaces/{namespace}/testkinds")
+}
+
+// The file the caller named is the one that is read, even when the directory
+// holds another manifest under the conventional name.
+func TestLoadManifestNamedFileWins(t *testing.T) {
+	dir := t.TempDir()
+	named := filepath.Join(dir, "other-manifest.json")
+
+	require.NoError(t, os.WriteFile(named, []byte(
+		`{"apiVersion":"apps.grafana.app/v1alpha2","kind":"AppManifest",`+
+			`"spec":{"appName":"named-app","versions":[{"name":"v1alpha1","served":true}]}}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app-sdk-manifest.json"), []byte("{}"), 0600))
+
+	plugin, err := LoadManifest(context.Background(), named)
+	require.NoError(t, err)
+	require.Equal(t, "named-app", plugin.JSONData.ID)
+}
+
+func TestLoadManifestErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := LoadManifest(context.Background(), "testdata/nope.json")
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("not a manifest", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "app-sdk-manifest.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"hello":"world"}`), 0600))
+
+		_, err := LoadManifest(context.Background(), path)
+		require.ErrorContains(t, err, "unsupported AppManifest apiVersion")
+	})
+
+	t.Run("no app name to fall back on", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "app-sdk-manifest.json")
+		require.NoError(t, os.WriteFile(path, []byte(
+			`{"apiVersion":"apps.grafana.app/v1alpha2","kind":"AppManifest","spec":{}}`), 0600))
+
+		_, err := LoadManifest(context.Background(), path)
+		require.ErrorContains(t, err, "no appName")
+	})
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/manifest_test.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/manifest_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // A manifest on its own is enough to render from: the app name stands in for
-// the plugin id, and the manifest group is what the APIs are served under.
+// the plugin ID, and the manifest group is what the APIs are served under.
 func TestLoadManifestStandalone(t *testing.T) {
 	plugin, err := LoadManifest(context.Background(), "testdata/standalone/app-sdk-manifest.json")
 	require.NoError(t, err)
@@ -32,7 +32,7 @@ func TestLoadManifestStandalone(t *testing.T) {
 }
 
 // A built plugin has its plugin.json beside the manifest, and that is where the
-// plugin id comes from, but the APIs are still served under the manifest group.
+// plugin ID comes from, but the APIs are still served under the manifest group.
 func TestLoadManifestBesidePluginJSON(t *testing.T) {
 	plugin, err := LoadManifest(context.Background(), "testdata/plugin/app-sdk-manifest.json")
 	require.NoError(t, err)

--- a/pkg/registry/apis/appplugin/pluginopenapi/spec.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/spec.go
@@ -1,0 +1,202 @@
+// Package pluginopenapi renders the OpenAPI v3 spec an app plugin's API server
+// serves, without starting Grafana.
+//
+// The spec is built from the same builder, scheme and post-processors the
+// running server uses, so the output matches what
+// /openapi/v3/apis/{pluginID}/{version} returns. Only the pieces that show up
+// in the spec are wired: storage, plugin clients and access control are stubbed
+// out, so nothing connects to a database or to the plugin backend.
+package pluginopenapi
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	restful "github.com/emicklei/go-restful/v3"
+	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryendpoint "k8s.io/apiserver/pkg/endpoints/discovery/aggregated"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	clientrest "k8s.io/client-go/rest"
+	"k8s.io/kube-openapi/pkg/builder3"
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/common/restfuladapter"
+	"k8s.io/kube-openapi/pkg/spec3"
+
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/plugins/definition"
+	"github.com/grafana/grafana/pkg/registry/apis/appplugin"
+	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/storage/unified/apistore"
+)
+
+// Options are the parts of a running server's configuration that are visible in
+// the generated spec.
+type Options struct {
+	// BuildVersion stamps the spec info version, the same way the server does.
+	BuildVersion string
+
+	// RegisterProxy mirrors the appplugins.handleProxyRequests feature toggle,
+	// which adds the plugin proxy subresource.
+	RegisterProxy bool
+}
+
+// Versions returns the versions the plugin serves, preferred version first.
+// Every version is renderable, including the settings version a manifest never
+// mentions.
+func Versions(plugin definition.PluginDefinition, opts Options) ([]string, error) {
+	b, err := newBuilder(plugin, opts)
+	if err != nil {
+		return nil, err
+	}
+	return servedVersions(b.GetGroupVersions()), nil
+}
+
+// newBuilder wires the API builder with everything a request would need left
+// out: nothing here is called, it only describes.
+func newBuilder(plugin definition.PluginDefinition, opts Options) (*appplugin.AppPluginAPIBuilder, error) {
+	if plugin.JSONData.ID == "" {
+		return nil, fmt.Errorf("plugin is missing an id")
+	}
+	return appplugin.NewAppPluginAPIBuilder(
+		plugin,
+		nil, // health+resource subresources are described by the spec, never called
+		offlineClientV3{},
+		nil, // plugin context is only needed to call the backend
+		nil, // no decrypter: reading secrets is a request time concern
+		appplugin.NewPluginAccessChecker(nil),
+		offlineSearchClient{},
+		appplugin.AppPluginRunnerOptions{
+			RegisterProxy: opts.RegisterProxy,
+			// A rendered spec should describe what a default server serves, and
+			// both endpoints are on unless an operator turns them off. Which
+			// kinds actually get them is still the manifest's decision.
+			SearchAPIEnabled: true,
+			TrashAPIEnabled:  true,
+		},
+		tracing.NewNoopTracerService(),
+		featuremgmt.WithFeatures(),
+	)
+}
+
+// Build returns the OpenAPI v3 spec for one app plugin group version.
+func Build(plugin definition.PluginDefinition, version string, opts Options) (*spec3.OpenAPI, error) {
+	b, err := newBuilder(plugin, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// The served versions, preferred version first. They all share the group the
+	// plugin is served under, which is the manifest group when it declares one.
+	gvs := b.GetGroupVersions()
+	group := gvs[0].Group
+	if version == "" {
+		version = gvs[0].Version
+	}
+	gv := schema.GroupVersion{Group: group, Version: version}
+	if !slices.Contains(gvs, gv) {
+		return nil, fmt.Errorf("plugin %s does not serve version %q (available: %s)",
+			plugin.JSONData.ID, version, strings.Join(servedVersions(gvs), ", "))
+	}
+
+	scheme := builder.ProvideScheme()
+	if err := b.InstallSchema(scheme); err != nil {
+		return nil, err
+	}
+	codecs := builder.ProvideCodecFactory(scheme)
+
+	builders := []builder.APIGroupBuilder{b}
+	apiResourceConfig := serverstorage.NewResourceConfig()
+	apiResourceConfig.EnableVersions(gvs...)
+
+	serverConfig := genericapiserver.NewRecommendedConfig(codecs)
+	// Complete() derives the external address from the secure serving port,
+	// which this server does not have, and would exit the process without one.
+	serverConfig.ExternalAddress = "localhost:3000"
+	serverConfig.LoopbackClientConfig = &clientrest.Config{Host: serverConfig.ExternalAddress}
+	serverConfig.EffectiveVersion = builder.GetEffectiveVersion(0, opts.BuildVersion, "", "")
+	serverConfig.RESTOptionsGetter = appinstaller.NewNoopRESTOptionsGetter()
+	serverConfig.AggregatedDiscoveryGroupManager = discoveryendpoint.NewResourceManager("apis")
+
+	if err := builder.SetupConfig(
+		scheme,
+		serverConfig,
+		builders,
+		opts.BuildVersion,
+		builder.ProvideDefaultBuildHandlerChainFuncFromBuilders(),
+		gvs,
+		// The server always adds these (through
+		// appinstaller.BuildOpenAPIDefGetter) and they replace some of the
+		// shared meta definitions, so the spec only matches with them in place.
+		[]common.GetOpenAPIDefinitions{appsdkapiserver.GetCommonOpenAPIDefinitions},
+		prometheus.NewRegistry(),
+		apiResourceConfig,
+	); err != nil {
+		return nil, err
+	}
+
+	server, err := serverConfig.Complete().New("plugin-openapi", genericapiserver.NewEmptyDelegate())
+	if err != nil {
+		return nil, err
+	}
+
+	// The paths in the spec come from the installed resource handlers, so the
+	// group has to be installed even though no request is ever served.
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(group, scheme, metav1.ParameterCodec, codecs)
+	if err := b.UpdateAPIGroupInfo(&apiGroupInfo, builder.APIGroupOptions{
+		Scheme:              scheme,
+		OptsGetter:          serverConfig.RESTOptionsGetter,
+		MetricsRegister:     prometheus.NewRegistry(),
+		StorageOptsRegister: func(schema.GroupResource, apistore.StorageOptions) {},
+	}); err != nil {
+		return nil, err
+	}
+	apiGroupInfo.NegotiatedSerializer = grafanarest.DefaultNoProtobufNegotiatedSerializer(codecs)
+	if err := server.InstallAPIGroup(&apiGroupInfo); err != nil {
+		return nil, err
+	}
+
+	return buildSpec(server, serverConfig, gv)
+}
+
+// buildSpec renders one group version's spec, the same way the server's
+// /openapi/v3 endpoint does. See routes.OpenAPI.InstallV3 upstream: it builds a
+// spec per registered web service, and each group version has exactly one.
+func buildSpec(
+	server *genericapiserver.GenericAPIServer,
+	serverConfig *genericapiserver.RecommendedConfig,
+	gv schema.GroupVersion,
+) (*spec3.OpenAPI, error) {
+	root := "/apis/" + gv.String()
+	var services []*restful.WebService
+	for _, ws := range server.Handler.GoRestfulContainer.RegisteredWebServices() {
+		if ws.RootPath() == root {
+			services = append(services, ws)
+		}
+	}
+	if len(services) == 0 {
+		return nil, fmt.Errorf("no resources are served under %s", root)
+	}
+
+	oas, err := builder3.BuildOpenAPISpecFromRoutes(
+		restfuladapter.AdaptWebServices(services), serverConfig.OpenAPIV3Config)
+	if err != nil {
+		return nil, err
+	}
+	return oas, nil
+}
+
+func servedVersions(gvs []schema.GroupVersion) []string {
+	out := make([]string, 0, len(gvs))
+	for _, gv := range gvs {
+		out = append(out, gv.Version)
+	}
+	return out
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/spec.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/spec.go
@@ -1,11 +1,10 @@
 // Package pluginopenapi renders the OpenAPI v3 spec an app plugin's API server
 // serves, without starting Grafana.
 //
-// The spec is built from the same builder, scheme and post-processors the
-// running server uses, so the output matches what
-// /openapi/v3/apis/{pluginID}/{version} returns. Only the pieces that show up
-// in the spec are wired: storage, plugin clients and access control are stubbed
-// out, so nothing connects to a database or to the plugin backend.
+// The spec is built from the same builder, scheme, and post-processors the
+// running server uses. Runtime dependencies such as storage, plugin clients,
+// and access control are stubbed, so rendering does not connect to a database
+// or plugin backend.
 package pluginopenapi
 
 import (
@@ -59,15 +58,15 @@ func Versions(plugin definition.PluginDefinition, opts Options) ([]string, error
 	return servedVersions(b.GetGroupVersions()), nil
 }
 
-// newBuilder wires the API builder with everything a request would need left
-// out: nothing here is called, it only describes.
+// newBuilder uses offline substitutes for dependencies that are required to
+// register routes but are only called while serving requests.
 func newBuilder(plugin definition.PluginDefinition, opts Options) (*appplugin.AppPluginAPIBuilder, error) {
 	if plugin.JSONData.ID == "" {
 		return nil, fmt.Errorf("plugin is missing an id")
 	}
 	return appplugin.NewAppPluginAPIBuilder(
 		plugin,
-		nil, // health+resource subresources are described by the spec, never called
+		nil, // only used when serving health and resource subresource requests
 		offlineClientV3{},
 		nil, // plugin context is only needed to call the backend
 		nil, // no decrypter: reading secrets is a request time concern
@@ -75,9 +74,8 @@ func newBuilder(plugin definition.PluginDefinition, opts Options) (*appplugin.Ap
 		offlineSearchClient{},
 		appplugin.AppPluginRunnerOptions{
 			RegisterProxy: opts.RegisterProxy,
-			// A rendered spec should describe what a default server serves, and
-			// both endpoints are on unless an operator turns them off. Which
-			// kinds actually get them is still the manifest's decision.
+			// Generated specs always enable search and trash route registration.
+			// searchroutes still applies its per-kind eligibility rules.
 			SearchAPIEnabled: true,
 			TrashAPIEnabled:  true,
 		},
@@ -93,8 +91,8 @@ func Build(plugin definition.PluginDefinition, version string, opts Options) (*s
 		return nil, err
 	}
 
-	// The served versions, preferred version first. They all share the group the
-	// plugin is served under, which is the manifest group when it declares one.
+	// All served versions share the plugin's API group. A manifest can override
+	// the default group derived from the plugin ID.
 	gvs := b.GetGroupVersions()
 	group := gvs[0].Group
 	if version == "" {
@@ -132,9 +130,8 @@ func Build(plugin definition.PluginDefinition, version string, opts Options) (*s
 		opts.BuildVersion,
 		builder.ProvideDefaultBuildHandlerChainFuncFromBuilders(),
 		gvs,
-		// The server always adds these (through
-		// appinstaller.BuildOpenAPIDefGetter) and they replace some of the
-		// shared meta definitions, so the spec only matches with them in place.
+		// The server adds these through appinstaller.BuildOpenAPIDefGetter. They
+		// replace shared metadata definitions used by app plugin schemas.
 		[]common.GetOpenAPIDefinitions{appsdkapiserver.GetCommonOpenAPIDefinitions},
 		prometheus.NewRegistry(),
 		apiResourceConfig,
@@ -166,9 +163,8 @@ func Build(plugin definition.PluginDefinition, version string, opts Options) (*s
 	return buildSpec(server, serverConfig, gv)
 }
 
-// buildSpec renders one group version's spec, the same way the server's
-// /openapi/v3 endpoint does. See routes.OpenAPI.InstallV3 upstream: it builds a
-// spec per registered web service, and each group version has exactly one.
+// buildSpec renders one group version using the registered web services, as the
+// server's /openapi/v3 endpoint does.
 func buildSpec(
 	server *genericapiserver.GenericAPIServer,
 	serverConfig *genericapiserver.RecommendedConfig,
@@ -185,12 +181,8 @@ func buildSpec(
 		return nil, fmt.Errorf("no resources are served under %s", root)
 	}
 
-	oas, err := builder3.BuildOpenAPISpecFromRoutes(
+	return builder3.BuildOpenAPISpecFromRoutes(
 		restfuladapter.AdaptWebServices(services), serverConfig.OpenAPIV3Config)
-	if err != nil {
-		return nil, err
-	}
-	return oas, nil
 }
 
 func servedVersions(gvs []schema.GroupVersion) []string {

--- a/pkg/registry/apis/appplugin/pluginopenapi/spec_test.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/spec_test.go
@@ -1,0 +1,166 @@
+package pluginopenapi
+
+import (
+	"encoding/json"
+	"maps"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"k8s.io/klog/v2"
+	"k8s.io/kube-openapi/pkg/spec3"
+
+	"github.com/grafana/grafana-app-sdk/app"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/plugins/definition"
+)
+
+// TestMain quiets the apiserver machinery's reports about the server each Build
+// constructs, which say nothing about the spec under test.
+func TestMain(m *testing.M) {
+	klog.SetLogger(logr.Discard())
+	os.Exit(m.Run())
+}
+
+func TestBuildManifestVersion(t *testing.T) {
+	oas, err := Build(testPlugin(t), "v1alpha1", Options{BuildVersion: "12.3.4"})
+	require.NoError(t, err)
+
+	require.Equal(t, "example.ext.grafana.com/v1alpha1", oas.Info.Title)
+	require.Equal(t, "12.3.4", oas.Info.Version)
+	require.Equal(t, "An example", oas.Info.Description)
+
+	root := "/apis/example.ext.grafana.com/v1alpha1/"
+	paths := slices.Sorted(maps.Keys(oas.Paths.Paths))
+	require.Equal(t, []string{
+		root,
+		root + "namespaces/{namespace}/app/instance",
+		root + "namespaces/{namespace}/app/instance/health",
+		root + "namespaces/{namespace}/app/instance/resources",
+		// The kind, from resource storage.
+		root + "namespaces/{namespace}/testkinds",
+		// The routes the manifest declares, plus the generic ones.
+		root + "namespaces/{namespace}/testkinds/search",
+		root + "namespaces/{namespace}/testkinds/{name}",
+		root + "namespaces/{namespace}/testkinds/{name}/reload",
+	}, paths, "paths should not include the watch or all-namespace routes the server hides")
+
+	// The kind's schema, and the list wrapper around it, are the response types.
+	kind := "example.ext.grafana.com.v1alpha1.TestKind"
+	require.Contains(t, oas.Components.Schemas, kind)
+	require.Contains(t, oas.Components.Schemas, kind+"List")
+	require.Equal(t, "#/components/schemas/"+kind+"List",
+		responseRef(t, oas.Paths.Paths[root+"namespaces/{namespace}/testkinds"].Get))
+	require.Equal(t, "#/components/schemas/"+kind,
+		responseRef(t, oas.Paths.Paths[root+"namespaces/{namespace}/testkinds/{name}"].Get))
+}
+
+// The settings API is served in every version, including the one a manifest
+// never mentions.
+func TestBuildSettingsVersion(t *testing.T) {
+	oas, err := Build(testPlugin(t), "v0alpha1", Options{BuildVersion: "12.3.4"})
+	require.NoError(t, err)
+
+	require.Equal(t, "example.ext.grafana.com/v0alpha1", oas.Info.Title)
+	root := "/apis/example.ext.grafana.com/v0alpha1/"
+	require.Equal(t, []string{
+		root,
+		root + "namespaces/{namespace}/app/instance",
+		root + "namespaces/{namespace}/app/instance/health",
+		root + "namespaces/{namespace}/app/instance/resources",
+	}, slices.Sorted(maps.Keys(oas.Paths.Paths)))
+}
+
+func TestBuildVersionSelection(t *testing.T) {
+	t.Run("no version renders the preferred one", func(t *testing.T) {
+		oas, err := Build(testPlugin(t), "", Options{})
+		require.NoError(t, err)
+		require.Equal(t, "example.ext.grafana.com/v1alpha1", oas.Info.Title)
+	})
+
+	t.Run("an unserved version is refused", func(t *testing.T) {
+		_, err := Build(testPlugin(t), "v9", Options{})
+		require.ErrorContains(t, err, `does not serve version "v9"`)
+	})
+
+	t.Run("a plugin without a manifest still serves settings", func(t *testing.T) {
+		plugin := testPlugin(t)
+		plugin.Manifest = nil
+		oas, err := Build(plugin, "", Options{})
+		require.NoError(t, err)
+		require.Equal(t, "example-app/v0alpha1", oas.Info.Title)
+	})
+}
+
+// The proxy subresource is only served when the toggle for it is on.
+func TestBuildProxyRoute(t *testing.T) {
+	proxy := "/apis/example.ext.grafana.com/v1alpha1/namespaces/{namespace}/app/instance/proxy"
+
+	oas, err := Build(testPlugin(t), "v1alpha1", Options{})
+	require.NoError(t, err)
+	require.NotContains(t, oas.Paths.Paths, proxy)
+
+	oas, err = Build(testPlugin(t), "v1alpha1", Options{RegisterProxy: true})
+	require.NoError(t, err)
+	require.Contains(t, oas.Paths.Paths, proxy)
+}
+
+// responseRef returns the schema an operation's 200 response refers to.
+func responseRef(t *testing.T, op *spec3.Operation) string {
+	t.Helper()
+
+	require.NotNil(t, op)
+	content := op.Responses.StatusCodeResponses[200].Content["application/json"]
+	require.NotNil(t, content)
+	return content.Schema.Ref.String()
+}
+
+func testPlugin(t *testing.T) definition.PluginDefinition {
+	t.Helper()
+
+	var schema app.VersionSchema
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"TestKind":{"type":"object","properties":{"spec":{"$ref":"#/components/schemas/spec"}},"required":["spec"]},
+		"spec":{"type":"object","additionalProperties":false,"properties":{"testField":{"type":"string"}},"required":["testField"]}
+	}`), &schema))
+
+	return definition.PluginDefinition{
+		JSONData: plugins.JSONData{
+			ID:   "example-app",
+			Type: plugins.TypeApp,
+			Info: plugins.Info{Description: "An example"},
+			// A route makes the plugin proxy available.
+			Routes: []*plugins.Route{{Path: "example", URL: "http://example.com"}},
+		},
+		Manifest: &app.ManifestData{
+			AppName:          "example",
+			Group:            "example.ext.grafana.com",
+			PreferredVersion: "v1alpha1",
+			Versions: []app.ManifestVersion{{
+				Name:   "v1alpha1",
+				Served: true,
+				Kinds: []app.ManifestVersionKind{{
+					Kind:   "TestKind",
+					Plural: "TestKinds",
+					Scope:  "Namespaced",
+					Schema: &schema,
+					// Declared search fields are what enrol a kind in the
+					// generic search endpoint.
+					SearchFields: []app.ManifestVersionKindSearchField{{
+						Name: "testField", Path: "spec.testField", Type: "string",
+					}},
+					Routes: map[string]spec3.PathProps{
+						"/reload": {Post: &spec3.Operation{OperationProps: spec3.OperationProps{
+							OperationId: "reloadTestKind",
+							Responses: &spec3.Responses{ResponsesProps: spec3.ResponsesProps{
+								Default: &spec3.Response{ResponseProps: spec3.ResponseProps{Description: "OK"}},
+							}},
+						}}},
+					},
+				}},
+			}},
+		},
+	}
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/spec_test.go
+++ b/pkg/registry/apis/appplugin/pluginopenapi/spec_test.go
@@ -28,11 +28,11 @@ func TestBuildManifestVersion(t *testing.T) {
 	oas, err := Build(testPlugin(t), "v1alpha1", Options{BuildVersion: "12.3.4"})
 	require.NoError(t, err)
 
-	require.Equal(t, "example.ext.grafana.com/v1alpha1", oas.Info.Title)
+	require.Equal(t, "example.ext.grafana.app/v1alpha1", oas.Info.Title)
 	require.Equal(t, "12.3.4", oas.Info.Version)
 	require.Equal(t, "An example", oas.Info.Description)
 
-	root := "/apis/example.ext.grafana.com/v1alpha1/"
+	root := "/apis/example.ext.grafana.app/v1alpha1/"
 	paths := slices.Sorted(maps.Keys(oas.Paths.Paths))
 	require.Equal(t, []string{
 		root,
@@ -48,7 +48,7 @@ func TestBuildManifestVersion(t *testing.T) {
 	}, paths, "paths should not include the watch or all-namespace routes the server hides")
 
 	// The kind's schema, and the list wrapper around it, are the response types.
-	kind := "example.ext.grafana.com.v1alpha1.TestKind"
+	kind := "example.ext.grafana.app.v1alpha1.TestKind"
 	require.Contains(t, oas.Components.Schemas, kind)
 	require.Contains(t, oas.Components.Schemas, kind+"List")
 	require.Equal(t, "#/components/schemas/"+kind+"List",
@@ -63,8 +63,8 @@ func TestBuildSettingsVersion(t *testing.T) {
 	oas, err := Build(testPlugin(t), "v0alpha1", Options{BuildVersion: "12.3.4"})
 	require.NoError(t, err)
 
-	require.Equal(t, "example.ext.grafana.com/v0alpha1", oas.Info.Title)
-	root := "/apis/example.ext.grafana.com/v0alpha1/"
+	require.Equal(t, "example.ext.grafana.app/v0alpha1", oas.Info.Title)
+	root := "/apis/example.ext.grafana.app/v0alpha1/"
 	require.Equal(t, []string{
 		root,
 		root + "namespaces/{namespace}/app/instance",
@@ -77,7 +77,7 @@ func TestBuildVersionSelection(t *testing.T) {
 	t.Run("no version renders the preferred one", func(t *testing.T) {
 		oas, err := Build(testPlugin(t), "", Options{})
 		require.NoError(t, err)
-		require.Equal(t, "example.ext.grafana.com/v1alpha1", oas.Info.Title)
+		require.Equal(t, "example.ext.grafana.app/v1alpha1", oas.Info.Title)
 	})
 
 	t.Run("an unserved version is refused", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestBuildVersionSelection(t *testing.T) {
 
 // The proxy subresource is only served when the toggle for it is on.
 func TestBuildProxyRoute(t *testing.T) {
-	proxy := "/apis/example.ext.grafana.com/v1alpha1/namespaces/{namespace}/app/instance/proxy"
+	proxy := "/apis/example.ext.grafana.app/v1alpha1/namespaces/{namespace}/app/instance/proxy"
 
 	oas, err := Build(testPlugin(t), "v1alpha1", Options{})
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func testPlugin(t *testing.T) definition.PluginDefinition {
 		},
 		Manifest: &app.ManifestData{
 			AppName:          "example",
-			Group:            "example.ext.grafana.com",
+			Group:            "example.ext.grafana.app",
 			PreferredVersion: "v1alpha1",
 			Versions: []app.ManifestVersion{{
 				Name:   "v1alpha1",

--- a/pkg/registry/apis/appplugin/pluginopenapi/testdata/plugin/app-sdk-manifest.json
+++ b/pkg/registry/apis/appplugin/pluginopenapi/testdata/plugin/app-sdk-manifest.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "apps.grafana.app/v1alpha2",
+  "kind": "AppManifest",
+  "metadata": { "name": "example-app" },
+  "spec": {
+    "appName": "example-app",
+    "group": "example.ext.grafana.app",
+    "preferredVersion": "v1alpha1",
+    "versions": [
+      {
+        "name": "v1alpha1",
+        "served": true,
+        "kinds": [
+          {
+            "kind": "TestKind",
+            "plural": "TestKinds",
+            "scope": "Namespaced",
+            "schemas": {
+              "TestKind": {
+                "properties": { "spec": { "$ref": "#/components/schemas/spec" } },
+                "required": ["spec"]
+              },
+              "spec": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "testField": { "type": "string" } },
+                "required": ["testField"]
+              }
+            }
+          }
+        ]
+      },
+      { "name": "v2alpha1", "served": false, "kinds": [] }
+    ]
+  }
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/testdata/plugin/plugin.json
+++ b/pkg/registry/apis/appplugin/pluginopenapi/testdata/plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "grafana-example-app",
+  "type": "app",
+  "name": "Example",
+  "info": {
+    "description": "An example app plugin",
+    "version": "4.5.6"
+  }
+}

--- a/pkg/registry/apis/appplugin/pluginopenapi/testdata/standalone/app-sdk-manifest.json
+++ b/pkg/registry/apis/appplugin/pluginopenapi/testdata/standalone/app-sdk-manifest.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "apps.grafana.app/v1alpha2",
+  "kind": "AppManifest",
+  "metadata": { "name": "example-app" },
+  "spec": {
+    "appName": "example-app",
+    "group": "example.ext.grafana.app",
+    "preferredVersion": "v1alpha1",
+    "versions": [
+      {
+        "name": "v1alpha1",
+        "served": true,
+        "kinds": [
+          {
+            "kind": "TestKind",
+            "plural": "TestKinds",
+            "scope": "Namespaced",
+            "schemas": {
+              "TestKind": {
+                "properties": { "spec": { "$ref": "#/components/schemas/spec" } },
+                "required": ["spec"]
+              },
+              "spec": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": { "testField": { "type": "string" } },
+                "required": ["testField"]
+              }
+            }
+          }
+        ]
+      },
+      { "name": "v2alpha1", "served": false, "kinds": [] }
+    ]
+  }
+}

--- a/pkg/services/apiserver/appinstaller/noop_opts_getter.go
+++ b/pkg/services/apiserver/appinstaller/noop_opts_getter.go
@@ -21,6 +21,13 @@ type noopRESTOptionsGetter struct{}
 
 var _ generic.RESTOptionsGetter = (*noopRESTOptionsGetter)(nil)
 
+// NewNoopRESTOptionsGetter returns a getter for a server that registers stores
+// it never reads or writes through, such as one built only to render an
+// OpenAPI spec.
+func NewNoopRESTOptionsGetter() generic.RESTOptionsGetter {
+	return &noopRESTOptionsGetter{}
+}
+
 func (n *noopRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, _ runtime.Object) (generic.RESTOptions, error) {
 	return generic.RESTOptions{
 		StorageConfig: &storagebackend.ConfigForResource{

--- a/pkg/services/apiserver/appinstaller/noop_opts_getter.go
+++ b/pkg/services/apiserver/appinstaller/noop_opts_getter.go
@@ -15,8 +15,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// noopRESTOptionsGetter satisfies generic.RESTOptionsGetter for apps that do not need Unified Storage.
-// Lets k8s complete store registration; NewStorage discards the stub in favour of the app's own storage.
+// noopRESTOptionsGetter provides placeholder storage when API registration does
+// not need Unified Storage. App installers replace it with their own storage;
+// offline renderers never serve requests through it.
 type noopRESTOptionsGetter struct{}
 
 var _ generic.RESTOptionsGetter = (*noopRESTOptionsGetter)(nil)
@@ -53,7 +54,8 @@ func (n *noopRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, _ 
 	}, nil
 }
 
-// noopStorage satisfies storage.Interface at registration time; never called at request time.
+// noopStorage satisfies storage.Interface for registration and rejects storage
+// operations.
 type noopStorage struct{}
 
 var _ storage.Interface = (*noopStorage)(nil)


### PR DESCRIPTION
Add a CLI option to create the openapi from command line -- this will allow us to generate RTK clients for plugins.  Initially this would require running a docker/cli command, but eventually it can be moved into the external package.

```
./bin/grafana cli write-openapi /Users/ryan/workspace/grafana/plugins/grafana-app-sdk-testing-plugin/dist/app-sdk-manifest.json -o out
```

## What this PR does

This PR adds `grafana cli write-openapi`, which renders an app plugin's OpenAPI v3 specification without starting Grafana, connecting to a database, or launching the plugin backend.

The command accepts either:

- an App SDK manifest file, optionally accompanied by a `plugin.json` in the same directory; or
- the ID of an installed app plugin, optionally followed by a specific API version.

For a single requested version, it writes the specification to a file or stdout. When no version is specified, it writes every served version to the output directory using `<group>-<version>.json` filenames. This includes the `v0alpha1` settings API that every app plugin serves.

The implementation reuses the app plugin API builder, schema registration, route registration, and OpenAPI post-processing used by Grafana's API server. Runtime-only dependencies such as storage, plugin clients, search, and access control are replaced with offline implementations. Generated specifications always enable search and trash route registration, while retaining the normal per-kind eligibility rules.

## Why this exists

Plugin projects need a stable way to generate and commit the API contract produced by their manifest. In particular, this enables build pipelines to generate typed clients such as RTK Query clients without first installing the plugin, starting a Grafana server, and downloading `/openapi/v3/apis/<group>/<version>`.

Keeping the renderer on the same code path as the running API server also makes manifest and schema changes easier to review and reduces the risk that generated clients drift from the API Grafana exposes.
