### PR TITLE
Chore: Modernize wait group

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/cache_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/cache_test.go
@@ -133,12 +133,10 @@ func TestCachedProvider_ConcurrentAccess(t *testing.T) {
 
 	// Launch many goroutines that all try to access the cache simultaneously
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			idx := cached.Get(ctx)
 			require.NotNil(t, idx)
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -429,12 +427,10 @@ func TestCachedProvider_SameNamespaceSerialFetch(t *testing.T) {
 	// Launch multiple fetches for the SAME namespace simultaneously
 	ctx := request.WithNamespace(context.Background(), "default")
 	for range numGoroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			idx := cached.Get(ctx)
 			require.NotNil(t, idx)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/apps/provisioning/pkg/quotas/tracker_test.go
+++ b/apps/provisioning/pkg/quotas/tracker_test.go
@@ -113,11 +113,9 @@ func TestQuotaTracker_ConcurrentAccess(t *testing.T) {
 
 	// Launch 200 goroutines each trying to acquire
 	for range 200 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			acquired <- tracker.TryAcquire()
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -173,11 +171,9 @@ func TestQuotaTracker_ConcurrentAcquireAndRelease(t *testing.T) {
 
 	// Release 10 slots concurrently
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			tracker.Release()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -505,17 +505,15 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
 	// handle http shutdown on server context done
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		<-ctx.Done()
 		if err := hs.httpSrv.Shutdown(context.Background()); err != nil {
 			hs.log.Error("Failed to shutdown server", "error", err)
 		}
-	}()
+	})
 
 	errg, _ := errgroup.WithContext(ctx)
 

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -508,7 +508,6 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 
 	// handle http shutdown on server context done
 	wg.Go(func() {
-
 		<-ctx.Done()
 		if err := hs.httpSrv.Shutdown(context.Background()); err != nil {
 			hs.log.Error("Failed to shutdown server", "error", err)

--- a/pkg/components/loki/lokihttp/fake.go
+++ b/pkg/components/loki/lokihttp/fake.go
@@ -20,14 +20,11 @@ func NewFake() *Fake {
 		wg:      &sync.WaitGroup{},
 	}
 
-	c.wg.Add(1)
-
-	go func() {
+	c.wg.Go(func() {
 		entry := <-c.entries
 		c.Labels = entry.Labels
 		c.Entry = entry.Line
-		c.wg.Done()
-	}()
+	})
 
 	return c
 }

--- a/pkg/infra/nats/connection_test.go
+++ b/pkg/infra/nats/connection_test.go
@@ -120,15 +120,13 @@ func TestConnection(t *testing.T) {
 			conns = map[*natsclient.Conn]struct{}{}
 		)
 		for i := 0; i < 50; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				nc, err := c.get(context.Background())
 				require.NoError(t, err)
 				mu.Lock()
 				conns[nc] = struct{}{}
 				mu.Unlock()
-			}()
+			})
 		}
 		wg.Wait()
 

--- a/pkg/infra/nats/integration_test.go
+++ b/pkg/infra/nats/integration_test.go
@@ -250,15 +250,13 @@ func TestIntegrationEmbeddedServer(t *testing.T) {
 		// -race build asserts it stays thread-safe.
 		var wg sync.WaitGroup
 		for range publishers {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for range perPublisher {
 					if err := pub.Publish(ctx, subject, []byte("x")); err != nil {
 						t.Errorf("publish: %v", err)
 					}
 				}
-			}()
+			})
 		}
 		wg.Wait()
 

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -89,15 +89,13 @@ func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		logger.Info("job queue controller started")
 		if err := driver.Run(ctx); err != nil {
 			logger.Error("job driver failed", "error", err)
 		}
 		logger.Info("job driver stopped")
-	}()
+	})
 
 	// Start the informer and wait for its cache to sync.
 	go jobInformer.Run(ctx.Done())

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -72,9 +72,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		jobCleanupController := jobs.NewJobCleanupController(
 			jobStore,
 			jobHistoryWriter,
@@ -84,7 +82,7 @@ func RunJobController(ctx context.Context, deps server.OperatorDependencies) err
 			logger.Error("job cleanup controller failed", "error", err)
 		}
 		logger.Info("job cleanup controller stopped")
-	}()
+	})
 
 	// Start the historic-job source when history cleanup is enabled; cleanup runs
 	// off its re-lists.

--- a/pkg/plugins/manager/process/process_test.go
+++ b/pkg/plugins/manager/process/process_test.go
@@ -146,14 +146,12 @@ func TestProcessManager_ManagedBackendPluginLifecycle(t *testing.T) {
 		require.Equal(t, 1, bp.StartCount)
 
 		var wgKill sync.WaitGroup
-		wgKill.Add(1)
-		go func() {
+		wgKill.Go(func() {
 			bp.Kill() // manually kill process
 			for bp.Exited() {
 
 			}
-			wgKill.Done()
-		}()
+		})
 		wgKill.Wait()
 		require.True(t, !p.Exited())
 		require.Equal(t, 2, bp.StartCount)

--- a/pkg/registry/apis/dashboard/home/getter_test.go
+++ b/pkg/registry/apis/dashboard/home/getter_test.go
@@ -329,9 +329,7 @@ func TestHomeDashboardWatch_StopsWhenWatcherIsClosed(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// Mirror home.watch() shape: drain both channels until both are closed.
 		eventsOpen, errorsOpen := true, true
 		for eventsOpen || errorsOpen {
@@ -346,7 +344,7 @@ func TestHomeDashboardWatch_StopsWhenWatcherIsClosed(t *testing.T) {
 				}
 			}
 		}
-	}()
+	})
 
 	require.NoError(t, w.Close())
 	done := make(chan struct{})

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -17,9 +17,7 @@ func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr Life
 	ctx, cancel := context.WithCancel(parentCtx)
 	a.cleanupCancel = cancel
 
-	a.cleanupWg.Add(1)
-	go func() {
-		defer a.cleanupWg.Done()
+	a.cleanupWg.Go(func() {
 
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
@@ -38,7 +36,7 @@ func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr Life
 				return
 			}
 		}
-	}()
+	})
 }
 
 // runCleanup executes the cleanup operation with a timeout

--- a/pkg/registry/apps/annotation/lifecycle.go
+++ b/pkg/registry/apps/annotation/lifecycle.go
@@ -18,7 +18,6 @@ func (a *AppInstaller) startCleanup(parentCtx context.Context, lifecycleMgr Life
 	a.cleanupCancel = cancel
 
 	a.cleanupWg.Go(func() {
-
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -206,15 +206,13 @@ func TestIntegrationDistributor(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for _, testServer := range testServers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if err := testServer.server.Shutdown(ctx, "tests are done"); err != nil {
 				require.NoError(t, err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/services/accesscontrol/acimpl/uid_resolver_test.go
+++ b/pkg/services/accesscontrol/acimpl/uid_resolver_test.go
@@ -148,12 +148,10 @@ func TestUIDToIDResolver_Caching(t *testing.T) {
 
 		// One caller cancels mid-flight; it must observe its own cancellation.
 		cancelCtx, cancel := context.WithCancel(context.Background())
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, err := r.GetUserIDByUID(cancelCtx, ns, "user-uid")
 			require.ErrorIs(t, err, context.Canceled)
-		}()
+		})
 
 		// The rest share the same flight and must still resolve successfully.
 		wg.Add(survivors)

--- a/pkg/services/accesscontrol/actest/common.go
+++ b/pkg/services/accesscontrol/actest/common.go
@@ -30,16 +30,14 @@ func ConcurrentBatch(workers, count, size int, eachFn func(start, end int) error
 
 	// Launch all workers
 	for x := 0; x < workers; x++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for ck := range chunk {
 				if err := eachFn(ck.start, ck.end); err != nil {
 					ret <- err
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	go func() {

--- a/pkg/services/accesscontrol/permreg/permreg_test.go
+++ b/pkg/services/accesscontrol/permreg/permreg_test.go
@@ -310,9 +310,7 @@ func Test_permissionRegistry_ConcurrentPluginAndFixedRoleRegistration(t *testing
 	var wg sync.WaitGroup
 
 	for worker := range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 
 			for iteration := range iterations {
@@ -347,7 +345,7 @@ func Test_permissionRegistry_ConcurrentPluginAndFixedRoleRegistration(t *testing
 					errs <- fmt.Errorf("scope prefixes not found for %s", action)
 				}
 			}
-		}()
+		})
 	}
 
 	close(start)

--- a/pkg/services/diagnostics/metrics_test.go
+++ b/pkg/services/diagnostics/metrics_test.go
@@ -31,15 +31,13 @@ func TestMetricsConcurrentInstancesDoNotLoseIncrements(t *testing.T) {
 	const incrementsPerInstance = 20
 	var wg sync.WaitGroup
 	for i := range incrementsPerInstance * 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if i%2 == 0 {
 				first.RecordStarted(ctx, ScopeDashboard)
 				return
 			}
 			second.RecordStarted(ctx, ScopeDashboard)
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -116,11 +114,9 @@ func TestMetricsConcurrentIncrementsAreNotLost(t *testing.T) {
 	const increments = 50
 	var wg sync.WaitGroup
 	for range increments {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			metrics.RecordStarted(ctx, ScopeDashboard)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -131,10 +131,8 @@ func newRemoteSecondaryForkedAlertmanager(cfg RemoteSecondaryConfig, internal no
 // We don't care about errors in the remote Alertmanager in remote secondary mode.
 func (fam *RemoteSecondaryForkedAlertmanager) ApplyConfig(ctx context.Context, config alertingNotify.NotificationsConfiguration) (bool, error) {
 	var wg sync.WaitGroup
-	wg.Add(1)
 	// Figure out if we need to sync the external Alertmanager in another goroutine.
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// If the Alertmanager has not been marked as "ready" yet, delegate the call to the remote Alertmanager.
 		// This will perform a readiness check and sync the Alertmanagers.
 		if !fam.remote.Ready() {
@@ -156,7 +154,7 @@ func (fam *RemoteSecondaryForkedAlertmanager) ApplyConfig(ctx context.Context, c
 			}
 			fam.log.Debug("Finished syncing configuration with the remote Alertmanager")
 		}
-	}()
+	})
 
 	if fam.shouldFetchRemoteState {
 		wg.Wait()

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -64,12 +64,10 @@ func TestAlertRule(t *testing.T) {
 			version2 := &Evaluation{rule: gen.With(gen.WithIsPaused(false)).GenerateRef()}
 
 			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				wg.Done()
 				r.Update(version1)
-				wg.Done()
-			}()
+			})
 			wg.Wait()
 			wg.Add(2) // one when time1 is sent, another when go-routine for time2 has started
 			go func() {
@@ -231,8 +229,7 @@ func TestAlertRule(t *testing.T) {
 		rule.UID = r.key.UID
 		rule.OrgID = r.key.OrgID
 		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				for i := 0; i < 20; i++ {
 					max := 3
 					if i <= 10 {
@@ -251,8 +248,7 @@ func TestAlertRule(t *testing.T) {
 						r.Stop(nil)
 					}
 				}
-				wg.Done()
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -118,8 +118,7 @@ func TestRecordingRule(t *testing.T) {
 		}()
 
 		for i := 0; i < 10; i++ {
-			wg.Add(1)
-			go func() {
+			wg.Go(func() {
 				for i := 0; i < 20; i++ {
 					max := 3
 					if i <= 10 {
@@ -141,8 +140,7 @@ func TestRecordingRule(t *testing.T) {
 						r.Stop(nil)
 					}
 				}
-				wg.Done()
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -440,21 +440,17 @@ func TestIntegrationSetProvenance_DeadlockScenarios(t *testing.T) {
 		var wg sync.WaitGroup
 		// Mix SetProvenance and GetProvenance operations
 		for range concurrency {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				time.Sleep(time.Microsecond * time.Duration(rand.Intn(100)))
 				err := store.SetProvenance(context.Background(), rule, orgID, models.ProvenanceAPI)
 				require.NoError(t, err)
-			}()
+			})
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				time.Sleep(time.Microsecond * time.Duration(rand.Intn(100)))
 				_, err := store.GetProvenance(context.Background(), rule, orgID)
 				require.NoError(t, err)
-			}()
+			})
 		}
 		wg.Wait()
 	})

--- a/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic_test.go
+++ b/pkg/services/pluginsintegration/angulardetectorsprovider/dynamic_test.go
@@ -655,12 +655,10 @@ func (s *backgroundServiceScenario) run(ctx context.Context) {
 	s.ctxCancFunc = canc
 
 	// Start background service
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
+	s.wg.Go(func() {
 		err := s.svc.Run(ctx)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			panic(err)
 		}
-	}()
+	})
 }

--- a/pkg/services/screenshot/ratelimit_test.go
+++ b/pkg/services/screenshot/ratelimit_test.go
@@ -42,13 +42,11 @@ func TestTokenRateLimiter(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			screenshot, err := r.Do(ctx, ScreenshotOptions{}, testScreenshotFunc)
 			require.NoError(t, err)
 			assert.NotNil(t, screenshot)
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/storage/unified/migrations/registry_test.go
+++ b/pkg/storage/unified/migrations/registry_test.go
@@ -584,12 +584,10 @@ func TestMigrationRegistry_ConcurrentAccess(t *testing.T) {
 
 		var wg sync.WaitGroup
 		for i := 0; i < 100; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				fn := r.GetMigratorFunc(gr)
 				require.NotNil(t, fn)
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/pkg/storage/unified/resource/broadcaster_test.go
+++ b/pkg/storage/unified/resource/broadcaster_test.go
@@ -349,9 +349,7 @@ func TestBroadcasterUnsubscribesOnCancelDuringSubscribe(t *testing.T) {
 	const n = 200
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			cctx, ccancel := context.WithCancel(ctx)
 			// Cancel concurrently to race the two-phase Subscribe so that some
 			// callers take the ctx.Done() path after the subscription is queued.
@@ -361,7 +359,7 @@ func TestBroadcasterUnsubscribesOnCancelDuringSubscribe(t *testing.T) {
 				// Registered before the cancel landed; a real caller would clean up.
 				b.Unsubscribe(sub)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -214,9 +214,7 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 	errorCh := make(chan error, expectedInstances)
 
 	for _, inst := range rs.Instances {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			client, err := ds.clientPool.GetClientForInstance(inst)
 			if err != nil {
@@ -236,7 +234,7 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 			}
 
 			responseCh <- rsp
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -215,7 +215,6 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 
 	for _, inst := range rs.Instances {
 		wg.Go(func() {
-
 			client, err := ds.clientPool.GetClientForInstance(inst)
 			if err != nil {
 				errorCh <- fmt.Errorf("instance %s: failed to get client, %w", inst.Id, err)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -472,13 +472,11 @@ func TestSearchGetOrCreateIndex(t *testing.T) {
 
 	const concurrency = 100
 	wg := sync.WaitGroup{}
-	for i := 0; i < concurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range concurrency {
+		wg.Go(func() {
 			<-start
 			_, _ = support.getOrCreateIndex(context.Background(), nil, NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}, "test")
-		}()
+		})
 	}
 
 	// Wait a bit for goroutines to start (hopefully)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 
 	authlib "github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -2391,7 +2392,6 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	const searchConcurrency = 25
 	for i := range searchConcurrency {
 		wg.Go(func() {
-
 			for ctx.Err() == nil {
 				select {
 				case <-ctx.Done():
@@ -2473,7 +2473,6 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 	const searchConcurrency = 25
 	for range searchConcurrency {
 		wg.Go(func() {
-
 			prevRV := int64(0)
 			for ctx.Err() == nil {
 				// We use t.Context() here to avoid getting errors from context cancellation.
@@ -2529,7 +2528,6 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	const searchConcurrency = 10
 	for range searchConcurrency {
 		wg.Go(func() {
-
 			var collectedRVs []int64
 			for ctx.Err() == nil {
 				attemptedUpdates.Add(1)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -2390,9 +2390,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	var rebuilds, updates, searches atomic.Int64
 	const searchConcurrency = 25
 	for i := range searchConcurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for ctx.Err() == nil {
 				select {
@@ -2432,18 +2430,16 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 				require.Equal(t, int64(10), resp.TotalHits)
 				searches.Add(1)
 			}
-		}()
+		})
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for ctx.Err() == nil {
 			_, err := be.BuildIndex(t.Context(), ns, 10, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 			require.NoError(t, err)
 			rebuilds.Add(1)
 		}
-	}()
+	})
 
 	time.Sleep(5 * time.Second)
 	cancel()
@@ -2476,9 +2472,7 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 
 	const searchConcurrency = 25
 	for range searchConcurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			prevRV := int64(0)
 			for ctx.Err() == nil {
@@ -2493,7 +2487,7 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 				updatedRVs[rv]++
 				mu.Unlock()
 			}
-		}()
+		})
 	}
 
 	time.Sleep(1 * time.Second)
@@ -2534,9 +2528,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	// Verify that each returned RV (unix timestamp in millis) is either the same as before, or at least minInterval later.
 	const searchConcurrency = 10
 	for range searchConcurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			var collectedRVs []int64
 			for ctx.Err() == nil {
@@ -2559,7 +2551,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 				// (We get measurements from update function, but check is done on times inside updater)
 				require.GreaterOrEqual(t, collectedRVs[i], collectedRVs[i-1]+(9*int64(minInterval/time.Millisecond)/10))
 			}
-		}()
+		})
 	}
 
 	// Run updates and searches for this time.

--- a/pkg/storage/unified/search/vector/query_cache_test.go
+++ b/pkg/storage/unified/search/vector/query_cache_test.go
@@ -104,12 +104,10 @@ func TestIntegrationQueryCacheConcurrentPutSameKeyIsHarmless(t *testing.T) {
 	// ON CONFLICT DO NOTHING must collapse racing inserts to one row.
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			err := cache.Put(ctx, ns, testModel, hash, makeEmbedding(1, 0))
 			assert.NoError(t, err)
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/util/debouncer/debouncer.go
+++ b/pkg/util/debouncer/debouncer.go
@@ -203,9 +203,7 @@ func (g *Group[T]) Add(value T) error {
 
 func (g *Group[T]) Start(ctx context.Context) {
 	g.ctx, g.cancel = context.WithCancel(ctx) // #nosec G118 -- cancel is invoked in Stop
-	g.wg.Add(1)
-	go func() {
-		defer g.wg.Done()
+	g.wg.Go(func() {
 		for {
 			select {
 			case <-g.ctx.Done():
@@ -214,7 +212,7 @@ func (g *Group[T]) Start(ctx context.Context) {
 				g.processValue(value)
 			}
 		}
-	}()
+	})
 }
 
 func (g *Group[T]) Stop() {
@@ -237,11 +235,9 @@ func (g *Group[T]) processValue(key T) {
 				delete(g.debouncers, key)
 			}
 		})
-		g.wg.Add(1)
-		go func() {
-			defer g.wg.Done()
+		g.wg.Go(func() {
 			deb.run(g.ctx)
-		}()
+		})
 		g.debouncers[key] = deb
 	}
 	g.debouncersMu.Unlock()

--- a/pkg/util/debouncer/queue_test.go
+++ b/pkg/util/debouncer/queue_test.go
@@ -77,23 +77,19 @@ func TestQueueConcurrency(t *testing.T) {
 	// We will add some numbers to the queue.
 	writesWG := sync.WaitGroup{}
 	for i := 0; i < writeConcurrency; i++ {
-		writesWG.Add(1)
-		go func() {
-			defer writesWG.Done()
+		writesWG.Go(func() {
 			for j := 0; j < numbers; j++ {
 				v := rand.Int64N(100) // Generate small number, so that we have a chance for combining some numbers.
 				q.Add(v)
 				addCalls.Inc()
 				totalWrittenSum.Add(v)
 			}
-		}()
+		})
 	}
 
 	readsWG := sync.WaitGroup{}
 	for i := 0; i < readConcurrency; i++ {
-		readsWG.Add(1)
-		go func() {
-			defer readsWG.Done()
+		readsWG.Go(func() {
 
 			for {
 				v, err := q.Next(context.Background())
@@ -105,7 +101,7 @@ func TestQueueConcurrency(t *testing.T) {
 				nextCalls.Inc()
 				totalReadSum.Add(v)
 			}
-		}()
+		})
 	}
 
 	writesWG.Wait()
@@ -128,12 +124,10 @@ func TestQueueCloseUnblocksReaders(t *testing.T) {
 	})
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		time.Sleep(50 * time.Millisecond)
 		q.Close()
-	}()
+	})
 
 	_, err := q.Next(context.Background())
 	require.ErrorIs(t, err, ErrClosed)

--- a/pkg/util/debouncer/queue_test.go
+++ b/pkg/util/debouncer/queue_test.go
@@ -76,9 +76,9 @@ func TestQueueConcurrency(t *testing.T) {
 
 	// We will add some numbers to the queue.
 	writesWG := sync.WaitGroup{}
-	for i := 0; i < writeConcurrency; i++ {
+	for range writeConcurrency {
 		writesWG.Go(func() {
-			for j := 0; j < numbers; j++ {
+			for range numbers {
 				v := rand.Int64N(100) // Generate small number, so that we have a chance for combining some numbers.
 				q.Add(v)
 				addCalls.Inc()
@@ -88,9 +88,8 @@ func TestQueueConcurrency(t *testing.T) {
 	}
 
 	readsWG := sync.WaitGroup{}
-	for i := 0; i < readConcurrency; i++ {
+	for range readConcurrency {
 		readsWG.Go(func() {
-
 			for {
 				v, err := q.Next(context.Background())
 				if errors.Is(err, ErrClosed) {

--- a/pkg/util/scheduler/queue_test.go
+++ b/pkg/util/scheduler/queue_test.go
@@ -64,16 +64,14 @@ func TestQueue(t *testing.T) {
 
 		// Dequeue items
 		for i := 0; i < numItems; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				dequeueCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 				defer cancel()
 				runnable, err := q.Dequeue(dequeueCtx)
 				require.NoError(t, err, "Dequeue should succeed")
 				require.NotNil(t, runnable, "Dequeued runnable should not be nil")
 				runnable()
-			}()
+			})
 		}
 
 		wg.Wait()
@@ -574,16 +572,14 @@ func TestQueue(t *testing.T) {
 
 		// Start a goroutine to dequeue and run the item
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			runnable, err := q.Dequeue(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, runnable)
 			runnable()
-		}()
+		})
 
 		// Wait for the item to be processed
 		select {


### PR DESCRIPTION
**What is this feature?**

Replaces manual `WaitGroup.Add` / goroutine / `WaitGroup.Done` sequences with `WaitGroup.Go` across the Go codebase. The changes were generated with the `waitgroupgo` analyzer from `modernize`.

This is a mechanical modernization with no intended behavior change.

**Why do we need this feature?**

`WaitGroup.Go` keeps goroutine startup and WaitGroup bookkeeping in one operation. This removes repetitive synchronization code and makes it harder to:

- forget `Done` on an early return,
- mismatch `Add` and `Done` calls, or
- call `Add` too late and race with `Wait`.

Using the standard API consistently makes concurrent code easier to review and safer to maintain.

**Who is this feature for?**

Grafana maintainers and contributors. Users benefit indirectly from clearer, less error-prone concurrency code.

**Special notes for your reviewer:**

- The final `modernize -waitgroupgo` check reports no remaining applicable changes.
- All changed Go packages pass a compile-only test run with `go test -run '^$'`.
