### PR TITLE
Alerting: Cap label/annotation value size in state manager

### DIFF
--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -8,6 +8,7 @@ import (
 type State struct {
 	StateUpdateDuration   prometheus.Histogram
 	StateFullSyncDuration prometheus.Histogram
+	ClampedLabelStrings   *prometheus.CounterVec
 	r                     prometheus.Registerer
 }
 
@@ -36,6 +37,15 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Help:      "The duration of fully synchronizing the state with the database.",
 				Buckets:   []float64{0.01, 0.1, 1, 2, 5, 10, 60},
 			},
+		),
+		ClampedLabelStrings: promauto.With(r).NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "state_clamped_label_strings_total",
+				Help:      "Total number of expanded label/annotation values truncated before being written into alert state, by kind (label or annotation).",
+			},
+			[]string{"kind"},
 		),
 	}
 }

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 	"unicode"
-	"unicode/utf8"
 
 	alertingModels "github.com/grafana/alerting/models"
 	"github.com/prometheus/alertmanager/api/v2/models"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const (
@@ -413,7 +413,7 @@ func (s *ExternalAlertmanager) clampLabelSet(lbls models.LabelSet, kind, alertNa
 	for k, v := range lbls {
 		if len(k) > maxSize {
 			s.logger.Warn("Dropping label/annotation with name exceeding size cap",
-				"kind", kind, "namePrefix", truncateUTF8(k, 64), "size", len(k), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
+				"kind", kind, "namePrefix", util.TruncateUTF8(k, 64), "size", len(k), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
 			s.manager.metrics.clampedStrings.WithLabelValues(kind, "name_dropped").Inc()
 			continue
 		}
@@ -421,23 +421,11 @@ func (s *ExternalAlertmanager) clampLabelSet(lbls models.LabelSet, kind, alertNa
 			s.logger.Warn("Truncating label/annotation value exceeding size cap",
 				"kind", kind, "name", k, "size", len(v), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
 			s.manager.metrics.clampedStrings.WithLabelValues(kind, "value_truncated").Inc()
-			v = truncateUTF8(v, maxSize)
+			v = util.TruncateUTF8(v, maxSize)
 		}
 		clamped[k] = v
 	}
 	return clamped
-}
-
-// truncateUTF8 truncates s to at most n bytes without splitting a multi-byte
-// rune; the Alertmanager API rejects invalid UTF-8 label values.
-func truncateUTF8(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	for n > 0 && !utf8.RuneStart(s[n]) {
-		n--
-	}
-	return s[:n]
 }
 
 // sanitizeLabelSet sanitizes all given LabelSet keys according to sanitizeLabelName.

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,6 +21,16 @@ import (
 )
 
 const emptyLabelKeyPrefix = "__empty_label_key__"
+
+// DefaultMaxLabelValueSize is the default byte cap applied to any single
+// expanded label/annotation value written into alert state. It guards state
+// storage (AlertInstance.Labels/Annotations, persisted as DB TEXT columns)
+// and anything else reading persisted alert state, complementing the
+// sender-side clamp (pkg/services/ngalert/sender) which only protects the
+// external-Alertmanager send path. Chosen generously to avoid clamping
+// legitimate values; it exists as a safety net against pathological
+// template expansions, not as a routine content limit.
+const DefaultMaxLabelValueSize = 1 << 22 // 4 MiB
 
 type ruleStates struct {
 	states map[data.Fingerprint]*State
@@ -122,7 +133,7 @@ func (c *cache) RegisterMetrics(r prometheus.Registerer) {
 	r.MustRegister(newAlertCountByState(eval.Recovering))
 }
 
-func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) (data.Labels, data.Labels) {
+func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *ngModels.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL, maxLabelValueSize int, stateMetrics *metrics.State) (data.Labels, data.Labels) {
 	var reserved []string
 	resultLabels := result.Instance
 	if len(resultLabels) > 0 {
@@ -158,6 +169,8 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 	// In the future, we want to show these errors to the user somehow.
 	labels, _ := expand(ctx, log, alertRule.Title, alertRule.Labels, templateData, externalURL, result.EvaluatedAt)
 	annotations, _ := expand(ctx, log, alertRule.Title, alertRule.Annotations, templateData, externalURL, result.EvaluatedAt)
+	labels = clampExpandedValues(log, labels, "label", maxLabelValueSize, alertRule.Title, alertRule.UID, stateMetrics)
+	annotations = clampExpandedValues(log, annotations, "annotation", maxLabelValueSize, alertRule.Title, alertRule.UID, stateMetrics)
 
 	// If the result contains an error, we want to add the ref_id and datasource_uid labels
 	// to the new state if the alert rule should be in the ErrorErrState.
@@ -204,6 +217,51 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 		log.Debug("Evaluation result contains either reserved labels or labels declared in the rules. Those labels from the result will be ignored", "labels", dupes)
 	}
 	return lbs, annotations
+}
+
+// clampExpandedValues truncates any value in vals exceeding maxSize bytes.
+// A non-positive maxSize disables the clamp and returns vals unmodified.
+// This bounds what expandAnnotationsAndLabels writes into state.State (and,
+// from there, into the persisted AlertInstance.Labels/Annotations columns)
+// against pathological template expansions; it does not replace the
+// sender-side clamp, which only protects the external-Alertmanager send
+// path and never sees un-fired/resolved instances.
+func clampExpandedValues(log log.Logger, vals map[string]string, kind string, maxSize int, ruleTitle, ruleUID string, stateMetrics *metrics.State) map[string]string {
+	if maxSize <= 0 {
+		return vals
+	}
+	var clamped map[string]string
+	for k, v := range vals {
+		if len(v) <= maxSize {
+			continue
+		}
+		if clamped == nil {
+			clamped = make(map[string]string, len(vals))
+			maps.Copy(clamped, vals)
+		}
+		clamped[k] = truncateUTF8(v, maxSize)
+		log.Warn("Truncating expanded label/annotation value exceeding size cap",
+			"kind", kind, "name", k, "size", len(v), "cap", maxSize, "rule", ruleTitle, "rule_uid", ruleUID)
+		if stateMetrics != nil {
+			stateMetrics.ClampedLabelStrings.WithLabelValues(kind).Inc()
+		}
+	}
+	if clamped != nil {
+		return clamped
+	}
+	return vals
+}
+
+// truncateUTF8 truncates s to at most n bytes without splitting a
+// multi-byte rune.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }
 
 // expand returns the expanded templates of all annotations or labels for the template data.

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,18 +17,15 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state/template"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 const emptyLabelKeyPrefix = "__empty_label_key__"
 
 // DefaultMaxLabelValueSize is the default byte cap applied to any single
-// expanded label/annotation value written into alert state. It guards state
-// storage (AlertInstance.Labels/Annotations, persisted as DB TEXT columns)
-// and anything else reading persisted alert state, complementing the
-// sender-side clamp (pkg/services/ngalert/sender) which only protects the
-// external-Alertmanager send path. Chosen generously to avoid clamping
-// legitimate values; it exists as a safety net against pathological
-// template expansions, not as a routine content limit.
+// expanded label/annotation value written into alert state, complementing
+// the sender-side clamp (pkg/services/ngalert/sender). Chosen generously as
+// a safety net, not a routine content limit.
 const DefaultMaxLabelValueSize = 1 << 22 // 4 MiB
 
 type ruleStates struct {
@@ -239,7 +235,7 @@ func clampExpandedValues(log log.Logger, vals map[string]string, kind string, ma
 			clamped = make(map[string]string, len(vals))
 			maps.Copy(clamped, vals)
 		}
-		clamped[k] = truncateUTF8(v, maxSize)
+		clamped[k] = util.TruncateUTF8(v, maxSize)
 		log.Warn("Truncating expanded label/annotation value exceeding size cap",
 			"kind", kind, "name", k, "size", len(v), "cap", maxSize, "rule", ruleTitle, "rule_uid", ruleUID)
 		if stateMetrics != nil {
@@ -250,18 +246,6 @@ func clampExpandedValues(log log.Logger, vals map[string]string, kind string, ma
 		return clamped
 	}
 	return vals
-}
-
-// truncateUTF8 truncates s to at most n bytes without splitting a
-// multi-byte rune.
-func truncateUTF8(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	for n > 0 && !utf8.RuneStart(s[n]) {
-		n--
-	}
-	return s[:n]
 }
 
 // expand returns the expanded templates of all annotations or labels for the template data.

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -15,6 +17,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state/template"
 	"github.com/grafana/grafana/pkg/util"
@@ -132,6 +135,54 @@ func Test_expand(t *testing.T) {
 		results, err := expand(ctx, logger, "test", original, template.Data{}, nil, time.Now())
 		require.NoError(t, err)
 		require.Equal(t, map[string]string{emptyLabelKeyPrefix: "value"}, results)
+	})
+}
+
+func Test_expandAnnotationsAndLabels_sizeCap(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	result := eval.Result{Instance: data.Labels{}, EvaluatedAt: time.Now()}
+
+	newRule := func() *models.AlertRule {
+		return models.RuleGen.With(
+			models.RuleMuts.WithLabels(data.Labels{"big": strings.Repeat("a", 20)}),
+			models.RuleMuts.WithAnnotations(data.Labels{"summary": strings.Repeat("b", 20)}),
+		).GenerateRef()
+	}
+
+	t.Run("values within the cap are untouched", func(t *testing.T) {
+		lbs, anns := expandAnnotationsAndLabels(ctx, logger, newRule(), result, nil, nil, 100, nil)
+		require.Equal(t, strings.Repeat("a", 20), lbs["big"])
+		require.Equal(t, strings.Repeat("b", 20), anns["summary"])
+	})
+
+	t.Run("oversized values are truncated and counted per kind", func(t *testing.T) {
+		reg := prometheus.NewPedanticRegistry()
+		stateMetrics := metrics.NewStateMetrics(reg)
+
+		lbs, anns := expandAnnotationsAndLabels(ctx, logger, newRule(), result, nil, nil, 10, stateMetrics)
+
+		require.Len(t, lbs["big"], 10)
+		require.Len(t, anns["summary"], 10)
+		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.ClampedLabelStrings.WithLabelValues("label")))
+		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.ClampedLabelStrings.WithLabelValues("annotation")))
+	})
+
+	t.Run("non-positive cap disables the clamp", func(t *testing.T) {
+		lbs, anns := expandAnnotationsAndLabels(ctx, logger, newRule(), result, nil, nil, 0, nil)
+		require.Equal(t, strings.Repeat("a", 20), lbs["big"])
+		require.Equal(t, strings.Repeat("b", 20), anns["summary"])
+	})
+
+	t.Run("truncation does not split a multi-byte rune", func(t *testing.T) {
+		rule := models.RuleGen.With(
+			models.RuleMuts.WithLabels(data.Labels{"emoji": strings.Repeat("é", 10)}), // 2 bytes each
+		).GenerateRef()
+
+		lbs, _ := expandAnnotationsAndLabels(ctx, logger, rule, result, nil, nil, 5, nil)
+
+		require.LessOrEqual(t, len(lbs["emoji"]), 5)
+		require.True(t, utf8.ValidString(lbs["emoji"]))
 	})
 }
 

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -56,6 +56,10 @@ type Manager struct {
 
 	rulesPerRuleGroupLimit int64
 
+	// maxLabelValueSize caps the byte length of any single expanded label/annotation
+	// value written into state. A non-positive value disables the clamp.
+	maxLabelValueSize int
+
 	persister StatePersister
 
 	ignorePendingForNoDataAndError bool
@@ -82,6 +86,11 @@ type ManagerCfg struct {
 	StatePeriodicSaveJitterEnabled bool
 
 	RulesPerRuleGroupLimit int64
+
+	// MaxLabelValueSize caps the byte length of any single expanded label/annotation
+	// value written into state. Zero uses [DefaultMaxLabelValueSize]; a negative
+	// value disables the clamp.
+	MaxLabelValueSize int
 
 	DisableExecution bool
 
@@ -115,6 +124,14 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 		readiness = newGatedProbe(cfg.Clock, cfg.WarmGateTimeout)
 	}
 
+	maxLabelValueSize := cfg.MaxLabelValueSize
+	switch {
+	case maxLabelValueSize == 0:
+		maxLabelValueSize = DefaultMaxLabelValueSize
+	case maxLabelValueSize < 0:
+		maxLabelValueSize = 0
+	}
+
 	m := &Manager{
 		cache:                  c,
 		ResendDelay:            ResendDelay, // TODO: make this configurable
@@ -127,6 +144,7 @@ func NewManager(cfg ManagerCfg, statePersister StatePersister) *Manager {
 		clock:                  cfg.Clock,
 		externalURL:            cfg.ExternalURL,
 		rulesPerRuleGroupLimit: cfg.RulesPerRuleGroupLimit,
+		maxLabelValueSize:      maxLabelValueSize,
 		persister:              statePersister,
 		tracer:                 cfg.Tracer,
 
@@ -488,7 +506,7 @@ func (st *Manager) setNextStateForRule(ctx context.Context, alertRule *ngModels.
 	}
 	transitions := make([]StateTransition, 0, len(results))
 	for _, result := range results {
-		newState := newState(ctx, logger, alertRule, result, extraLabels, st.externalURL)
+		newState := newState(ctx, logger, alertRule, result, extraLabels, st.externalURL, st.maxLabelValueSize, st.metrics)
 		if curState := st.cache.get(alertRule.OrgID, alertRule.UID, newState.CacheID); curState != nil {
 			patch(newState, curState, result)
 		}

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -5689,6 +5689,30 @@ func (f *fakePersister) Sync(_ context.Context, _ trace.Span, _ ngmodels.AlertRu
 
 var _ StatePersister = (*fakePersister)(nil)
 
+func TestNewManager_MaxLabelValueSize(t *testing.T) {
+	testCases := []struct {
+		name     string
+		cfgValue int
+		expected int
+	}{
+		{name: "zero uses the default", cfgValue: 0, expected: DefaultMaxLabelValueSize},
+		{name: "positive value is kept as-is", cfgValue: 100, expected: 100},
+		{name: "negative value disables the clamp", cfgValue: -1, expected: 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := NewManager(ManagerCfg{
+				Clock:             clock.NewMock(),
+				Log:               log.NewNopLogger(),
+				MaxLabelValueSize: tc.cfgValue,
+			}, &fakePersister{name: "test"})
+
+			require.Equal(t, tc.expected, mgr.maxLabelValueSize)
+		})
+	}
+}
+
 func TestDatasourceErrorInfo(t *testing.T) {
 	rule := &ngmodels.AlertRule{
 		Data: []ngmodels.AlertQuery{

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
+	ngmetrics "github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/screenshot"
 )
@@ -80,8 +81,8 @@ type State struct {
 	EvaluationDuration   time.Duration
 }
 
-func newState(ctx context.Context, log log.Logger, alertRule *models.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL) *State {
-	lbs, annotations := expandAnnotationsAndLabels(ctx, log, alertRule, result, extraLabels, externalURL)
+func newState(ctx context.Context, log log.Logger, alertRule *models.AlertRule, result eval.Result, extraLabels data.Labels, externalURL *url.URL, maxLabelValueSize int, stateMetrics *ngmetrics.State) *State {
+	lbs, annotations := expandAnnotationsAndLabels(ctx, log, alertRule, result, extraLabels, externalURL, maxLabelValueSize, stateMetrics)
 
 	cacheID := lbs.Fingerprint()
 	// For new states, we set StartsAt & EndsAt to EvaluatedAt as this is the

--- a/pkg/services/ngalert/state/state_bench_test.go
+++ b/pkg/services/ngalert/state/state_bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkCreateAndPatch(b *testing.B) {
 	// values := make([]int64, count)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			s := newState(ctx, log, rule, result, nil, u)
+			s := newState(ctx, log, rule, result, nil, u, 0, nil)
 			current := cache.get(rule.OrgID, rule.UID, s.CacheID)
 			if current == nil {
 				patch(s, current, result)

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -930,7 +930,7 @@ func TestNewState(t *testing.T) {
 		result := eval.Result{
 			Instance: ngmodels.GenerateAlertLabels(5, "result-"),
 		}
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 		for key, expected := range extraLabels {
 			require.Equal(t, expected, state.Labels[key])
 		}
@@ -958,7 +958,7 @@ func TestNewState(t *testing.T) {
 			result.Instance[key] = "result-" + util.GenerateShortUID()
 		}
 
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 		for key, expected := range extraLabels {
 			require.Equal(t, expected, state.Labels[key])
 		}
@@ -974,7 +974,7 @@ func TestNewState(t *testing.T) {
 		for key := range rule.Labels {
 			result.Instance[key] = "result-" + util.GenerateShortUID()
 		}
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 		for key, expected := range rule.Labels {
 			require.Equal(t, expected, state.Labels[key])
 		}
@@ -996,7 +996,7 @@ func TestNewState(t *testing.T) {
 		}
 		rule.Labels = labelTemplates
 
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 		for key, expected := range extraLabels {
 			assert.Equal(t, expected, state.Labels["rule-"+key])
 		}
@@ -1022,7 +1022,7 @@ func TestNewState(t *testing.T) {
 		}
 		rule.Annotations = annotationTemplates
 
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 		for key, expected := range extraLabels {
 			assert.Equal(t, expected, state.Annotations["rule-"+key])
 		}
@@ -1052,7 +1052,7 @@ func TestNewState(t *testing.T) {
 
 		rule := generateRule()
 
-		state := newState(context.Background(), l, rule, result, nil, url)
+		state := newState(context.Background(), l, rule, result, nil, url, 0, nil)
 
 		for key := range ngmodels.LabelsUserCannotSpecify {
 			assert.NotContains(t, state.Labels, key)
@@ -1074,7 +1074,7 @@ func TestNewState(t *testing.T) {
 			result.Instance["label1_user"] = uuid.NewString()
 			result.Instance["label4_user"] = uuid.NewString()
 
-			state = newState(context.Background(), l, rule, result, nil, url)
+			state = newState(context.Background(), l, rule, result, nil, url, 0, nil)
 			assert.NotContains(t, state.Labels, "__label1__")
 			assert.Contains(t, state.Labels, "label1")
 			assert.Equal(t, state.Labels["label1"], result.Instance["label1"])
@@ -1094,9 +1094,9 @@ func TestNewState(t *testing.T) {
 			Instance: ngmodels.GenerateAlertLabels(5, "result-"),
 		}
 
-		expectedLbl, expectedAnn := expandAnnotationsAndLabels(context.Background(), l, rule, result, extraLabels, url)
+		expectedLbl, expectedAnn := expandAnnotationsAndLabels(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 
-		state := newState(context.Background(), l, rule, result, extraLabels, url)
+		state := newState(context.Background(), l, rule, result, extraLabels, url, 0, nil)
 
 		assert.Equal(t, rule.OrgID, state.OrgID)
 		assert.Equal(t, rule.UID, state.AlertRuleUID)

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -182,7 +182,11 @@ func ByteCountSI(b int64) string {
 }
 
 // TruncateUTF8 truncates s to at most n bytes without splitting a multi-byte rune.
+// A non-positive n returns an empty string.
 func TruncateUTF8(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	if len(s) <= n {
 		return s
 	}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 )
 
 var stringListItemMatcher = regexp.MustCompile(`"[^"]+"|[^,\t\n\v\f\r ]+`)
@@ -178,6 +179,17 @@ func ByteCountSI(b int64) string {
 	}
 	return fmt.Sprintf("%.1f %cB",
 		float64(b)/float64(div), "kMGTPE"[exp])
+}
+
+// TruncateUTF8 truncates s to at most n bytes without splitting a multi-byte rune.
+func TruncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }
 
 // StripBOM removes Byte Order Mark (BOM) characters from a string.

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -367,12 +367,15 @@ func TestTruncateUTF8(t *testing.T) {
 		{name: "ascii is truncated to n bytes", s: "hello world", n: 5, expected: "hello"},
 		{name: "does not split a multi-byte rune", s: "héllo", n: 2, expected: "h"}, // 'é' is 2 bytes, byte 2 is mid-rune
 		{name: "n=0 returns empty string", s: "hello", n: 0, expected: ""},
+		{name: "negative n returns empty string instead of panicking", s: "hello", n: -1, expected: ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := TruncateUTF8(tc.s, tc.n)
 			assert.Equal(t, tc.expected, result)
-			assert.LessOrEqual(t, len(result), tc.n)
+			if tc.n >= 0 {
+				assert.LessOrEqual(t, len(result), tc.n)
+			}
 			assert.True(t, utf8.ValidString(result))
 		})
 	}

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -350,6 +351,29 @@ func TestStripBOMFromInterface(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := StripBOMFromInterface(tt.input)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		n        int
+		expected string
+	}{
+		{name: "shorter than n is untouched", s: "hello", n: 10, expected: "hello"},
+		{name: "exactly n is untouched", s: "hello", n: 5, expected: "hello"},
+		{name: "ascii is truncated to n bytes", s: "hello world", n: 5, expected: "hello"},
+		{name: "does not split a multi-byte rune", s: "héllo", n: 2, expected: "h"}, // 'é' is 2 bytes, byte 2 is mid-rune
+		{name: "n=0 returns empty string", s: "hello", n: 0, expected: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := TruncateUTF8(tc.s, tc.n)
+			assert.Equal(t, tc.expected, result)
+			assert.LessOrEqual(t, len(result), tc.n)
+			assert.True(t, utf8.ValidString(result))
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Caps the byte length of expanded label/annotation values written into ngalert alert state. Oversized values are truncated at a rune boundary. Default cap is 4 MiB (`state.DefaultMaxLabelValueSize`), configurable via `state.ManagerCfg.MaxLabelValueSize` (0 = default, negative = disabled).

**Why do we need this feature?**

`expandAnnotationsAndLabels` writes template-expanded label/annotation values into `state.State`, persisted as `AlertInstance.Labels`/`Annotations`. #124466 clamped this only in the external-Alertmanager sender path, which never sees un-fired/resolved instances. This closes that gap for state storage and anything else reading persisted alert state.

**Who is this feature for?**

Operators of ngalert (consumers of `pkg/services/ngalert/state`).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Clamps only the two `expand()` outputs (rule Labels/Annotations post-expansion), not raw eval-result or extra labels.
- Truncation uses the new shared `util.TruncateUTF8`, extracted from the sender's private duplicate to avoid two copies of the same logic.
- 4 MiB matches the sender's default — a safety net, not a routine content limit.
- Adds `grafana_alerting_state_clamped_label_strings_total{kind="label"|"annotation"}` for observability.