### PR TITLE
Chore: modernize reflect.TypeFor

### DIFF
--- a/pkg/expr/query_test.go
+++ b/pkg/expr/query_test.go
@@ -89,7 +89,7 @@ func TestQueryTypeDefinitions(t *testing.T) {
 		},
 	}, {
 		Discriminators: data.NewDiscriminators("type", QueryTypeClassic),
-		GoType:         reflect.TypeOf(&ClassicQuery{}),
+		GoType:         reflect.TypeFor[*ClassicQuery](),
 		Examples: []data.QueryExample{
 			{
 				Name: "Where query A > 5",
@@ -116,7 +116,7 @@ func TestQueryTypeDefinitions(t *testing.T) {
 		},
 	}, {
 		Discriminators: data.NewDiscriminators("type", QueryTypeThreshold),
-		GoType:         reflect.TypeOf(&ThresholdQuery{}),
+		GoType:         reflect.TypeFor[*ThresholdQuery](),
 		Examples: []data.QueryExample{
 			{
 				Name: "Where query A > 5",

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -320,7 +320,7 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 			}
 
 			notGood, err := ctx.tokenService.LookupToken(context.Background(), userToken.UnhashedToken)
-			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&auth.TokenExpiredError{}))
+			require.Equal(t, reflect.TypeOf(err), reflect.TypeFor[*auth.TokenExpiredError]())
 			require.Nil(t, notGood)
 
 			t.Run("should not find active token when expired", func(t *testing.T) {
@@ -357,7 +357,7 @@ func TestIntegrationUserAuthToken(t *testing.T) {
 			}
 
 			notGood, err := ctx.tokenService.LookupToken(context.Background(), userToken.UnhashedToken)
-			require.Equal(t, reflect.TypeOf(err), reflect.TypeOf(&auth.TokenExpiredError{}))
+			require.Equal(t, reflect.TypeOf(err), reflect.TypeFor[*auth.TokenExpiredError]())
 			require.Nil(t, notGood)
 		})
 	})

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -1084,7 +1084,7 @@ func TestGeneratorFillsAllFields(t *testing.T) {
 		"FolderFullpath": {},
 	}
 
-	tpe := reflect.TypeOf(AlertRule{})
+	tpe := reflect.TypeFor[AlertRule]()
 	fields := make(map[string]struct{}, tpe.NumField())
 	for i := 0; i < tpe.NumField(); i++ {
 		if _, ok := ignoredFields[tpe.Field(i).Name]; ok {
@@ -1127,7 +1127,7 @@ func TestGeneratorFillsAllRecordingRuleFields(t *testing.T) {
 		"FolderFullpath":              {},
 	}
 
-	tpe := reflect.TypeOf(AlertRule{})
+	tpe := reflect.TypeFor[AlertRule]()
 	fields := make(map[string]struct{}, tpe.NumField())
 	for i := 0; i < tpe.NumField(); i++ {
 		if _, ok := ignoredFields[tpe.Field(i).Name]; ok {

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -358,7 +358,7 @@ func TestReceiver_Fingerprint(t *testing.T) {
 
 		reflectVal := reflect.ValueOf(&completelyDifferentReceiver).Elem()
 
-		receiverType := reflect.TypeOf((*Receiver)(nil)).Elem()
+		receiverType := reflect.TypeFor[Receiver]()
 		for i := 0; i < receiverType.NumField(); i++ {
 			field := receiverType.Field(i).Name
 			if _, ok := excludedFields[field]; ok {
@@ -386,7 +386,7 @@ func TestReceiver_Fingerprint(t *testing.T) {
 		excludedFields = map[string]struct{}{}
 
 		reflectVal = reflect.ValueOf(completelyDifferentReceiver.Integrations[0]).Elem()
-		integrationType := reflect.TypeOf((*Integration)(nil)).Elem()
+		integrationType := reflect.TypeFor[Integration]()
 		for i := 0; i < integrationType.NumField(); i++ {
 			field := integrationType.Field(i).Name
 			if _, ok := excludedFields[field]; ok {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/time_interval_test.go
@@ -262,7 +262,7 @@ func TestTimeIntervalFingerprint(t *testing.T) {
 	t.Run("stable across metadata modification", func(t *testing.T) {
 		fingerprint := TimeIntervalFingerprint(baseInterval())
 
-		metadataType := reflect.TypeOf(ResourceMetadata{})
+		metadataType := reflect.TypeFor[ResourceMetadata]()
 		otherMetadata := reflect.ValueOf(ResourceMetadata{
 			UID:        "some-other-uid",
 			Version:    "some-other-version",
@@ -302,7 +302,7 @@ func TestTimeIntervalFingerprint(t *testing.T) {
 		}
 		otherValue := reflect.ValueOf(other)
 
-		intervalType := reflect.TypeOf(timeinterval.TimeInterval{})
+		intervalType := reflect.TypeFor[timeinterval.TimeInterval]()
 		for i := 0; i < intervalType.NumField(); i++ {
 			field := intervalType.Field(i).Name
 			cp := baseInterval()

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -473,7 +473,7 @@ func TestRoute_Fingerprint(t *testing.T) {
 
 		reflectVal := reflect.ValueOf(&completelyDifferentRoute).Elem()
 
-		receiverType := reflect.TypeOf((*v1.Route)(nil)).Elem()
+		receiverType := reflect.TypeFor[v1.Route]()
 		for i := 0; i < receiverType.NumField(); i++ {
 			field := receiverType.Field(i).Name
 			if _, ok := excludedFields[field]; ok {

--- a/pkg/services/ngalert/store/proto_instance_database_test.go
+++ b/pkg/services/ngalert/store/proto_instance_database_test.go
@@ -293,7 +293,7 @@ func TestModelAlertInstanceMatchesProtobuf(t *testing.T) {
 	// If the AlertInstance model changes, review the protobuf and the test
 	// and update them accordingly.
 	t.Run("when AlertInstance model changes", func(t *testing.T) {
-		modelType := reflect.TypeOf(models.AlertInstance{})
+		modelType := reflect.TypeFor[models.AlertInstance]()
 		require.Equal(t, 15, modelType.NumField(), "AlertInstance model has changed, update the protobuf")
 	})
 }

--- a/pkg/util/xorm/core/core.go
+++ b/pkg/util/xorm/core/core.go
@@ -2153,24 +2153,24 @@ func SQLType2Type(st SQLType) reflect.Type {
 	name := strings.ToUpper(st.Name)
 	switch name {
 	case Bit, TinyInt, SmallInt, MediumInt, Int, Integer, Serial:
-		return reflect.TypeOf(1)
+		return reflect.TypeFor[int]()
 	case BigInt, BigSerial:
-		return reflect.TypeOf(int64(1))
+		return reflect.TypeFor[int64]()
 	case Float, Real:
-		return reflect.TypeOf(float32(1))
+		return reflect.TypeFor[float32]()
 	case Double:
-		return reflect.TypeOf(float64(1))
+		return reflect.TypeFor[float64]()
 	case Char, NChar, Varchar, NVarchar, TinyText, Text, NText, MediumText, LongText, Enum, Set, Uuid, Clob, SysName:
-		return reflect.TypeOf("")
+		return reflect.TypeFor[string]()
 	case TinyBlob, Blob, LongBlob, Bytea, Binary, MediumBlob, VarBinary, UniqueIdentifier:
-		return reflect.TypeOf([]byte{})
+		return reflect.TypeFor[[]byte]()
 	case Bool:
 		return reflect.TypeOf(true)
 	case DateTime, Date, Time, TimeStamp, TimeStampz, SmallDateTime, Year:
 		return reflect.TypeOf(c_TIME_DEFAULT)
 	case Decimal, Numeric, Money, SmallMoney:
-		return reflect.TypeOf("")
+		return reflect.TypeFor[string]()
 	default:
-		return reflect.TypeOf("")
+		return reflect.TypeFor[string]()
 	}
 }

--- a/pkg/util/xorm/engine.go
+++ b/pkg/util/xorm/engine.go
@@ -405,7 +405,7 @@ type TableName interface {
 }
 
 var (
-	tpTableName = reflect.TypeOf((*TableName)(nil)).Elem()
+	tpTableName = reflect.TypeFor[TableName]()
 )
 
 func (engine *Engine) mapType(v reflect.Value) (*core.Table, error) {

--- a/pkg/util/xorm/session_convert.go
+++ b/pkg/util/xorm/session_convert.go
@@ -102,7 +102,7 @@ func (session *Session) byte2Time(col *core.Column, data []byte) (outTime time.T
 }
 
 var (
-	nullFloatType = reflect.TypeOf(sql.NullFloat64{})
+	nullFloatType = reflect.TypeFor[sql.NullFloat64]()
 )
 
 // convert a db data([]byte) to a field value

--- a/pkg/util/xorm/statement.go
+++ b/pkg/util/xorm/statement.go
@@ -100,8 +100,8 @@ func (statement *Statement) Init() {
 }
 
 var (
-	ptrPkType = reflect.TypeOf(&core.PK{})
-	pkType    = reflect.TypeOf(core.PK{})
+	ptrPkType = reflect.TypeFor[*core.PK]()
+	pkType    = reflect.TypeFor[core.PK]()
 )
 
 // NoAutoCondition if you do not want convert bean's field as query condition, then use this function
@@ -548,7 +548,7 @@ func (statement *Statement) ID(id any) *Statement {
 
 	switch idType.Kind() {
 	case reflect.String:
-		statement.idParam = &core.PK{idValue.Convert(reflect.TypeOf("")).Interface()}
+		statement.idParam = &core.PK{idValue.Convert(reflect.TypeFor[string]()).Interface()}
 		return statement
 	}
 


### PR DESCRIPTION
**What is this feature?**

Replaces eligible `reflect.TypeOf` calls with `reflect.TypeFor`, as identified by the Go `modernize` analyzer.

This is a refactor only and does not change runtime behavior.

**Why do we need this feature?**

`reflect.TypeFor[T]()` expresses the intent directly: obtain the reflection type for `T`. This is clearer than constructing a placeholder value solely for `reflect.TypeOf`, and it removes indirect patterns such as `reflect.TypeOf((*T)(nil)).Elem()`.

Naming the type explicitly also makes the code easier to read and refactor because the compiler checks the requested type without relying on the shape of a dummy value. It uses the modern standard-library API intended for cases where the type is already known at compile time.

**Who is this feature for?**

Grafana developers maintaining the Go codebase. There is no user-visible change.

**Which issue(s) does this PR fix?**

N/A

**Special notes for your reviewer:**

The changes were generated with the `reflecttypefor` rule from Go modernize. Targeted tests for all changed packages pass, and `git diff --check` is clean.

Please check that:

- [x] It works as expected from a users perspective.
- [x] This change does not require a feature toggle.
- [x] This internal refactor does not require documentation or a Whats New entry.