### PR TITLE
Dashboards: Surface real save errors from the apiserver

### DIFF
--- a/public/app/features/apiserver/client.test.ts
+++ b/public/app/features/apiserver/client.test.ts
@@ -51,15 +51,48 @@ describe('DatasourceAPIVersions', () => {
 describe('ScopedResourceClient', () => {
   let client: ScopedResourceClient;
   let postMock: jest.Mock;
+  let putMock: jest.Mock;
   const gvr: GroupVersionResource = { group: 'test.grafana.app', version: 'v1', resource: 'testresources' };
 
   beforeEach(() => {
     jest.clearAllMocks();
     postMock = jest.fn().mockResolvedValue({ metadata: { name: 'created-resource' } });
+    putMock = jest.fn().mockResolvedValue({ metadata: { name: 'updated-resource' } });
     (getBackendSrv as jest.Mock).mockReturnValue({
       post: postMock,
+      put: putMock,
     });
     client = new ScopedResourceClient(gvr);
+  });
+
+  describe('request options', () => {
+    it('forwards showErrorAlert to the backend on create so callers can render the error themselves', async () => {
+      await client.create({ metadata: { name: 'a' }, spec: {} }, undefined, { showErrorAlert: false });
+
+      expect(postMock.mock.calls[0][2]).toEqual({ params: undefined, showErrorAlert: false });
+    });
+
+    it('forwards showErrorAlert to the backend on update so callers can render the error themselves', async () => {
+      await client.update(
+        {
+          apiVersion: 'test.grafana.app/v1',
+          kind: 'TestResource',
+          metadata: { name: 'a', resourceVersion: '1', creationTimestamp: '1' },
+          spec: {},
+          status: {},
+        },
+        undefined,
+        { showErrorAlert: false }
+      );
+
+      expect(putMock.mock.calls[0][2]).toEqual({ params: undefined, showErrorAlert: false });
+    });
+
+    it('leaves the global error alert enabled when no request options are given', async () => {
+      await client.create({ metadata: { name: 'a' }, spec: {} });
+
+      expect(postMock.mock.calls[0][2]).not.toHaveProperty('showErrorAlert');
+    });
   });
 
   describe('create', () => {

--- a/public/app/features/apiserver/client.ts
+++ b/public/app/features/apiserver/client.ts
@@ -20,6 +20,7 @@ import {
   type K8sAPIGroupList,
   AnnoKeySavedFromUI,
   type ResourceEvent,
+  type ResourceClientRequestOptions,
   type ResourceClientWriteParams,
   type GroupVersionResource,
   type TableResponse,
@@ -136,7 +137,11 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     });
   }
 
-  public async create(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>> {
+  public async create(
+    obj: ResourceForCreate<T, K>,
+    params?: ResourceClientWriteParams,
+    requestOptions?: ResourceClientRequestOptions
+  ): Promise<Resource<T, S, K>> {
     if (!obj.metadata.name && !obj.metadata.generateName) {
       const login = contextSrv.user.login;
       // GenerateName lets the apiserver create a unique name by appending random characters to the prefix.
@@ -147,16 +152,21 @@ export class ScopedResourceClient<T = object, S = object, K = string> implements
     setSavedFromUIAnnotation(obj.metadata);
     return getBackendSrv().post(this.url, obj, {
       params,
+      ...requestOptions,
     });
   }
 
-  public async update(obj: Resource<T, S, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>> {
+  public async update(
+    obj: Resource<T, S, K>,
+    params?: ResourceClientWriteParams,
+    requestOptions?: ResourceClientRequestOptions
+  ): Promise<Resource<T, S, K>> {
     const { name } = obj.metadata;
     if (!name) {
       return Promise.reject(new Error('update requires metadata.name'));
     }
     setSavedFromUIAnnotation(obj.metadata);
-    return getBackendSrv().put<Resource<T, S, K>>(`${this.url}/${name}`, obj, { params });
+    return getBackendSrv().put<Resource<T, S, K>>(`${this.url}/${name}`, obj, { params, ...requestOptions });
   }
 
   public async delete(name: string, showSuccessAlert: boolean): Promise<MetaStatus> {

--- a/public/app/features/apiserver/types.ts
+++ b/public/app/features/apiserver/types.ts
@@ -10,6 +10,8 @@
 
 import { type Observable } from 'rxjs';
 
+import { type BackendSrvRequest, type FetchError, isFetchError } from '@grafana/runtime';
+
 /** The object type and version */
 interface TypeMeta<K = string> {
   apiVersion: string;
@@ -293,9 +295,30 @@ export interface WatchOptions {
   fieldSelector?: ListOptionsFieldSelector;
 }
 
+// A single field-level explanation attached to a MetaStatus, as produced by
+// apierrors.NewInvalid on the backend.
+export interface MetaStatusCause {
+  message?: string;
+  field?: string;
+  reason?: string;
+}
+
+export interface MetaStatusDetails {
+  uid?: string;
+  name?: string;
+  group?: string;
+  kind?: string;
+  retryAfterSeconds?: number;
+  causes?: MetaStatusCause[];
+}
+
 export interface MetaStatus {
   // Status of the operation. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   status: 'Success' | 'Failure';
+
+  kind?: 'Status';
+
+  apiVersion?: string;
 
   // A human-readable description of the status of this operation.
   message: string;
@@ -307,7 +330,13 @@ export interface MetaStatus {
   reason?: string;
 
   // Extended data associated with the reason
-  details?: object;
+  details?: MetaStatusDetails;
+}
+
+// Failed writes to an apiserver reject with a FetchError whose body is a Status object. The
+// discriminator lives in `data.reason`, not `data.status` (which is always 'Failure').
+export function isApiMachineryError(error: unknown): error is FetchError<MetaStatus> {
+  return isFetchError(error) && error.data?.kind === 'Status' && error.data?.status === 'Failure';
 }
 
 export interface ResourceEvent<T = object, S = object, K = string> {
@@ -320,10 +349,24 @@ export type ResourceClientWriteParams = {
   fieldValidation?: 'Ignore' | 'Warn' | 'Strict';
 };
 
+/**
+ * Request level options, as opposed to query parameters. Callers that render the failure in their
+ * own UI pass `showErrorAlert: false` to suppress the global error toast.
+ */
+export type ResourceClientRequestOptions = Pick<BackendSrvRequest, 'showErrorAlert'>;
+
 export interface ResourceClient<T = object, S = object, K = string> {
   get(name: string, params?: Record<string, unknown>): Promise<Resource<T, S, K>>;
-  create(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>>;
-  update(obj: ResourceForCreate<T, K>, params?: ResourceClientWriteParams): Promise<Resource<T, S, K>>;
+  create(
+    obj: ResourceForCreate<T, K>,
+    params?: ResourceClientWriteParams,
+    requestOptions?: ResourceClientRequestOptions
+  ): Promise<Resource<T, S, K>>;
+  update(
+    obj: ResourceForCreate<T, K>,
+    params?: ResourceClientWriteParams,
+    requestOptions?: ResourceClientRequestOptions
+  ): Promise<Resource<T, S, K>>;
   delete(name: string, showSuccessAlert?: boolean): Promise<MetaStatus>;
   list(opts?: ListOptions): Promise<ResourceList<T, S, K>>;
   subresource<S>(name: string, path: string, params?: Record<string, unknown>): Promise<S>;

--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -3,7 +3,7 @@ import { type UseFormSetValue, useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Button, Input, Switch, Field, Label, TextArea, Stack, Alert, Box } from '@grafana/ui';
+import { Button, Input, Switch, Field, Label, TextArea, Stack, Box } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import {
   AnnoKeyIgnorePredefinedVariables,
@@ -16,7 +16,8 @@ import { type DashboardMeta } from 'app/types/dashboard';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
-import { type DashboardChangeInfo, NameAlreadyExistsError, SaveButton, isNameExistsError } from './shared';
+import { getSaveDashboardErrorInfo } from './saveErrors';
+import { type DashboardChangeInfo, NameAlreadyExistsError, SaveButton, SaveDashboardErrorAlert } from './shared';
 import { useSaveDashboard } from './useSaveDashboard';
 
 interface SaveDashboardAsFormDTO {
@@ -185,22 +186,15 @@ export function SaveDashboardAsForm({ dashboard, changeInfo, onCancel }: Props) 
   function renderFooter(error?: Error) {
     const formValuesMatchContentSent =
       formValues.title.trim() === contentSent.title && formValues.folder.uid === contentSent.folderUid;
-    if (isNameExistsError(error) && formValuesMatchContentSent) {
+    // Once the user edits the title or folder the error no longer describes what they'd be saving.
+    const errorInfo = formValuesMatchContentSent ? getSaveDashboardErrorInfo(error) : undefined;
+
+    if (errorInfo?.kind === 'already-exists') {
       return <NameAlreadyExistsError />;
     }
     return (
       <>
-        {error && formValuesMatchContentSent && (
-          <Alert
-            title={t(
-              'dashboard-scene.save-dashboard-as-form.render-footer.title-failed-to-save-dashboard',
-              'Failed to save dashboard'
-            )}
-            severity="error"
-          >
-            {error.message && <p>{error.message}</p>}
-          </Alert>
-        )}
+        {errorInfo && <SaveDashboardErrorAlert info={errorInfo} />}
         <Stack alignItems="center">
           {cancelButton}
           {saveButton(false)}

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -4,13 +4,14 @@ import { TestProvider } from 'test/helpers/TestProvider';
 import { byTestId, byText } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { config } from '@grafana/runtime';
+import { config, type FetchError } from '@grafana/runtime';
 import { ConstantVariable, sceneGraph, SceneRefreshPicker } from '@grafana/scenes';
 import {
   AnnoKeyIgnorePredefinedVariables,
   AnnoKeyManagerKind,
   DENY_ALL_PREDEFINED,
   ManagerKind,
+  type MetaStatus,
 } from 'app/features/apiserver/types';
 import { type SaveDashboardResponseDTO } from 'app/types/dashboard';
 
@@ -257,6 +258,88 @@ describe('SaveDashboardDrawer', () => {
       const dataSent = saveDashboardMutationMock.mock.calls[1][0];
       expect(dataSent.overwrite).toEqual(true);
     });
+
+    it('Offers overwrite when the apiserver rejects the save with reason Conflict', async () => {
+      const { dashboard, openAndRender } = setup();
+
+      dashboard.setState({ title: 'New title' });
+      openAndRender();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(409, {
+          reason: 'Conflict',
+          message: 'deprecatedInternalID=5 is already in use',
+        }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('Someone else has updated this dashboard')).toBeInTheDocument();
+      expect(await screen.findByText('Save and overwrite')).toBeInTheDocument();
+    });
+
+    it('Lists each field level cause when the apiserver rejects the save as Invalid', async () => {
+      const { dashboard, openAndRender } = setup();
+
+      dashboard.setState({ title: 'New title' });
+      openAndRender();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(422, {
+          reason: 'Invalid',
+          message: 'Dashboard.dashboard.grafana.app "my-uid" is invalid',
+          details: {
+            causes: [
+              { field: 'spec.title', message: 'title cannot be empty' },
+              { field: 'spec.panels[0].id', message: 'must be unique' },
+            ],
+          },
+        }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('spec.title: title cannot be empty')).toBeInTheDocument();
+      expect(await screen.findByText('spec.panels[0].id: must be unique')).toBeInTheDocument();
+    });
+
+    it('Shows the server message rather than a blank alert for an unrecognised apiserver error', async () => {
+      const { dashboard, openAndRender } = setup();
+
+      dashboard.setState({ title: 'New title' });
+      openAndRender();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(500, {
+          reason: 'InternalError',
+          message: 'failed to write to unified storage',
+        }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('Failed to save dashboard')).toBeInTheDocument();
+      expect(await screen.findByText('failed to write to unified storage')).toBeInTheDocument();
+    });
+
+    it('Explains the failure when the apiserver denies permission to save', async () => {
+      const { dashboard, openAndRender } = setup();
+
+      dashboard.setState({ title: 'New title' });
+      openAndRender();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(403, {
+          reason: 'Forbidden',
+          message: 'dashboards.dashboard.grafana.app is forbidden',
+        }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('You do not have permission to save this dashboard')).toBeInTheDocument();
+      expect(await screen.findByText('dashboards.dashboard.grafana.app is forbidden')).toBeInTheDocument();
+    });
   });
 
   describe('When a dashboard is managed by an external system', () => {
@@ -340,6 +423,41 @@ describe('SaveDashboardDrawer', () => {
       const dataSent = saveDashboardMutationMock.mock.calls[0][0];
       expect(dataSent.dashboard.uid).toEqual('');
       expect(dataSent.k8s).toBeUndefined();
+    });
+
+    it('Shows the server message rather than a blank alert when the copy cannot be saved', async () => {
+      const { openAndRender } = setup();
+      openAndRender({ saveAsCopy: true });
+
+      expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(429, { reason: 'TooManyRequests', message: 'dashboard quota reached' }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('Failed to save dashboard')).toBeInTheDocument();
+      expect(await screen.findByText('dashboard quota reached')).toBeInTheDocument();
+    });
+
+    it('Lists each field level cause when the apiserver rejects the copy as Invalid', async () => {
+      const { openAndRender } = setup();
+      openAndRender({ saveAsCopy: true });
+
+      expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
+
+      mockSaveDashboard({
+        rawError: k8sStatusError(422, {
+          reason: 'Invalid',
+          message: 'Dashboard.dashboard.grafana.app "hello-copy" is invalid',
+          details: { causes: [{ field: 'metadata.name', message: 'uid too long, max 40 characters' }] },
+        }),
+      });
+
+      await userEvent.click(await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveButton));
+
+      expect(await screen.findByText('metadata.name: uid too long, max 40 characters')).toBeInTheDocument();
     });
 
     it('restores meta on cancel after a Save As folder change', async () => {
@@ -504,10 +622,35 @@ describe('SaveDashboardDrawer', () => {
 
 interface MockBackendApiOptions {
   saveError: 'version-mismatch' | 'name-exists' | 'plugin-dashboard';
+  /** A verbatim rejection, so tests can use the real apiserver Status shape. */
+  rawError: FetchError;
+}
+
+/** Mirrors what the apiserver actually rejects a failed write with. */
+function k8sStatusError(status: number, overrides: Partial<MetaStatus>): FetchError<MetaStatus> {
+  return {
+    status,
+    statusText: 'Error',
+    config: { url: '/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/my-uid' },
+    data: {
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Failure',
+      code: status,
+      message: '',
+      ...overrides,
+    },
+  };
 }
 
 function mockSaveDashboard(options: Partial<MockBackendApiOptions> = {}) {
   saveDashboardMutationMock.mockClear();
+
+  if (options.rawError) {
+    saveDashboardMutationMock.mockResolvedValue({ error: options.rawError });
+
+    return;
+  }
 
   if (options.saveError) {
     saveDashboardMutationMock.mockResolvedValue({

--- a/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx
@@ -8,14 +8,8 @@ import { type SaveDashboardOptions } from 'app/features/dashboard/components/Sav
 import { type DashboardScene } from '../scene/DashboardScene';
 
 import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
-import {
-  type DashboardChangeInfo,
-  NameAlreadyExistsError,
-  SaveButton,
-  isNameExistsError,
-  isPluginDashboardError,
-  isVersionMismatchError,
-} from './shared';
+import { getSaveDashboardErrorInfo } from './saveErrors';
+import { type DashboardChangeInfo, NameAlreadyExistsError, SaveButton, SaveDashboardErrorAlert } from './shared';
 import { useSaveDashboard } from './useSaveDashboard';
 
 export interface Props {
@@ -96,7 +90,9 @@ export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
       );
     }
 
-    if (isVersionMismatchError(error)) {
+    const errorInfo = getSaveDashboardErrorInfo(error);
+
+    if (errorInfo?.kind === 'conflict') {
       return (
         <Alert
           title={t(
@@ -110,6 +106,7 @@ export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
               Would you still like to save this dashboard?
             </Trans>
           </p>
+          <p>{errorInfo.message}</p>
           <Box paddingTop={2}>
             <Stack alignItems="center">
               {cancelButton}
@@ -120,11 +117,11 @@ export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
       );
     }
 
-    if (isNameExistsError(error)) {
+    if (errorInfo?.kind === 'already-exists') {
       return <NameAlreadyExistsError />;
     }
 
-    if (isPluginDashboardError(error)) {
+    if (errorInfo?.kind === 'plugin-dashboard') {
       return (
         <Alert
           title={t('dashboard-scene.save-dashboard-form.render-footer.title-plugin-dashboard', 'Plugin dashboard')}
@@ -148,17 +145,7 @@ export function SaveDashboardForm({ dashboard, drawer, changeInfo }: Props) {
 
     return (
       <>
-        {error && (
-          <Alert
-            title={t(
-              'dashboard-scene.save-dashboard-form.render-footer.title-failed-to-save-dashboard',
-              'Failed to save dashboard'
-            )}
-            severity="error"
-          >
-            <p>{error.message}</p>
-          </Alert>
-        )}
+        {errorInfo && <SaveDashboardErrorAlert info={errorInfo} />}
         <Stack alignItems="center">
           {cancelButton}
           {saveButton(false)}

--- a/public/app/features/dashboard-scene/saving/saveErrors.test.ts
+++ b/public/app/features/dashboard-scene/saving/saveErrors.test.ts
@@ -1,0 +1,170 @@
+import { type FetchError } from '@grafana/runtime';
+
+import { type MetaStatus } from '../../apiserver/types';
+
+import { getSaveDashboardErrorInfo } from './saveErrors';
+
+function k8sError(status: Partial<MetaStatus>, httpStatus = 400): FetchError<MetaStatus> {
+  return {
+    status: httpStatus,
+    statusText: 'Bad Request',
+    config: { url: '/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/abc' },
+    data: {
+      kind: 'Status',
+      apiVersion: 'v1',
+      status: 'Failure',
+      code: httpStatus,
+      message: 'something went wrong',
+      ...status,
+    },
+  };
+}
+
+describe('getSaveDashboardErrorInfo', () => {
+  it('returns undefined when there is no error', () => {
+    expect(getSaveDashboardErrorInfo(undefined)).toBeUndefined();
+  });
+
+  describe('apimachinery Status errors', () => {
+    it('classifies reason Conflict as conflict so the overwrite affordance can be offered', () => {
+      const info = getSaveDashboardErrorInfo(k8sError({ reason: 'Conflict', message: 'the object was deleted' }, 409));
+
+      expect(info?.kind).toBe('conflict');
+      expect(info?.message).toBe('the object was deleted');
+    });
+
+    it('classifies reason AlreadyExists as already-exists', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError({ reason: 'AlreadyExists', message: 'the resource already exists' }, 409)
+      );
+
+      expect(info?.kind).toBe('already-exists');
+    });
+
+    it('classifies reason Forbidden as forbidden and keeps the server message', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError({ reason: 'Forbidden', message: 'dashboards.dashboard.grafana.app is forbidden' }, 403)
+      );
+
+      expect(info?.kind).toBe('forbidden');
+      expect(info?.message).toBe('dashboards.dashboard.grafana.app is forbidden');
+    });
+
+    it('lists each Invalid cause as "field: message"', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError(
+          {
+            reason: 'Invalid',
+            message: 'Dashboard.dashboard.grafana.app "abc" is invalid',
+            details: {
+              causes: [
+                { field: 'spec.title', message: 'title cannot be empty', reason: 'FieldValueRequired' },
+                { field: 'spec.panels[0].id', message: 'must be unique', reason: 'FieldValueDuplicate' },
+              ],
+            },
+          },
+          422
+        )
+      );
+
+      expect(info?.kind).toBe('invalid');
+      expect(info?.causes).toEqual(['spec.title: title cannot be empty', 'spec.panels[0].id: must be unique']);
+    });
+
+    it('lists an Invalid cause without a field as the bare message', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError({ reason: 'Invalid', details: { causes: [{ message: 'schema version is not supported' }] } }, 422)
+      );
+
+      expect(info?.causes).toEqual(['schema version is not supported']);
+    });
+
+    it('drops Invalid causes that carry no message', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError(
+          { reason: 'Invalid', details: { causes: [{ field: 'spec.title' }, { message: 'must be unique' }] } },
+          422
+        )
+      );
+
+      expect(info?.causes).toEqual(['must be unique']);
+    });
+
+    it('falls back to the Status message when Invalid carries no causes', () => {
+      const info = getSaveDashboardErrorInfo(k8sError({ reason: 'Invalid', message: 'dashboard is invalid' }, 422));
+
+      expect(info?.kind).toBe('invalid');
+      expect(info?.causes).toEqual([]);
+      expect(info?.message).toBe('dashboard is invalid');
+    });
+
+    it('classifies an unrecognised reason as unknown but keeps the server message', () => {
+      const info = getSaveDashboardErrorInfo(
+        k8sError({ reason: 'InternalError', message: 'failed to write to unified storage' }, 500)
+      );
+
+      expect(info?.kind).toBe('unknown');
+      expect(info?.message).toBe('failed to write to unified storage');
+    });
+  });
+
+  describe('legacy dashboard error shapes', () => {
+    it.each([
+      ['version-mismatch', 'conflict'],
+      ['name-exists', 'already-exists'],
+      ['plugin-dashboard', 'plugin-dashboard'],
+    ])('classifies legacy status %s as %s', (legacyStatus, expectedKind) => {
+      const error: FetchError = {
+        status: 412,
+        statusText: 'Precondition Failed',
+        config: { url: '/api/dashboards/db' },
+        data: { status: legacyStatus, message: 'sad face' },
+      };
+
+      expect(getSaveDashboardErrorInfo(error)?.kind).toBe(expectedKind);
+    });
+  });
+
+  describe('message never renders blank', () => {
+    it('uses data.message when the error has no top level message', () => {
+      const info = getSaveDashboardErrorInfo(k8sError({ message: 'quota exceeded' }, 429));
+
+      expect(info?.message).toBe('quota exceeded');
+    });
+
+    it('falls back to status and statusText when the response body carries no message', () => {
+      const error: FetchError = {
+        status: 502,
+        statusText: 'Bad Gateway',
+        config: { url: '/apis/dashboard.grafana.app' },
+        data: {},
+      };
+
+      expect(getSaveDashboardErrorInfo(error)?.message).toBe('502 Bad Gateway');
+    });
+
+    it('falls back to a generic message when there is no message, statusText or body', () => {
+      const error: FetchError = {
+        status: 0,
+        config: { url: '/apis/dashboard.grafana.app' },
+        data: undefined,
+      };
+
+      expect(getSaveDashboardErrorInfo(error)?.message).toBe('An unexpected error occurred while saving.');
+    });
+
+    it('uses the message of a plain Error', () => {
+      const info = getSaveDashboardErrorInfo(new Error('Invalid dashboard version'));
+
+      expect(info?.kind).toBe('unknown');
+      expect(info?.message).toBe('Invalid dashboard version');
+    });
+
+    it('falls back to a generic message for a thrown value that is not an error', () => {
+      const info = getSaveDashboardErrorInfo('boom');
+
+      expect(info?.kind).toBe('unknown');
+      expect(info?.message).toBe('An unexpected error occurred while saving.');
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/saving/saveErrors.ts
+++ b/public/app/features/dashboard-scene/saving/saveErrors.ts
@@ -1,0 +1,101 @@
+import { t } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
+
+import { isApiMachineryError, type MetaStatusCause } from '../../apiserver/types';
+
+export type SaveDashboardErrorKind =
+  | 'conflict'
+  | 'already-exists'
+  | 'forbidden'
+  | 'invalid'
+  | 'plugin-dashboard'
+  | 'unknown';
+
+export interface SaveDashboardErrorInfo {
+  kind: SaveDashboardErrorKind;
+  /** Human readable explanation. Never empty, so the error alert never renders blank. */
+  message: string;
+  /** Field level validation failures. Only populated for `invalid`. */
+  causes: string[];
+}
+
+// Dashboards are saved through the apiserver, which rejects with an apimachinery Status.
+// Legacy `/api/dashboards/db` statuses are still recognised because provisioning and other
+// non-apiserver paths can surface them.
+const LEGACY_STATUS_KINDS: Record<string, SaveDashboardErrorKind> = {
+  'version-mismatch': 'conflict',
+  'name-exists': 'already-exists',
+  'plugin-dashboard': 'plugin-dashboard',
+};
+
+const API_MACHINERY_REASON_KINDS: Record<string, SaveDashboardErrorKind> = {
+  Conflict: 'conflict',
+  AlreadyExists: 'already-exists',
+  Forbidden: 'forbidden',
+  Invalid: 'invalid',
+};
+
+export function getSaveDashboardErrorInfo(error: unknown): SaveDashboardErrorInfo | undefined {
+  if (error === undefined || error === null) {
+    return undefined;
+  }
+
+  if (isApiMachineryError(error)) {
+    return {
+      kind: API_MACHINERY_REASON_KINDS[error.data.reason ?? ''] ?? 'unknown',
+      message: resolveMessage(error),
+      causes: formatCauses(error.data.details?.causes),
+    };
+  }
+
+  if (isFetchError(error)) {
+    return {
+      kind: LEGACY_STATUS_KINDS[error.data?.status] ?? 'unknown',
+      message: resolveMessage(error),
+      causes: [],
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    message: error instanceof Error && error.message ? error.message : genericMessage(),
+    causes: [],
+  };
+}
+
+function formatCauses(causes?: MetaStatusCause[]): string[] {
+  if (!causes) {
+    return [];
+  }
+
+  return causes.flatMap((cause) => {
+    if (!cause.message) {
+      return [];
+    }
+    return [cause.field ? `${cause.field}: ${cause.message}` : cause.message];
+  });
+}
+
+/**
+ * A FetchError is built from the response, so it has no `message` of its own — the server text
+ * lives in `data.message`. Walk every source before giving up so the alert always says something.
+ */
+function resolveMessage(error: unknown): string {
+  if (isFetchError(error)) {
+    if (error.data?.message) {
+      return error.data.message;
+    }
+    if (error.message) {
+      return error.message;
+    }
+    if (error.statusText) {
+      return `${error.status} ${error.statusText}`;
+    }
+  }
+
+  return genericMessage();
+}
+
+function genericMessage(): string {
+  return t('dashboard-scene.save-errors.unexpected', 'An unexpected error occurred while saving.');
+}

--- a/public/app/features/dashboard-scene/saving/shared.tsx
+++ b/public/app/features/dashboard-scene/saving/shared.tsx
@@ -1,11 +1,12 @@
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { isFetchError } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import { Alert, Button } from '@grafana/ui';
 
 import { type Diffs } from '../settings/version-history/utils';
+
+import { getSaveDashboardErrorInfo, type SaveDashboardErrorInfo } from './saveErrors';
 
 export interface DashboardChangeInfo {
   changedSaveModel: Dashboard | DashboardV2Spec;
@@ -23,15 +24,61 @@ export interface DashboardChangeInfo {
 }
 
 export function isVersionMismatchError(error?: Error) {
-  return isFetchError(error) && error.data && error.data.status === 'version-mismatch';
+  return getSaveDashboardErrorInfo(error)?.kind === 'conflict';
 }
 
 export function isNameExistsError(error?: Error) {
-  return isFetchError(error) && error.data && error.data.status === 'name-exists';
+  return getSaveDashboardErrorInfo(error)?.kind === 'already-exists';
 }
 
 export function isPluginDashboardError(error?: Error) {
-  return isFetchError(error) && error.data && error.data.status === 'plugin-dashboard';
+  return getSaveDashboardErrorInfo(error)?.kind === 'plugin-dashboard';
+}
+
+/**
+ * Renders the save failures that leave the form usable, so the user can correct the dashboard and
+ * retry. Conflicts and name collisions are rendered by their callers instead, because they replace
+ * the footer with their own recovery actions.
+ */
+export function SaveDashboardErrorAlert({ info }: { info: SaveDashboardErrorInfo }) {
+  if (info.kind === 'forbidden') {
+    return (
+      <Alert
+        title={t('save-dashboards.forbidden.title', 'You do not have permission to save this dashboard')}
+        severity="error"
+      >
+        <p>{info.message}</p>
+      </Alert>
+    );
+  }
+
+  if (info.kind === 'invalid') {
+    return (
+      <Alert title={t('save-dashboards.invalid.title', 'This dashboard is not valid')} severity="error">
+        {info.causes.length > 0 ? (
+          <ul>
+            {info.causes.map((cause) => (
+              <li key={cause}>{cause}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>{info.message}</p>
+        )}
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert
+      title={t(
+        'dashboard-scene.save-dashboard-form.render-footer.title-failed-to-save-dashboard',
+        'Failed to save dashboard'
+      )}
+      severity="error"
+    >
+      <p>{info.message}</p>
+    </Alert>
+  );
 }
 
 export function NameAlreadyExistsError() {

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -6,6 +6,7 @@ import {
   AnnoKeyGrantPermissions,
   type Resource,
   type ResourceClient,
+  type ResourceClientRequestOptions,
   type ResourceForCreate,
 } from 'app/features/apiserver/types';
 import { type DashboardDataDTO } from 'app/types/dashboard';
@@ -134,4 +135,18 @@ export async function fetchDeletedDashboard<T>(
     fieldSelector: `metadata.name=${name}`,
   });
   return list.items.find((item) => item.metadata.name === name);
+}
+
+/**
+ * Callers that render the save failure in their own UI (the save drawer) pass
+ * `showErrorAlert: false` so the global error toast doesn't double-report it. Returns undefined
+ * when the caller didn't ask, to keep the request options out of the payload entirely.
+ */
+export function getRequestOptions(
+  command: Pick<SaveDashboardCommand<unknown>, 'showErrorAlert'>
+): ResourceClientRequestOptions | undefined {
+  if (command.showErrorAlert === undefined) {
+    return undefined;
+  }
+  return { showErrorAlert: command.showErrorAlert };
 }

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -260,6 +260,22 @@ describe('v2 dashboard API', () => {
       );
     });
 
+    it('should suppress the global error toast when the caller sets showErrorAlert false', async () => {
+      const api = new K8sDashboardV2API();
+
+      await api.saveDashboard({ ...defaultSaveCommand, showErrorAlert: false });
+
+      expect(mockPut.mock.calls[0][2]).toEqual({ params: undefined, showErrorAlert: false });
+    });
+
+    it('should suppress the global error toast on create when the caller sets showErrorAlert false', async () => {
+      const api = new K8sDashboardV2API();
+
+      await api.saveDashboard({ ...defaultSaveCommand, k8s: undefined, showErrorAlert: false });
+
+      expect(mockPost.mock.calls[0][2]).toEqual({ params: undefined, showErrorAlert: false });
+    });
+
     it('should handle empty string folderUid for root folder', async () => {
       const api = new K8sDashboardV2API();
       const saveCommand = {

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -36,7 +36,7 @@ import {
   type ListDashboardHistoryOptions,
   type ListDeletedDashboardsOptions,
 } from './types';
-import { buildRestorePayload, fetchDeletedDashboard, isV0V1StoredVersion } from './utils';
+import { buildRestorePayload, fetchDeletedDashboard, getRequestOptions, isV0V1StoredVersion } from './utils';
 
 export function getK8sV2DashboardApiConfig() {
   return {
@@ -155,16 +155,18 @@ export class K8sDashboardV2API
       [AnnoKeyGrantPermissions]: 'default',
     };
 
+    const requestOptions = getRequestOptions(options);
+
     if (obj.metadata.name) {
       // remove resource version when updating
       delete obj.metadata.resourceVersion;
       delete obj.metadata.labels?.[DeprecatedInternalId];
-      return this.client.update(obj).then((v) => this.asSaveDashboardResponseDTO(v));
+      return this.client.update(obj, undefined, requestOptions).then((v) => this.asSaveDashboardResponseDTO(v));
     }
 
     // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
     delete obj.metadata.labels?.[DeprecatedInternalId];
-    return await this.client.create(obj).then((v) => this.asSaveDashboardResponseDTO(v));
+    return await this.client.create(obj, undefined, requestOptions).then((v) => this.asSaveDashboardResponseDTO(v));
   }
 
   asSaveDashboardResponseDTO(v: Resource<DashboardV2Spec>): SaveDashboardResponseDTO {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7633,9 +7633,6 @@
       },
       "label-copy-tags": "Copy tags",
       "label-folder": "Folder",
-      "render-footer": {
-        "title-failed-to-save-dashboard": "Failed to save dashboard"
-      },
       "required": "Required"
     },
     "save-dashboard-drawer": {
@@ -7678,6 +7675,9 @@
       "save-variables-label-update-default-variable-values": "Update default variable values",
       "show-variables-warning-alert-body": "Some variables failed to load. If you keep “Update default variable values” checked, the current (failed) values will become the dashboard defaults. You can save anyway or uncheck the option to avoid storing those (failed) values.",
       "show-variables-warning-alert-title": "Variable queries failed"
+    },
+    "save-errors": {
+      "unexpected": "An unexpected error occurred while saving."
     },
     "save-library-viz-panel-modal": {
       "affected-dashboards_one": "This update will affect <1>{{count}} dashboards.</1> The following dashboards using the panel will be affected:",
@@ -15593,6 +15593,12 @@
     "title": "Unable to find application file"
   },
   "save-dashboards": {
+    "forbidden": {
+      "title": "You do not have permission to save this dashboard"
+    },
+    "invalid": {
+      "title": "This dashboard is not valid"
+    },
     "message-length": {
       "info": "The message is {{messageLength}} characters, which exceeds the maximum length of 500 characters. Please shorten it before saving.",
       "title": "Message too long"


### PR DESCRIPTION
**What is this feature?**

Makes the dashboard save drawer show the error the apiserver actually returned.

The save drawer classified failures by the legacy `/api/dashboards/db` error shape — `error.data.status === 'version-mismatch' | 'name-exists' | 'plugin-dashboard'`. Saves go through the apiserver, which rejects with an apimachinery `Status` where `data.status` is always `'Failure'` and the discriminator is `data.reason`. So none of those branches ever matched.

Three consequences, all fixed here:

1. **The conflict recovery path was unreachable.** "Someone else has updated this dashboard → Save and overwrite" could never render.
2. **The fallback alert was blank.** It rendered `error.message`, but a `FetchError` is built from the response (`{status, statusText, data, config, traceId}`) and has no `message` — the server text lives in `data.message`. Users got an empty red box titled "Failed to save dashboard"; Save-as guarded on `error.message` and so showed nothing at all.
3. **`showErrorAlert: false` was silently dropped.** `useSaveDashboard` set it, but `ScopedResourceClient.create/update` never forwarded it to `getBackendSrv()`, so the global toast fired alongside the drawer's own alert.

**Changes**

- New `saveErrors.ts` classifies by `reason` (`Conflict`, `AlreadyExists`, `Forbidden`, `Invalid`) and resolves a message through `details.causes[]` → `data.message` → `error.message` → `${status} ${statusText}` → generic, so the alert body can never be empty. Legacy statuses are still recognised, so non-apiserver paths keep working.
- New `SaveDashboardErrorAlert` in `shared.tsx`: `Invalid` lists each field-level cause (the big practical win — schema validation failures from `apierrors.NewInvalid` used to render blank), `Forbidden` explains the permission problem, everything else shows the server message.
- `isVersionMismatchError` / `isNameExistsError` / `isPluginDashboardError` now delegate to the classifier, so `JsonModelEditView` picks up apiserver support without being restructured.
- `ScopedResourceClient.create/update` take an optional `ResourceClientRequestOptions`; `getRequestOptions` threads `showErrorAlert` from the save command through the v2 client.
- `MetaStatus.details` typed to the real apimachinery shape, plus an `isApiMachineryError` guard.

**Why do we need this feature?**

Today a failed dashboard save can show an empty error box, and the recovery affordance for a conflict is dead code. Users have no way to tell what went wrong or what to do next.

**Who is this feature for?**

Anyone saving a dashboard — most visibly anyone hitting a validation error, a permission error, or a conflict.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Scoped to the **v2** dashboard API, so dashboards saved through the v1 client still get the duplicate global toast — it's the same one-line `getRequestOptions` call there when we want it.

Two related problems found but deliberately left out, as each is a behavior change rather than error surfacing:

- **Optimistic concurrency is off.** `v2.ts` deletes `metadata.resourceVersion` before the PUT, so the backend check in `apistore/store.go` never runs — a stale save silently clobbers a concurrent edit. The `conflict` branch is wired now, but until that's restored it mostly catches `deprecatedInternalID` and deleted-object conflicts rather than concurrent edits.
- **`overwrite` is a no-op** — accepted by `SaveDashboardCommand`, never read by the v2 client, so "Save and overwrite" is just a retry.

Also worth a look: the existing "A dashboard with the same name in the selected folder already exists" copy is now factually wrong. `ErrDashboardWithSameNameInFolderExists` is gone from the backend and `NewAlreadyExists` is only used for library panels, so `AlreadyExists` means a UID collision. I left the user-facing string alone rather than reword it unasked — happy to fix in this PR.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. — N/A, bug fix
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. — N/A
