### PR TITLE
Dashboard: Fix JSON file drops over HTTP in Chromium

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,7 @@ const esModules = [
   'mimic-function',
   'monaco-promql',
   'react-calendar',
+  'react-dropzone',
   '@kusto/monaco-kusto',
   'monaco-editor',
   '@msagl',

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.test.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { FileDropzone } from './FileDropzone';
@@ -51,6 +51,35 @@ describe('The FileDropzone component', () => {
     render(<FileDropzone options={{ accept: { 'text/*': ['.json', '.txt'] } }} />);
 
     expect(await screen.findByText('Accepted file types: .json, .txt')).toBeInTheDocument();
+  });
+
+  describe('file system access', () => {
+    const originalSecureContext = Object.getOwnPropertyDescriptor(globalThis, 'isSecureContext');
+
+    afterEach(() => {
+      if (originalSecureContext) {
+        Object.defineProperty(globalThis, 'isSecureContext', originalSecureContext);
+      } else {
+        Reflect.deleteProperty(globalThis, 'isSecureContext');
+      }
+    });
+
+    it.each([false, true])('reads a dropped file with isSecureContext=%s', async (isSecureContext) => {
+      Object.defineProperty(globalThis, 'isSecureContext', { configurable: true, value: isSecureContext });
+      const fileToUpload = file({});
+      const getAsFileSystemHandle = jest
+        .fn()
+        .mockResolvedValue(isSecureContext ? { getFile: async () => fileToUpload } : undefined);
+      const data = mockData([fileToUpload]);
+      Object.assign(data.dataTransfer.items[0], { getAsFileSystemHandle });
+      const onLoad = jest.fn();
+      render(<FileDropzone onLoad={onLoad} options={{ accept: '.json', multiple: false }} />);
+
+      dispatchEvt(await screen.findByTestId('dropzone'), 'drop', data);
+
+      await waitFor(() => expect(onLoad).toHaveBeenCalledWith('{"ping":true}'));
+      expect(getAsFileSystemHandle).toHaveBeenCalledTimes(isSecureContext ? 1 : 0);
+    });
   });
 
   it('should handle file removal from the list', async () => {

--- a/public/test/jest-resolver.js
+++ b/public/test/jest-resolver.js
@@ -4,6 +4,11 @@ module.exports = (path, options) => {
     ...options,
     // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
     packageFilter: (pkg) => {
+      // Match the browser entry: the UMD bundle embeds its own copy of file-selector.
+      if (pkg.name === 'react-dropzone') {
+        delete pkg.exports;
+        pkg.main = pkg.module;
+      }
       // jest-environment-jsdom 28+ tries to use browser exports instead of default exports,
       // but react-colorful only offers an ESM browser export and not a CommonJS one.
       // Deleting exports forces fallback to the CommonJS "main" entry.

--- a/yarn.lock
+++ b/yarn.lock
@@ -19256,11 +19256,11 @@ __metadata:
   linkType: hard
 
 "file-selector@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "file-selector@npm:2.1.0"
+  version: 2.1.2
+  resolution: "file-selector@npm:2.1.2"
   dependencies:
     tslib: "npm:^2.7.0"
-  checksum: 10/050c24a27b8582a9c5d010a3ea77b22ccbe3969733a044bcb210ba2f85454fb7a6d8b6f91de468517fe59998e94d5c9533447ad063b9e74a67161946474164d4
+  checksum: 10/2a6be0e1904df85f8705a5171fd3b93c1b1ff2ad0143556adb78ac4de899bfc0ba1a20083b4febd4f7000759ec9119a31af76a057e29dd9215907da69ac95e50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Refresh file-selector from 2.1.0 to 2.1.2 within the existing dependency range so dashboard JSON files can be dropped over HTTP in Chromium.

**Why do we need this feature?**

The old version calls getAsFileSystemHandle in insecure contexts, which can crash the renderer. The upstream fix checks the secure context and falls back to getAsFile.

**Who is this feature for?**

Users importing dashboards into Grafana served over HTTP.

**Which issue(s) does this PR fix?**

Fixes #132023

**Special notes for your reviewer:**

The regression uses react-dropzone's browser ESM entry because its UMD bundle embeds file-selector and ignores the lockfile update. The resolver adjustment is limited to that package.

Automated validation: 219 tests across 9 affected suites, ESLint and Prettier pass. Both file-system-access cases also pass in isolation with the lazy-loaded component. An isolated FileDropzone build in Chrome 153 reproduces the renderer crash with 2.1.0 and reads the dropped JSON with 2.1.2; the file picker works in both versions.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it is added to the What's New doc.
