### PR TITLE
TraceView: tighten header metadata (spans, icons, shorter URL)

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -140,6 +140,27 @@ describe('TracePageHeader test', () => {
     config.feedbackLinksEnabled = false; // Default to false to avoid interference with tests
   });
 
+  it('shows the span count next to the other header metadata', () => {
+    const singleSpanTraceId = 'single-span-trace-id';
+    const singleSpanTrace = {
+      ...trace,
+      traceID: singleSpanTraceId,
+      spans: [
+        {
+          ...trace.spans[0],
+          traceID: singleSpanTraceId,
+        },
+      ],
+    };
+
+    setup({ links: [], isLoading: false }, false, undefined, singleSpanTrace);
+
+    expect(screen.getByText('Spans').nextElementSibling).toHaveTextContent('1');
+    expect(
+      screen.getByText('Services').compareDocumentPosition(screen.getByText('Spans')) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
   it('should render the new trace header', () => {
     setup();
 
@@ -588,6 +609,8 @@ describe('TracePageHeader test', () => {
       expect(screen.getByText('Start time')).toBeInTheDocument();
       expect(screen.getByText('Duration')).toBeInTheDocument();
       expect(screen.getByText('Services')).toBeInTheDocument();
+      expect(screen.getByText('Spans')).toBeInTheDocument();
+      expect(screen.getByText('Spans').nextElementSibling).toHaveTextContent('3');
       expect(screen.getByText('URL')).toBeInTheDocument();
 
       expect(screen.getByTestId(selectors.components.TraceViewer.shareMenu.triggerButton)).toBeInTheDocument();

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -352,7 +352,10 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
             </div>
 
             <div className={styles.metadataItem}>
-              <span className={styles.metadataLabel}>{t('explore.trace-page-header.start-time', 'Start time')}</span>
+              <span className={styles.metadataField}>
+                <Icon name="clock-nine" size="xs" className={styles.metadataIcon} aria-hidden />
+                <span className={styles.metadataLabel}>{t('explore.trace-page-header.start-time', 'Start time')}</span>
+              </span>
               <span
                 className={cx(
                   styles.metadataValue,
@@ -367,13 +370,21 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
             </div>
 
             <div className={styles.metadataItem}>
-              <span className={styles.metadataLabel}>{t('explore.trace-page-header.duration', 'Duration')}</span>
+              <span className={styles.metadataField}>
+                <Icon name="stopwatch" type="default" size="sm" className={styles.metadataIcon} aria-hidden />
+                <span className={styles.metadataLabel}>{t('explore.trace-page-header.duration', 'Duration')}</span>
+              </span>
               <span className={styles.metadataValue}>{formatDuration(trace.duration)}</span>
             </div>
 
             <div className={styles.metadataItem}>
               <span className={styles.metadataLabel}>{t('explore.trace-page-header.services', 'Services')}</span>
               <span className={styles.metadataValue}>{serviceCount}</span>
+            </div>
+
+            <div className={styles.metadataItem}>
+              <span className={styles.metadataLabel}>{t('explore.trace-page-header.spans', 'Spans')}</span>
+              <span className={styles.metadataValue}>{trace.spans.length}</span>
             </div>
 
             {url && url.length > 0 && (
@@ -580,7 +591,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       columnGap: theme.spacing(3),
+      rowGap: theme.spacing(0.5),
       fontSize: theme.typography.bodySmall.fontSize,
+      lineHeight: theme.typography.bodySmall.lineHeight,
       color: theme.colors.text.secondary,
       flexWrap: 'wrap',
     }),
@@ -589,11 +602,28 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(0.5),
+      lineHeight: 1,
+    }),
+
+    metadataField: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      lineHeight: 1,
+    }),
+
+    metadataIcon: css({
+      color: theme.colors.text.secondary,
+      display: 'block',
+      flexShrink: 0,
+      lineHeight: 0,
+      transform: 'translateY(-1px)',
     }),
 
     metadataLabel: css({
       fontWeight: theme.typography.fontWeightMedium,
       color: theme.colors.text.secondary,
+      lineHeight: 1,
     }),
 
     metadataValue: css({
@@ -601,6 +631,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(1),
+      lineHeight: 1,
     }),
 
     traceIdButton: css({
@@ -608,12 +639,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       border: 'none',
       color: theme.colors.text.primary,
       cursor: 'pointer',
-      textDecoration: 'underline',
+      textDecoration: 'none',
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(0.5),
       padding: 0,
       font: 'inherit',
+      lineHeight: theme.typography.bodySmall.lineHeight,
 
       '&:hover': {
         color: theme.colors.emphasize(theme.colors.text.primary, 0.15),
@@ -635,11 +667,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
 
     url: css({
-      maxWidth: '700px',
+      maxWidth: '240px',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-      display: 'inline-block',
+      display: 'block',
+      lineHeight: theme.typography.bodySmall.lineHeight,
       color: theme.colors.text.primary,
     }),
     overviewLabel: css({

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9143,6 +9143,7 @@
       "share-export-json": "Export as JSON",
       "share-group": "Share",
       "share-tooltip": "Share and feedback",
+      "spans": "Spans",
       "start-time": "Start time",
       "success-indicator": "Trace succeeded",
       "target": "Target",


### PR DESCRIPTION
**What is this feature?**

Part of https://github.com/grafana/grafana/issues/130743

TraceView: tighten header metadata (spans, icons, shorter URL)

**Why do we need this feature?**

- Show the span count in the metadata row, after Services
- Add small clock / stopwatch icons next to Start time and Duration
- Truncate the URL so it does not dominate the row (full value stays in the tooltip)
- Drop the underline on the Trace ID
- Keep metadata items vertically aligned

**Who is this feature for?**

Trace view users.