### PR TITLE
Folders: Migrate `foldersAppPlatformAPI` reads to OpenFeature

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -45,6 +45,7 @@ declare module "@openfeature/core" {
     | "datasources.azureMonitorBatchAPI"
     | "recentlyViewedDashboards"
     | "experimentRecentlyViewedDashboards"
+    | "foldersAppPlatformAPI"
     | "otelLogsFormatting"
     | "grafana.starredFolders"
     | "grafana.newTextPanel"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -61,6 +61,8 @@ export const FlagKeys = {
   FlameGraphTableNg: "flameGraph.tableNg",
   /** Enables the new Flame Graph UI containing the Call Tree view */
   FlameGraphWithCallTree: "flameGraphWithCallTree",
+  /** Enables use of app platform API for folders */
+  FoldersAppPlatformAPI: "foldersAppPlatformAPI",
   /** Enables global and folder-scoped dashboard variables via dashboard.grafana.app */
   GlobalDashboardVariables: "globalDashboardVariables",
   /** Uses the hybrid (lexical + semantic) search endpoint as the dashboard search backend in the command palette */
@@ -471,6 +473,17 @@ export const useFlagFlameGraphTableNg = (options?: ReactFlagEvaluationOptions): 
  */
 export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("flameGraphWithCallTree", false, options).value;
+};
+
+/**
+ * Enables use of app platform API for folders
+ *
+ * **Details:**
+ * - flag key: `foldersAppPlatformAPI`
+ * - default value: `true`
+ */
+export const useFlagFoldersAppPlatformAPI = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("foldersAppPlatformAPI", true, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1940,7 +1940,7 @@ var (
 			Stage:        FeatureStageGeneralAvailability,
 			Owner:        grafanaFrontendNavigation,
 			HideFromDocs: true,
-			Generate:     Generate{LegacyFrontend: true},
+			Generate:     Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
 			Expression:   "true",
 		},
 		{

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -5,7 +5,7 @@ import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1bet
 import { AppEvents } from '@grafana/data';
 import { config, setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
@@ -142,6 +142,14 @@ afterAll(() => {
   config.provisioningEnabled = originalProvisioningEnabled;
 });
 
+// setTestFlags mutates a module-level provider, so reset it for every test. The act wrap is needed
+// because the reset fires OpenFeature events while components are still mounted.
+afterEach(async () => {
+  await act(async () => {
+    setTestFlags({});
+  });
+});
+
 describe('useGetFolderQueryFacade', () => {
   const originalAppSubUrl = String(config.appSubUrl);
   const originalSharedWithMeFolderUID = config.sharedWithMeFolderUID;
@@ -157,7 +165,7 @@ describe('useGetFolderQueryFacade', () => {
   });
 
   it('merges multiple responses into a single FolderDTO-like object if flag is true', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
 
     const result = await renderFolderHook();
 
@@ -193,7 +201,7 @@ describe('useGetFolderQueryFacade', () => {
   });
 
   it('runs a real access query for the root/general virtual folder', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
 
     const { result } = renderHook(() => useGetFolderQueryFacade('general'), {
       wrapper: getWrapper({}),
@@ -224,7 +232,7 @@ describe('useGetFolderQueryFacade', () => {
   });
 
   it('runs a real access query for the sharedwithme virtual folder (no access)', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
     config.sharedWithMeFolderUID = 'sharedwithme';
 
     const { result } = renderHook(() => useGetFolderQueryFacade('sharedwithme'), {
@@ -247,7 +255,7 @@ describe('useGetFolderQueryFacade', () => {
   });
 
   it('returns legacy folder response if flag is false', async () => {
-    config.featureToggles.foldersAppPlatformAPI = false;
+    setTestFlags({ foldersAppPlatformAPI: false });
     const result = await renderFolderHook();
     expect(result.current.data).toMatchObject({
       id: 791,
@@ -301,11 +309,15 @@ describe('useDeleteMultipleFoldersMutationFacade', () => {
   });
 
   it('deletes multiple folders and publishes success alert', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
     // Same test as for legacy as right now we always use legacy API for deletes.
     const folderUIDs = ['uid1', 'uid2'];
-    const deleteFolders = useDeleteMultipleFoldersMutationFacade();
-    await deleteFolders({ folderUIDs });
+    const { result } = renderHook(() => useDeleteMultipleFoldersMutationFacade(), {
+      wrapper: getWrapper({}),
+    });
+    await act(async () => {
+      await result.current({ folderUIDs });
+    });
 
     // Should call deleteFolder for each UID
     expect(mockDeleteFolderLegacy).toHaveBeenCalledTimes(1);
@@ -313,10 +325,14 @@ describe('useDeleteMultipleFoldersMutationFacade', () => {
   });
 
   it('uses legacy call when flag is false', async () => {
-    config.featureToggles.foldersAppPlatformAPI = false;
+    setTestFlags({ foldersAppPlatformAPI: false });
     const folderUIDs = ['uid1', 'uid2'];
-    const deleteFolders = useDeleteMultipleFoldersMutationFacade();
-    await deleteFolders({ folderUIDs });
+    const { result } = renderHook(() => useDeleteMultipleFoldersMutationFacade(), {
+      wrapper: getWrapper({}),
+    });
+    await act(async () => {
+      await result.current({ folderUIDs });
+    });
 
     // Should call deleteFolder for each UID
     expect(mockDeleteFolderLegacy).toHaveBeenCalledTimes(1);
@@ -338,7 +354,7 @@ describe('useMoveMultipleFoldersMutationFacade', () => {
   });
 
   it('moves multiple folders and publishes success alert', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
     setupUpdateFolderHandler(patchSpy);
     const folderUIDs = ['uid1', 'uid2'];
     const { result } = renderHook(() => useMoveMultipleFoldersMutationFacade(), {
@@ -369,7 +385,7 @@ describe('useMoveMultipleFoldersMutationFacade', () => {
   });
 
   it('uses legacy call when flag is false', async () => {
-    config.featureToggles.foldersAppPlatformAPI = false;
+    setTestFlags({ foldersAppPlatformAPI: false });
     const folderUIDs = ['uid1', 'uid2'];
     const { result } = renderHook(() => useMoveMultipleFoldersMutationFacade(), {
       wrapper: getWrapper({}),
@@ -391,7 +407,7 @@ describe.each([
   false,
 ])('folderAppPlatformAPI toggle set to: %s', (toggle) => {
   beforeEach(() => {
-    config.featureToggles.foldersAppPlatformAPI = toggle;
+    setTestFlags({ foldersAppPlatformAPI: toggle });
     if (toggle) {
       folderAPIVersionResolver.set('v1beta1');
     }
@@ -484,7 +500,7 @@ describe.each([
 describe('useUpdateFolder app-platform starred nav update', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
     folderAPIVersionResolver.set('v1beta1');
     setupUpdateFolderHandler();
   });
@@ -521,7 +537,7 @@ describe('getFolderByUidFacade', () => {
   });
 
   it('throws the original error with HTTP status when folder API returns 403 and foldersAppPlatformAPI is enabled', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
 
     const fetchError = { status: 403, data: { message: 'Forbidden' } };
     dispatchMockFn
@@ -533,7 +549,7 @@ describe('getFolderByUidFacade', () => {
   });
 
   it('throws the original error with HTTP status when folder API returns 403 and foldersAppPlatformAPI is disabled', async () => {
-    config.featureToggles.foldersAppPlatformAPI = false;
+    setTestFlags({ foldersAppPlatformAPI: false });
 
     const fetchError = { status: 403, data: { message: 'Forbidden' } };
     dispatchMockFn.mockResolvedValueOnce({ error: fetchError, data: undefined });
@@ -542,7 +558,7 @@ describe('getFolderByUidFacade', () => {
   });
 
   it('throws a generic error when all responses are undefined and no error is available', async () => {
-    config.featureToggles.foldersAppPlatformAPI = true;
+    setTestFlags({ foldersAppPlatformAPI: true });
 
     dispatchMockFn
       .mockResolvedValueOnce({ data: undefined })

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -1,4 +1,3 @@
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useEffect, useMemo } from 'react';
 
@@ -6,7 +5,7 @@ import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1'
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
-import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient, useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import {
   API_GROUP as IAM_API_GROUP,
   API_VERSION as IAM_API_VERSION,
@@ -140,7 +139,7 @@ export async function getFolderByUidFacade(uid: string) {
   // folder for either rather than fetching a folder resource that doesn't exist.
   const isRoot = isRootFolderUID(uid);
   const isVirtualFolder = uid && (isRoot || uid === config.sharedWithMeFolderUID);
-  const shouldUseAppPlatformAPI = getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true);
 
   if (shouldUseAppPlatformAPI) {
     // Virtual folders aren't real resources, so the folder object comes from a
@@ -206,7 +205,7 @@ export async function getFolderByUidFacade(uid: string) {
  * @param uid
  */
 export function useGetFolderQueryFacade(uid?: string) {
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   // "" / undefined and "general" both mean the synthetic root folder —
   // neither is a real folder resource.
   const isRoot = isRootFolderUID(uid);
@@ -294,7 +293,7 @@ export function useDeleteFolderMutationFacade() {
   const [deleteFolderLegacy] = useDeleteFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
@@ -322,7 +321,7 @@ export function useDeleteMultipleFoldersMutationFacade() {
   const [deleteFolder] = useDeleteFolderMutation();
   const dispatch = useDispatch();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
@@ -363,7 +362,7 @@ export function useMoveMultipleFoldersMutationFacade() {
   const [updateFolder, updateFolderData] = useUpdateFolderMutation();
   const dispatch = useDispatch();
   const refetch = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   if (!shouldUseAppPlatformAPI) {
     return moveFoldersLegacyResult;
@@ -406,7 +405,7 @@ export function useCreateFolder() {
   const [createFolder, result] = useCreateFolderMutation();
   const legacyHook = useLegacyNewFolderMutation();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   if (!shouldUseAppPlatformAPI) {
     return legacyHook;
@@ -479,7 +478,7 @@ export function useUpdateFolder() {
   const [updateFolder, result] = useUpdateFolderMutation();
   const legacyHook = useLegacySaveFolderMutation();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   if (!shouldUseAppPlatformAPI) {
     return legacyHook;
@@ -520,7 +519,7 @@ export function useMoveFolderMutationFacade() {
   const moveFolderResult = useMoveFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   if (!shouldUseAppPlatformAPI) {
     return moveFolderResult;
@@ -572,7 +571,7 @@ export function useGetAffectedItems({ folder, dashboard }: Pick<DashboardTreeSel
 
   // Note the app platform counts are not calculated recursively, so the two APIs don't report the same numbers for
   // nested folders but both are good enough to report whether folder is empty or not.
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const hookParams:
     | Parameters<typeof useLegacyGetAffectedItemsQuery>[0]
     | Parameters<typeof useGetAffectedItemsQuery>[0] = {

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -5,6 +5,7 @@ import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1'
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient, useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import {
   API_GROUP as IAM_API_GROUP,
   API_VERSION as IAM_API_VERSION,
@@ -138,7 +139,7 @@ export async function getFolderByUidFacade(uid: string) {
   // folder for either rather than fetching a folder resource that doesn't exist.
   const isRoot = isRootFolderUID(uid);
   const isVirtualFolder = uid && (isRoot || uid === config.sharedWithMeFolderUID);
-  const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
+  const shouldUseAppPlatformAPI = getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true);
 
   if (shouldUseAppPlatformAPI) {
     // Virtual folders aren't real resources, so the folder object comes from a
@@ -204,7 +205,7 @@ export async function getFolderByUidFacade(uid: string) {
  * @param uid
  */
 export function useGetFolderQueryFacade(uid?: string) {
-  const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   // "" / undefined and "general" both mean the synthetic root folder —
   // neither is a real folder resource.
   const isRoot = isRootFolderUID(uid);
@@ -292,10 +293,11 @@ export function useDeleteFolderMutationFacade() {
   const [deleteFolderLegacy] = useDeleteFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
-  if (!(config.featureToggles.foldersAppPlatformAPI && isBackendSupport)) {
+  if (!(shouldUseAppPlatformAPI && isBackendSupport)) {
     return deleteFolderLegacy;
   }
 
@@ -319,10 +321,11 @@ export function useDeleteMultipleFoldersMutationFacade() {
   const [deleteFolder] = useDeleteFolderMutation();
   const dispatch = useDispatch();
   const refresh = useRefreshFolders();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
-  if (!(config.featureToggles.foldersAppPlatformAPI && isBackendSupport)) {
+  if (!(shouldUseAppPlatformAPI && isBackendSupport)) {
     return deleteFoldersLegacy;
   }
 
@@ -359,8 +362,9 @@ export function useMoveMultipleFoldersMutationFacade() {
   const [updateFolder, updateFolderData] = useUpdateFolderMutation();
   const dispatch = useDispatch();
   const refetch = useRefreshFolders();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
-  if (!config.featureToggles.foldersAppPlatformAPI) {
+  if (!shouldUseAppPlatformAPI) {
     return moveFoldersLegacyResult;
   }
 
@@ -401,8 +405,9 @@ export function useCreateFolder() {
   const [createFolder, result] = useCreateFolderMutation();
   const legacyHook = useLegacyNewFolderMutation();
   const refresh = useRefreshFolders();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
-  if (!config.featureToggles.foldersAppPlatformAPI) {
+  if (!shouldUseAppPlatformAPI) {
     return legacyHook;
   }
 
@@ -473,8 +478,9 @@ export function useUpdateFolder() {
   const [updateFolder, result] = useUpdateFolderMutation();
   const legacyHook = useLegacySaveFolderMutation();
   const refresh = useRefreshFolders();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
-  if (!config.featureToggles.foldersAppPlatformAPI) {
+  if (!shouldUseAppPlatformAPI) {
     return legacyHook;
   }
 
@@ -513,8 +519,9 @@ export function useMoveFolderMutationFacade() {
   const moveFolderResult = useMoveFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
 
-  if (!config.featureToggles.foldersAppPlatformAPI) {
+  if (!shouldUseAppPlatformAPI) {
     return moveFolderResult;
   }
 
@@ -564,7 +571,7 @@ export function useGetAffectedItems({ folder, dashboard }: Pick<DashboardTreeSel
 
   // Note the app platform counts are not calculated recursively, so the two APIs don't report the same numbers for
   // nested folders but both are good enough to report whether folder is empty or not.
-  const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const hookParams:
     | Parameters<typeof useLegacyGetAffectedItemsQuery>[0]
     | Parameters<typeof useGetAffectedItemsQuery>[0] = {

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useEffect, useMemo } from 'react';
 
@@ -5,7 +6,7 @@ import { invalidateQuotaUsage } from '@grafana/api-clients/rtkq/quotas/v0alpha1'
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getAppEvents } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient, useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   API_GROUP as IAM_API_GROUP,
   API_VERSION as IAM_API_VERSION,
@@ -139,7 +140,7 @@ export async function getFolderByUidFacade(uid: string) {
   // folder for either rather than fetching a folder resource that doesn't exist.
   const isRoot = isRootFolderUID(uid);
   const isVirtualFolder = uid && (isRoot || uid === config.sharedWithMeFolderUID);
-  const shouldUseAppPlatformAPI = getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true);
+  const shouldUseAppPlatformAPI = getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false);
 
   if (shouldUseAppPlatformAPI) {
     // Virtual folders aren't real resources, so the folder object comes from a
@@ -205,7 +206,7 @@ export async function getFolderByUidFacade(uid: string) {
  * @param uid
  */
 export function useGetFolderQueryFacade(uid?: string) {
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
   // "" / undefined and "general" both mean the synthetic root folder —
   // neither is a real folder resource.
   const isRoot = isRootFolderUID(uid);
@@ -293,7 +294,7 @@ export function useDeleteFolderMutationFacade() {
   const [deleteFolderLegacy] = useDeleteFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
@@ -321,7 +322,7 @@ export function useDeleteMultipleFoldersMutationFacade() {
   const [deleteFolder] = useDeleteFolderMutation();
   const dispatch = useDispatch();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
   const isBackendSupport = false;
@@ -362,7 +363,7 @@ export function useMoveMultipleFoldersMutationFacade() {
   const [updateFolder, updateFolderData] = useUpdateFolderMutation();
   const dispatch = useDispatch();
   const refetch = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   if (!shouldUseAppPlatformAPI) {
     return moveFoldersLegacyResult;
@@ -405,7 +406,7 @@ export function useCreateFolder() {
   const [createFolder, result] = useCreateFolderMutation();
   const legacyHook = useLegacyNewFolderMutation();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   if (!shouldUseAppPlatformAPI) {
     return legacyHook;
@@ -478,7 +479,7 @@ export function useUpdateFolder() {
   const [updateFolder, result] = useUpdateFolderMutation();
   const legacyHook = useLegacySaveFolderMutation();
   const refresh = useRefreshFolders();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   if (!shouldUseAppPlatformAPI) {
     return legacyHook;
@@ -519,7 +520,7 @@ export function useMoveFolderMutationFacade() {
   const moveFolderResult = useMoveFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
 
   if (!shouldUseAppPlatformAPI) {
     return moveFolderResult;
@@ -571,7 +572,7 @@ export function useGetAffectedItems({ folder, dashboard }: Pick<DashboardTreeSel
 
   // Note the app platform counts are not calculated recursively, so the two APIs don't report the same numbers for
   // nested folders but both are good enough to report whether folder is empty or not.
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
   const hookParams:
     | Parameters<typeof useLegacyGetAffectedItemsQuery>[0]
     | Parameters<typeof useGetAffectedItemsQuery>[0] = {

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse } from 'msw';
-import { act, render, screen, testWithFeatureToggles, userEvent, waitFor, within } from 'test/test-utils';
+import { act, render, screen, userEvent, waitFor, within } from 'test/test-utils';
 
 import { type NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -577,12 +577,10 @@ describe('MegaMenu', () => {
   });
 
   describe('when starredFolders is enabled', () => {
-    testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
     // Flag cleanup is handled by the outer afterEach (act-wrapped, since setTestFlags fires
     // OpenFeature events into the still-mounted menu).
     beforeEach(() => {
-      setTestFlags({ 'grafana.starredFolders': true });
+      setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
     });
 
     it('renders a starred folder and a same-named starred dashboard as two distinct, per-kind-iconed rows', async () => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -51,10 +51,6 @@ describe('NestedFolderPicker', () => {
   });
 
   beforeEach(() => {
-    // These tests were written against the legacy folder tree, so pin the flag off by default.
-    // The describes below that need the app-platform tree opt in explicitly.
-    setTestFlags({ foldersAppPlatformAPI: false });
-
     const { useFoldersQuery: realUseFoldersQuery } = jest.requireActual('./useFoldersQuery');
     useFoldersQueryMock.mockImplementation(realUseFoldersQuery);
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -51,6 +51,10 @@ describe('NestedFolderPicker', () => {
   });
 
   beforeEach(() => {
+    // These tests were written against the legacy folder tree, so pin the flag off by default.
+    // The describes below that need the app-platform tree opt in explicitly.
+    setTestFlags({ foldersAppPlatformAPI: false });
+
     const { useFoldersQuery: realUseFoldersQuery } = jest.requireActual('./useFoldersQuery');
     useFoldersQueryMock.mockImplementation(realUseFoldersQuery);
 

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -53,6 +53,8 @@ describe('NestedFolderPicker', () => {
   beforeEach(() => {
     // These tests were written against the legacy folder tree, so pin the flag off by default.
     // The describes below that need the app-platform tree opt in explicitly.
+    // TODO: add app platform folder fixtures and drop this pin, so these tests cover the API
+    // that production actually uses.
     setTestFlags({ foldersAppPlatformAPI: false });
 
     const { useFoldersQuery: realUseFoldersQuery } = jest.requireActual('./useFoldersQuery');

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, testWithFeatureToggles } from 'test/test-utils';
+import { act, fireEvent, render, screen, waitFor } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
@@ -51,6 +51,10 @@ describe('NestedFolderPicker', () => {
   });
 
   beforeEach(() => {
+    // These tests were written against the legacy folder tree, so pin the flag off by default.
+    // The describes below that need the app-platform tree opt in explicitly.
+    setTestFlags({ foldersAppPlatformAPI: false });
+
     const { useFoldersQuery: realUseFoldersQuery } = jest.requireActual('./useFoldersQuery');
     useFoldersQueryMock.mockImplementation(realUseFoldersQuery);
 
@@ -77,7 +81,10 @@ describe('NestedFolderPicker', () => {
     window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
     jest.resetAllMocks();
   });
 
@@ -339,14 +346,14 @@ describe('NestedFolderPicker', () => {
   });
 
   describe('when starredFolders is enabled', () => {
-    testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
     beforeEach(() => {
-      setTestFlags({ 'grafana.starredFolders': true });
+      setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
     });
 
-    afterEach(() => {
-      setTestFlags({});
+    afterEach(async () => {
+      await act(async () => {
+        setTestFlags({});
+      });
     });
 
     it('shows the starred folders virtual root with its selectable children', async () => {
@@ -389,14 +396,14 @@ describe('NestedFolderPicker', () => {
   });
 
   describe('when starredFolders is enabled but foldersAppPlatformAPI is disabled', () => {
-    testWithFeatureToggles({ disable: ['foldersAppPlatformAPI'] });
-
     beforeEach(() => {
-      setTestFlags({ 'grafana.starredFolders': true });
+      setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: false });
     });
 
-    afterEach(() => {
-      setTestFlags({});
+    afterEach(async () => {
+      await act(async () => {
+        setTestFlags({});
+      });
     });
 
     it('does not render starred folders (hard gate on the app-platform folder API)', async () => {

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
@@ -3,7 +3,7 @@ import { act, getWrapper, renderHook, waitFor } from 'test/test-utils';
 
 import * as runtime from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { ManagerKind } from 'app/features/apiserver/types';
 
@@ -23,24 +23,24 @@ const wrapper = ({ children }: { children: ReactNode }) => {
 };
 
 describe('useFoldersQuery', () => {
-  let configBackup: runtime.GrafanaBootConfig;
-
-  beforeAll(() => {
-    configBackup = { ...runtime.config };
-  });
-
-  afterAll(() => {
-    runtime.config.featureToggles = configBackup.featureToggles;
-  });
-
   describe.each([
     // foldersAppPlatformAPI enabled
     true,
     // foldersAppPlatformAPI disabled
     false,
   ])('foldersAppPlatformAPI feature toggle set to %s', (featureToggleState) => {
+    beforeEach(() => {
+      setTestFlags({ foldersAppPlatformAPI: featureToggleState });
+    });
+
+    // The act wrap is needed because resetting fires OpenFeature events while the hook is mounted.
+    afterEach(async () => {
+      await act(async () => {
+        setTestFlags({});
+      });
+    });
+
     it('returns data', async () => {
-      runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
       const [_dashboardsContainer, ...items] = await testFn();
 
       const sortedItemTitles = items.map((item) => (item.item as DashboardViewItem).title).sort();
@@ -57,7 +57,6 @@ describe('useFoldersQuery', () => {
     });
 
     it('uses custom root folder display name when rootFolderItem is provided', async () => {
-      runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
       const { result } = renderHook(
         () =>
           useFoldersQuery({

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,4 +1,5 @@
-import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
+
 import { type DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { type PermissionLevel } from 'app/types/acl';
 
@@ -21,7 +22,7 @@ export function useFoldersQuery({
   rootFolderUID,
   rootFolderItem,
 }: UseFoldersQueryProps) {
-  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
   const resultLegacy = useFoldersQueryLegacy({ isBrowsing, openFolders, permission, rootFolderUID, rootFolderItem });
   const resultAppPlatform = useFoldersQueryAppPlatform({
     isBrowsing,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,4 +1,4 @@
-import { config } from '@grafana/runtime';
+import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import { type DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { type PermissionLevel } from 'app/types/acl';
 
@@ -21,6 +21,7 @@ export function useFoldersQuery({
   rootFolderUID,
   rootFolderItem,
 }: UseFoldersQueryProps) {
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const resultLegacy = useFoldersQueryLegacy({ isBrowsing, openFolders, permission, rootFolderUID, rootFolderItem });
   const resultAppPlatform = useFoldersQueryAppPlatform({
     isBrowsing,
@@ -32,5 +33,5 @@ export function useFoldersQuery({
 
   // Running the hooks themselves don't have any side effects, so we can just conditionally use one or the other
   // requestNextPage function from the result
-  return config.featureToggles.foldersAppPlatformAPI ? resultAppPlatform : resultLegacy;
+  return shouldUseAppPlatformAPI ? resultAppPlatform : resultLegacy;
 }

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,5 +1,4 @@
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
-
+import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import { type DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { type PermissionLevel } from 'app/types/acl';
 
@@ -22,7 +21,7 @@ export function useFoldersQuery({
   rootFolderUID,
   rootFolderItem,
 }: UseFoldersQueryProps) {
-  const shouldUseAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const shouldUseAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const resultLegacy = useFoldersQueryLegacy({ isBrowsing, openFolders, permission, rootFolderUID, rootFolderItem });
   const resultAppPlatform = useFoldersQueryAppPlatform({
     isBrowsing,

--- a/public/app/features/alerting/unified/mockApi.ts
+++ b/public/app/features/alerting/unified/mockApi.ts
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { type SetupServer } from 'msw/node';
 
@@ -5,6 +6,7 @@ import { type DashboardHit } from '@grafana/api-clients/rtkq/dashboard/v0alpha1'
 import { setBackendSrv } from '@grafana/runtime';
 import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import allHandlers from 'app/features/alerting/unified/mocks/server/all-handlers';
 import {
   setupAlertmanagerConfigMapDefaultState,
@@ -313,6 +315,23 @@ export function setupMswServer() {
 
   beforeAll(() => {
     setupBackendSrv();
+  });
+
+  // Rule permissions and the rule editor's folder picker read folders through the facades in
+  // app/api/clients/folder, which default to the app platform API. Only the legacy /api/folders
+  // handlers exist here, so pin the flag off.
+  // TODO: add app platform folder fixtures (folders/:name plus its access and parents
+  // subresources) and drop this, so these tests cover the API that production actually uses.
+  beforeEach(() => {
+    setTestFlags({ foldersAppPlatformAPI: false });
+  });
+
+  afterEach(async () => {
+    // The act wrap is needed because clearing the flag fires OpenFeature events while components
+    // are still mounted.
+    await act(async () => {
+      setTestFlags({});
+    });
   });
 
   afterEach(() => {

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.test.tsx
@@ -3,7 +3,7 @@ import { type ComponentProps } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 import type AutoSizer from 'react-virtualized-auto-sizer';
 import { of } from 'rxjs';
-import { act, render as testRender, screen, waitFor, testWithFeatureToggles } from 'test/test-utils';
+import { act, render as testRender, screen, waitFor } from 'test/test-utils';
 
 import { type DataSourceInstanceListItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -208,9 +208,15 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
     });
 
     describe('folder owner', () => {
-      testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
       beforeEach(() => {
+        setTestFlags({ foldersAppPlatformAPI: true });
         jest.spyOn(contextSrv, 'hasRole').mockReturnValue(true);
+      });
+
+      afterEach(async () => {
+        await act(async () => {
+          setTestFlags({});
+        });
       });
 
       it('allows choosing a team to own the folder', async () => {
@@ -403,10 +409,8 @@ describe('browse-dashboards BrowseDashboardsPage', () => {
     });
 
     describe('with starred folders enabled', () => {
-      testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
       beforeEach(() => {
-        setTestFlags({ 'grafana.starredFolders': true });
+        setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
       });
 
       afterEach(async () => {

--- a/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from 'test/test-utils';
+import { act, render, screen } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
@@ -37,12 +38,19 @@ describe('browse-dashboards BrowseFolderAlertingPage', () => {
   };
 
   beforeEach(() => {
+    // foldersAppPlatformAPI defaults to on, but the alerting mock server only serves the legacy
+    // /api/folders endpoints, so pin it off.
+    setTestFlags({ foldersAppPlatformAPI: false });
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => mockPermissions);
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     jest.restoreAllMocks();
+    // The act wrap is needed because resetting fires OpenFeature events into the mounted page.
+    await act(async () => {
+      setTestFlags({});
+    });
   });
 
   it('displays the folder title', async () => {

--- a/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
@@ -40,6 +40,8 @@ describe('browse-dashboards BrowseFolderAlertingPage', () => {
   beforeEach(() => {
     // foldersAppPlatformAPI defaults to on, but the alerting mock server only serves the legacy
     // /api/folders endpoints, so pin it off.
+    // TODO: add app platform folder fixtures and drop this pin, so these tests cover the API
+    // that production actually uses.
     setTestFlags({ foldersAppPlatformAPI: false });
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => mockPermissions);
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);

--- a/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderAlertingPage.test.tsx
@@ -1,7 +1,6 @@
-import { act, render, screen } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import { config } from '@grafana/runtime';
-import { setTestFlags } from '@grafana/test-utils/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 
@@ -38,19 +37,12 @@ describe('browse-dashboards BrowseFolderAlertingPage', () => {
   };
 
   beforeEach(() => {
-    // foldersAppPlatformAPI defaults to on, but the alerting mock server only serves the legacy
-    // /api/folders endpoints, so pin it off.
-    setTestFlags({ foldersAppPlatformAPI: false });
     jest.spyOn(permissions, 'getFolderPermissions').mockImplementation(() => mockPermissions);
     jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     jest.restoreAllMocks();
-    // The act wrap is needed because resetting fires OpenFeature events into the mounted page.
-    await act(async () => {
-      setTestFlags({});
-    });
   });
 
   it('displays the folder title', async () => {

--- a/public/app/features/browse-dashboards/BrowseFolderVariablesPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderVariablesPage.test.tsx
@@ -57,7 +57,8 @@ describe('browse-dashboards BrowseFolderVariablesPage', () => {
 
   beforeEach(() => {
     config.unifiedAlertingEnabled = true;
-    setTestFlags({ [GLOBAL_DASHBOARD_VARIABLES_FLAG]: true });
+    // foldersAppPlatformAPI defaults to on, but this suite's folder handlers are the legacy ones.
+    setTestFlags({ [GLOBAL_DASHBOARD_VARIABLES_FLAG]: true, foldersAppPlatformAPI: false });
     server.use(
       http.get('/apis/dashboard.grafana.app/v2beta1/namespaces/:namespace/variables', () => {
         return HttpResponse.json({

--- a/public/app/features/browse-dashboards/BrowseFolderVariablesPage.test.tsx
+++ b/public/app/features/browse-dashboards/BrowseFolderVariablesPage.test.tsx
@@ -57,8 +57,7 @@ describe('browse-dashboards BrowseFolderVariablesPage', () => {
 
   beforeEach(() => {
     config.unifiedAlertingEnabled = true;
-    // foldersAppPlatformAPI defaults to on, but this suite's folder handlers are the legacy ones.
-    setTestFlags({ [GLOBAL_DASHBOARD_VARIABLES_FLAG]: true, foldersAppPlatformAPI: false });
+    setTestFlags({ [GLOBAL_DASHBOARD_VARIABLES_FLAG]: true });
     server.use(
       http.get('/apis/dashboard.grafana.app/v2beta1/namespaces/:namespace/variables', () => {
         return HttpResponse.json({

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -9,7 +9,7 @@ import { config, setBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { customFolderCountsHandler } from '@grafana/test-utils/unstable';
+import { customFolderCountsHandler, setTestFlags } from '@grafana/test-utils/unstable';
 import { folderAPIv1beta1 } from 'app/api/clients/folder/v1beta1';
 import { legacyAPI } from 'app/api/clients/legacy';
 import { setStarred, updateDashboardName } from 'app/core/reducers/navBarTree';
@@ -114,11 +114,14 @@ describe('browseDashboardsAPI', () => {
     config.provisioningEnabled = false;
     getDashboardAPIMock.mockReset();
     folderAPIVersionResolver.set('v1beta1');
+    // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy endpoints.
+    setTestFlags({ foldersAppPlatformAPI: false });
     server.use(http.get('/api/access-control/user/actions', () => HttpResponse.json({})));
   });
 
   afterEach(() => {
     config.provisioningEnabled = originalProvisioningEnabled;
+    setTestFlags({});
   });
 
   const createMockDashboardAPI = (saveDashboard: jest.Mock) =>

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -115,6 +115,8 @@ describe('browseDashboardsAPI', () => {
     getDashboardAPIMock.mockReset();
     folderAPIVersionResolver.set('v1beta1');
     // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy endpoints.
+    // TODO: add app platform folder fixtures and drop this pin, so these tests cover the API
+    // that production actually uses.
     setTestFlags({ foldersAppPlatformAPI: false });
     server.use(http.get('/api/access-control/user/actions', () => HttpResponse.json({})));
   });

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -9,7 +9,7 @@ import { config, setBackendSrv } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { type Spec as DashboardV2Spec } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { customFolderCountsHandler, setTestFlags } from '@grafana/test-utils/unstable';
+import { customFolderCountsHandler } from '@grafana/test-utils/unstable';
 import { folderAPIv1beta1 } from 'app/api/clients/folder/v1beta1';
 import { legacyAPI } from 'app/api/clients/legacy';
 import { setStarred, updateDashboardName } from 'app/core/reducers/navBarTree';
@@ -114,14 +114,11 @@ describe('browseDashboardsAPI', () => {
     config.provisioningEnabled = false;
     getDashboardAPIMock.mockReset();
     folderAPIVersionResolver.set('v1beta1');
-    // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy endpoints.
-    setTestFlags({ foldersAppPlatformAPI: false });
     server.use(http.get('/api/access-control/user/actions', () => HttpResponse.json({})));
   });
 
   afterEach(() => {
     config.provisioningEnabled = originalProvisioningEnabled;
-    setTestFlags({});
   });
 
   const createMockDashboardAPI = (saveDashboard: jest.Mock) =>

--- a/public/app/features/browse-dashboards/api/services.test.ts
+++ b/public/app/features/browse-dashboards/api/services.test.ts
@@ -75,13 +75,17 @@ describe('browse-dashboards services', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       mockContextSrv.hasPermission = jest.fn().mockReturnValue(true);
-      config.featureToggles.foldersAppPlatformAPI = false;
+      setTestFlags({ foldersAppPlatformAPI: false });
       config.sharedWithMeFolderUID = 'sharedwithme';
+    });
+
+    afterEach(() => {
+      setTestFlags({});
     });
 
     describe('old API (foldersAppPlatformAPI = false)', () => {
       beforeEach(() => {
-        config.featureToggles.foldersAppPlatformAPI = false;
+        setTestFlags({ foldersAppPlatformAPI: false });
       });
 
       it('returns folders in correct format', async () => {
@@ -118,7 +122,7 @@ describe('browse-dashboards services', () => {
 
     describe('new API (foldersAppPlatformAPI = true)', () => {
       beforeEach(() => {
-        config.featureToggles.foldersAppPlatformAPI = true;
+        setTestFlags({ foldersAppPlatformAPI: true });
       });
 
       it('returns the correct folders for the requested page', async () => {
@@ -226,13 +230,9 @@ describe('browse-dashboards services', () => {
     });
 
     describe('starred folders virtual item', () => {
+      // One call — putConfiguration replaces the whole flag set, so a second call would drop the first.
       beforeEach(() => {
-        config.featureToggles.foldersAppPlatformAPI = true;
-        setTestFlags({ 'grafana.starredFolders': true });
-      });
-
-      afterEach(() => {
-        setTestFlags({});
+        setTestFlags({ foldersAppPlatformAPI: true, 'grafana.starredFolders': true });
       });
 
       it('inserts the starred folders item after team folders and before real folders', async () => {

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { collectionsAPIv1alpha1 } from 'app/api/clients/collections/v1alpha1';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
 import { legacyAPI } from 'app/api/clients/legacy';
@@ -110,7 +111,7 @@ export async function listFolders(
 ): Promise<DashboardViewItem[]> {
   let folders: NestedFolderDTO[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
-    if (config.featureToggles.foldersAppPlatformAPI) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)) {
       folders = await searchNewAPI(parentUID, page, pageSize);
     } else {
       folders = await searchOldAPI(parentUID, page, pageSize);

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
-import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { collectionsAPIv1alpha1 } from 'app/api/clients/collections/v1alpha1';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
 import { legacyAPI } from 'app/api/clients/legacy';
@@ -111,7 +111,7 @@ export async function listFolders(
 ): Promise<DashboardViewItem[]> {
   let folders: NestedFolderDTO[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
-    if (getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)) {
+    if (getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false)) {
       folders = await searchNewAPI(parentUID, page, pageSize);
     } else {
       folders = await searchOldAPI(parentUID, page, pageSize);

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
-import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { collectionsAPIv1alpha1 } from 'app/api/clients/collections/v1alpha1';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
 import { legacyAPI } from 'app/api/clients/legacy';
@@ -111,7 +111,7 @@ export async function listFolders(
 ): Promise<DashboardViewItem[]> {
   let folders: NestedFolderDTO[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
-    if (getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false)) {
+    if (getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)) {
       folders = await searchNewAPI(parentUID, page, pageSize);
     } else {
       folders = await searchOldAPI(parentUID, page, pageSize);

--- a/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
@@ -1,9 +1,9 @@
 import { HttpResponse } from 'msw';
-import { render, screen } from 'test/test-utils';
+import { act, render, screen } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { customFolderCountsHandler, getFolderFixtures } from '@grafana/test-utils/unstable';
+import { customFolderCountsHandler, getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { AffectedFolderContents } from './AffectedFolderContents';
@@ -24,6 +24,18 @@ const folderASelection = {
 };
 
 describe('AffectedFolderContents', () => {
+  // foldersAppPlatformAPI defaults to on, but the counts handler here is the legacy one.
+  beforeEach(() => {
+    setTestFlags({ foldersAppPlatformAPI: false });
+  });
+
+  // The act wrap is needed because resetting fires OpenFeature events into the mounted component.
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
+  });
+
   it('always renders the default message', () => {
     render(<AffectedFolderContents selectedItems={emptySelection} defaultMessage={<p>Default body</p>} />);
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
@@ -1,9 +1,9 @@
 import { HttpResponse } from 'msw';
-import { act, render, screen } from 'test/test-utils';
+import { render, screen } from 'test/test-utils';
 
 import { setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
-import { customFolderCountsHandler, getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
+import { customFolderCountsHandler, getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { AffectedFolderContents } from './AffectedFolderContents';
@@ -24,18 +24,6 @@ const folderASelection = {
 };
 
 describe('AffectedFolderContents', () => {
-  // foldersAppPlatformAPI defaults to on, but the counts handler here is the legacy one.
-  beforeEach(() => {
-    setTestFlags({ foldersAppPlatformAPI: false });
-  });
-
-  // The act wrap is needed because resetting fires OpenFeature events into the mounted component.
-  afterEach(async () => {
-    await act(async () => {
-      setTestFlags({});
-    });
-  });
-
   it('always renders the default message', () => {
     render(<AffectedFolderContents selectedItems={emptySelection} defaultMessage={<p>Default body</p>} />);
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/AffectedFolderContents.test.tsx
@@ -25,6 +25,8 @@ const folderASelection = {
 
 describe('AffectedFolderContents', () => {
   // foldersAppPlatformAPI defaults to on, but the counts handler here is the legacy one.
+  // TODO: add app platform folder fixtures and drop this pin, so these tests cover the API
+  // that production actually uses.
   beforeEach(() => {
     setTestFlags({ foldersAppPlatformAPI: false });
   });

--- a/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/MoveModal.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from 'test/test-utils';
+import { act, render, screen } from 'test/test-utils';
 
-import { config, setBackendSrv } from '@grafana/runtime';
+import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { MoveModal, type Props } from './MoveModal';
@@ -11,8 +11,6 @@ const [_, { folderA }] = getFolderFixtures();
 
 setBackendSrv(backendSrv);
 setupMockServer();
-
-const originalToggles = { ...config.featureToggles };
 
 describe('browse-dashboards MoveModal', () => {
   const mockOnDismiss = jest.fn();
@@ -69,10 +67,13 @@ describe('browse-dashboards MoveModal', () => {
         props.selectedItems.folder = {
           [folderA.item.uid]: true,
         };
-        config.featureToggles.foldersAppPlatformAPI = toggle;
+        setTestFlags({ foldersAppPlatformAPI: toggle });
       });
-      afterEach(() => {
-        config.featureToggles = originalToggles;
+      // The act wrap is needed because resetting fires OpenFeature events while the modal is mounted.
+      afterEach(async () => {
+        await act(async () => {
+          setTestFlags({});
+        });
       });
 
       it('displays a warning about permissions if a folder is selected', async () => {

--- a/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.test.tsx
+++ b/public/app/features/browse-dashboards/components/FolderDetailsActions/FolderDetailsActions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { setBackendSrv } from '@grafana/runtime';
@@ -31,15 +31,15 @@ const StarredFoldersList = () => {
 };
 
 describe('FolderDetailsActions', () => {
-  // starredFoldersEnabled() gates the star button on this feature toggle plus the OpenFeature flag
-  testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
+  // starredFoldersEnabled() gates the star button on both of these flags
   beforeEach(() => {
-    setTestFlags({ 'grafana.starredFolders': true });
+    setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
   });
 
-  afterEach(() => {
-    setTestFlags({});
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
   });
 
   it('refetches the starred folders list when a folder is starred', async () => {

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import { ConfirmModal, Space, Text, useStyles2 } from '@grafana/ui';
 import { getStatusFromError } from 'app/core/utils/errors';
 
@@ -47,7 +47,7 @@ export const RestoreModal = ({
 }: RestoreModalProps) => {
   const styles = useStyles2(getStyles);
   const [userTarget, setUserTarget] = useState<string | undefined>();
-  const foldersAppPlatformAPI = useFlagFoldersAppPlatformAPI();
+  const foldersAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
   const numberOfDashboards = selectedDashboards.length;
   const { error: originError, isFetching } = useGetFolderQuery(
     originCandidate

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
+import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import { ConfirmModal, Space, Text, useStyles2 } from '@grafana/ui';
 import { getStatusFromError } from 'app/core/utils/errors';
 
@@ -47,7 +47,7 @@ export const RestoreModal = ({
 }: RestoreModalProps) => {
   const styles = useStyles2(getStyles);
   const [userTarget, setUserTarget] = useState<string | undefined>();
-  const foldersAppPlatformAPI = useBooleanFlagValue('foldersAppPlatformAPI', false);
+  const foldersAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const numberOfDashboards = selectedDashboards.length;
   const { error: originError, isFetching } = useGetFolderQuery(
     originCandidate

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
+import { useFlagFoldersAppPlatformAPI } from '@grafana/runtime/internal';
 import { ConfirmModal, Space, Text, useStyles2 } from '@grafana/ui';
 import { getStatusFromError } from 'app/core/utils/errors';
 
@@ -46,13 +47,14 @@ export const RestoreModal = ({
 }: RestoreModalProps) => {
   const styles = useStyles2(getStyles);
   const [userTarget, setUserTarget] = useState<string | undefined>();
+  const foldersAppPlatformAPI = useFlagFoldersAppPlatformAPI();
   const numberOfDashboards = selectedDashboards.length;
   const { error: originError, isFetching } = useGetFolderQuery(
     originCandidate
       ? {
           folderUID: originCandidate,
           accesscontrol: false,
-          isLegacyCall: Boolean(config.featureToggles.foldersAppPlatformAPI),
+          isLegacyCall: foldersAppPlatformAPI,
         }
       : skipToken,
     { refetchOnMountOrArgChange: true }

--- a/public/app/features/browse-dashboards/utils/dashboards.ts
+++ b/public/app/features/browse-dashboards/utils/dashboards.ts
@@ -73,7 +73,7 @@ export function isNonSelectableVirtualFolder(uid: string): boolean {
 export function starredFoldersEnabled(): boolean {
   return (
     getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaStarredFolders, false) &&
-    getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false)
+    getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)
   );
 }
 

--- a/public/app/features/browse-dashboards/utils/dashboards.ts
+++ b/public/app/features/browse-dashboards/utils/dashboards.ts
@@ -68,12 +68,12 @@ export function isNonSelectableVirtualFolder(uid: string): boolean {
   );
 }
 
-// Single gate for the starred-folders feature: the OpenFeature flag and the app-platform folder API
-// (`foldersAppPlatformAPI`), which renders the virtual root in the browse list.
+// Single gate for the starred-folders feature: its own flag and the app-platform folder API, which
+// renders the virtual root in the browse list.
 export function starredFoldersEnabled(): boolean {
   return (
     getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaStarredFolders, false) &&
-    Boolean(config.featureToggles.foldersAppPlatformAPI)
+    getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)
   );
 }
 

--- a/public/app/features/browse-dashboards/utils/dashboards.ts
+++ b/public/app/features/browse-dashboards/utils/dashboards.ts
@@ -73,7 +73,7 @@ export function isNonSelectableVirtualFolder(uid: string): boolean {
 export function starredFoldersEnabled(): boolean {
   return (
     getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaStarredFolders, false) &&
-    getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, true)
+    getFeatureFlagClient().getBooleanValue('foldersAppPlatformAPI', false)
   );
 }
 

--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -181,8 +181,8 @@ describe('Unified Storage Searcher', () => {
 
     beforeEach(() => {
       searchRequests = [];
-      config.featureToggles.foldersAppPlatformAPI = true;
-      setTestFlags({ 'grafana.starredFolders': true });
+      // One call — putConfiguration replaces the whole flag set, so a second call would drop the first.
+      setTestFlags({ foldersAppPlatformAPI: true, 'grafana.starredFolders': true });
       // starred() reads stars via an RTK Query dispatch on the global store, so wire one up.
       const store = configureStore({
         reducer: { [collectionsAPIv1alpha1.reducerPath]: collectionsAPIv1alpha1.reducer },
@@ -192,7 +192,6 @@ describe('Unified Storage Searcher', () => {
     });
 
     afterEach(() => {
-      config.featureToggles.foldersAppPlatformAPI = false;
       setTestFlags({});
     });
 

--- a/public/app/features/stars/hooks.test.tsx
+++ b/public/app/features/stars/hooks.test.tsx
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import { useState } from 'react';
-import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { act, render, screen, waitFor } from 'test/test-utils';
 
 import { config, setBackendSrv } from '@grafana/runtime';
 import server, { setupMockServer } from '@grafana/test-utils/server';
@@ -191,10 +191,8 @@ describe('useSyncStarredItemsInNav', () => {
   });
 
   describe('when starredFolders is enabled', () => {
-    testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
     beforeEach(() => {
-      setTestFlags({ 'grafana.starredFolders': true });
+      setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
       // Provide a starred section in the nav tree so the reducer has a target
       config.bootData.navTree = [
         { id: 'home', text: 'Home', url: '/' },
@@ -202,8 +200,10 @@ describe('useSyncStarredItemsInNav', () => {
       ];
     });
 
-    afterEach(() => {
-      setTestFlags({});
+    afterEach(async () => {
+      await act(async () => {
+        setTestFlags({});
+      });
     });
 
     it('syncs both a starred dashboard and folder, each with its per-kind icon', async () => {
@@ -329,8 +329,8 @@ describe('useSyncStarredItemsInNav', () => {
 });
 
 describe('useStarItem', () => {
-  // The folder gates (grafana.starredFolders flag, foldersAppPlatformAPI) stay off, so kind Folder
-  // must never surface in the nav Starred section.
+  // grafana.starredFolders stays off, so starredFoldersEnabled() is false and kind Folder must
+  // never surface in the nav Starred section.
   describe('with starred folders disabled', () => {
     beforeEach(() => {
       // Provide a starred section in the nav tree so the reducer has a target
@@ -361,10 +361,8 @@ describe('useStarItem', () => {
 
   // Folder gates on: a successful star would land in the nav, so a rejected one must not.
   describe('with starred folders enabled', () => {
-    testWithFeatureToggles({ enable: ['foldersAppPlatformAPI'] });
-
     beforeEach(() => {
-      setTestFlags({ 'grafana.starredFolders': true });
+      setTestFlags({ 'grafana.starredFolders': true, foldersAppPlatformAPI: true });
       // Provide a starred section in the nav tree so the reducer has a target
       config.bootData.navTree = [
         { id: 'home', text: 'Home', url: '/' },
@@ -372,8 +370,10 @@ describe('useStarItem', () => {
       ];
     });
 
-    afterEach(() => {
-      setTestFlags({});
+    afterEach(async () => {
+      await act(async () => {
+        setTestFlags({});
+      });
     });
 
     it('leaves the nav starred section untouched when the server rejects the star', async () => {

--- a/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
+++ b/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
@@ -48,6 +48,8 @@ describe('useCreateTeamOrchestrate', () => {
 
     // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy folder
     // handlers, so pin it off and let the app-platform cases opt in.
+    // TODO: add app platform folder fixtures and drop this pin, so these tests cover the API
+    // that production actually uses.
     setTestFlags({ foldersAppPlatformAPI: false });
 
     contextSrv.fetchUserPermissions = jest.fn().mockResolvedValue(undefined);

--- a/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
+++ b/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
@@ -3,13 +3,14 @@ import { delay, HttpResponse } from 'msw';
 import useMountedState from 'react-use/lib/useMountedState';
 
 import { AppEvents } from '@grafana/data';
-import { config, getAppEvents, setBackendSrv } from '@grafana/runtime';
+import { getAppEvents, setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import {
   customCreateFolderHandler,
   customCreateFolderHandlerAppPlatform,
   customCreateTeamHandler,
   customSetTeamRolesHandler,
+  setTestFlags,
 } from '@grafana/test-utils/unstable';
 
 import { getWrapper } from '../../../../test/test-utils';
@@ -45,9 +46,20 @@ describe('useCreateTeamOrchestrate', () => {
     mockUseMountedState.mockReturnValue(() => true);
     mockGetAppEvents.mockReturnValue({ publish: mockPublish } as never);
 
+    // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy folder
+    // handlers, so pin it off and let the app-platform cases opt in.
+    setTestFlags({ foldersAppPlatformAPI: false });
+
     contextSrv.fetchUserPermissions = jest.fn().mockResolvedValue(undefined);
     contextSrv.licensedAccessControlEnabled = () => false;
     contextSrv.hasPermission = () => true;
+  });
+
+  // The act wrap is needed because resetting fires OpenFeature events while the hook is mounted.
+  afterEach(async () => {
+    await act(async () => {
+      setTestFlags({});
+    });
   });
 
   it('returns undefined statuses before trigger is called', () => {
@@ -279,7 +291,7 @@ describe('useCreateTeamOrchestrate', () => {
     });
 
     it('reports error when the app platform folder API returns an error response', async () => {
-      config.featureToggles.foldersAppPlatformAPI = true;
+      setTestFlags({ foldersAppPlatformAPI: true });
       server.use(
         customCreateFolderHandlerAppPlatform(() =>
           HttpResponse.json({ message: 'Internal server error' }, { status: 500 })
@@ -293,7 +305,6 @@ describe('useCreateTeamOrchestrate', () => {
       });
 
       expect(result.current.folderCreationStatus?.state).toBe('error');
-      config.featureToggles.foldersAppPlatformAPI = false;
     });
 
     it('skips folder creation when autocreateTeamFolder is false', async () => {

--- a/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
+++ b/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
@@ -46,10 +46,6 @@ describe('useCreateTeamOrchestrate', () => {
     mockUseMountedState.mockReturnValue(() => true);
     mockGetAppEvents.mockReturnValue({ publish: mockPublish } as never);
 
-    // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy folder
-    // handlers, so pin it off and let the app-platform cases opt in.
-    setTestFlags({ foldersAppPlatformAPI: false });
-
     contextSrv.fetchUserPermissions = jest.fn().mockResolvedValue(undefined);
     contextSrv.licensedAccessControlEnabled = () => false;
     contextSrv.hasPermission = () => true;

--- a/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
+++ b/public/app/features/teams/create-team/CreateTeamAPICalls.test.tsx
@@ -46,6 +46,10 @@ describe('useCreateTeamOrchestrate', () => {
     mockUseMountedState.mockReturnValue(() => true);
     mockGetAppEvents.mockReturnValue({ publish: mockPublish } as never);
 
+    // foldersAppPlatformAPI defaults to on, but these tests assert against the legacy folder
+    // handlers, so pin it off and let the app-platform cases opt in.
+    setTestFlags({ foldersAppPlatformAPI: false });
+
     contextSrv.fetchUserPermissions = jest.fn().mockResolvedValue(undefined);
     contextSrv.licensedAccessControlEnabled = () => false;
     contextSrv.hasPermission = () => true;


### PR DESCRIPTION
**What is this feature?**

Moves every read of `foldersAppPlatformAPI` from `config.featureToggles` over to OpenFeature, and the affected tests onto `setTestFlags`.

Kept `LegacyFrontend` alongside `React` (same as `useKubernetesShortURLsAPI`)

**Why do we need this feature?**

So we're off the legacy toggle. Also `config.featureToggles` is empty in the fully MT instance and this flag is important for a lot of that behaviour, so want to have it "on" properly in that env

**Who is this feature for?**

UI devs.
