### PR TITLE
Inpsect: Table bg color should be transparent for viz refresh

### DIFF
--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -313,7 +313,13 @@ export class InspectDataTab extends PureComponent<Props, State> {
                 // so it needs an explicitly-sized wrapper here (unlike the legacy Table).
                 return (
                   <div style={{ width, height }}>
-                    <TableNG width={width} height={height} data={dataFrame} showTypeIcons={true} />
+                    <TableNG
+                      width={width}
+                      height={height}
+                      data={dataFrame}
+                      showTypeIcons={true}
+                      transparent={config.theme2.flags.visualDesignRefresh}
+                    />
                   </div>
                 );
               }


### PR DESCRIPTION
Noticed that the bg color was wrong for the TableNG-based Inspect view in the refresh flag. The non-refresh flag was fine already.

### Before

#### Refresh disabled

https://github.com/user-attachments/assets/c8ac0b7f-875b-42de-a66a-c608db9bc9fc

#### Refresh enabled

**this was the error case. notice the off background color in the table.**

https://github.com/user-attachments/assets/02b3b6ad-dbd8-4367-b9e9-c3d811c0fa7d

### After

#### Refresh disabled

_No change_.

#### Refresh enabled

https://github.com/user-attachments/assets/2ab7c6c1-2d86-4443-bb99-fc54c53e05b2