### PR TITLE
Dashboard: Replace static spinner with LoadingBar in panel options pane

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelEditorRendererNext.tsx
@@ -1,10 +1,11 @@
 import { css, cx } from '@emotion/css';
+import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { type SceneComponentProps } from '@grafana/scenes';
-import { Spinner, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { LoadingBar, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { LibraryPanelEditModals } from '../LibraryPanelEditModals';
 import { type PanelEditor } from '../PanelEditor';
@@ -18,6 +19,7 @@ export function PanelEditorRendererNext({ model }: SceneComponentProps<PanelEdit
   const { containerProps, primaryProps, secondaryProps, splitterProps, splitterState, onToggleCollapse } = splitter;
 
   const styles = useStyles2(getWrapperStyles);
+  const [optionsPaneRef, { width: optionsPaneWidth }] = useMeasure<HTMLDivElement>();
 
   return (
     <div className={styles.container} data-testid={selectors.components.PanelEditor.General.content}>
@@ -30,6 +32,9 @@ export function PanelEditorRendererNext({ model }: SceneComponentProps<PanelEdit
           </div>
           <div {...splitterProps} />
           <div {...secondaryProps} className={cx(secondaryProps.className, styles.optionsPane)}>
+            <div ref={optionsPaneRef} className={styles.loadingBarContainer}>
+              {!splitterState.collapsed && !optionsPane && <LoadingBar width={optionsPaneWidth} />}
+            </div>
             {splitterState.collapsed && (
               <div className={styles.expandOptionsWrapper}>
                 <ToolbarButton
@@ -46,7 +51,6 @@ export function PanelEditorRendererNext({ model }: SceneComponentProps<PanelEdit
               </div>
             )}
             {!splitterState.collapsed && optionsPane && <optionsPane.Component model={optionsPane} />}
-            {!splitterState.collapsed && !optionsPane && <Spinner />}
           </div>
         </div>
       </div>
@@ -99,11 +103,19 @@ function getWrapperStyles(theme: GrafanaTheme2) {
       minHeight: 0,
     }),
     optionsPane: css({
+      position: 'relative',
       flexDirection: 'column',
       borderLeft: `1px solid ${theme.colors.border.weak}`,
       background: theme.colors.background.primary,
       borderTop: `1px solid ${theme.colors.border.weak}`,
       borderTopLeftRadius: theme.shape.radius.default,
+    }),
+    loadingBarContainer: css({
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      overflow: 'hidden',
     }),
     expandOptionsWrapper: css({
       display: 'flex',

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditorRenderer.tsx
@@ -1,12 +1,13 @@
 import { css, cx } from '@emotion/css';
 import { useEffect, useMemo } from 'react';
+import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { useFlagGrafanaVisualDesignRefresh } from '@grafana/runtime/internal';
 import { type SceneComponentProps } from '@grafana/scenes';
-import { Button, Spinner, ToolbarButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, LoadingBar, ToolbarButton, useStyles2, useTheme2 } from '@grafana/ui';
 import { MIN_SUGGESTIONS_PANE_WIDTH } from 'app/features/panel/suggestions/constants';
 
 import { useSidebarCollapsed } from '../sidebar/shared';
@@ -30,6 +31,7 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
   const [isInitiallyCollapsed, setIsCollapsed] = useSidebarCollapsed();
 
   const isScrollingLayout = useScrollReflowLimit();
+  const [optionsPaneRef, { width: optionsPaneWidth }] = useMeasure<HTMLDivElement>();
 
   const theme = useTheme2();
   const panePadding = useMemo(() => +theme.spacing(2).replace(/px$/, ''), [theme]);
@@ -57,6 +59,9 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
         </div>
         <div {...splitterProps} />
         <div {...secondaryProps} className={cx(secondaryProps.className, styles.optionsPane)}>
+          <div ref={optionsPaneRef} className={styles.loadingBarContainer}>
+            {!splitterState.collapsed && !optionsPane && <LoadingBar width={optionsPaneWidth} />}
+          </div>
           {splitterState.collapsed && (
             <div className={styles.expandOptionsWrapper}>
               <ToolbarButton
@@ -73,7 +78,6 @@ export function PanelEditorRenderer({ model }: SceneComponentProps<PanelEditor>)
             </div>
           )}
           {!splitterState.collapsed && optionsPane && <optionsPane.Component model={optionsPane} />}
-          {!splitterState.collapsed && !optionsPane && <Spinner />}
         </div>
       </div>
     </div>
@@ -186,6 +190,7 @@ function getStyles(theme: GrafanaTheme2, visualRefreshEnabled: boolean) {
     }),
     optionsPane: css(
       {
+        position: 'relative',
         flexDirection: 'column',
         borderLeft: `1px solid ${theme.colors.border.weak}`,
         background: theme.colors.background.primary,
@@ -196,6 +201,13 @@ function getStyles(theme: GrafanaTheme2, visualRefreshEnabled: boolean) {
         borderBottomRightRadius: theme.shape.radius.lg,
       }
     ),
+    loadingBarContainer: css({
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      overflow: 'hidden',
+    }),
     expandOptionsWrapper: css({
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
## What is this feature?

The panel options pane (right side of Panel Edit) briefly shows a spinner while the options pane scene is initializing. That spinner was misaligned and not animating. This replaces it with the standard `LoadingBar` component (https://developers.grafana.com/ui/latest/index.html?path=/docs/information-loadingbar--docs) pinned to the top of the pane, matching the pattern already used in `PanelChrome`.

Applied to both the v1 (`PanelEditorRenderer`) and v2 (`PanelEditorRendererNext`) panel editors, since they share the same scene.

## Who is this feature for?

Anyone using Panel Edit.

### Before

https://github.com/user-attachments/assets/579cb65c-8dec-44a4-96dc-a6f73abaab83

### After

https://github.com/user-attachments/assets/4deeb18e-0880-42d5-91bd-d55a1700b207

🤖 Generated with [Claude Code](https://claude.com/claude-code)