### PR TITLE
unified-storage: update Decode to properly handle error

### DIFF
--- a/pkg/storage/unified/apistore/stream.go
+++ b/pkg/storage/unified/apistore/stream.go
@@ -63,23 +63,13 @@ func (d *streamDecoder) Decode() (action watch.EventType, object runtime.Object,
 	defer d.done.Done()
 decode:
 	for {
-		var evt *resourcepb.WatchEvent
-		var err error
-		select {
-		case <-d.client.Context().Done():
-		default:
-			evt, err = d.client.Recv()
-		}
+		// gRPC cancels the stream context for all terminal statuses, not just
+		// caller cancellation. Read the actual status from Recv instead.
+		evt, err := d.client.Recv()
 
 		switch {
-		case errors.Is(d.client.Context().Err(), context.Canceled):
+		case errors.Is(err, io.EOF), errors.Is(err, context.Canceled), grpcStatus.Code(err) == grpcCodes.Canceled:
 			return watch.Error, nil, io.EOF
-		case d.client.Context().Err() != nil:
-			return watch.Error, nil, d.client.Context().Err()
-		case errors.Is(err, io.EOF):
-			return watch.Error, nil, io.EOF
-		case grpcStatus.Code(err) == grpcCodes.Canceled:
-			return watch.Error, nil, err
 		case resource.IsResourceVersionExpired(err):
 			// Surface a 410/Expired status object (instead of an error) so clients
 			// such as reflectors re-list from scratch rather than retrying the

--- a/pkg/storage/unified/apistore/stream_test.go
+++ b/pkg/storage/unified/apistore/stream_test.go
@@ -3,12 +3,18 @@ package apistore
 import (
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -127,39 +133,124 @@ func TestStreamDecoderBookmarkAnnotation(t *testing.T) {
 	})
 }
 
-// errWatchClient implements resourcepb.ResourceStore_WatchClient and always
-// fails Recv with the same error, like a terminated gRPC stream does.
-type errWatchClient struct {
-	grpc.ClientStream
-	ctx context.Context
-	err error
+type streamDecoderTestServer struct {
+	resourcepb.UnimplementedResourceStoreServer
+	watch func(resourcepb.ResourceStore_WatchServer) error
 }
 
-func (m *errWatchClient) Recv() (*resourcepb.WatchEvent, error) { return nil, m.err }
-func (m *errWatchClient) Context() context.Context              { return m.ctx }
-func (m *errWatchClient) Header() (metadata.MD, error)          { return nil, nil }
-func (m *errWatchClient) Trailer() metadata.MD                  { return nil }
-func (m *errWatchClient) CloseSend() error                      { return nil }
-func (m *errWatchClient) SendMsg(any) error                     { return nil }
-func (m *errWatchClient) RecvMsg(any) error                     { return nil }
+func (s *streamDecoderTestServer) Watch(_ *resourcepb.WatchRequest, stream resourcepb.ResourceStore_WatchServer) error {
+	return s.watch(stream)
+}
+
+func newStreamDecoderGRPCClient(t *testing.T, handler func(resourcepb.ResourceStore_WatchServer) error) (resourcepb.ResourceStore_WatchClient, context.CancelFunc) {
+	t.Helper()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	resourcepb.RegisterResourceStoreServer(server, &streamDecoderTestServer{watch: handler})
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		require.NoError(t, <-serveErr)
+	})
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	t.Cleanup(cancel)
+	client, err := resourcepb.NewResourceStoreClient(conn).Watch(ctx, &resourcepb.WatchRequest{})
+	require.NoError(t, err)
+	return client, cancel
+}
 
 func TestStreamDecoderExpiredResourceVersion(t *testing.T) {
 	newFunc := func() runtime.Object { return &unstructured.Unstructured{} }
-	client := &errWatchClient{ctx: t.Context(), err: resource.NewResourceVersionExpiredError(1234)}
-	decoder := newStreamDecoder(client, newFunc, storage.Everything, unstructuredCodec(), func() {}, false)
+	client, cancel := newStreamDecoderGRPCClient(t, func(resourcepb.ResourceStore_WatchServer) error {
+		return resource.NewResourceVersionExpiredError(1234)
+	})
+	decoder := newStreamDecoder(client, newFunc, storage.Everything, unstructuredCodec(), cancel, false)
+	t.Cleanup(decoder.Close)
 
-	// The expired resource version is reported as a 410/Expired status object so
-	// that clients (e.g. reflectors) re-list from scratch.
+	// Real gRPC cancels the stream context when Recv returns a terminal error.
+	// That cancellation must not hide the 410 status from the watch client.
 	action, obj, err := decoder.Decode()
 	require.NoError(t, err)
 	require.Equal(t, watch.Error, action)
+	require.ErrorIs(t, client.Context().Err(), context.Canceled)
 	status, ok := obj.(*metav1.Status)
 	require.True(t, ok, "expected a metav1.Status, got %T", obj)
 	require.Equal(t, int32(http.StatusGone), status.Code)
 	require.Equal(t, metav1.StatusReasonExpired, status.Reason)
 	require.True(t, apierrors.IsResourceExpired(apierrors.FromObject(status)))
 
-	// The stream is done: the same error must not be reported again.
 	_, _, err = decoder.Decode()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestStreamDecoderGRPCTermination(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		eof  bool
+	}{
+		{name: "clean close", eof: true},
+		{name: "canceled", err: status.Error(codes.Canceled, "watch canceled"), eof: true},
+		{name: "deadline exceeded", err: status.Error(codes.DeadlineExceeded, "watch deadline exceeded")},
+		{name: "unavailable", err: status.Error(codes.Unavailable, "storage unavailable")},
+		{name: "permission denied", err: status.Error(codes.PermissionDenied, "watch denied")},
+		{name: "internal", err: status.Error(codes.Internal, "storage error")},
+		{name: "out of range without expiry details", err: status.Error(codes.OutOfRange, "invalid range")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, cancel := newStreamDecoderGRPCClient(t, func(stream resourcepb.ResourceStore_WatchServer) error {
+				if err := stream.Send(&resourcepb.WatchEvent{
+					Type:     resourcepb.WatchEvent_BOOKMARK,
+					Resource: &resourcepb.WatchEvent_Resource{Version: 10},
+				}); err != nil {
+					return err
+				}
+				return tc.err
+			})
+			decoder := newStreamDecoder(client, func() runtime.Object { return &unstructured.Unstructured{} }, storage.Everything, unstructuredCodec(), cancel, false)
+			t.Cleanup(decoder.Close)
+
+			action, obj, err := decoder.Decode()
+			require.NoError(t, err)
+			require.Equal(t, watch.Bookmark, action)
+			require.Equal(t, "10", obj.(*unstructured.Unstructured).GetResourceVersion())
+
+			action, obj, err = decoder.Decode()
+			require.Equal(t, watch.Error, action)
+			require.Nil(t, obj)
+			require.ErrorIs(t, client.Context().Err(), context.Canceled)
+			if tc.eof {
+				require.ErrorIs(t, err, io.EOF)
+			} else {
+				require.EqualError(t, err, tc.err.Error())
+			}
+		})
+	}
+}
+
+func TestStreamDecoderCallerCancellation(t *testing.T) {
+	client, cancel := newStreamDecoderGRPCClient(t, func(stream resourcepb.ResourceStore_WatchServer) error {
+		<-stream.Context().Done()
+		return status.FromContextError(stream.Context().Err()).Err()
+	})
+	decoder := newStreamDecoder(client, func() runtime.Object { return &unstructured.Unstructured{} }, storage.Everything, unstructuredCodec(), cancel, false)
+	t.Cleanup(decoder.Close)
+
+	cancel()
+	action, obj, err := decoder.Decode()
+	require.Equal(t, watch.Error, action)
+	require.Nil(t, obj)
 	require.ErrorIs(t, err, io.EOF)
 }


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/130585 introduced a branch to handle `410 Gone` error when the resource version has expired. However the branch never hits because of the context cancellation check a few lines above.

We should simply interpret the check from `Recv` instead. Otherwise that lines swallows every error.