### PR TITLE
Canvas: Fix MT plugins core API to filter `as_external` instead of falling back to core Canvas when external Canvas should load

### DIFF
--- a/apps/plugins/pkg/app/meta/core.go
+++ b/apps/plugins/pkg/app/meta/core.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/pluginassets"
 	"github.com/grafana/grafana/pkg/plugins/pluginerrs"
 	"github.com/grafana/grafana/pkg/plugins/pluginscdn"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pipeline"
 )
 
 const (
@@ -48,6 +49,9 @@ type CoreProviderOpts struct {
 	// so that the frontend can prepend a CDN domain. Set to true when running in
 	// standalone (MT apiserver) mode.
 	CDNAssets bool
+	// PluginSettings mirrors setting.Cfg.PluginSettings so core plugins marked
+	// [plugin.<id>] as_external = true are skipped during discovery.
+	PluginSettings config.PluginSettings
 }
 
 // NewCoreProvider creates a new CoreProvider for core plugins.
@@ -58,15 +62,21 @@ func NewCoreProvider(logger logging.Logger, opts CoreProviderOpts) (*CoreProvide
 		return nil, err
 	}
 
-	return NewCoreProviderWithTTL(logger, staticRootPath, opts.CDNAssets, defaultCoreTTL), nil
+	return NewCoreProviderWithTTLAndSettings(logger, staticRootPath, opts.CDNAssets, defaultCoreTTL, opts.PluginSettings), nil
 }
 
 // NewCoreProviderWithTTL creates a new CoreProvider with a custom TTL.
 func NewCoreProviderWithTTL(logger logging.Logger, staticRootPath string, cdnAssets bool, ttl time.Duration) *CoreProvider {
+	return NewCoreProviderWithTTLAndSettings(logger, staticRootPath, cdnAssets, ttl, nil)
+}
+
+// NewCoreProviderWithTTLAndSettings creates a new CoreProvider that honors
+// [plugin.<id>] as_external = true from the provided PluginSettings.
+func NewCoreProviderWithTTLAndSettings(logger logging.Logger, staticRootPath string, cdnAssets bool, ttl time.Duration, pluginSettings config.PluginSettings) *CoreProvider {
 	return &CoreProvider{
 		loadedPlugins:  make(map[string]pluginsv0alpha1.MetaSpec),
 		ttl:            ttl,
-		loader:         createLoader(cdnAssets, staticRootPath),
+		loader:         createLoader(cdnAssets, staticRootPath, pluginSettings),
 		staticRootPath: staticRootPath,
 		logger:         logger,
 	}
@@ -152,11 +162,13 @@ func (p *CoreProvider) loadPlugins(ctx context.Context) error {
 }
 
 // createLoader creates a loader service configured for core plugins.
-func createLoader(cdnAssets bool, staticRootPath string) pluginsLoader.Service {
-	cfg := &config.PluginManagementCfg{}
+func createLoader(cdnAssets bool, staticRootPath string, pluginSettings config.PluginSettings) pluginsLoader.Service {
+	cfg := &config.PluginManagementCfg{PluginSettings: pluginSettings}
 	d := discovery.New(cfg, discovery.Opts{
 		FilterFuncs: []discovery.FilterFunc{
-			// Allow all plugin types for core plugins
+			func(_ context.Context, c plugins.Class, b []*plugins.FoundBundle) ([]*plugins.FoundBundle, error) {
+				return pipeline.NewAsExternalStep(cfg).Filter(c, b)
+			},
 		},
 	})
 	b := bootstrap.New(cfg, bootstrap.Opts{

--- a/apps/plugins/pkg/app/meta/core_test.go
+++ b/apps/plugins/pkg/app/meta/core_test.go
@@ -172,6 +172,22 @@ func TestCoreProvider_loadPlugins(t *testing.T) {
 		assert.Empty(t, provider.loadedPlugins)
 	})
 
+	t.Run("skips core plugin when as_external is true", func(t *testing.T) {
+		// Otherwise the metas endpoint keeps returning the core meta and the frontend
+		// loads the built-in chunk instead of the externalized plugin.
+		staticRootPath := filepath.Join(t.TempDir(), "public")
+		canvasDir := filepath.Join(staticRootPath, "app", "plugins", "panel", "canvas")
+		require.NoError(t, os.MkdirAll(canvasDir, 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(canvasDir, "plugin.json"), []byte(`{"id":"canvas","name":"Canvas","type":"panel","info":{"version":""}}`), 0644))
+
+		provider := NewCoreProviderWithTTLAndSettings(&logging.NoOpLogger{}, staticRootPath, false, defaultCoreTTL, map[string]map[string]string{"canvas": {"as_external": "true"}})
+		require.NoError(t, provider.loadPlugins(ctx))
+		result, err := provider.GetMeta(ctx, PluginRef{ID: "canvas"})
+
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrMetaNotFound)
+	})
+
 	t.Run("returns no error when no plugins found", func(t *testing.T) {
 		tempDir := t.TempDir()
 		staticRootPath := filepath.Join(tempDir, "public")

--- a/pkg/registry/apps/plugins/register.go
+++ b/pkg/registry/apps/plugins/register.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/apps/plugins/pkg/app/meta"
 	"github.com/grafana/grafana/apps/plugins/pkg/app/metrics"
 	"github.com/grafana/grafana/pkg/configprovider"
+	"github.com/grafana/grafana/pkg/plugins/config"
 	"github.com/grafana/grafana/pkg/plugins/pluginassets/modulehash"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver"
@@ -61,6 +62,7 @@ func ProvideAppInstaller(
 		StaticRootPath: func() (string, error) {
 			return getStaticRootPath(cfgProvider, logger)
 		},
+		PluginSettings: pluginSettingsFromProvider(cfgProvider, logger),
 	})
 	if err != nil {
 		return nil, err
@@ -85,6 +87,15 @@ func ProvideAppInstaller(
 		restConfigProvider: restConfigProvider,
 		PluginAppInstaller: i,
 	}, nil
+}
+
+func pluginSettingsFromProvider(cfgProvider configprovider.ConfigProvider, logger logging.Logger) config.PluginSettings {
+	cfg, err := cfgProvider.Get(context.Background())
+	if err != nil {
+		logger.Warn("Could not load plugin settings; as_external will not be honored by core meta discovery", "error", err)
+		return nil
+	}
+	return cfg.PluginSettings
 }
 
 func getStaticRootPath(cfgProvider configprovider.ConfigProvider, logger logging.Logger) (string, error) {


### PR DESCRIPTION
**What is this feature?**

This change adds logic to the new MT plugin meta API to filter on `as_external` so that plugin loading doesn't incorrectly load the core plugin instead of the externalized one when `as_external` is set in config.ini AND `plugins.useMTPlugins` feature flag is enabled.

**Why do we need this feature?**

For externalizing the core Canvas plugin _(among others)_ in a way that's compatible with the MT plugin API.

**Who is this feature for?**

Ultimately all users of Grafana, for now, only one targeted instance in the `dev` environment.

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/grafana/issues/132135

**Special notes for your reviewer:**

🎚️ The levers to flip for this are:
1. In config.ini configure `[plugin.canvas] as_external = true`
2. Also set the `plugins.useMTPlugins` feature flag to `true`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
