### PR TITLE
Chore: Modernize errors as type

### DIFF
--- a/apps/advisor/pkg/app/metrics/metrics.go
+++ b/apps/advisor/pkg/app/metrics/metrics.go
@@ -130,8 +130,7 @@ func MustRegister(registerer prometheus.Registerer) {
 	}
 	for _, metric := range metricsToRegister {
 		if err := registerer.Register(metric); err != nil {
-			var alreadyRegistered prometheus.AlreadyRegisteredError
-			if errors.As(err, &alreadyRegistered) {
+			if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 				continue
 			}
 			panic(err)

--- a/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
@@ -458,8 +458,7 @@ func checkConversionDataLoss(sourceVersionAPI, targetVersionAPI string, a, b int
 
 	// If data loss was detected, update the error with API versions
 	if err != nil {
-		var dataLossErr *ConversionDataLossError
-		if errors.As(err, &dataLossErr) {
+		if dataLossErr, ok := errors.AsType[*ConversionDataLossError](err); ok {
 			dataLossErr.sourceAPIVersion = sourceVersionAPI
 			dataLossErr.targetAPIVersion = targetVersionAPI
 		}

--- a/apps/dashboard/pkg/migration/conversion/metrics.go
+++ b/apps/dashboard/pkg/migration/conversion/metrics.go
@@ -31,8 +31,7 @@ func getLogger() logging.Logger {
 
 // getErroredSchemaVersionFunc determines the schema version function that errored
 func getErroredSchemaVersionFunc(err error) string {
-	var migrationErr *schemaversion.MigrationError
-	if errors.As(err, &migrationErr) {
+	if migrationErr, ok := errors.AsType[*schemaversion.MigrationError](err); ok {
 		return migrationErr.GetFunctionName()
 	}
 	return ""
@@ -40,18 +39,15 @@ func getErroredSchemaVersionFunc(err error) string {
 
 // getErroredConversionFunc determines the conversion function that errored
 func getErroredConversionFunc(err error) string {
-	var conversionErr *ConversionError
-	if errors.As(err, &conversionErr) {
+	if conversionErr, ok := errors.AsType[*ConversionError](err); ok {
 		return conversionErr.GetFunctionName()
 	}
 
-	var migrationErr *schemaversion.MigrationError
-	if errors.As(err, &migrationErr) {
+	if migrationErr, ok := errors.AsType[*schemaversion.MigrationError](err); ok {
 		return migrationErr.GetFunctionName()
 	}
 
-	var dataLossErr *ConversionDataLossError
-	if errors.As(err, &dataLossErr) {
+	if dataLossErr, ok := errors.AsType[*ConversionDataLossError](err); ok {
 		return dataLossErr.GetFunctionName()
 	}
 

--- a/apps/dashvalidator/pkg/validator/errors.go
+++ b/apps/dashvalidator/pkg/validator/errors.go
@@ -159,8 +159,7 @@ func IsValidationError(err error) bool {
 
 // GetValidationError extracts a ValidationError from an error chain
 func GetValidationError(err error) *ValidationError {
-	var validationErr *ValidationError
-	if errors.As(err, &validationErr) {
+	if validationErr, ok := errors.AsType[*ValidationError](err); ok {
 		return validationErr
 	}
 	return nil

--- a/apps/plugins/pkg/app/metrics/metrics.go
+++ b/apps/plugins/pkg/app/metrics/metrics.go
@@ -102,8 +102,7 @@ func MustRegister(registerer prometheus.Registerer) {
 
 	for _, metric := range metricsToRegister {
 		if err := registerer.Register(metric); err != nil {
-			var alreadyRegistered prometheus.AlreadyRegisteredError
-			if errors.As(err, &alreadyRegistered) {
+			if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 				continue
 			}
 			panic(err)

--- a/apps/provisioning/pkg/connection/github/client.go
+++ b/apps/provisioning/pkg/connection/github/client.go
@@ -236,8 +236,7 @@ func (r *githubClient) CreateInstallationAccessToken(ctx context.Context, instal
 
 	token, _, err := r.gh.Apps.CreateInstallationToken(ctx, int64(id), opts)
 	if err != nil {
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) {
+		if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok {
 			switch ghErr.Response.StatusCode {
 			case http.StatusServiceUnavailable:
 				return InstallationToken{}, ErrServiceUnavailable

--- a/apps/provisioning/pkg/repository/github/impl.go
+++ b/apps/provisioning/pkg/repository/github/impl.go
@@ -136,8 +136,7 @@ func (r *githubClient) GetBranchProtection(ctx context.Context, branch string) (
 		}
 
 		// Return custom errors for common cases
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) {
+		if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok {
 			switch ghErr.Response.StatusCode {
 			case http.StatusUnauthorized:
 				return nil, repo.ErrUnauthorized
@@ -180,8 +179,7 @@ func (r *githubClient) GetRulesets(ctx context.Context, branch string) (*Ruleset
 	branchRules, _, err := r.gh.Repositories.GetRulesForBranch(ctx, r.owner, r.repo, branch, nil)
 	if err != nil {
 		// Handle common error cases
-		var ghErr *github.ErrorResponse
-		if errors.As(err, &ghErr) {
+		if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok {
 			switch ghErr.Response.StatusCode {
 			case http.StatusUnauthorized:
 				return nil, repo.ErrUnauthorized

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -597,8 +597,7 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
-				var statusErr *apierrors.StatusError
-				if errors.As(tt.expectedError, &statusErr) {
+				if statusErr, ok := errors.AsType[*apierrors.StatusError](tt.expectedError); ok {
 					var actualStatusErr *apierrors.StatusError
 					require.True(t, errors.As(err, &actualStatusErr))
 					require.Equal(t, statusErr.Status().Code, actualStatusErr.Status().Code)

--- a/pkg/api/apierrors/dashboard.go
+++ b/pkg/api/apierrors/dashboard.go
@@ -21,8 +21,7 @@ import (
 // ToDashboardErrorResponse returns a different response status according to the dashboard error type
 func ToDashboardErrorResponse(ctx context.Context, pluginStore pluginstore.Store, err error) response.Response {
 	// --- Dashboard errors ---
-	var dashboardErr dashboardaccess.DashboardErr
-	if errors.As(err, &dashboardErr) {
+	if dashboardErr, ok := errors.AsType[dashboardaccess.DashboardErr](err); ok {
 		if body := dashboardErr.Body(); body != nil {
 			return response.JSON(dashboardErr.StatusCode, body)
 		}
@@ -38,8 +37,7 @@ func ToDashboardErrorResponse(ctx context.Context, pluginStore pluginstore.Store
 		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 
-	var pluginErr dashboards.UpdatePluginDashboardError
-	if errors.As(err, &pluginErr) {
+	if pluginErr, ok := errors.AsType[dashboards.UpdatePluginDashboardError](err); ok {
 		message := fmt.Sprintf("The dashboard belongs to plugin %s.", pluginErr.PluginId)
 		// look up plugin name
 		if plugin, exists := pluginStore.Plugin(ctx, pluginErr.PluginId); exists {

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -36,8 +36,7 @@ func ToFolderErrorResponse(err error) response.Response {
 	var dashboardErr dashboardaccess.DashboardErr
 	if ok := errors.As(err, &dashboardErr); ok {
 		msg := err.Error()
-		var grafanaErr errutil.Error
-		if errors.As(err, &grafanaErr) {
+		if _, ok := errors.AsType[errutil.Error](err); ok {
 			for _, s := range stableDashboardErrSentinels {
 				if errors.Is(err, s) {
 					msg = s.Error()
@@ -53,8 +52,7 @@ func ToFolderErrorResponse(err error) response.Response {
 		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
 		errors.Is(err, folder.ErrMaximumDepthReached) ||
 		errors.Is(err, folder.ErrInvalidUID) {
-		var grafanaErr errutil.Error
-		if errors.As(err, &grafanaErr) {
+		if _, ok := errors.AsType[errutil.Error](err); ok {
 			for _, s := range stableFolderErrSentinels {
 				if errors.Is(err, s) {
 					return response.Error(http.StatusBadRequest, s.Error(), nil)
@@ -87,8 +85,7 @@ func ToFolderErrorResponse(err error) response.Response {
 	}
 
 	// --- Kubernetes status errors ---
-	var statusErr *k8sErrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*k8sErrors.StatusError](err); ok {
 		message := statusErr.ErrStatus.Message
 		if message == "" {
 			message = getDefaultMessageForStatus(int(statusErr.ErrStatus.Code))
@@ -140,8 +137,7 @@ func ToFolderStatusError(err error) k8sErrors.StatusError {
 	// can match the rejection without relying on the human-readable message.
 	// errutil.Error.Status() is the source of truth for the message ID; if
 	// the underlying error is one, copy its Details across.
-	var grafanaErr errutil.Error
-	if errors.As(err, &grafanaErr) {
+	if grafanaErr, ok := errors.AsType[errutil.Error](err); ok {
 		if details := grafanaErr.Status().Details; details != nil {
 			statusErr.ErrStatus.Details = details
 		}

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -1049,8 +1049,7 @@ func dashboardErrResponse(err error, fallbackMessage string) response.Response {
 		return response.Error(dashboardErr.StatusCode, dashboardErr.Error(), err)
 	}
 
-	var statusErr *k8serrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*k8serrors.StatusError](err); ok {
 		return response.Error(int(statusErr.ErrStatus.Code), statusErr.ErrStatus.Message, err)
 	}
 

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -95,8 +95,7 @@ func (hs *HTTPServer) CookieOptionsFromCfg() cookies.CookieOptions {
 }
 
 func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
-	var tokenRotationErr authn.TokenNeedsRotationError
-	if errors.As(c.LookupTokenErr, &tokenRotationErr) {
+	if _, ok := errors.AsType[authn.TokenNeedsRotationError](c.LookupTokenErr); ok {
 		c.Redirect(hs.Cfg.AppSubURL + "/")
 		return
 	}
@@ -403,8 +402,7 @@ func (hs *HTTPServer) samlAllowAssignGrafanaAdminEnabled(ctx context.Context) bo
 }
 
 func getLoginExternalError(err error) string {
-	var createTokenErr *auth.CreateTokenErr
-	if errors.As(err, &createTokenErr) {
+	if createTokenErr, ok := errors.AsType[*auth.CreateTokenErr](err); ok {
 		return createTokenErr.ExternalErr
 	}
 

--- a/pkg/api/plugin_dashboards.go
+++ b/pkg/api/plugin_dashboards.go
@@ -23,8 +23,7 @@ func (hs *HTTPServer) GetPluginDashboards(c *contextmodel.ReqContext) response.R
 	}
 	list, err := hs.pluginDashboardService.ListPluginDashboards(c.Req.Context(), listReq)
 	if err != nil {
-		var notFound plugins.NotFoundError
-		if errors.As(err, &notFound) {
+		if notFound, ok := errors.AsType[plugins.NotFoundError](err); ok {
 			return response.Error(http.StatusNotFound, notFound.Error(), nil)
 		}
 

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -118,8 +118,7 @@ func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http
 }
 
 func handleCallResourceError(err error, reqCtx *contextmodel.ReqContext) {
-	var maxBytesErr *http.MaxBytesError
-	if errors.As(err, &maxBytesErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 		resp := response.Error(http.StatusRequestEntityTooLarge, "Request body too large", err)
 		resp.WriteTo(reqCtx)
 		return

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -303,8 +303,7 @@ func (hs *HTTPServer) GetPluginMarkdown(c *contextmodel.ReqContext) response.Res
 
 	content, err := hs.pluginMarkdown(c.Req.Context(), pluginID, p.Info.Version, name)
 	if err != nil {
-		var notFound plugins.NotFoundError
-		if errors.As(err, &notFound) {
+		if notFound, ok := errors.AsType[plugins.NotFoundError](err); ok {
 			return response.Error(http.StatusNotFound, notFound.Error(), nil)
 		}
 
@@ -483,12 +482,10 @@ func (hs *HTTPServer) InstallPlugin(c *contextmodel.ReqContext) response.Respons
 	ctx := repo.WithRequestOrigin(c.Req.Context(), "api")
 	err := hs.pluginInstaller.Add(ctx, pluginID, dto.Version, compatOpts)
 	if err != nil {
-		var dupeErr plugins.DuplicateError
-		if errors.As(err, &dupeErr) {
+		if _, ok := errors.AsType[plugins.DuplicateError](err); ok {
 			return response.Error(http.StatusConflict, "Plugin already installed", err)
 		}
-		var clientError repo.ErrResponse4xx
-		if errors.As(err, &clientError) {
+		if clientError, ok := errors.AsType[repo.ErrResponse4xx](err); ok {
 			return response.Error(clientError.StatusCode(), clientError.Message(), err)
 		}
 		if errors.Is(err, plugins.ErrInstallCorePlugin) {

--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -116,8 +116,7 @@ func (r *NormalResponse) writeLogLine(c *contextmodel.ReqContext) {
 	}
 
 	logger := c.Logger.Error
-	var gfErr errutil.Error
-	if errors.As(r.err, &gfErr) {
+	if gfErr, ok := errors.AsType[errutil.Error](r.err); ok {
 		logger = gfErr.LogLevel.LogFunc(c.Logger)
 	}
 	logger(r.errMessage, "error", r.err, "remote_addr", c.RemoteAddr(), "traceID", traceID)

--- a/pkg/cmd/grafana-cli/services/api_client_test.go
+++ b/pkg/cmd/grafana-cli/services/api_client_test.go
@@ -89,8 +89,7 @@ func makeBody(t *testing.T, body string) io.ReadCloser {
 }
 
 func asBadRequestError(t *testing.T, err error) *BadRequestError {
-	var badErr *BadRequestError
-	if errors.As(err, &badErr) {
+	if badErr, ok := errors.AsType[*BadRequestError](err); ok {
 		return badErr
 	}
 	assert.FailNow(t, "Error was not of type BadRequestError")

--- a/pkg/expr/dataplane.go
+++ b/pkg/expr/dataplane.go
@@ -45,8 +45,7 @@ func shouldUseDataplane(frames data.Frames, logger log.Logger, disable bool) (dt
 
 	dt, err := reader.CanReadBasedOnMeta(frames)
 	if err != nil {
-		var vw *sdata.VersionWarning
-		if errors.As(err, &vw) {
+		if _, ok := errors.AsType[*sdata.VersionWarning](err); ok {
 			logger.Warn("Attempting to read mismatched version dataplane data", "error", err, "datatype", dt)
 			return dt, true, nil
 		}

--- a/pkg/expr/errors.go
+++ b/pkg/expr/errors.go
@@ -86,9 +86,8 @@ var QueryError = errutil.BadRequest("sse.dataQueryError").MustTemplate(
 
 func MakeQueryError(refID, datasourceUID string, err error) error {
 	var pErr error
-	var utilErr errutil.Error
 	// See if this is grafana error, if so, grab public message
-	if errors.As(err, &utilErr) {
+	if utilErr, ok := errors.AsType[errutil.Error](err); ok {
 		pErr = utilErr.Public()
 	} else {
 		pErr = err

--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -96,8 +96,7 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 		// dependency-error path — no separate transitive propagation needed.
 		if disabledErr := node.DisabledErr(); disabledErr != nil {
 			if node.NodeType() == TypeCMDNode && node.(*CMDNode).CMDType == TypeSQL {
-				var sqlErr *sql.ErrorWithCategory
-				if errors.As(disabledErr, &sqlErr) {
+				if sqlErr, ok := errors.AsType[*sql.ErrorWithCategory](disabledErr); ok {
 					s.metrics.SqlCommandCount.WithLabelValues("error", sqlErr.Category()).Inc()
 				}
 			}
@@ -118,8 +117,7 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 						// although the SQL expression won't be executed,
 						// we track a dependency error on the metric.
 						eType := e.Category()
-						var errWithType *sql.ErrorWithCategory
-						if errors.As(res.Error, &errWithType) {
+						if errWithType, ok := errors.AsType[*sql.ErrorWithCategory](res.Error); ok {
 							// If it is already SQL error with type (e.g. limit exceeded, input conversion, capture the type as that)
 							eType = errWithType.Category()
 						}
@@ -221,8 +219,7 @@ func (s *Service) buildPipeline(ctx context.Context, req *Request) (DataPipeline
 	}
 
 	instrumentSQLError := func(err error, span trace.Span) {
-		var sqlErr *sql.ErrorWithCategory
-		if errors.As(err, &sqlErr) {
+		if sqlErr, ok := errors.AsType[*sql.ErrorWithCategory](err); ok {
 			// The SQL expression (and the entire pipeline) will not be executed, so we
 			// track the attempt to execute here.
 			s.metrics.SqlCommandCount.WithLabelValues("error", sqlErr.Category()).Inc()

--- a/pkg/expr/service.go
+++ b/pkg/expr/service.go
@@ -115,8 +115,7 @@ func (s *Service) BuildPipeline(ctx context.Context, req *Request) (DataPipeline
 		if nodeErr := node.DisabledErr(); nodeErr != nil {
 			// Record SQL metrics before returning, matching the behavior of
 			// the non-degraded path where instrumentSQLError fires on failure.
-			var sqlErr *sql.ErrorWithCategory
-			if errors.As(nodeErr, &sqlErr) {
+			if sqlErr, ok := errors.AsType[*sql.ErrorWithCategory](nodeErr); ok {
 				s.metrics.SqlCommandCount.WithLabelValues("error", sqlErr.Category()).Inc()
 			}
 			return nil, nodeErr

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -54,8 +54,7 @@ func AllowQuery(refID, rawSQL string) (bool, error) {
 	}
 
 	if err := walkNodes(s); err != nil {
-		var bn *ErrorWithCategory
-		if !errors.As(err, &bn) {
+		if _, ok := errors.AsType[*ErrorWithCategory](err); !ok {
 			return false, fmt.Errorf("failed to parse SQL expression: %w", err)
 		}
 		return false, err

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -49,8 +49,7 @@ func notAuthorized(c *contextmodel.ReqContext) {
 		writeRedirectCookie(c)
 	}
 
-	var tokenRotationErr authn.TokenNeedsRotationError
-	if errors.As(c.LookupTokenErr, &tokenRotationErr) {
+	if _, ok := errors.AsType[authn.TokenNeedsRotationError](c.LookupTokenErr); ok {
 		if !c.UseSessionStorageRedirect {
 			c.Redirect(setting.AppSubUrl + "/user/auth-tokens/rotate")
 			return
@@ -211,8 +210,7 @@ func Auth(options *AuthOptions) web.Handler {
 		requireLogin := !c.AllowAnonymous || forceLogin || options.ReqNoAnonynmous
 
 		if !c.IsSignedIn && options.ReqSignedIn && requireLogin {
-			var revokedErr *auth.TokenRevokedError
-			if errors.As(c.LookupTokenErr, &revokedErr) {
+			if revokedErr, ok := errors.AsType[*auth.TokenRevokedError](c.LookupTokenErr); ok {
 				tokenRevoked(c, revokedErr)
 				return
 			}

--- a/pkg/plugins/manager/installer.go
+++ b/pkg/plugins/manager/installer.go
@@ -75,8 +75,7 @@ func (m *PluginInstaller) Add(ctx context.Context, pluginID, version string, opt
 
 		err = m.Add(ctx, dep.ID, "", plugins.NewAddOpts(opts.GrafanaVersion(), opts.OS(), opts.Arch(), ""))
 		if err != nil {
-			var dupeErr plugins.DuplicateError
-			if errors.As(err, &dupeErr) {
+			if _, ok := errors.AsType[plugins.DuplicateError](err); ok {
 				m.log.Info("Dependency already installed", "pluginId", dep.ID)
 				continue
 			}

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -47,8 +47,7 @@ func New(
 }
 
 func (l *Loader) recordError(ctx context.Context, p *plugins.Plugin, err error) {
-	var pErr *plugins.Error
-	if errors.As(err, &pErr) {
+	if pErr, ok := errors.AsType[*plugins.Error](err); ok {
 		l.errorTracker.Record(ctx, pErr)
 		return
 	}

--- a/pkg/plugins/repo/client.go
+++ b/pkg/plugins/repo/client.go
@@ -158,8 +158,7 @@ func (c *Client) downloadFile(ctx context.Context, tmpFile *os.File, pluginURL, 
 	// Note: This is also used as part of the grafana plugin install CLI operation
 	bodyReader, err := c.sendReqNoTimeout(ctx, u, compatOpts)
 	if err != nil {
-		var errResp ErrResponse4xx
-		if errors.As(err, &errResp) {
+		if errResp, ok := errors.AsType[ErrResponse4xx](err); ok {
 			if errResp.StatusCode() == 401 {
 				c.log.Error("Unauthorized download plugin", "error", err)
 				return err

--- a/pkg/registry/apis/iam/team/retryable.go
+++ b/pkg/registry/apis/iam/team/retryable.go
@@ -34,20 +34,17 @@ func isRetryableTxnError(err error) bool {
 	if sqlite.IsBusyOrLocked(err) {
 		return true
 	}
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) {
+	if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		switch mysqlErr.Number {
 		case mysqlErrLockDeadlock, mysqlErrLockWaitTimeout:
 			return true
 		}
 	}
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == postgresErrDeadlockDetected ||
 			pgErr.Code == postgresErrSerializationFailure
 	}
-	var pqErr *pq.Error
-	if errors.As(err, &pqErr) {
+	if pqErr, ok := errors.AsType[*pq.Error](err); ok {
 		return string(pqErr.Code) == postgresErrDeadlockDetected ||
 			string(pqErr.Code) == postgresErrSerializationFailure
 	}

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -134,8 +134,7 @@ func (r *jobProgressRecorder) record(ctx context.Context, result JobResourceResu
 
 		// Automatically track failed operations based on error type and action
 		// Check if this is a PathCreationError (folder creation failure)
-		var pathErr *resources.PathCreationError
-		if errors.As(result.Error(), &pathErr) {
+		if pathErr, ok := errors.AsType[*resources.PathCreationError](result.Error()); ok {
 			r.failedCreations = append(r.failedCreations, pathErr.Path)
 		}
 
@@ -169,8 +168,7 @@ func (r *jobProgressRecorder) record(ctx context.Context, result JobResourceResu
 			}
 
 			// Folder creation failures may be surfaced as warnings.
-			var pathErr *resources.PathCreationError
-			if errors.As(result.Warning(), &pathErr) {
+			if pathErr, ok := errors.AsType[*resources.PathCreationError](result.Warning()); ok {
 				r.failedCreations = append(r.failedCreations, pathErr.Path)
 			}
 		}

--- a/pkg/registry/apis/provisioning/jobs/sync/changes.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/changes.go
@@ -425,8 +425,7 @@ func processInvalidFolderMetadataChanges(
 			continue
 		}
 
-		var invalidErr *resources.InvalidFolderMetadata
-		if errors.As(err, &invalidErr) {
+		if invalidErr, ok := errors.AsType[*resources.InvalidFolderMetadata](err); ok {
 			logging.FromContext(ctx).Info("invalid folder metadata", "path", change.Path, "action", change.Action, "error", err)
 			invalidErr = invalidErr.WithAction(change.Action)
 			invalidFolderMetadata = append(invalidFolderMetadata, invalidErr)

--- a/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/folder_metadata_incremental_diff.go
@@ -357,8 +357,7 @@ func (d *folderMetadataIncrementalDiffBuilder) readMetadata(
 		return nil, nil, nil
 	}
 
-	var invalidErr *resources.InvalidFolderMetadata
-	if errors.As(err, &invalidErr) {
+	if invalidErr, ok := errors.AsType[*resources.InvalidFolderMetadata](err); ok {
 		return nil, []*resources.InvalidFolderMetadata{invalidErr.WithAction(action)}, nil
 	}
 

--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -66,8 +66,7 @@ func FullSync(
 			// the pull job output and stop cleanly: no children can be
 			// placed under an unclaimed root, but failing the whole job
 			// hides the actual cause.
-			var unmanagedErr *resources.ResourceUnmanagedConflictError
-			if errors.As(err, &unmanagedErr) {
+			if _, ok := errors.AsType[*resources.ResourceUnmanagedConflictError](err); ok {
 				progress.Record(ctx, jobs.NewFolderResult("").
 					WithName(rootFolder).
 					WithAction(repository.FileActionCreated).

--- a/pkg/registry/apis/provisioning/request.go
+++ b/pkg/registry/apis/provisioning/request.go
@@ -33,8 +33,7 @@ func readBody(r *http.Request, maxSize int64) ([]byte, error) {
 	limitedBody := http.MaxBytesReader(nil, r.Body, maxSize)
 	body, err := io.ReadAll(limitedBody)
 	if err != nil {
-		var maxBytesError *http.MaxBytesError
-		if errors.As(err, &maxBytesError) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			return nil, apierrors.NewRequestEntityTooLargeError(
 				fmt.Sprintf("%s: max size %d bytes", errMsgRequestTooLarge, maxSize),
 			)
@@ -64,8 +63,7 @@ func unmarshalJSON(r *http.Request, maxSize int64, v interface{}) error {
 	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(v); err != nil {
-		var maxBytesError *http.MaxBytesError
-		if errors.As(err, &maxBytesError) {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 			return fmt.Errorf("%s: max size %d bytes", errMsgRequestTooLarge, maxSize)
 		}
 		if err == io.EOF {

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -72,10 +72,9 @@ func TestResourceValidationError(t *testing.T) {
 		require.Len(t, unwrapped, 2, "Unwrap should return 2 errors for joined error")
 
 		// Check that one of the unwrapped errors is a BadRequest
-		var badRequestErr *apierrors.StatusError
 		foundBadRequest := false
 		for _, err := range unwrapped {
-			if errors.As(err, &badRequestErr) {
+			if _, ok := errors.AsType[*apierrors.StatusError](err); ok {
 				foundBadRequest = true
 				require.True(t, apierrors.IsBadRequest(err), "unwrapped error should be a BadRequest")
 				break
@@ -102,9 +101,8 @@ func TestResourceValidationError(t *testing.T) {
 		require.Len(t, unwrapped, 2)
 
 		// Find the BadRequest error in the unwrapped slice
-		var badRequestErr *apierrors.StatusError
 		for _, err := range unwrapped {
-			if errors.As(err, &badRequestErr) {
+			if _, ok := errors.AsType[*apierrors.StatusError](err); ok {
 				// errors.Is should work with the unwrapped BadRequest error
 				require.True(t, errors.Is(validationErr, err), "errors.Is should find the unwrapped BadRequest error")
 				break

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -225,8 +225,7 @@ func (fm *FolderManager) resolveFolderForPath(ctx context.Context, path, ref str
 		return f, nil
 	}
 
-	var invalidErr *InvalidFolderMetadata
-	if !errors.As(err, &invalidErr) {
+	if _, ok := errors.AsType[*InvalidFolderMetadata](err); !ok {
 		return Folder{}, err
 	}
 
@@ -514,8 +513,7 @@ func (fm *FolderManager) RemoveFolder(ctx context.Context, name string) error {
 func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, previousRef, newPath, newRef string, opts ...EnsurePathOption) (string, error) {
 	oldFolder, err := ParseFolderWithMetadata(ctx, fm.repo, previousPath, previousRef, fm.folderMetadataEnabled)
 	if err != nil {
-		var invalidErr *InvalidFolderMetadata
-		if !errors.As(err, &invalidErr) {
+		if _, ok := errors.AsType[*InvalidFolderMetadata](err); !ok {
 			return "", fmt.Errorf("parse old folder: %w", err)
 		}
 
@@ -539,8 +537,7 @@ func (fm *FolderManager) RenameFolderPath(ctx context.Context, previousPath, pre
 
 	newFolder, err := ParseFolderWithMetadata(ctx, fm.repo, newPath, newRef, fm.folderMetadataEnabled)
 	if err != nil {
-		var invalidErr *InvalidFolderMetadata
-		if !errors.As(err, &invalidErr) {
+		if _, ok := errors.AsType[*InvalidFolderMetadata](err); !ok {
 			return "", fmt.Errorf("parse new folder: %w", err)
 		}
 

--- a/pkg/registry/apis/provisioning/resources/resources.go
+++ b/pkg/registry/apis/provisioning/resources/resources.go
@@ -42,14 +42,12 @@ func wrapAsValidationErrorIfNeeded(err error) error {
 	}
 
 	// Check if it's already a validation error
-	var validationErr *ResourceValidationError
-	if errors.As(err, &validationErr) {
+	if _, ok := errors.AsType[*ResourceValidationError](err); ok {
 		return err
 	}
 
 	// Check if it's a field validation error (e.g., missing name)
-	var fieldErr *field.Error
-	if errors.As(err, &fieldErr) {
+	if _, ok := errors.AsType[*field.Error](err); ok {
 		return NewResourceValidationError(err)
 	}
 
@@ -64,8 +62,7 @@ func wrapAsValidationErrorIfNeeded(err error) error {
 	}
 
 	// Check if it's a dashboard validation error (wrap all dashboard errors as validation errors)
-	var dashboardErr dashboardaccess.DashboardErr
-	if errors.As(err, &dashboardErr) {
+	if _, ok := errors.AsType[dashboardaccess.DashboardErr](err); ok {
 		return NewResourceValidationError(err)
 	}
 

--- a/pkg/registry/apis/provisioning/resources/retry_client.go
+++ b/pkg/registry/apis/provisioning/resources/retry_client.go
@@ -93,8 +93,7 @@ func isTransientError(err error) bool {
 	}
 
 	// Check for network errors
-	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if netErr, ok := errors.AsType[net.Error](err); ok {
 		if netErr.Timeout() {
 			return true
 		}

--- a/pkg/registry/apis/provisioning/response.go
+++ b/pkg/registry/apis/provisioning/response.go
@@ -9,8 +9,7 @@ import (
 
 // respondWithError checks if the provided error contains an API error and unwraps it before passing it to the responder.
 func respondWithError(responder rest.Responder, err error) {
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*apierrors.StatusError](err); ok {
 		responder.Error(statusErr)
 	} else {
 		responder.Error(err)

--- a/pkg/registry/apis/query/errors.go
+++ b/pkg/registry/apis/query/errors.go
@@ -14,9 +14,8 @@ var QueryError = errutil.BadRequest("query.error").MustTemplate(
 
 func MakeQueryError(refID, err error) error {
 	var pErr error
-	var utilErr errutil.Error
 	// See if this is grafana error, if so, grab public message
-	if errors.As(err, &utilErr) {
+	if utilErr, ok := errors.AsType[errutil.Error](err); ok {
 		pErr = utilErr.Public()
 	} else {
 		pErr = err

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -201,8 +201,7 @@ func isAlreadyExistsError(err error) bool {
 		return false
 	}
 	// Check for pgx error code "42P07" (duplicate_table)
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "42P07"
 	}
 	return false

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -48,8 +48,7 @@ func Middleware(ac AccessControl) func(Evaluator) web.Handler {
 			}
 
 			if c.LookupTokenErr != nil {
-				var revokedErr *usertoken.TokenRevokedError
-				if errors.As(c.LookupTokenErr, &revokedErr) {
+				if revokedErr, ok := errors.AsType[*usertoken.TokenRevokedError](c.LookupTokenErr); ok {
 					tokenRevoked(c, revokedErr)
 					return
 				}
@@ -146,8 +145,7 @@ func unauthorized(c *contextmodel.ReqContext) {
 		writeRedirectCookie(c)
 	}
 
-	var tokenRotationErr authn.TokenNeedsRotationError
-	if errors.As(c.LookupTokenErr, &tokenRotationErr) {
+	if _, ok := errors.AsType[authn.TokenNeedsRotationError](c.LookupTokenErr); ok {
 		if !c.UseSessionStorageRedirect {
 			c.Redirect(setting.AppSubUrl + "/user/auth-tokens/rotate")
 			return

--- a/pkg/services/authn/authnimpl/service.go
+++ b/pkg/services/authn/authnimpl/service.go
@@ -122,8 +122,7 @@ func (s *Service) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 			if err != nil {
 				// Note: special case for token rotation
 				// We don't want to fallthrough in this case
-				var tokenRotationErr authn.TokenNeedsRotationError
-				if errors.As(err, &tokenRotationErr) {
+				if _, ok := errors.AsType[authn.TokenNeedsRotationError](err); ok {
 					return nil, err
 				}
 
@@ -482,8 +481,7 @@ func (s *Service) errorLogFunc(ctx context.Context, err error) func(msg string, 
 
 	l := s.log.FromContext(ctx)
 
-	var grfErr errutil.Error
-	if errors.As(err, &grfErr) {
+	if grfErr, ok := errors.AsType[errutil.Error](err); ok {
 		return grfErr.LogLevel.LogFunc(l)
 	}
 

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -188,8 +188,7 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 	userInfo, err := connector.UserInfo(ctx, connector.Client(clientCtx, token), token)
 	if err != nil {
-		var sErr *connectors.SocialError
-		if errors.As(err, &sErr) {
+		if sErr, ok := errors.AsType[*connectors.SocialError](err); ok {
 			return nil, fromSocialErr(sErr)
 		}
 		return nil, errOAuthUserInfo.Errorf("failed to get user info: %w", err)

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go
@@ -183,8 +183,7 @@ func ProvideService(
 	}
 
 	if err := prom.Register(s.metrics); err != nil {
-		var alreadyRegisterErr prometheus.AlreadyRegisteredError
-		if errors.As(err, &alreadyRegisterErr) {
+		if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 			s.log.Warn("cloud migration metrics already registered")
 		} else {
 			return s, fmt.Errorf("registering cloud migration metrics: %w", err)

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -136,8 +136,7 @@ func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context 
 		// Hack: set all errors on LookupTokenErr, so we can check it in auth middlewares
 		reqContext.LookupTokenErr = err
 
-		var tokenRotationErr authn.TokenNeedsRotationError
-		if errors.As(err, &tokenRotationErr) {
+		if tokenRotationErr, ok := errors.AsType[authn.TokenNeedsRotationError](err); ok {
 			userId = tokenRotationErr.UserID
 		}
 	} else {

--- a/pkg/services/dashboardsnapshots/service.go
+++ b/pkg/services/dashboardsnapshots/service.go
@@ -82,8 +82,7 @@ func CreateDashboardSnapshot(c *contextmodel.ReqContext, cfg snapshot.SnapshotSh
 		if err != nil {
 			status := http.StatusInternalServerError
 			message := "Failed to create external snapshot"
-			var grafanaErr errutil.Error
-			if errors.As(err, &grafanaErr) {
+			if grafanaErr, ok := errors.AsType[errutil.Error](err); ok {
 				status = grafanaErr.Reason.Status().HTTPStatus()
 				message = grafanaErr.PublicMessage
 			}

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -141,8 +141,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqConte
 	proxy, err := pluginproxy.NewDataSourceProxy(loader, plugin.Routes, hc, proxyPath, p.proxyCfg,
 		p.HTTPClientProvider, p.OAuthTokenService, p.tracer, p.features)
 	if err != nil {
-		var urlValidationError validation.URLValidationError
-		if errors.As(err, &urlValidationError) {
+		if _, ok := errors.AsType[validation.URLValidationError](err); ok {
 			c.JsonApiErr(http.StatusBadRequest, fmt.Sprintf("Invalid data source URL: %q", ds.URL), err)
 		} else {
 			c.JsonApiErr(http.StatusInternalServerError, "Failed creating data source proxy", err)

--- a/pkg/services/frontend/settings_service.go
+++ b/pkg/services/frontend/settings_service.go
@@ -81,8 +81,7 @@ func setupSettingsService(cfg *setting.Cfg, promRegister prometheus.Registerer) 
 	}
 
 	if err := promRegister.Register(settingsService); err != nil {
-		var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-		if !errors.As(err, &alreadyRegisteredErr) {
+		if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); !ok {
 			return nil, fmt.Errorf("failed to register settings service metrics: %w", err)
 		}
 	}

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -148,12 +148,10 @@ func (srv AlertmanagerSrv) RoutePostGrafanaAlertingConfigHistoryActivate(c *cont
 
 	err = srv.mam.ActivateHistoricalConfiguration(c.Req.Context(), c.GetOrgID(), confId)
 	if err != nil {
-		var unknownReceiverError notifier.UnknownReceiverError
-		if errors.As(err, &unknownReceiverError) {
+		if unknownReceiverError, ok := errors.AsType[notifier.UnknownReceiverError](err); ok {
 			return ErrResp(http.StatusBadRequest, unknownReceiverError, "")
 		}
-		var configRejectedError notifier.AlertmanagerConfigRejectedError
-		if errors.As(err, &configRejectedError) {
+		if configRejectedError, ok := errors.AsType[notifier.AlertmanagerConfigRejectedError](err); ok {
 			return ErrResp(http.StatusBadRequest, configRejectedError, "")
 		}
 		if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {

--- a/pkg/services/ngalert/eval/eval.go
+++ b/pkg/services/ngalert/eval/eval.go
@@ -196,8 +196,7 @@ func (evalResults Results) HasNonRetryableErrors() bool {
 // IsNonRetryableError reports whether an error is persistent and not worth retrying within an
 // evaluation cycle: malformed results, or deterministic Mimir query-limit / write rejections.
 func IsNonRetryableError(err error) bool {
-	var nonRetryableError *invalidEvalResultFormatError
-	if errors.As(err, &nonRetryableError) {
+	if _, ok := errors.AsType[*invalidEvalResultFormatError](err); ok {
 		return true
 	}
 	if errors.Is(err, expr.ErrSeriesMustBeWide) {

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -400,8 +400,7 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 
 	cfg.ExtraConfigs, err = modifyFn(cfg.ExtraConfigs)
 	if err != nil {
-		var grafanaErr errutil.Error
-		if errors.As(err, &grafanaErr) {
+		if _, ok := errors.AsType[errutil.Error](err); ok {
 			return merge.MergeResult{}, err
 		}
 		return merge.MergeResult{}, fmt.Errorf("failed to apply extra configuration: %w", err)

--- a/pkg/services/ngalert/notifier/external_am_syncer.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer.go
@@ -139,8 +139,7 @@ func (e *SyncError) Unwrap() error { return e.Cause }
 // ReasonUnclassified for un-tagged errors — keeps metric label cardinality
 // bounded.
 func reasonOf(err error) SyncReason {
-	var se *SyncError
-	if errors.As(err, &se) {
+	if se, ok := errors.AsType[*SyncError](err); ok {
 		return se.Reason
 	}
 	return ReasonUnclassified
@@ -154,8 +153,7 @@ func ClassifySaveError(err error) *SyncError {
 		return nil
 	}
 	// Already classified — return as-is so we don't double-wrap.
-	var existing *SyncError
-	if errors.As(err, &existing) {
+	if existing, ok := errors.AsType[*SyncError](err); ok {
 		return existing
 	}
 	if errors.Is(err, ErrAlertmanagerMultipleExtraConfigsUnsupported.Base) {

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -463,12 +463,10 @@ func (am *Alertmanager) CreateSilence(ctx context.Context, silence *apimodels.Po
 	if err != nil {
 		// Translate downstream 4xx errors into a well-known bad payload error so callers can surface HTTP 400.
 		// The swagger client returns typed errors and/or an *openapiRuntime.APIError with a Code field.
-		var badReq *amsilence.PostSilencesBadRequest
-		if errors.As(err, &badReq) {
+		if _, ok := errors.AsType[*amsilence.PostSilencesBadRequest](err); ok {
 			return "", fmt.Errorf("%w: %v", alertingNotify.ErrCreateSilenceBadPayload, err)
 		}
-		var apiErr *openapiRuntime.APIError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[*openapiRuntime.APIError](err); ok {
 			if apiErr.Code >= http.StatusBadRequest && apiErr.Code < http.StatusInternalServerError {
 				return "", fmt.Errorf("%w: %v", alertingNotify.ErrCreateSilenceBadPayload, err)
 			}

--- a/pkg/services/ngalert/rulesync/status.go
+++ b/pkg/services/ngalert/rulesync/status.go
@@ -44,8 +44,7 @@ func (e *SyncError) Unwrap() error { return e.Cause }
 // reasonOf extracts the SyncReason via errors.As. Returns ReasonUnclassified
 // for un-tagged errors — keeps metric label cardinality bounded.
 func reasonOf(err error) SyncReason {
-	var se *SyncError
-	if errors.As(err, &se) {
+	if se, ok := errors.AsType[*SyncError](err); ok {
 		return se.Reason
 	}
 	return ReasonUnclassified

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -436,8 +436,7 @@ func newTokenRefreshDurationMetric(registerer prometheus.Registerer) *prometheus
 	}
 
 	if err := registerer.Register(tokenRefreshDuration); err != nil {
-		var alreadyRegistered prometheus.AlreadyRegisteredError
-		if errors.As(err, &alreadyRegistered) {
+		if alreadyRegistered, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 			if existing, ok := alreadyRegistered.ExistingCollector.(*prometheus.HistogramVec); ok {
 				return existing
 			}

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -221,8 +221,7 @@ func SignatureValidationStep(signatureValidator signature.Validator) validation.
 func (v *SignatureValidation) Validate(ctx context.Context, p *plugins.Plugin) error {
 	err := v.signatureValidator.ValidateSignature(p)
 	if err != nil {
-		var sigErr *plugins.Error
-		if errors.As(err, &sigErr) {
+		if sigErr, ok := errors.AsType[*plugins.Error](err); ok {
 			v.log.Warn("Skipping loading plugin due to problem with signature",
 				"pluginId", p.ID, "status", sigErr.SignatureStatus)
 			p.Error = sigErr

--- a/pkg/services/pluginsintegration/plugininstaller/service.go
+++ b/pkg/services/pluginsintegration/plugininstaller/service.go
@@ -125,8 +125,7 @@ func (s *Service) installPlugins(ctx context.Context, pluginsToInstall []setting
 		compatOpts := plugins.NewAddOpts(s.cfg.BuildVersion, runtime.GOOS, runtime.GOARCH, installPlugin.URL)
 		err := s.pluginInstaller.Add(ctx, installPlugin.ID, installPlugin.Version, compatOpts)
 		if err != nil {
-			var dupeErr plugins.DuplicateError
-			if errors.As(err, &dupeErr) {
+			if _, ok := errors.AsType[plugins.DuplicateError](err); ok {
 				s.log.Debug("Plugin already installed", "pluginId", installPlugin.ID, "version", installPlugin.Version)
 				continue
 			}

--- a/pkg/services/publicdashboards/internal/metric/metric.go
+++ b/pkg/services/publicdashboards/internal/metric/metric.go
@@ -36,8 +36,7 @@ func ProvideService(
 
 func (s *Service) registerMetrics(prom prometheus.Registerer) error {
 	err := prom.Register(s.Metrics.PublicDashboardsAmount)
-	var alreadyRegisterErr prometheus.AlreadyRegisteredError
-	if errors.As(err, &alreadyRegisterErr) {
+	if alreadyRegisterErr, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); ok {
 		if alreadyRegisterErr.ExistingCollector == alreadyRegisterErr.NewCollector {
 			err = nil
 		}

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -157,8 +157,7 @@ func (rs *RenderingService) doRequest(ctx context.Context, u *url.URL, headers m
 	resp, err := rs.netClient.Do(req)
 	if err != nil {
 		logger.Error("Failed to send request to remote rendering service", "error", err)
-		var urlErr *url.Error
-		if errors.As(err, &urlErr) {
+		if urlErr, ok := errors.AsType[*url.Error](err); ok {
 			if urlErr.Timeout() {
 				return nil, ErrServerTimeout
 			}

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -205,8 +205,7 @@ func (db *MySQLDialect) TruncateDBTables(engine *xorm.Engine) error {
 }
 
 func (db *MySQLDialect) isThisError(err error, errcode uint16) bool {
-	var driverErr *mysql.MySQLError
-	if errors.As(err, &driverErr) {
+	if driverErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		if driverErr.Number == errcode {
 			return true
 		}
@@ -220,8 +219,7 @@ func (db *MySQLDialect) IsUniqueConstraintViolation(err error) bool {
 }
 
 func (db *MySQLDialect) ErrorMessage(err error) string {
-	var driverErr *mysql.MySQLError
-	if errors.As(err, &driverErr) {
+	if driverErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		return driverErr.Message
 	}
 	return ""

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -183,8 +183,7 @@ func (db *PostgresDialect) TruncateDBTables(engine *xorm.Engine) error {
 }
 
 func (db *PostgresDialect) isThisError(err error, errcode string) bool {
-	var driverErr *pq.Error
-	if errors.As(err, &driverErr) {
+	if driverErr, ok := errors.AsType[*pq.Error](err); ok {
 		if string(driverErr.Code) == errcode {
 			return true
 		}
@@ -194,8 +193,7 @@ func (db *PostgresDialect) isThisError(err error, errcode string) bool {
 }
 
 func (db *PostgresDialect) ErrorMessage(err error) string {
-	var driverErr *pq.Error
-	if errors.As(err, &driverErr) {
+	if driverErr, ok := errors.AsType[*pq.Error](err); ok {
 		return driverErr.Message
 	}
 	return ""

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -387,8 +387,7 @@ func (ss *SQLStore) ensureTransactionIsolationCompatibility(engine *xorm.Engine,
 	var result string
 	_, err := engine.SQL("SELECT 1").Get(&result)
 
-	var mysqlError *mysql.MySQLError
-	if errors.As(err, &mysqlError) {
+	if mysqlError, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		// if there was an error due to transaction isolation
 		if strings.Contains(mysqlError.Message, "Unknown system variable 'transaction_isolation'") {
 			ss.log.Debug("transaction_isolation system var is unknown, overriding in connection string with tx_isolation instead")
@@ -431,8 +430,7 @@ func (ss *SQLStore) RecursiveQueriesAreSupported() (bool, error) {
 			err := sess.SQL(recQry).Find(&result)
 			return err
 		}); err != nil {
-			var driverErr *mysql.MySQLError
-			if errors.As(err, &driverErr) {
+			if driverErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 				if driverErr.Number == mysqlerr.ER_PARSE_ERROR || driverErr.Number == mysqlerr.ER_NOT_SUPPORTED_YET {
 					return false, nil
 				}

--- a/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
+++ b/pkg/services/ssosettings/ssosettingsimpl/mtsettings_client.go
@@ -111,8 +111,7 @@ func newMTSettingsClient(cfg *setting.Cfg, promRegister prometheus.Registerer) (
 	}
 
 	if err := promRegister.Register(settingsService); err != nil {
-		var alreadyRegisteredErr prometheus.AlreadyRegisteredError
-		if !errors.As(err, &alreadyRegisteredErr) {
+		if _, ok := errors.AsType[prometheus.AlreadyRegisteredError](err); !ok {
 			return nil, fmt.Errorf("failed to register settings service metrics: %w", err)
 		}
 	}

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -1186,18 +1186,15 @@ func isRowAlreadyExistsError(err error) bool {
 		return true
 	}
 
-	var pg *pgconn.PgError
-	if errors.As(err, &pg) {
+	if pg, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pg.Code == "23505"
 	}
 
-	var pqerr *pq.Error
-	if errors.As(err, &pqerr) {
+	if pqerr, ok := errors.AsType[*pq.Error](err); ok {
 		return pqerr.Code == "23505"
 	}
 
-	var mysqlerr *mysql.MySQLError
-	if errors.As(err, &mysqlerr) {
+	if mysqlerr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		return mysqlerr.Number == 1062
 	}
 

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -682,18 +682,15 @@ func isDuplicateKeyError(err error) bool {
 		return true
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23505"
 	}
 
-	var pqErr *pq.Error
-	if errors.As(err, &pqErr) {
+	if pqErr, ok := errors.AsType[*pq.Error](err); ok {
 		return pqErr.Code == "23505"
 	}
 
-	var mysqlErr *mysql.MySQLError
-	if errors.As(err, &mysqlErr) {
+	if mysqlErr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		return mysqlErr.Number == 1062
 	}
 

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1081,9 +1081,8 @@ func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*re
 	})
 
 	if err != nil {
-		var quotaErr QuotaExceededError
 		msg := err.Error()
-		if errors.As(err, &quotaErr) {
+		if quotaErr, ok := errors.AsType[QuotaExceededError](err); ok {
 			msg = quotaErr.Message()
 		}
 		return &resourcepb.CreateResponse{

--- a/pkg/storage/unified/search/embed/backfill/backfiller.go
+++ b/pkg/storage/unified/search/embed/backfill/backfiller.go
@@ -349,12 +349,10 @@ func isPermanentItemError(err error) bool {
 	}
 	// SQLSTATE class 22 = data exception, e.g. NUL byte in text. Class 23
 	// is excluded: missing partitions surface as 23514 check_violation.
-	var pgxErr *pgconn.PgError
-	if errors.As(err, &pgxErr) {
+	if pgxErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return strings.HasPrefix(pgxErr.Code, "22")
 	}
-	var pqErr *pq.Error
-	if errors.As(err, &pqErr) {
+	if pqErr, ok := errors.AsType[*pq.Error](err); ok {
 		return pqErr.Code.Class() == "22"
 	}
 	return false

--- a/pkg/storage/unified/search/lock_cdk_backend_options.go
+++ b/pkg/storage/unified/search/lock_cdk_backend_options.go
@@ -149,8 +149,7 @@ func (o *s3Ops) Delete(ctx context.Context, key string, attrs *blob.Attributes) 
 		IfMatch: aws.String(attrs.ETag),
 	})
 	if err != nil {
-		var respErr *smithyhttp.ResponseError
-		if errors.As(err, &respErr) {
+		if respErr, ok := errors.AsType[*smithyhttp.ResponseError](err); ok {
 			return mapDeleteStatus(respErr.HTTPStatusCode(), err)
 		}
 	}
@@ -194,8 +193,7 @@ func (o *gcsOps) Delete(ctx context.Context, key string, attrs *blob.Attributes)
 	}).Delete(ctx)
 	if err != nil {
 		// GCS uses REST by default (*googleapi.Error), but may use gRPC. Check both.
-		var apiErr *googleapi.Error
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[*googleapi.Error](err); ok {
 			return mapDeleteStatus(apiErr.Code, err)
 		}
 		if s, ok := status.FromError(err); ok {
@@ -244,8 +242,7 @@ func (o *azureOps) Delete(ctx context.Context, key string, attrs *blob.Attribute
 		},
 	})
 	if err != nil {
-		var respErr *azcore.ResponseError
-		if errors.As(err, &respErr) {
+		if respErr, ok := errors.AsType[*azcore.ResponseError](err); ok {
 			return mapDeleteStatus(respErr.StatusCode, err)
 		}
 	}

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -984,20 +984,17 @@ func IsRowAlreadyExistsError(err error) bool {
 		return true
 	}
 
-	var pg *pgconn.PgError
-	if errors.As(err, &pg) {
+	if pg, ok := errors.AsType[*pgconn.PgError](err); ok {
 		// https://www.postgresql.org/docs/current/errcodes-appendix.html
 		return pg.Code == "23505" // unique_violation
 	}
 
-	var pqerr *pq.Error
-	if errors.As(err, &pqerr) {
+	if pqerr, ok := errors.AsType[*pq.Error](err); ok {
 		// https://www.postgresql.org/docs/current/errcodes-appendix.html
 		return pqerr.Code == "23505" // unique_violation
 	}
 
-	var mysqlerr *mysql.MySQLError
-	if errors.As(err, &mysqlerr) {
+	if mysqlerr, ok := errors.AsType[*mysql.MySQLError](err); ok {
 		// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
 		return mysqlerr.Number == 1062 // ER_DUP_ENTRY
 	}

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -102,8 +102,7 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 			Do(t.Context())
 		// Note: This might fail if branch doesn't exist, but the important thing is it doesn't return MethodNotAllowed
 		if result.Error() != nil {
-			var statusErr *apierrors.StatusError
-			if errors.As(result.Error(), &statusErr) {
+			if statusErr, ok := errors.AsType[*apierrors.StatusError](result.Error()); ok {
 				require.NotEqual(t, int32(http.StatusMethodNotAllowed), statusErr.ErrStatus.Code, "should not return MethodNotAllowed for branch delete")
 			}
 		}

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -658,8 +658,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 				if test.expectError != nil {
 					require.Error(t, err, "Expected error for repository with path: %s", test.path)
 					require.ErrorContains(t, err, test.expectError.Error(), "Error should contain expected message for path: %s", test.path)
-					var statusError *apierrors.StatusError
-					if errors.As(err, &statusError) {
+					if statusError, ok := errors.AsType[*apierrors.StatusError](err); ok {
 						require.Equal(t, metav1.StatusReasonInvalid, statusError.ErrStatus.Reason, "Should be a validation error")
 						require.Equal(t, http.StatusUnprocessableEntity, int(statusError.ErrStatus.Code), "Should return 422 status code")
 					}
@@ -822,8 +821,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 				if test.expectError != nil {
 					require.Error(t, err, "Expected error for repo branch=%s path=%s", test.branch, test.path)
 					require.ErrorContains(t, err, test.expectError.Error(), "Error should contain expected message for branch=%s path=%s", test.branch, test.path)
-					var statusError *apierrors.StatusError
-					if errors.As(err, &statusError) {
+					if statusError, ok := errors.AsType[*apierrors.StatusError](err); ok {
 						require.Equal(t, metav1.StatusReasonInvalid, statusError.ErrStatus.Reason, "Should be a validation error")
 						require.Equal(t, http.StatusUnprocessableEntity, int(statusError.ErrStatus.Code), "Should return 422 status code")
 					}
@@ -861,8 +859,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		_, err = helper.Repositories.Resource.Create(t.Context(), secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.Error(t, err, "Second repository with same URL, branch, and empty path should fail")
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
-		var statusError *apierrors.StatusError
-		if errors.As(err, &statusError) {
+		if statusError, ok := errors.AsType[*apierrors.StatusError](err); ok {
 			require.Equal(t, metav1.StatusReasonInvalid, statusError.ErrStatus.Reason, "Should be a validation error")
 			require.Equal(t, http.StatusUnprocessableEntity, int(statusError.ErrStatus.Code), "Should return 422 status code")
 		}

--- a/pkg/tsdb/azuremonitor/utils/utils.go
+++ b/pkg/tsdb/azuremonitor/utils/utils.go
@@ -73,8 +73,7 @@ func ParseSubscriptions(res *http.Response, logger log.Logger) ([]string, error)
 }
 
 func ApplySourceFromError(errorMessage error, err error) error {
-	var errorWithSource backend.ErrorWithSource
-	if errors.As(err, &errorWithSource) {
+	if errorWithSource, ok := errors.AsType[backend.ErrorWithSource](err); ok {
 		if errorWithSource.ErrorSource() == backend.ErrorSourcePlugin {
 			return backend.PluginError(errorMessage)
 		}

--- a/pkg/tsdb/azuremonitor/utils/utils.go
+++ b/pkg/tsdb/azuremonitor/utils/utils.go
@@ -73,7 +73,8 @@ func ParseSubscriptions(res *http.Response, logger log.Logger) ([]string, error)
 }
 
 func ApplySourceFromError(errorMessage error, err error) error {
-	if errorWithSource, ok := errors.AsType[backend.ErrorWithSource](err); ok {
+	var errorWithSource backend.ErrorWithSource
+	if errors.As(err, &errorWithSource) {
 		if errorWithSource.ErrorSource() == backend.ErrorSourcePlugin {
 			return backend.PluginError(errorMessage)
 		}

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -751,8 +751,7 @@ func (ds *DataSource) executeGetQueryResults(ctx context.Context, logsClient mod
 
 	getQueryResultsResponse, err := logsClient.GetQueryResults(ctx, queryInput)
 	if err != nil {
-		var awsErr smithy.APIError
-		if errors.As(err, &awsErr) {
+		if awsErr, ok := errors.AsType[smithy.APIError](err); ok {
 			err = &AWSError{Code: awsErr.ErrorCode(), Message: awsErr.ErrorMessage()}
 		}
 		err = backend.DownstreamError(err)

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -751,7 +751,8 @@ func (ds *DataSource) executeGetQueryResults(ctx context.Context, logsClient mod
 
 	getQueryResultsResponse, err := logsClient.GetQueryResults(ctx, queryInput)
 	if err != nil {
-		if awsErr, ok := errors.AsType[smithy.APIError](err); ok {
+		var awsErr smithy.APIError
+		if errors.As(err, &awsErr) {
 			err = &AWSError{Code: awsErr.ErrorCode(), Message: awsErr.ErrorMessage()}
 		}
 		err = backend.DownstreamError(err)

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -48,8 +48,7 @@ var executeSyncLogQuery = func(ctx context.Context, ds *DataSource, req *backend
 		}
 
 		getQueryResultsOutput, err := ds.syncQuery(ctx, logsClient, q, logsQuery, ds.Settings.LogsTimeout.Duration)
-		var sourceError backend.ErrorWithSource
-		if errors.As(err, &sourceError) {
+		if sourceError, ok := errors.AsType[backend.ErrorWithSource](err); ok {
 			resp.Responses[refId] = backend.ErrorResponseWithErrorSource(sourceError)
 			continue
 		}

--- a/pkg/tsdb/cloudwatch/log_sync_query.go
+++ b/pkg/tsdb/cloudwatch/log_sync_query.go
@@ -48,7 +48,8 @@ var executeSyncLogQuery = func(ctx context.Context, ds *DataSource, req *backend
 		}
 
 		getQueryResultsOutput, err := ds.syncQuery(ctx, logsClient, q, logsQuery, ds.Settings.LogsTimeout.Duration)
-		if sourceError, ok := errors.AsType[backend.ErrorWithSource](err); ok {
+		var sourceError backend.ErrorWithSource
+		if errors.As(err, &sourceError) {
 			resp.Responses[refId] = backend.ErrorResponseWithErrorSource(sourceError)
 			continue
 		}

--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -119,8 +119,7 @@ func DriverType() string {
 }
 
 func IsBusyOrLocked(err error) bool {
-	var sqliteErr *sqlite.Error
-	if errors.As(err, &sqliteErr) {
+	if sqliteErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		// Code is 32-bit number, low 8 bits are the SQLite error code, high 24 bits are extended code.
 		code := sqliteErr.Code() & 0xff
 		return code == sqlite3.SQLITE_BUSY || code == sqlite3.SQLITE_LOCKED
@@ -132,8 +131,7 @@ func IsBusyOrLocked(err error) bool {
 }
 
 func IsUniqueConstraintViolation(err error) bool {
-	var sqliteErr *sqlite.Error
-	if errors.As(err, &sqliteErr) {
+	if sqliteErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		// These constants are extended codes combined with primary code, so we can check them directly.
 		return sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY || sqliteErr.Code() == sqlite3.SQLITE_CONSTRAINT_UNIQUE
 	}
@@ -144,8 +142,7 @@ func IsUniqueConstraintViolation(err error) bool {
 }
 
 func ErrorMessage(err error) string {
-	var sqliteErr *sqlite.Error
-	if errors.As(err, &sqliteErr) {
+	if sqliteErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqliteErr.Error()
 	}
 	return err.Error()


### PR DESCRIPTION
## What is this change?

Replaces eligible uses of `errors.As` with the generic `errors.AsType` API introduced in Go 1.26. The changes were generated with the dedicated `modernize -errorsastype` analyzer.

## Why is this a good change?

`errors.AsType` returns the matched error directly, removing the separate target declaration and pointer-to-target boilerplate required by `errors.As`. This makes the type being matched explicit at the call site and keeps the matched value scoped to the branch where it is valid.

The generic API also provides stronger compile-time type checking: its type parameter must implement `error`, avoiding invalid target shapes that `errors.As` can only reject at runtime. It preserves the same error-tree traversal and custom `As` behavior, so this is a mechanical readability and type-safety improvement without changing error-handling semantics.

Applying it consistently now also prevents a mix of old and new patterns as Grafana adopts Go 1.26.

## Verification

- Re-ran the `errorsastype` analyzer across all checked-in Go modules with no remaining findings.
- Compile-tested every changed package with `go test -run ^$`.
- All changed packages passed.