### PR TITLE
Provisioning: Instrument CompareFiles git operation

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -767,7 +767,10 @@ func (r *gitRepository) LatestRef(ctx context.Context) (string, error) {
 	return branchRef.Hash.String(), nil
 }
 
-func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]repository.VersionedFileChange, error) {
+func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) (changes []repository.VersionedFileChange, err error) {
+	start := time.Now()
+	defer func() { r.metrics.Compare(start, err) }()
+
 	if base == "" && ref == "" {
 		return nil, fmt.Errorf("base and ref cannot be empty")
 	}
@@ -781,7 +784,6 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 	// Resolve base ref to hash
 	var baseHash hash.Hash
 	if base != "" {
-		var err error
 		baseHash, err = r.resolveRefToHash(ctx, base)
 		if err != nil {
 			return nil, fmt.Errorf("resolve base ref: %w", err)
@@ -799,7 +801,7 @@ func (r *gitRepository) CompareFiles(ctx context.Context, base, ref string) ([]r
 		return nil, fmt.Errorf("compare commits: %w", err)
 	}
 
-	changes := make([]repository.VersionedFileChange, 0)
+	changes = make([]repository.VersionedFileChange, 0)
 	for _, f := range files {
 		switch f.Status {
 		case protocol.FileStatusAdded:

--- a/apps/provisioning/pkg/repository/git/repository_metrics_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_metrics_test.go
@@ -105,6 +105,36 @@ func TestGitRepository_OperationMetrics(t *testing.T) {
 		assert.Equal(t, 1.0, after.count(repository.OperationList, "success")-before.count(repository.OperationList, "success"))
 	})
 
+	t.Run("compare", func(t *testing.T) {
+		client := &mocks.FakeClient{}
+		client.GetRefReturns(nanogit.Ref{Name: "refs/heads/main", Hash: hash.Hash{}}, nil)
+		client.CompareCommitsReturns([]nanogit.CommitFile{{
+			Path: "configs/test.yaml", Status: protocol.FileStatusAdded,
+		}}, nil)
+		repo := newMetricsRepo(t, provisioning.GitRepositoryType, client)
+
+		before := gitSnapshot(t, provisioning.GitRepositoryType)
+		_, err := repo.CompareFiles(ctx, "main", "feature")
+		require.NoError(t, err)
+		after := gitSnapshot(t, provisioning.GitRepositoryType)
+
+		assert.Equal(t, 1.0, after.count(repository.OperationCompare, "success")-before.count(repository.OperationCompare, "success"))
+	})
+
+	t.Run("failed compare", func(t *testing.T) {
+		client := &mocks.FakeClient{}
+		client.GetRefReturns(nanogit.Ref{Name: "refs/heads/main", Hash: hash.Hash{}}, nil)
+		client.CompareCommitsReturns(nil, errors.New("compare failed"))
+		repo := newMetricsRepo(t, provisioning.GitRepositoryType, client)
+
+		before := gitSnapshot(t, provisioning.GitRepositoryType)
+		_, err := repo.CompareFiles(ctx, "main", "feature")
+		require.Error(t, err)
+		after := gitSnapshot(t, provisioning.GitRepositoryType)
+
+		assert.Equal(t, 1.0, after.count(repository.OperationCompare, "error")-before.count(repository.OperationCompare, "error"))
+	})
+
 	t.Run("create, update, delete and move", func(t *testing.T) {
 		repo := newMetricsRepo(t, provisioning.GitRepositoryType, writableClient())
 

--- a/apps/provisioning/pkg/repository/operation_metrics.go
+++ b/apps/provisioning/pkg/repository/operation_metrics.go
@@ -13,12 +13,13 @@ import (
 // a byte payload and are observed on the size histogram too; the rest only
 // record duration and outcome.
 const (
-	OperationRead   = "read"
-	OperationWrite  = "write"
-	OperationList   = "list"
-	OperationDelete = "delete"
-	OperationMove   = "move"
-	OperationPush   = "push"
+	OperationRead    = "read"
+	OperationWrite   = "write"
+	OperationList    = "list"
+	OperationDelete  = "delete"
+	OperationMove    = "move"
+	OperationPush    = "push"
+	OperationCompare = "compare"
 )
 
 // OperationMetrics tracks the work repositories do on behalf of their callers:
@@ -134,6 +135,12 @@ func (r *OperationRecorder) Delete(start time.Time, err error) {
 // Move records a move that started at start.
 func (r *OperationRecorder) Move(start time.Time, err error) {
 	r.recordOutcome(OperationMove, start, err)
+}
+
+// Compare records a diff between two refs that started at start, which is the
+// network round trip incremental sync makes to work out what changed.
+func (r *OperationRecorder) Compare(start time.Time, err error) {
+	r.recordOutcome(OperationCompare, start, err)
 }
 
 // Push records a staged batch being committed and pushed to the remote, which


### PR DESCRIPTION
## What

Adds operation instrumentation to the git repository's `CompareFiles` — the incremental-sync diff path that wraps the nanogit `CompareCommits` network call. Its duration and outcome are now recorded on the shared repository-operation metrics under a new `operation="compare"` label.

## Why

`CompareFiles` (`apps/provisioning/pkg/repository/git/repository.go`) was the one method on the Repository interface with zero instrumentation — no metric, no span — unlike `Read`/`ReadTree`/`Write`/`Delete`/`Move`, which all record themselves via the shared `OperationRecorder`. That left a blind spot on the network round trip incremental sync makes to work out what changed.

## How

- Added an `OperationCompare = "compare"` label alongside the existing operation labels in `operation_metrics.go`.
- Added a `Compare(start, err)` method on `OperationRecorder`, mirroring `List`/`Delete`/`Move` (duration + outcome; no byte payload, so no size histogram).
- Wrapped `CompareFiles` the same way `ReadTree` does: named returns `(changes, err)` plus `defer func() { r.metrics.Compare(start, err) }()`, covering the whole method including the `CompareCommits` call for both success and error outcomes.

The Repository Operations dashboard templates on `$operation` via `label_values(...)`, so the new series shows up automatically — no dashboard JSON changes required.

## Testing

- Added `compare` and `failed compare` subtests to `TestGitRepository_OperationMetrics` pinning one success/error observation per call.
- `go test ./apps/provisioning/pkg/repository/...` passes; `gofmt` clean.

## Checklist
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Documentation updated (n/a — metric surfaces automatically on existing dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)