### PR TITLE
Provisioning: Instrument folder metadata reads

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -588,6 +588,12 @@ func (c *ControllerConfig) URLProvider() (func(ctx context.Context, namespace st
 }
 
 func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
+	// Folder metadata read metrics are a process-global singleton recorded by
+	// resources.ReadFolderMetadata rather than threaded through the returned
+	// extras, so they must be registered regardless of which extras path is taken
+	// below — including the custom RepositoryExtrasFunc path, which returns early.
+	resources.RegisterFolderMetadataMetrics(c.Registry())
+
 	if c.repositoryExtras != nil {
 		return c.repositoryExtras, nil
 	}
@@ -608,7 +614,6 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 	}
 	decrypter := repository.ProvideDecrypter(decryptSvc, repository.RegisterDecryptMetrics(c.Registry()))
 	operationMetrics := repository.RegisterOperationMetrics(c.Registry())
-	resources.RegisterFolderMetadataMetrics(c.Registry())
 
 	operatorSec := c.Settings.SectionWithEnvOverrides("operator")
 	provisioningSec := c.Settings.SectionWithEnvOverrides("provisioning")

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -608,6 +608,7 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 	}
 	decrypter := repository.ProvideDecrypter(decryptSvc, repository.RegisterDecryptMetrics(c.Registry()))
 	operationMetrics := repository.RegisterOperationMetrics(c.Registry())
+	resources.RegisterFolderMetadataMetrics(c.Registry())
 
 	operatorSec := c.Settings.SectionWithEnvOverrides("operator")
 	provisioningSec := c.Settings.SectionWithEnvOverrides("provisioning")

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/webhooks"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/webhooks/pullrequest"
 	"github.com/grafana/grafana/pkg/setting"
@@ -37,6 +38,7 @@ func ProvideProvisioningOSSRepositoryExtras(
 ) []repository.Extra {
 	decrypter := repository.ProvideDecrypter(decryptSvc, repository.RegisterDecryptMetrics(reg))
 	operationMetrics := repository.RegisterOperationMetrics(reg)
+	resources.RegisterFolderMetadataMetrics(reg)
 	// http:// URLs with a token are only allowed in development or when explicitly opted in,
 	// since the token would otherwise travel in cleartext.
 	allowInsecure := cfg.Env == setting.Dev || cfg.ProvisioningAllowInsecure

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,6 +20,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -172,7 +175,25 @@ func marshalFolderManifest(folder *folders.Folder) ([]byte, error) {
 }
 
 // ReadFolderMetadata reads _folder.json from folderPath and returns the Folder resource and its file hash.
-func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath, ref string) (*folders.Folder, string, error) {
+func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath, ref string) (_ *folders.Folder, _ string, err error) {
+	ctx, span := tracing.Start(ctx, "provisioning.resources.read_folder_metadata",
+		attribute.String("path", folderPath),
+		attribute.String("ref", ref),
+	)
+	start := time.Now()
+	defer func() {
+		outcome := folderReadOutcome(err)
+		span.SetAttributes(attribute.String("outcome", outcome))
+		// A missing _folder.json is an expected state, not a failure, so it does
+		// not mark the span as errored — only a malformed or otherwise unreadable
+		// file does.
+		if outcome == folderReadOutcomeInvalid || outcome == folderReadOutcomeError {
+			span.RecordError(err)
+		}
+		span.End()
+		folderMetadataMetrics.recordRead(repo, start, err)
+	}()
+
 	metadataPath := safepath.Join(folderPath, folderMetadataFileName)
 	info, err := repo.Read(ctx, metadataPath, ref)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -186,9 +186,10 @@ func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath,
 		span.SetAttributes(attribute.String("outcome", outcome))
 		// A missing _folder.json is an expected state, not a failure, so it does
 		// not mark the span as errored — only a malformed or otherwise unreadable
-		// file does.
+		// file does. tracing.Error (not RecordError) sets the span status to
+		// codes.Error so these show up in status-based trace queries.
 		if outcome == folderReadOutcomeInvalid || outcome == folderReadOutcomeError {
-			span.RecordError(err)
+			tracing.Error(span, err)
 		}
 		span.End()
 		folderMetadataMetrics.recordRead(repo, start, err)

--- a/pkg/registry/apis/provisioning/resources/folder_metadata.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata.go
@@ -189,7 +189,7 @@ func ReadFolderMetadata(ctx context.Context, repo repository.Reader, folderPath,
 		// file does. tracing.Error (not RecordError) sets the span status to
 		// codes.Error so these show up in status-based trace queries.
 		if outcome == folderReadOutcomeInvalid || outcome == folderReadOutcomeError {
-			tracing.Error(span, err)
+			_ = tracing.Error(span, err)
 		}
 		span.End()
 		folderMetadataMetrics.recordRead(repo, start, err)

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_metrics.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_metrics.go
@@ -1,0 +1,109 @@
+package resources
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+)
+
+// Folder metadata read outcomes. found means _folder.json was read and parsed
+// into a usable folder identity; missing means the folder has no _folder.json,
+// an expected state (not a failure) that leaves the folder UID hash-derived and
+// unstable; invalid means a _folder.json exists but could not be parsed or lacks
+// an identity; error covers any other read failure.
+const (
+	folderReadOutcomeFound   = "found"
+	folderReadOutcomeMissing = "missing"
+	folderReadOutcomeInvalid = "invalid"
+	folderReadOutcomeError   = "error"
+)
+
+// FolderMetadataMetrics tracks reads of _folder.json files. These sit on the
+// sync hot path — every folder is read to resolve its stable UID — and their
+// outcome mirrors the folder-metadata health reasons (missing/invalid), so the
+// breakdown is worth its own series rather than folding into the generic
+// repository read metric, where "missing" would masquerade as an error.
+type FolderMetadataMetrics struct {
+	readsTotal   *prometheus.CounterVec   // repository_type, outcome
+	readDuration *prometheus.HistogramVec // repository_type
+}
+
+var (
+	folderMetadataMetricsOnce sync.Once
+	folderMetadataMetrics     *FolderMetadataMetrics
+)
+
+// RegisterFolderMetadataMetrics registers the folder metadata read metrics and
+// stores them in a package singleton so ReadFolderMetadata — a free function
+// called from the parser, folder manager, dual writer and sync without access
+// to the registry — can record to them without threading a recorder through
+// every caller.
+func RegisterFolderMetadataMetrics(reg prometheus.Registerer) *FolderMetadataMetrics {
+	folderMetadataMetricsOnce.Do(func() {
+		folderMetadataMetrics = newFolderMetadataMetrics(reg)
+	})
+	return folderMetadataMetrics
+}
+
+// newFolderMetadataMetrics builds and registers the metrics on reg without
+// touching the package singleton, so tests can exercise recording against an
+// isolated registry.
+func newFolderMetadataMetrics(reg prometheus.Registerer) *FolderMetadataMetrics {
+	readsTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grafana_provisioning_folder_metadata_reads_total",
+			Help: "Total _folder.json reads, by outcome (found, missing, invalid, error)",
+		},
+		[]string{"repository_type", "outcome"},
+	)
+	reg.MustRegister(readsTotal)
+
+	readDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "grafana_provisioning_folder_metadata_read_duration_seconds",
+			Help:    "Duration of _folder.json reads",
+			Buckets: prometheus.ExponentialBucketsRange(0.001, 30, 10), // 1ms -> 30s
+		},
+		[]string{"repository_type"},
+	)
+	reg.MustRegister(readDuration)
+
+	return &FolderMetadataMetrics{
+		readsTotal:   readsTotal,
+		readDuration: readDuration,
+	}
+}
+
+// recordRead records a folder metadata read that started at start. A nil
+// receiver records nothing (and never touches repo), so ReadFolderMetadata works
+// unchanged when the metrics were never registered (tests, dev tooling). The
+// repository type is resolved from repo only on the recording path.
+func (m *FolderMetadataMetrics) recordRead(repo repository.Reader, start time.Time, err error) {
+	if m == nil {
+		return
+	}
+	repoType := string(repo.Config().Spec.Type)
+	m.readsTotal.WithLabelValues(repoType, folderReadOutcome(err)).Inc()
+	m.readDuration.WithLabelValues(repoType).Observe(time.Since(start).Seconds())
+}
+
+// folderReadOutcome classifies the result of a folder metadata read. A missing
+// _folder.json is reported as its own outcome rather than an error because it is
+// an expected state when folder metadata is disabled or a folder predates it.
+func folderReadOutcome(err error) string {
+	switch {
+	case err == nil:
+		return folderReadOutcomeFound
+	case errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err):
+		return folderReadOutcomeMissing
+	case errors.Is(err, ErrInvalidFolderMetadata):
+		return folderReadOutcomeInvalid
+	default:
+		return folderReadOutcomeError
+	}
+}

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_metrics.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_metrics.go
@@ -99,10 +99,16 @@ func folderReadOutcome(err error) string {
 	switch {
 	case err == nil:
 		return folderReadOutcomeFound
-	case errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err):
-		return folderReadOutcomeMissing
 	case errors.Is(err, ErrInvalidFolderMetadata):
 		return folderReadOutcomeInvalid
+	// A missing ref (branch gone) is a genuine read failure, not an absent
+	// _folder.json. It must be checked before the not-found catch-all below,
+	// which would otherwise swallow it — ErrRefNotFound is itself a NotFound
+	// status error — and mislabel it as missing.
+	case errors.Is(err, repository.ErrRefNotFound):
+		return folderReadOutcomeError
+	case errors.Is(err, repository.ErrFileNotFound) || apierrors.IsNotFound(err):
+		return folderReadOutcomeMissing
 	default:
 		return folderReadOutcomeError
 	}

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_metrics_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_metrics_test.go
@@ -1,0 +1,88 @@
+package resources
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+)
+
+func TestFolderReadOutcome(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"found", nil, folderReadOutcomeFound},
+		{"missing via repository error", repository.ErrFileNotFound, folderReadOutcomeMissing},
+		{"missing via apierror", apierrors.NewNotFound(schema.GroupResource{}, "x"), folderReadOutcomeMissing},
+		{"invalid", NewInvalidFolderMetadata("f", errors.New("bad json")), folderReadOutcomeInvalid},
+		{"error", errors.New("boom"), folderReadOutcomeError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, folderReadOutcome(tt.err))
+		})
+	}
+}
+
+func TestFolderMetadataMetrics_recordRead(t *testing.T) {
+	newReader := func(repoType provisioning.RepositoryType) *repository.MockReaderWriter {
+		r := repository.NewMockReaderWriter(t)
+		r.On("Config").Return(&provisioning.Repository{
+			Spec: provisioning.RepositorySpec{Type: repoType},
+		}).Maybe()
+		return r
+	}
+
+	t.Run("records outcome and repository_type", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := newFolderMetadataMetrics(reg)
+
+		m.recordRead(newReader(provisioning.GitRepositoryType), time.Now(), nil)
+		m.recordRead(newReader(provisioning.GitRepositoryType), time.Now(), repository.ErrFileNotFound)
+		m.recordRead(newReader(provisioning.GitHubRepositoryType), time.Now(), errors.New("boom"))
+
+		assert.Equal(t, 1.0, counterValue(t, reg, string(provisioning.GitRepositoryType), folderReadOutcomeFound))
+		assert.Equal(t, 1.0, counterValue(t, reg, string(provisioning.GitRepositoryType), folderReadOutcomeMissing))
+		assert.Equal(t, 1.0, counterValue(t, reg, string(provisioning.GitHubRepositoryType), folderReadOutcomeError))
+		assert.Equal(t, 0.0, counterValue(t, reg, string(provisioning.GitRepositoryType), folderReadOutcomeError))
+	})
+
+	t.Run("nil metrics records nothing and never touches the repository", func(t *testing.T) {
+		var m *FolderMetadataMetrics
+		r := repository.NewMockReaderWriter(t) // no Config expectation: must not be called
+		assert.NotPanics(t, func() {
+			m.recordRead(r, time.Now(), nil)
+		})
+	})
+}
+
+func counterValue(t *testing.T, reg *prometheus.Registry, repoType, outcome string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != "grafana_provisioning_folder_metadata_reads_total" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			if labels["repository_type"] == repoType && labels["outcome"] == outcome {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}

--- a/pkg/registry/apis/provisioning/resources/folder_metadata_metrics_test.go
+++ b/pkg/registry/apis/provisioning/resources/folder_metadata_metrics_test.go
@@ -25,6 +25,9 @@ func TestFolderReadOutcome(t *testing.T) {
 		{"missing via repository error", repository.ErrFileNotFound, folderReadOutcomeMissing},
 		{"missing via apierror", apierrors.NewNotFound(schema.GroupResource{}, "x"), folderReadOutcomeMissing},
 		{"invalid", NewInvalidFolderMetadata("f", errors.New("bad json")), folderReadOutcomeInvalid},
+		// ErrRefNotFound is a NotFound status error too, but a missing ref is a
+		// real failure, not an absent _folder.json.
+		{"ref not found is an error, not missing", repository.ErrRefNotFound, folderReadOutcomeError},
 		{"error", errors.New("boom"), folderReadOutcomeError},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## What
Adds a dedicated metric and a tracing span for `_folder.json` reads.

- `grafana_provisioning_folder_metadata_reads_total{repository_type, outcome}`
- `grafana_provisioning_folder_metadata_read_duration_seconds{repository_type}`
- Span `provisioning.resources.read_folder_metadata` (path, ref, outcome attributes)

Outcomes: `found` / `missing` / `invalid` / `error`.

## Why
Every folder's `_folder.json` is read on the sync hot path to resolve its stable
UID, but that read had no dedicated signal — it only surfaced as a generic
repository read (already covered by #132142), where a *missing* metadata file
(an expected state) is indistinguishable from a real failure. The read was also
a dark region inside the broader `write_resource_from_file` / `run_resource`
spans. Outcomes mirror the existing folder-metadata health reasons
(`MissingFolderMetadata` / `InvalidFolderMetadata`).

## How
Instrument the single `ReadFolderMetadata` chokepoint, so every caller (parser,
folder manager, dual writer, sync) is covered by one edit. Follows the existing
`operation_metrics.go` singleton + `sync.Once` convention so the free function can
record without threading a recorder through callers; the repo type is resolved
only on the recording path, so a nil (unregistered) metrics object never touches
`repo.Config()`. Registered at the two sites that already register
`RegisterOperationMetrics` (operator + single-binary). The span uses the
context-resolved `tracing.Start` (no signature change) and marks the span errored
only for `invalid`/`error`, not for an expected `missing` file.

## Testing
- `go test ./pkg/registry/apis/provisioning/resources/ ./pkg/registry/apis/provisioning/extras/` — pass
- `go vet` + `gofmt` clean
- New tests: outcome classification (incl. `apierrors.IsNotFound` → `missing`), label/counter correctness by repository type, and the nil-metrics no-op path (asserts `Config()` is never called).

## Notes
Unlike #132142, this is a new metric name, so it will not auto-appear on the
Repository Operations dashboard — it needs its own panel/row (happy to follow up).

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated
- [x] No breaking changes (or documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)