### PR TITLE
Alerting: Address review follow-ups on state label/annotation cap

### DIFF
--- a/pkg/services/ngalert/metrics/state.go
+++ b/pkg/services/ngalert/metrics/state.go
@@ -8,7 +8,7 @@ import (
 type State struct {
 	StateUpdateDuration   prometheus.Histogram
 	StateFullSyncDuration prometheus.Histogram
-	ClampedLabelStrings   *prometheus.CounterVec
+	TruncatedStrings      *prometheus.CounterVec
 	r                     prometheus.Registerer
 }
 
@@ -38,11 +38,11 @@ func NewStateMetrics(r prometheus.Registerer) *State {
 				Buckets:   []float64{0.01, 0.1, 1, 2, 5, 10, 60},
 			},
 		),
-		ClampedLabelStrings: promauto.With(r).NewCounterVec(
+		TruncatedStrings: promauto.With(r).NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
-				Name:      "state_clamped_label_strings_total",
+				Name:      "state_truncated_strings_total",
 				Help:      "Total number of expanded label/annotation values truncated before being written into alert state, by kind (label or annotation).",
 			},
 			[]string{"kind"},

--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -22,12 +22,6 @@ import (
 
 const emptyLabelKeyPrefix = "__empty_label_key__"
 
-// DefaultMaxLabelValueSize is the default byte cap applied to any single
-// expanded label/annotation value written into alert state, complementing
-// the sender-side clamp (pkg/services/ngalert/sender). Chosen generously as
-// a safety net, not a routine content limit.
-const DefaultMaxLabelValueSize = 1 << 22 // 4 MiB
-
 type ruleStates struct {
 	states map[data.Fingerprint]*State
 }
@@ -239,7 +233,7 @@ func clampExpandedValues(log log.Logger, vals map[string]string, kind string, ma
 		log.Warn("Truncating expanded label/annotation value exceeding size cap",
 			"kind", kind, "name", k, "size", len(v), "cap", maxSize, "rule", ruleTitle, "rule_uid", ruleUID)
 		if stateMetrics != nil {
-			stateMetrics.ClampedLabelStrings.WithLabelValues(kind).Inc()
+			stateMetrics.TruncatedStrings.WithLabelValues(kind).Inc()
 		}
 	}
 	if clamped != nil {

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -164,8 +164,8 @@ func Test_expandAnnotationsAndLabels_sizeCap(t *testing.T) {
 
 		require.Len(t, lbs["big"], 10)
 		require.Len(t, anns["summary"], 10)
-		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.ClampedLabelStrings.WithLabelValues("label")))
-		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.ClampedLabelStrings.WithLabelValues("annotation")))
+		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.TruncatedStrings.WithLabelValues("label")))
+		require.Equal(t, float64(1), testutil.ToFloat64(stateMetrics.TruncatedStrings.WithLabelValues("annotation")))
 	})
 
 	t.Run("non-positive cap disables the clamp", func(t *testing.T) {

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -39,6 +39,12 @@ type StatePersister interface {
 // Sender is an optional callback intended for sending the states to an alertmanager.
 type Sender func(context.Context, StateTransitions)
 
+// DefaultMaxLabelValueSize is the default byte cap applied to any single
+// expanded label/annotation value written into alert state, complementing
+// the sender-side clamp (pkg/services/ngalert/sender). Chosen generously as
+// a safety net, not a routine content limit.
+const DefaultMaxLabelValueSize = 1 << 22 // 4 MiB
+
 type Manager struct {
 	log     log.Logger
 	metrics *metrics.State


### PR DESCRIPTION
**What is this feature?**

Two small follow-ups from review comments left on #132081 after it merged.

**Why do we need this feature?**

- `DefaultMaxLabelValueSize` was defined in `cache.go` but only referenced in `manager.go` — moved it there.
- The new metric was named `state_clamped_label_strings_total`. "Truncated" is more precise than "clamped", and "label" was misleading since the metric also counts annotation values (the `kind` label already distinguishes label from annotation). Renamed to `state_truncated_strings_total`.

**Who is this feature for?**

Operators of ngalert (in-tree and downstream consumers of `pkg/services/ngalert/state`, e.g. the ruler).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- No behavior change, naming/placement only.
- The metric was merged less than a day ago and hasn't shipped in a release yet, so renaming it now has no live cost.