### PR TITLE
Alerting: Rename sender's clamped_strings_total metric

### DIFF
--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -138,8 +138,8 @@ type alertMetrics struct {
 	queueLength             prometheus.GaugeFunc
 	queueCapacity           prometheus.Gauge
 	alertmanagersDiscovered prometheus.GaugeFunc
-	// Extension: counts label/annotation strings clamped by the sender.
-	clampedStrings *prometheus.CounterVec
+	// Extension: counts label/annotation strings truncated or dropped by the sender.
+	truncatedStrings *prometheus.CounterVec
 }
 
 // NewManager is the manager constructor.

--- a/pkg/services/ngalert/sender/notifier_ext.go
+++ b/pkg/services/ngalert/sender/notifier_ext.go
@@ -104,11 +104,11 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 			Name: "alertmanagers_discovered",
 			Help: "The number of alertmanagers discovered and active.",
 		}, alertmanagersDiscovered),
-		// Extension: New metric counting label/annotation strings clamped before sending.
-		clampedStrings: prometheus.NewCounterVec(prometheus.CounterOpts{
+		// Extension: New metric counting label/annotation strings truncated or dropped before sending.
+		truncatedStrings: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
-			Name:      "clamped_strings_total",
+			Name:      "truncated_strings_total",
 			Help:      "Total number of label/annotation strings clamped before sending: oversized values truncated or oversized names dropped.",
 		},
 			[]string{"kind", "reason"},
@@ -126,7 +126,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 			m.queueLength,
 			m.queueCapacity,
 			m.alertmanagersDiscovered,
-			m.clampedStrings,
+			m.truncatedStrings,
 		)
 	}
 

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -414,13 +414,13 @@ func (s *ExternalAlertmanager) clampLabelSet(lbls models.LabelSet, kind, alertNa
 		if len(k) > maxSize {
 			s.logger.Warn("Dropping label/annotation with name exceeding size cap",
 				"kind", kind, "namePrefix", util.TruncateUTF8(k, 64), "size", len(k), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
-			s.manager.metrics.clampedStrings.WithLabelValues(kind, "name_dropped").Inc()
+			s.manager.metrics.truncatedStrings.WithLabelValues(kind, "name_dropped").Inc()
 			continue
 		}
 		if len(v) > maxSize {
 			s.logger.Warn("Truncating label/annotation value exceeding size cap",
 				"kind", kind, "name", k, "size", len(v), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
-			s.manager.metrics.clampedStrings.WithLabelValues(kind, "value_truncated").Inc()
+			s.manager.metrics.truncatedStrings.WithLabelValues(kind, "value_truncated").Inc()
 			v = util.TruncateUTF8(v, maxSize)
 		}
 		clamped[k] = v

--- a/pkg/services/ngalert/sender/sender_test.go
+++ b/pkg/services/ngalert/sender/sender_test.go
@@ -271,7 +271,7 @@ func TestClampLabelSet(t *testing.T) {
 				require.Equal(t, "X", result.Labels.Get("alertname"))
 			})
 
-			clamped := am.manager.metrics.clampedStrings
+			clamped := am.manager.metrics.truncatedStrings
 			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("annotation", "value_truncated")))
 			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("annotation", "name_dropped")))
 			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("label", "value_truncated")))


### PR DESCRIPTION
**What is this feature?**

Renames `grafana_alerting_sender_clamped_strings_total` to `grafana_alerting_sender_truncated_strings_total`.

**Why do we need this feature?**

Matches the naming just adopted for the state manager's equivalent metric in #132148: in this case, the sender might drop the metric entirely if the key goes over the limit. Keeping consistency in the naming still makes sense though.

**Who is this feature for?**

Operators of ngalert.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- No behavior change, naming only.
- This metric shipped in #124466 with no known dashboards/alerts/docs referencing it, so renaming now has no live cost on the grafana/grafana side. One caller does need updating before it merges its own change, though: grafana-ruler's `titolins/emit-new-clamped-sender-metrics` branch scrapes this metric by its old name string (`grafana_alerting_sender_clamped_strings_total`) via `pkg/ruler/manager_metrics.go`'s `data.SendSumOfCountersPerUser`. That branch isn't merged yet, so I'll update it to the new name as part of that follow-up work.