### PR TITLE
Dashboard search: support field-value results

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -587,6 +587,10 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.features != nil && s.features.IsEnabled(ctx, featuremgmt.FlagDashboardSearchFieldValueResults) { // nolint:staticcheck
+		searchRequest.ResultFormat = resourcepb.ResourceSearchRequest_FIELD_VALUES
+	}
+
 	result, err := s.client.Search(ctx, searchRequest)
 	if err != nil {
 		errhttp.Write(ctx, err, w)

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -32,20 +32,40 @@ import (
 )
 
 func TestSearch(t *testing.T) {
+	doSearch := func(t *testing.T, handler *SearchHandler, path string) *MockClient {
+		t.Helper()
+		client := handler.client.(*MockClient)
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Add("content-type", "application/json")
+		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test"}))
+		handler.DoSearch(rr, req)
+		return client
+	}
+
 	t.Run("should hit unified storage search handler", func(t *testing.T) {
 		mockClient := &MockClient{}
 		searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), mockClient, nil)
 
-		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/search", nil)
-		req.Header.Add("content-type", "application/json")
-		req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "test"}))
+		doSearch(t, searchHandler, "/search")
 
-		searchHandler.DoSearch(rr, req)
+		require.NotNil(t, mockClient.LastSearchRequest)
+	})
 
-		if mockClient.LastSearchRequest == nil {
-			t.Fatalf("expected Search to be called, but it was not")
-		}
+	t.Run("requests field-value results when enabled", func(t *testing.T) {
+		searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), &MockClient{}, featuremgmt.WithFeatures(featuremgmt.FlagDashboardSearchFieldValueResults))
+
+		client := doSearch(t, searchHandler, "/search")
+
+		assert.Equal(t, resourcepb.ResourceSearchRequest_FIELD_VALUES, client.LastSearchRequest.ResultFormat)
+	})
+
+	t.Run("ignores explanations when field-value results are enabled", func(t *testing.T) {
+		searchHandler := NewSearchHandler(tracing.NewNoopTracerService(), &MockClient{}, featuremgmt.WithFeatures(featuremgmt.FlagDashboardSearchFieldValueResults))
+
+		client := doSearch(t, searchHandler, "/search?explain=true")
+
+		assert.Equal(t, resourcepb.ResourceSearchRequest_FIELD_VALUES, client.LastSearchRequest.ResultFormat)
 	})
 }
 

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -94,7 +94,6 @@ func SearchAll(ctx context.Context, orgID int64, request *resourcepb.ResourceSea
 	return results, nil
 }
 
-// nolint:gocyclo
 func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {
 	if result == nil {
 		return v0alpha1.SearchResults{}, nil
@@ -102,7 +101,21 @@ func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0al
 		// Wrap via GetError so the status code/reason survives, letting callers
 		// classify transient search failures (e.g. 429/503) as retryable.
 		return v0alpha1.SearchResults{}, fmt.Errorf("error searching: %w", resource.GetError(result.Error))
-	} else if result.Results == nil {
+	}
+
+	switch result.ResultFormat {
+	case resourcepb.ResourceSearchRequest_UNSPECIFIED, resourcepb.ResourceSearchRequest_RESOURCE_TABLE:
+		return parseTableResults(result, offset)
+	case resourcepb.ResourceSearchRequest_FIELD_VALUES:
+		return parseFieldValueResults(result, offset)
+	default:
+		return v0alpha1.SearchResults{}, fmt.Errorf("unsupported search result format %d", result.ResultFormat)
+	}
+}
+
+// nolint:gocyclo
+func parseTableResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {
+	if result.Results == nil {
 		return v0alpha1.SearchResults{}, nil
 	}
 
@@ -210,24 +223,102 @@ func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0al
 		sr.Hits[i] = *hit
 	}
 
-	// Add facet results
-	if result.Facet != nil {
-		sr.Facets = make(map[string]v0alpha1.FacetResult)
-		for k, v := range result.Facet {
-			sr.Facets[k] = v0alpha1.FacetResult{
-				Field:   v.Field,
-				Total:   v.Total,
-				Missing: v.Missing,
-				Terms:   make([]v0alpha1.TermFacet, len(v.Terms)),
-			}
-			for j, t := range v.Terms {
-				sr.Facets[k].Terms[j] = v0alpha1.TermFacet{
-					Term:  t.Term,
-					Count: t.Count,
-				}
-			}
-		}
+	sr.Facets = parseFacets(result.Facet)
+	return sr, nil
+}
+
+func parseFieldValueResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {
+	sr := v0alpha1.SearchResults{
+		Offset:    offset,
+		TotalHits: result.TotalHits,
+		QueryCost: result.QueryCost,
+		MaxScore:  result.MaxScore,
+		Hits:      make([]v0alpha1.DashboardHit, len(result.Rows)),
 	}
 
+	for i, row := range result.Rows {
+		if row == nil || row.Key == nil {
+			return v0alpha1.SearchResults{}, fmt.Errorf("field-value search result row %d has no resource key", i)
+		}
+		values, err := resource.DecodeSearchValues(result.Fields, row)
+		if err != nil {
+			return v0alpha1.SearchResults{}, fmt.Errorf("decoding field-value search result row %d: %w", i, err)
+		}
+
+		fields := &common.Unstructured{}
+		for name, value := range values {
+			if _, ok := standardFields[name]; !ok {
+				fields.Set(name, jsonCompatibleValue(value))
+			}
+		}
+
+		hit := &v0alpha1.DashboardHit{
+			Resource: row.Key.Resource,
+			Name:     row.Key.Name,
+			Field:    fields,
+		}
+		if title, ok := values[resource.SEARCH_FIELD_TITLE].(string); ok {
+			hit.Title = title
+		} else {
+			hit.Title = "(no title)"
+		}
+		// The declarations determine these types; comma-ok keeps mixed-version responses from panicking.
+		hit.Folder, _ = values[resource.SEARCH_FIELD_FOLDER].(string)
+		hit.Description, _ = values[resource.SEARCH_FIELD_DESCRIPTION].(string)
+		hit.Tags, _ = values[resource.SEARCH_FIELD_TAGS].([]string)
+		hit.ManagedBy.ID, _ = values[resource.SEARCH_FIELD_MANAGER_ID].(string)
+		if managerKind, ok := values[resource.SEARCH_FIELD_MANAGER_KIND].(string); ok {
+			hit.ManagedBy.Kind = utils.ManagerKind(managerKind)
+		}
+		hit.OwnerReferences, _ = values[resource.SEARCH_FIELD_OWNER_REFERENCES].([]string)
+		if row.Score != nil {
+			hit.Score = row.GetScore()
+		}
+		sr.Hits[i] = *hit
+	}
+
+	sr.Facets = parseFacets(result.Facet)
 	return sr, nil
+}
+
+func parseFacets(facets map[string]*resourcepb.ResourceSearchResponse_Facet) map[string]v0alpha1.FacetResult {
+	if facets == nil {
+		return nil
+	}
+	out := make(map[string]v0alpha1.FacetResult, len(facets))
+	for name, facet := range facets {
+		out[name] = v0alpha1.FacetResult{
+			Field:   facet.Field,
+			Total:   facet.Total,
+			Missing: facet.Missing,
+			Terms:   make([]v0alpha1.TermFacet, len(facet.Terms)),
+		}
+		for i, term := range facet.Terms {
+			out[name].Terms[i] = v0alpha1.TermFacet{Term: term.Term, Count: term.Count}
+		}
+	}
+	return out
+}
+
+func jsonCompatibleValue(value any) any {
+	switch values := value.(type) {
+	case []string:
+		return sliceToAny(values)
+	case []int64:
+		return sliceToAny(values)
+	case []float64:
+		return sliceToAny(values)
+	case []bool:
+		return sliceToAny(values)
+	default:
+		return value
+	}
+}
+
+func sliceToAny[T any](values []T) []any {
+	out := make([]any, len(values))
+	for i, value := range values {
+		out[i] = value
+	}
+	return out
 }

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -115,9 +115,7 @@ func ParseResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0al
 
 // nolint:gocyclo
 func parseTableResults(result *resourcepb.ResourceSearchResponse, offset int64) (v0alpha1.SearchResults, error) {
-	if result.Results == nil {
-		return v0alpha1.SearchResults{}, nil
-	}
+	table := result.GetResults()
 
 	titleIDX := -1
 	folderIDX := -1
@@ -129,7 +127,7 @@ func parseTableResults(result *resourcepb.ResourceSearchResponse, offset int64) 
 	managerIdIDX := -1
 	ownerRefsIDX := -1
 
-	for i, v := range result.Results.Columns {
+	for i, v := range table.GetColumns() {
 		switch v.Name {
 		case resource.SEARCH_FIELD_EXPLAIN:
 			explainIDX = i
@@ -157,11 +155,11 @@ func parseTableResults(result *resourcepb.ResourceSearchResponse, offset int64) 
 		TotalHits: result.TotalHits,
 		QueryCost: result.QueryCost,
 		MaxScore:  result.MaxScore,
-		Hits:      make([]v0alpha1.DashboardHit, len(result.Results.Rows)),
+		Hits:      make([]v0alpha1.DashboardHit, len(table.GetRows())),
 	}
 
-	for i, row := range result.Results.Rows {
-		if len(row.Cells) != len(result.Results.Columns) {
+	for i, row := range table.GetRows() {
+		if len(row.Cells) != len(table.GetColumns()) {
 			// there should never be mismatch len between # Columns and # Cells in a row. This indicates a bug in our
 			// code
 			return v0alpha1.SearchResults{}, fmt.Errorf("error parsing Search Response: mismatch number of columns and cells")
@@ -169,7 +167,7 @@ func parseTableResults(result *resourcepb.ResourceSearchResponse, offset int64) 
 
 		// Dynamically defined fields
 		fields := &common.Unstructured{}
-		for colIndex, col := range result.Results.Columns {
+		for colIndex, col := range table.GetColumns() {
 			if _, ok := standardFields[col.Name]; !ok {
 				val, err := resource.DecodeCell(col, colIndex, row.Cells[colIndex])
 				if err != nil {

--- a/pkg/services/dashboards/service/search/search_test.go
+++ b/pkg/services/dashboards/service/search/search_test.go
@@ -18,6 +18,7 @@ import (
 func TestParseResults(t *testing.T) {
 	t.Run("should parse results", func(t *testing.T) {
 		resSearchResp := &resourcepb.ResourceSearchResponse{
+			ResultFormat: resourcepb.ResourceSearchRequest_RESOURCE_TABLE,
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{
 					{
@@ -64,6 +65,70 @@ func TestParseResults(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results.Hits, 1)
 		require.Equal(t, "description", results.Hits[0].Description)
+	})
+
+	t.Run("should parse field-value results", func(t *testing.T) {
+		score := 0.75
+		resSearchResp := &resourcepb.ResourceSearchResponse{
+			ResultFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES,
+			Fields: []*resourcepb.ResourceSearchField{
+				{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.ResourceSearchField_STRING},
+				{Name: resource.SEARCH_FIELD_FOLDER, Type: resourcepb.ResourceSearchField_STRING},
+				{Name: resource.SEARCH_FIELD_TAGS, Type: resourcepb.ResourceSearchField_STRING, IsArray: true},
+				{Name: resource.SEARCH_FIELD_DESCRIPTION, Type: resourcepb.ResourceSearchField_STRING},
+				{Name: resource.SEARCH_FIELD_MANAGER_KIND, Type: resourcepb.ResourceSearchField_STRING},
+				{Name: resource.SEARCH_FIELD_MANAGER_ID, Type: resourcepb.ResourceSearchField_STRING},
+				{Name: resource.SEARCH_FIELD_OWNER_REFERENCES, Type: resourcepb.ResourceSearchField_STRING, IsArray: true},
+				{Name: builders.DASHBOARD_ERRORS_LAST_1_DAYS, Type: resourcepb.ResourceSearchField_INT64},
+				{Name: "customFlags", Type: resourcepb.ResourceSearchField_BOOLEAN, IsArray: true},
+			},
+			Rows: []*resourcepb.ResourceSearchRow{{
+				Key:   &resourcepb.ResourceKey{Name: "uid", Resource: "dashboards"},
+				Score: &score,
+				Values: []*resourcepb.ResourceSearchValue{
+					{FieldIndex: 0, StringValues: []string{"Dashboard 1"}},
+					{FieldIndex: 1, StringValues: []string{"folder1"}},
+					{FieldIndex: 2, StringValues: []string{"tag1", "tag2"}},
+					{FieldIndex: 3, StringValues: []string{"description"}},
+					{FieldIndex: 4, StringValues: []string{"repo"}},
+					{FieldIndex: 5, StringValues: []string{"manager"}},
+					{FieldIndex: 6, StringValues: []string{"iam.grafana.app/Team/devops"}},
+					{FieldIndex: 7, Int64Values: []int64{100}},
+					{FieldIndex: 8, BooleanValues: []bool{true, false}},
+				},
+			}},
+			TotalHits: 1,
+		}
+
+		results, err := ParseResults(resSearchResp, 4)
+		require.NoError(t, err)
+		require.Len(t, results.Hits, 1)
+		hit := results.Hits[0]
+		assert.Equal(t, int64(4), results.Offset)
+		assert.Equal(t, "Dashboard 1", hit.Title)
+		assert.Equal(t, "folder1", hit.Folder)
+		assert.Equal(t, []string{"tag1", "tag2"}, hit.Tags)
+		assert.Equal(t, "description", hit.Description)
+		assert.Equal(t, "repo", string(hit.ManagedBy.Kind))
+		assert.Equal(t, "manager", hit.ManagedBy.ID)
+		assert.Equal(t, []string{"iam.grafana.app/Team/devops"}, hit.OwnerReferences)
+		assert.Equal(t, score, hit.Score)
+		assert.Equal(t, int64(100), hit.Field.Object[builders.DASHBOARD_ERRORS_LAST_1_DAYS])
+		assert.Equal(t, []any{true, false}, hit.Field.Object["customFlags"])
+	})
+
+	t.Run("should reject an invalid field-value index", func(t *testing.T) {
+		resSearchResp := &resourcepb.ResourceSearchResponse{
+			ResultFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES,
+			Fields:       []*resourcepb.ResourceSearchField{{Name: resource.SEARCH_FIELD_TITLE, Type: resourcepb.ResourceSearchField_STRING}},
+			Rows: []*resourcepb.ResourceSearchRow{{
+				Key:    &resourcepb.ResourceKey{Name: "uid", Resource: "dashboards"},
+				Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 1, StringValues: []string{"Dashboard 1"}}},
+			}},
+		}
+
+		_, err := ParseResults(resSearchResp, 0)
+		require.ErrorContains(t, err, "field index 1 is out of range")
 	})
 
 	t.Run("should return error when trying to parse results with mismatch length between Columns and row Cells", func(t *testing.T) {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2958,6 +2958,14 @@ var (
 			Generate:     Generate{React: true},
 		},
 		{
+			Name:        "dashboard.searchFieldValueResults",
+			Description: "Uses field-value results for dashboard search requests",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSearchAndStorageSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:        "dashboard.vectorSearch",
 			Description: "Exposes the semantic (vector) search endpoint for dashboards under the dashboard API",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -343,6 +343,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-30,paneledit.buttonLabels,experimental,@grafana/datapro,false,false,true
 2026-05-27,grafana.panelEditNextFeedbackEvent,experimental,@grafana/datapro,false,false,true
 2026-06-12,grafana.visualDesignRefresh,experimental,@grafana/grafana-frontend-platform,false,false,true
+2026-09-08,dashboard.searchFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
 2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false
 2026-06-25,grafana.vectorSearchCmdk,experimental,@grafana/search-and-storage,false,false,true
 2026-08-04,grafana.cmdkHybridSearch,experimental,@grafana/search-and-storage,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -938,6 +938,10 @@ const (
 	// Frontend Service doesn't rely on the /bootdata API, instead loads configuration as needed
 	FlagFrontendServiceReducedBootDataAPI = "frontendService.reducedBootDataAPI"
 
+	// FlagDashboardSearchFieldValueResults
+	// Uses field-value results for dashboard search requests
+	FlagDashboardSearchFieldValueResults = "dashboard.searchFieldValueResults"
+
 	// FlagDashboardVectorSearch
 	// Exposes the semantic (vector) search endpoint for dashboards under the dashboard API
 	FlagDashboardVectorSearch = "dashboard.vectorSearch"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1678,6 +1678,19 @@
     },
     {
       "metadata": {
+        "name": "dashboard.searchFieldValueResults",
+        "resourceVersion": "1788883151754",
+        "creationTimestamp": "2026-09-08T15:59:11Z"
+      },
+      "spec": {
+        "description": "Uses field-value results for dashboard search requests",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboard.vectorSearch",
         "resourceVersion": "1781031364322",
         "creationTimestamp": "2026-06-09T18:56:04Z",

--- a/pkg/storage/unified/resource/search_result.go
+++ b/pkg/storage/unified/resource/search_result.go
@@ -1,0 +1,64 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// DecodeSearchValues resolves a field-value row into values keyed by field name.
+func DecodeSearchValues(fields []*resourcepb.ResourceSearchField, row *resourcepb.ResourceSearchRow) (map[string]any, error) {
+	if row == nil {
+		return nil, fmt.Errorf("nil search result row")
+	}
+
+	values := make(map[string]any, len(row.Values))
+	seen := make(map[uint32]struct{}, len(row.Values))
+	for _, value := range row.Values {
+		if value == nil {
+			return nil, fmt.Errorf("nil field value")
+		}
+		if _, ok := seen[value.FieldIndex]; ok {
+			return nil, fmt.Errorf("duplicate field index %d", value.FieldIndex)
+		}
+		seen[value.FieldIndex] = struct{}{}
+		if value.FieldIndex >= uint32(len(fields)) {
+			return nil, fmt.Errorf("field index %d is out of range", value.FieldIndex)
+		}
+		field := fields[value.FieldIndex]
+		if field == nil {
+			return nil, fmt.Errorf("field index %d has no definition", value.FieldIndex)
+		}
+		decoded, err := decodeSearchValue(field, value)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", field.Name, err)
+		}
+		values[field.Name] = decoded
+	}
+	return values, nil
+}
+
+func decodeSearchValue(field *resourcepb.ResourceSearchField, value *resourcepb.ResourceSearchValue) (any, error) {
+	switch field.Type {
+	case resourcepb.ResourceSearchField_STRING:
+		return searchScalarOrArray(value.StringValues, field.IsArray)
+	case resourcepb.ResourceSearchField_INT64, resourcepb.ResourceSearchField_DATE:
+		return searchScalarOrArray(value.Int64Values, field.IsArray)
+	case resourcepb.ResourceSearchField_DOUBLE:
+		return searchScalarOrArray(value.DoubleValues, field.IsArray)
+	case resourcepb.ResourceSearchField_BOOLEAN:
+		return searchScalarOrArray(value.BooleanValues, field.IsArray)
+	default:
+		return nil, fmt.Errorf("unsupported type %s", field.Type)
+	}
+}
+
+func searchScalarOrArray[T any](values []T, isArray bool) (any, error) {
+	if isArray {
+		return values, nil
+	}
+	if len(values) != 1 {
+		return nil, fmt.Errorf("scalar has %d values", len(values))
+	}
+	return values[0], nil
+}

--- a/pkg/storage/unified/resource/search_result_test.go
+++ b/pkg/storage/unified/resource/search_result_test.go
@@ -1,0 +1,88 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+func TestDecodeSearchValues(t *testing.T) {
+	fields := []*resourcepb.ResourceSearchField{
+		{Name: "title", Type: resourcepb.ResourceSearchField_STRING},
+		{Name: "counts", Type: resourcepb.ResourceSearchField_INT64, IsArray: true},
+		{Name: "ratio", Type: resourcepb.ResourceSearchField_DOUBLE},
+		{Name: "flags", Type: resourcepb.ResourceSearchField_BOOLEAN, IsArray: true},
+		{Name: "created", Type: resourcepb.ResourceSearchField_DATE},
+	}
+	row := &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{
+		{FieldIndex: 0, StringValues: []string{"Dashboard"}},
+		{FieldIndex: 1, Int64Values: []int64{1, 2}},
+		{FieldIndex: 2, DoubleValues: []float64{0.5}},
+		{FieldIndex: 3, BooleanValues: []bool{true, false}},
+		{FieldIndex: 4, Int64Values: []int64{1234}},
+	}}
+
+	values, err := DecodeSearchValues(fields, row)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{
+		"title":   "Dashboard",
+		"counts":  []int64{1, 2},
+		"ratio":   0.5,
+		"flags":   []bool{true, false},
+		"created": int64(1234),
+	}, values)
+}
+
+func TestDecodeSearchValuesRejectsMalformedRows(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []*resourcepb.ResourceSearchField
+		row    *resourcepb.ResourceSearchRow
+		err    string
+	}{
+		{name: "nil row", err: "nil search result row"},
+		{
+			name:   "duplicate field",
+			fields: []*resourcepb.ResourceSearchField{{Name: "title", Type: resourcepb.ResourceSearchField_STRING}},
+			row: &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{
+				{FieldIndex: 0, StringValues: []string{"one"}},
+				{FieldIndex: 0, StringValues: []string{"two"}},
+			}},
+			err: "duplicate field index 0",
+		},
+		{
+			name:   "out of range",
+			fields: []*resourcepb.ResourceSearchField{{Name: "title", Type: resourcepb.ResourceSearchField_STRING}},
+			row:    &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 1}}},
+			err:    "field index 1 is out of range",
+		},
+		{
+			name:   "nil definition",
+			fields: []*resourcepb.ResourceSearchField{nil},
+			row:    &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 0}}},
+			err:    "field index 0 has no definition",
+		},
+		{
+			name:   "invalid scalar",
+			fields: []*resourcepb.ResourceSearchField{{Name: "title", Type: resourcepb.ResourceSearchField_STRING}},
+			row:    &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 0}}},
+			err:    `field "title": scalar has 0 values`,
+		},
+		{
+			name:   "unsupported type",
+			fields: []*resourcepb.ResourceSearchField{{Name: "title"}},
+			row:    &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 0}}},
+			err:    `field "title": unsupported type UNSPECIFIED`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := DecodeSearchValues(test.fields, test.row)
+			require.EqualError(t, err, test.err)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds client-side support for the field-value unified search result format to dashboard search.

The new format is requested only when `dashboard.searchFieldValueResults` is enabled. The client accepts both field-value and legacy `ResourceTable` responses, allowing immediate rollback and compatibility with older search servers.

Search explanations are not returned when the new format is enabled.

## Compatibility

The helper under `pkg/storage/unified/resource` only decodes responses for API-layer clients; it does not change storage or search server behavior. Keeping it with the dashboard client avoids duplicating the format decoder across later client migrations. The client remains compatible with old servers because it continues to decode unspecified-format `ResourceTable` responses.

Part of https://github.com/grafana/search-and-storage-team/issues/890
