### PR TITLE
Server: Render error pages without frontend assets

### DIFF
--- a/pkg/middleware/recovery_test.go
+++ b/pkg/middleware/recovery_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"errors"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -41,6 +43,19 @@ func TestRecoveryMiddleware(t *testing.T) {
 			assert.Equal(t, "text/html; charset=UTF-8", sc.resp.Header().Get("content-type"))
 			assert.Contains(t, sc.resp.Body.String(), "<title>Grafana - Error</title>")
 		})
+	})
+}
+
+func TestErrorTemplateRendersFromReqContextHandle(t *testing.T) {
+	recoveryScenario(t, "error template should render from ReqContext.Handle", "/error", func(t *testing.T, sc *scenarioContext) {
+		sc.handlerFunc = func(c *contextmodel.ReqContext) {
+			c.Handle(sc.cfg, http.StatusBadRequest, "intentional error-page test", errors.New("intentional error-page test"))
+		}
+		sc.fakeReq("GET", "/error").exec()
+
+		assert.Equal(t, http.StatusBadRequest, sc.resp.Code)
+		assert.Equal(t, "text/html; charset=UTF-8", sc.resp.Header().Get("content-type"))
+		assert.Contains(t, sc.resp.Body.String(), "</html>")
 	})
 }
 

--- a/public/views/error.html
+++ b/public/views/error.html
@@ -21,8 +21,6 @@
       :root {
         --fs-loader-bg: #f4f5f5;
         --fs-loader-text-color: rgb(36, 41, 46);
-        --fs-spinner-arc-color: #f55f3e;
-        --fs-spinner-track-color: rgba(36, 41, 46, 0.12);
         --fs-color-error: #e0226e;
       }
 
@@ -31,15 +29,7 @@
         :root {
           --fs-loader-bg: #111217;
           --fs-loader-text-color: rgb(204, 204, 220);
-          --fs-spinner-arc-color: #f55f3e;
-          --fs-spinner-track-color: rgba(204, 204, 220, 0.12);
           --fs-color-error: #d10e5c;
-        }
-      }
-
-      @keyframes spin {
-        to {
-          transform: rotate(360deg);
         }
       }
 
@@ -51,35 +41,6 @@
           -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
           'Segoe UI Emoji', 'Segoe UI Symbol';
         line-height: 1; /* prevent shift when css loads in that changes the body line-height */
-      }
-
-      .fs-spinner {
-        animation: spin 1500ms linear infinite;
-        width: 32px;
-        height: 32px;
-      }
-
-      .fs-spinner-track {
-        stroke: rgba(255, 255, 255, 0.15);
-      }
-
-      .fs-spinner-arc {
-        stroke: #f55f3e;
-      }
-
-      .fs-loader-text {
-        opacity: 0;
-        font-size: 16px;
-        margin-bottom: 0;
-        transition: opacity 300ms ease-in-out;
-      }
-
-      .fs-loader-starting-up .fs-loader-text {
-        opacity: 1;
-      }
-
-      .fs-variant-error .fs-loader-text {
-        opacity: 1;
       }
 
       .fs-error-icon {
@@ -144,7 +105,7 @@
     </style>
   </head>
 
-  <body class="fs-variant-error">
+  <body>
     <main class="fs-error-page">
       <section class="fs-error-page__content" aria-labelledby="error-title">
         <header class="fs-error-page__header">

--- a/public/views/error.html
+++ b/public/views/error.html
@@ -148,7 +148,7 @@
     <main class="fs-error-page">
       <section class="fs-error-page__content" aria-labelledby="error-title">
         <header class="fs-error-page__header">
-          <svg class="fs-error-icon fs-error-page__icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+          <svg class="fs-error-icon fs-error-page__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path
               d="M12,14a1.25,1.25,0,1,0,1.25,1.25A1.25,1.25,0,0,0,12,14Zm0-1.5a1,1,0,0,0,1-1v-3a1,1,0,0,0-2,0v3A1,1,0,0,0,12,12.5ZM12,2A10,10,0,1,0,22,12,10.01114,10.01114,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8.00917,8.00917,0,0,1,12,20Z"
             />

--- a/public/views/error.html
+++ b/public/views/error.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -10,79 +10,165 @@
 
     <base href="[[.AppSubUrl]]/" />
 
-    [[range $asset := .Assets.CSSFiles]]
-    <link rel="stylesheet" href="[[$asset.FilePath]]" />
-    [[end]]
-
-    [[ if eq .ThemeType "light" ]]
-    <link rel="stylesheet" href="[[.Assets.Light]]" />
-    [[ else ]]
-    <link rel="stylesheet" href="[[.Assets.Dark]]" />
-    [[ end ]]
-
-    <link rel="icon" type="image/png" href="public/img/fav32.png" />
-    <link rel="mask-icon" href="public/img/grafana_mask_icon.svg" color="#F05A28" />
     <style>
-      html {
-        height: 100%;
+      /**
+        * This style tag is purposefully inside the fs-loader div so
+        * when AppWrapper mounts and removes the div
+        * the styles are taken away with it as well.
+        */
+
+      /* Light theme */
+      :root {
+        --fs-loader-bg: #f4f5f5;
+        --fs-loader-text-color: rgb(36, 41, 46);
+        --fs-spinner-arc-color: #f55f3e;
+        --fs-spinner-track-color: rgba(36, 41, 46, 0.12);
+        --fs-color-error: #e0226e;
+      }
+
+      /* Dark theme */
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --fs-loader-bg: #111217;
+          --fs-loader-text-color: rgb(204, 204, 220);
+          --fs-spinner-arc-color: #f55f3e;
+          --fs-spinner-track-color: rgba(204, 204, 220, 0.12);
+          --fs-color-error: #d10e5c;
+        }
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
 
       body {
-        font-family: 'Inter', 'Helvetica', 'Arial', sans-serif;
-        font-size: 14px;
-        line-height: 1.5714285714285714;
-        height: 100%;
+        background-color: var(--fs-loader-bg);
+        color: var(--fs-loader-text-color);
         margin: 0;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+          'Segoe UI Emoji', 'Segoe UI Symbol';
+        line-height: 1; /* prevent shift when css loads in that changes the body line-height */
+      }
+
+      .fs-spinner {
+        animation: spin 1500ms linear infinite;
+        width: 32px;
+        height: 32px;
+      }
+
+      .fs-spinner-track {
+        stroke: rgba(255, 255, 255, 0.15);
+      }
+
+      .fs-spinner-arc {
+        stroke: #f55f3e;
+      }
+
+      .fs-loader-text {
+        opacity: 0;
+        font-size: 16px;
+        margin-bottom: 0;
+        transition: opacity 300ms ease-in-out;
+      }
+
+      .fs-loader-starting-up .fs-loader-text {
+        opacity: 1;
+      }
+
+      .fs-variant-error .fs-loader-text {
+        opacity: 1;
+      }
+
+      .fs-error-icon {
+        fill: var(--fs-color-error);
+      }
+
+      .fs-error-page {
+        box-sizing: border-box;
+        padding: 48px 32px;
+      }
+
+      .fs-error-page__content {
+        max-width: 720px;
         width: 100%;
       }
 
-      body.theme-dark {
-        background-color: #111217;
-        color: rgb(204, 204, 220);
+      .fs-error-page__header {
+        align-items: center;
+        display: flex;
+        gap: 12px;
+        margin-bottom: 24px;
       }
 
-      body.theme-light {
-        background-color: #fbfbfb;
-        color: rgba(36, 41, 46, 1);
+      .fs-error-page__icon {
+        flex: 0 0 auto;
+        height: 32px;
+        width: 32px;
+      }
+
+      .fs-error-page h1,
+      .fs-error-page h2,
+      .fs-error-page p {
+        line-height: 1.5;
+      }
+
+      .fs-error-page a {
+        color: currentColor;
+      }
+
+      .fs-error-page h1 {
+        font-size: 20px;
+        margin: 0;
+      }
+
+      .fs-error-page h2 {
+        font-size: 16px;
+        margin: 32px 0 8px;
+      }
+
+      .fs-error-page p {
+        margin: 4px 0 0;
+      }
+
+      .fs-error-page pre {
+        border-left: 3px solid var(--fs-color-error);
+        line-height: 1.5;
+        margin: 0;
+        overflow: auto;
+        padding: 12px 16px;
+        white-space: pre-wrap;
       }
     </style>
   </head>
 
-  <body class="theme-[[ .ThemeType ]]">
-    <div class="main-view">
-      <div class="page-container">
-        <div class="page-header">
-          <div class="page-header__inner">
-            <span class="page-header__logo">
-              <i class="page-header__icon fa fa-frown-o"></i>
-            </span>
-            <div class="page-header__info-block">
-              <h1 class="page-header__title">
-                <a class="text-link" href="login">Grafana</a><span> / Server Error</span><span></span>
-              </h1>
-              <div class="page-header__sub-title">Sadly something went wrong</div>
-            </div>
+  <body class="fs-variant-error">
+    <main class="fs-error-page">
+      <section class="fs-error-page__content" aria-labelledby="error-title">
+        <header class="fs-error-page__header">
+          <svg class="fs-error-icon fs-error-page__icon" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+            <path
+              d="M12,14a1.25,1.25,0,1,0,1.25,1.25A1.25,1.25,0,0,0,12,14Zm0-1.5a1,1,0,0,0,1-1v-3a1,1,0,0,0-2,0v3A1,1,0,0,0,12,12.5ZM12,2A10,10,0,1,0,22,12,10.01114,10.01114,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8.00917,8.00917,0,0,1,12,20Z"
+            />
+          </svg>
+
+          <div>
+            <h1 id="error-title"><a class="text-link" href="login">Grafana</a><span> / Server Error</span></h1>
+            <p>Sadly something went wrong.</p>
           </div>
-        </div>
-      </div>
-      <div class="page-container page-body ng-scope" style="padding: 2rem">
-        <div class="alert">
-          <div class="alert-icon"><icon name="'exclamation-triangle'"></icon></div>
-          <div class="alert-body">
-            <div class="alert-title">[[.Title]]</div>
-          </div>
-        </div>
-        <br />
+        </header>
+
         [[if .ErrorMsg]]
-        <h4 class="page-heading">Error details</h4>
-        <div class="alert-text">
-          <pre>[[.ErrorMsg]]</pre>
-        </div>
-        [[end]]
-        <div style="padding: 2rem 0 0">
-          <p>Check the Grafana server logs for the detailed error message.</p>
-        </div>
-      </div>
-    </div>
+        <h2>[[if .Title]][[.Title]][[else]]Error details[[end]]</h2>
+        <pre>[[.ErrorMsg]]</pre>
+        [[else]] [[if .Title]]
+        <h2>[[.Title]]</h2>
+        [[end]] [[end]]
+
+        <p>Check the Grafana server logs for the detailed error message.</p>
+      </section>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
**What is this feature?**

Replaces asset-dependent CSS in `error.html` with inline styles. Error pages render without `EntryPointAssets`.

<img width="1415" height="1276" alt="Screenshot 2026-09-09 at 12 47 40 pm" src="https://github.com/user-attachments/assets/cad9dc73-4db3-415b-96ac-94b4c7a5d5de" />


**Why do we need this feature?**

So `ReqContext.Handle` can render an HTML error page when no web asset manifest is available.

**Who is this feature for?**

Grafana users and operators.

**Which issue(s) does this PR fix?**:

Fixes #120356  
Closes #131851

**Special notes for your reviewer:**

`go test ./pkg/middleware -run '^TestErrorTemplateRendersFromReqContextHandle$'`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it is added to the What's New document.