### PR TITLE
DashboardScene: Preserve publicDashboardEnabled when rebuilding from spec

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.test.ts
@@ -244,6 +244,17 @@ describe('APPLY_SPEC with a panel open for editing', () => {
   });
 });
 
+describe('APPLY_SPEC preserves access flags through the rebuild', () => {
+  it('keeps publicDashboardEnabled when the live scene had a public dashboard', async () => {
+    const scene = buildScene(makeSpec());
+    scene.setState({ meta: { ...scene.state.meta, publicDashboardEnabled: true } });
+
+    expect((await applySpec(scene, makeSpec())).success).toBe(true);
+
+    expect(scene.state.meta.publicDashboardEnabled).toBe(true);
+  });
+});
+
 describe('APPLY_SPEC keeps the rebuilt layout draggable', () => {
   // Regression: the rebuild swaps in a freshly-deserialized layout manager whose grid is not
   // draggable/resizable by default. Only the pre-rebuild body ever got `editModeChanged(true)`

--- a/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/applySpec.ts
@@ -57,6 +57,10 @@ function dtoFromScene(scene: MutationContextScene, spec: DashboardV2Spec): Dashb
       canAdmin: meta.canAdmin !== false,
       slug: meta.slug,
       url: meta.url,
+      // transformSaveModelSchemaV2ToScene maps this back onto meta.publicDashboardEnabled.
+      // Dropping it would clear the public-dashboard flag on every APPLY_SPEC rebuild.
+      isPublic: meta.publicDashboardEnabled,
+      annotationsPermissions: meta.annotationsPermissions,
     },
     // Whichever v2 version the backend serves (stable v2 or v2beta1). It is
     // stamped onto the scene, so a wrong literal would mislabel it on save.
@@ -104,6 +108,8 @@ type MutationContextScene = {
       slug?: string;
       url?: string;
       key?: string;
+      publicDashboardEnabled?: boolean;
+      annotationsPermissions?: DashboardWithAccessInfo<DashboardV2Spec>['access']['annotationsPermissions'];
     };
   };
   serializer: { getK8SMetadata: () => Partial<ObjectMeta> | undefined };

--- a/public/app/features/dashboard-scene/sidebar/codePaneUtils.test.ts
+++ b/public/app/features/dashboard-scene/sidebar/codePaneUtils.test.ts
@@ -2,6 +2,8 @@ import yaml from 'js-yaml';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
+
 import { applyJsonToDashboard, getDashboardDiffTexts, getDashboardResourceText } from './codePaneUtils';
 
 jest.mock('../serialization/transformSceneToSaveModelSchemaV2', () => ({
@@ -41,9 +43,9 @@ function buildDashboard(uid?: string): DashboardScene {
   return { state: { uid } } as unknown as DashboardScene;
 }
 
-function buildApplyDashboard(uid?: string): DashboardScene {
+function buildApplyDashboard(uid?: string, meta: Record<string, unknown> = {}): DashboardScene {
   return {
-    state: { uid, key: 'key-1', isEditing: true, meta: {}, body: { editModeChanged: jest.fn() } },
+    state: { uid, key: 'key-1', isEditing: true, meta, body: { editModeChanged: jest.fn() } },
     serializer: { metadata: {} },
     onEnterEditMode: jest.fn(),
     setState: jest.fn(),
@@ -221,6 +223,19 @@ describe('applyJsonToDashboard', () => {
     );
     expect(result.success).toBe(false);
     expect(result.error).toContain('metadata');
+  });
+
+  it('passes access.isPublic from the live scene so the rebuild keeps publicDashboardEnabled', () => {
+    const dashboard = buildApplyDashboard('abc-123', { publicDashboardEnabled: true });
+    const text = getDashboardResourceText(buildDashboard('abc-123'));
+
+    applyJsonToDashboard(dashboard, text);
+
+    expect(jest.mocked(transformSaveModelSchemaV2ToScene)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        access: expect.objectContaining({ isPublic: true }),
+      })
+    );
   });
 
   it('applies the resource text generated for a saved dashboard', () => {

--- a/public/app/features/dashboard-scene/sidebar/codePaneUtils.ts
+++ b/public/app/features/dashboard-scene/sidebar/codePaneUtils.ts
@@ -196,6 +196,9 @@ export function applyJsonToDashboard(
         annotationsPermissions: meta.annotationsPermissions,
         url: meta.url,
         slug: meta.slug,
+        // transformSaveModelSchemaV2ToScene maps this back onto meta.publicDashboardEnabled.
+        // Dropping it would clear the public-dashboard flag on every JSON apply rebuild.
+        isPublic: meta.publicDashboardEnabled,
       },
     };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

APPLY_SPEC and the dashboard code-pane JSON apply path rebuild the live scene from a `DashboardWithAccessInfo` envelope. Both copied permission flags from `scene.state.meta` into `access`, but neither set `isPublic: meta.publicDashboardEnabled`. `transformSaveModelSchemaV2ToScene` always writes `meta.publicDashboardEnabled` from `dto.access.isPublic`, so the flag was wiped on every rebuild.

This PR copies `isPublic` (and `annotationsPermissions` on APPLY_SPEC, which was also missing from that envelope) so a public dashboard stays marked public after a spec/JSON apply.

**Why do we need this feature?**

Without it, applying a spec (mutation API) or applying JSON from the schema editor dropped `meta.publicDashboardEnabled`. That affects:

- The public dashboard toolbar badge (falls back to a query, or can flicker/mis-skip)
- Library panel repeat migration, which still must run on public dashboards even when `dashboardNewLayouts` is on (`LibraryPanelBehavior` checks `meta.publicDashboardEnabled === true`)

**Who is this feature for?**

Anyone editing a publicly shared dashboard via the v2 spec / JSON editor.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

This is a real round-trip bug, not a false positive. The displayed JSON envelope is a k8s `Dashboard` (spec + metadata.name only) and does not include access; the defect is only in the *apply* DTO that feeds `transformSaveModelSchemaV2ToScene`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44df2361-4ff3-4d26-bb03-b118174cea5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44df2361-4ff3-4d26-bb03-b118174cea5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

