### PR TITLE
Authz: Add RBAC/Zanzana evaluation parity tests

### DIFF
--- a/pkg/services/authz/rbac/service_test.go
+++ b/pkg/services/authz/rbac/service_test.go
@@ -3,26 +3,21 @@ package rbac
 import (
 	"context"
 	"fmt"
-	"slices"
 	"testing"
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/singleflight"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/authn"
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
-	"github.com/grafana/authlib/cache"
 	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
-	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/authz/rbac/store"
 	"github.com/grafana/grafana/pkg/services/team"
@@ -3441,244 +3436,6 @@ func actionSetsForVerb(t *testing.T, group, resource, subresource, verb string) 
 	_, actionSets, err := setupService().validateAction(context.Background(), group, resource, subresource, verb)
 	require.NoError(t, err)
 	return actionSets
-}
-
-func setupService() *Service {
-	cache := cache.NewLocalCache(cache.Config{Expiry: 5 * time.Minute, CleanupInterval: 5 * time.Minute})
-	logger := log.New("authz-rbac-service")
-	fStore := &fakeStore{}
-	tracer := tracing.NewNoopTracerService()
-	return &Service{
-		logger:          logger,
-		mapper:          NewMapperRegistry(),
-		tracer:          tracer,
-		metrics:         newMetrics(nil),
-		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
-		permCache:       newCacheWrap[map[string]bool](cache, logger, tracer, shortCacheTTL),
-		permDenialCache: newCacheWrap[bool](cache, logger, tracer, shortCacheTTL),
-		userTeamCache:   newCacheWrap[[]int64](cache, logger, tracer, shortCacheTTL),
-		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, longCacheTTL),
-		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, shortCacheTTL),
-		teamIDCache:     newCacheWrap[map[int64]string](cache, logger, tracer, shortCacheTTL),
-		settings:        Settings{AnonOrgRole: "Viewer"},
-		store:           fStore,
-		permissionStore: fStore,
-		folderStore:     fStore,
-		identityStore:   &fakeIdentityStore{},
-		sf:              new(singleflight.Group),
-	}
-}
-
-type fakeStore struct {
-	store.Store
-	// The namespace has to be set in the handlers for the correct organization to be picked up.
-	disableNsCheck  bool
-	folders         []store.Folder
-	basicRole       *store.BasicRole
-	userID          *store.UserIdentifiers
-	userPermissions []accesscontrol.Permission
-	err             bool
-	calls           int
-	// folderListCalls counts only ListFolders, since calls counts every store call.
-	folderListCalls int
-}
-
-func (f *fakeStore) GetBasicRoles(ctx context.Context, namespace types.NamespaceInfo, query store.BasicRoleQuery) (*store.BasicRole, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("store error")
-	}
-	return f.basicRole, nil
-}
-
-func (f *fakeStore) GetUserIdentifiers(ctx context.Context, query store.UserIdentifierQuery) (*store.UserIdentifiers, error) {
-	if _, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && !ok {
-		return nil, fmt.Errorf("namespace not found")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("store error")
-	}
-	return f.userID, nil
-}
-
-func (f *fakeStore) GetUserPermissions(ctx context.Context, namespace types.NamespaceInfo, query store.PermissionsQuery) ([]accesscontrol.Permission, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("store error")
-	}
-	var permissions []accesscontrol.Permission
-	for _, p := range f.userPermissions {
-		if p.Action == query.Action || slices.Contains(query.ActionSets, p.Action) {
-			permissions = append(permissions, p)
-		}
-	}
-	return permissions, nil
-}
-
-func (f *fakeStore) ListFolders(ctx context.Context, namespace types.NamespaceInfo) ([]store.Folder, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	f.folderListCalls++
-	if f.err {
-		return nil, fmt.Errorf("store error")
-	}
-	return f.folders, nil
-}
-
-type fakeIdentityStore struct {
-	legacy.LegacyIdentityStore
-	userTeams       []int64
-	teams           []team.Team
-	serviceAccounts []legacy.ServiceAccount
-	users           []common.UserWithRole
-	pageSize        int // if > 0, simulates pagination with this page size
-	disableNsCheck  bool
-	err             bool
-	calls           int
-}
-
-func (f *fakeIdentityStore) ListUserTeams(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserTeamsQuery) (*legacy.ListUserTeamsResult, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("identity store error")
-	}
-	items := make([]legacy.UserTeam, 0, len(f.userTeams))
-	for _, teamID := range f.userTeams {
-		items = append(items, legacy.UserTeam{ID: teamID})
-	}
-	return &legacy.ListUserTeamsResult{
-		Items:    items,
-		Continue: 0,
-	}, nil
-}
-
-func (f *fakeIdentityStore) ListTeams(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListTeamQuery) (*legacy.ListTeamResult, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("identity store error")
-	}
-	if query.Pagination.Limit < 1 && f.pageSize > 0 {
-		query.Pagination.Limit = int64(f.pageSize)
-	}
-	return paginateTeams(f.teams, query.Pagination), nil
-}
-
-func (f *fakeIdentityStore) ListServiceAccounts(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListServiceAccountsQuery) (*legacy.ListServiceAccountResult, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("identity store error")
-	}
-	if query.Pagination.Limit < 1 && f.pageSize > 0 {
-		query.Pagination.Limit = int64(f.pageSize)
-	}
-	return paginateServiceAccounts(f.serviceAccounts, query.Pagination), nil
-}
-
-func (f *fakeIdentityStore) ListUsers(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserQuery) (*legacy.ListUserResult, error) {
-	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
-		return nil, fmt.Errorf("namespace mismatch")
-	}
-	f.calls++
-	if f.err {
-		return nil, fmt.Errorf("identity store error")
-	}
-	if query.Pagination.Limit < 1 && f.pageSize > 0 {
-		query.Pagination.Limit = int64(f.pageSize)
-	}
-	return paginateUsers(f.users, query.Pagination), nil
-}
-
-// paginateTeams simulates cursor-based pagination over a slice of teams.
-func paginateTeams(items []team.Team, p common.Pagination) *legacy.ListTeamResult {
-	limit := int(p.Limit)
-	if limit < 1 {
-		limit = len(items) // no limit = return all
-	}
-	start := 0
-	if p.Continue > 0 {
-		for i, t := range items {
-			if t.ID >= p.Continue {
-				start = i
-				break
-			}
-		}
-	}
-	end := start + limit
-	if end >= len(items) {
-		return &legacy.ListTeamResult{Teams: items[start:]}
-	}
-	return &legacy.ListTeamResult{
-		Teams:    items[start:end],
-		Continue: items[end].ID,
-	}
-}
-
-// paginateServiceAccounts simulates cursor-based pagination over a slice of service accounts.
-func paginateServiceAccounts(items []legacy.ServiceAccount, p common.Pagination) *legacy.ListServiceAccountResult {
-	limit := int(p.Limit)
-	if limit < 1 {
-		limit = len(items)
-	}
-	start := 0
-	if p.Continue > 0 {
-		for i, sa := range items {
-			if sa.ID >= p.Continue {
-				start = i
-				break
-			}
-		}
-	}
-	end := start + limit
-	if end >= len(items) {
-		return &legacy.ListServiceAccountResult{Items: items[start:]}
-	}
-	return &legacy.ListServiceAccountResult{
-		Items:    items[start:end],
-		Continue: items[end].ID,
-	}
-}
-
-// paginateUsers simulates cursor-based pagination over a slice of users.
-func paginateUsers(items []common.UserWithRole, p common.Pagination) *legacy.ListUserResult {
-	limit := int(p.Limit)
-	if limit < 1 {
-		limit = len(items)
-	}
-	start := 0
-	if p.Continue > 0 {
-		for i, u := range items {
-			if u.ID >= p.Continue {
-				start = i
-				break
-			}
-		}
-	}
-	end := start + limit
-	if end >= len(items) {
-		return &legacy.ListUserResult{Items: items[start:]}
-	}
-	return &legacy.ListUserResult{
-		Items:    items[start:end],
-		Continue: items[end].ID,
-	}
 }
 
 func TestService_BatchCheck(t *testing.T) {

--- a/pkg/services/authz/rbac/testinfra.go
+++ b/pkg/services/authz/rbac/testinfra.go
@@ -1,0 +1,287 @@
+package rbac
+
+// Test infrastructure for the RBAC authorization service.
+//
+// This is deliberately a non-test file: the Zanzana parity suite
+// (pkg/services/authz/zanzana/server) builds a real RBAC Service to compare the
+// two engines' answers, and Service's fields are unexported, so the builder has
+// to live in this package. NewTestService is the only exported entry point; the
+// fakes below stay package-private and keep the field names the tests in this
+// package already use.
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/grafana/authlib/cache"
+	"github.com/grafana/authlib/types"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/authz/rbac/store"
+	"github.com/grafana/grafana/pkg/services/team"
+)
+
+// NewTestService returns a Service backed by in-memory fakes, seeded with the
+// permissions the identity holds and the namespace's folder tree. Everything
+// else (mapper, caches, folder-tree building) is the real implementation, so
+// the service evaluates requests exactly as it does in production.
+func NewTestService(userUID string, permissions []accesscontrol.Permission, folders []store.Folder) *Service {
+	s := setupService()
+	fake := &fakeStore{
+		userID:          &store.UserIdentifiers{UID: userUID, ID: 1},
+		userPermissions: permissions,
+		folders:         folders,
+	}
+	s.store = fake
+	s.permissionStore = fake
+	s.folderStore = fake
+	s.identityStore = &fakeIdentityStore{}
+	return s
+}
+
+func setupService() *Service {
+	cache := cache.NewLocalCache(cache.Config{Expiry: 5 * time.Minute, CleanupInterval: 5 * time.Minute})
+	logger := log.New("authz-rbac-service")
+	fStore := &fakeStore{}
+	tracer := tracing.NewNoopTracerService()
+	return &Service{
+		logger:          logger,
+		mapper:          NewMapperRegistry(),
+		tracer:          tracer,
+		metrics:         newMetrics(nil),
+		idCache:         newCacheWrap[store.UserIdentifiers](cache, logger, tracer, longCacheTTL),
+		permCache:       newCacheWrap[map[string]bool](cache, logger, tracer, shortCacheTTL),
+		permDenialCache: newCacheWrap[bool](cache, logger, tracer, shortCacheTTL),
+		userTeamCache:   newCacheWrap[[]int64](cache, logger, tracer, shortCacheTTL),
+		basicRoleCache:  newCacheWrap[store.BasicRole](cache, logger, tracer, longCacheTTL),
+		folderCache:     newCacheWrap[folderTree](cache, logger, tracer, shortCacheTTL),
+		teamIDCache:     newCacheWrap[map[int64]string](cache, logger, tracer, shortCacheTTL),
+		settings:        Settings{AnonOrgRole: "Viewer"},
+		store:           fStore,
+		permissionStore: fStore,
+		folderStore:     fStore,
+		identityStore:   &fakeIdentityStore{},
+		sf:              new(singleflight.Group),
+	}
+}
+
+type fakeStore struct {
+	store.Store
+	// The namespace has to be set in the handlers for the correct organization to be picked up.
+	disableNsCheck  bool
+	folders         []store.Folder
+	basicRole       *store.BasicRole
+	userID          *store.UserIdentifiers
+	userPermissions []accesscontrol.Permission
+	err             bool
+	calls           int
+	// folderListCalls counts only ListFolders, since calls counts every store call.
+	folderListCalls int
+}
+
+func (f *fakeStore) GetBasicRoles(ctx context.Context, namespace types.NamespaceInfo, query store.BasicRoleQuery) (*store.BasicRole, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("store error")
+	}
+	return f.basicRole, nil
+}
+
+func (f *fakeStore) GetUserIdentifiers(ctx context.Context, query store.UserIdentifierQuery) (*store.UserIdentifiers, error) {
+	if _, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && !ok {
+		return nil, fmt.Errorf("namespace not found")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("store error")
+	}
+	return f.userID, nil
+}
+
+func (f *fakeStore) GetUserPermissions(ctx context.Context, namespace types.NamespaceInfo, query store.PermissionsQuery) ([]accesscontrol.Permission, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("store error")
+	}
+	var permissions []accesscontrol.Permission
+	for _, p := range f.userPermissions {
+		if p.Action == query.Action || slices.Contains(query.ActionSets, p.Action) {
+			permissions = append(permissions, p)
+		}
+	}
+	return permissions, nil
+}
+
+func (f *fakeStore) ListFolders(ctx context.Context, namespace types.NamespaceInfo) ([]store.Folder, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	f.folderListCalls++
+	if f.err {
+		return nil, fmt.Errorf("store error")
+	}
+	return f.folders, nil
+}
+
+type fakeIdentityStore struct {
+	legacy.LegacyIdentityStore
+	userTeams       []int64
+	teams           []team.Team
+	serviceAccounts []legacy.ServiceAccount
+	users           []common.UserWithRole
+	pageSize        int // if > 0, simulates pagination with this page size
+	disableNsCheck  bool
+	err             bool
+	calls           int
+}
+
+func (f *fakeIdentityStore) ListUserTeams(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserTeamsQuery) (*legacy.ListUserTeamsResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	items := make([]legacy.UserTeam, 0, len(f.userTeams))
+	for _, teamID := range f.userTeams {
+		items = append(items, legacy.UserTeam{ID: teamID})
+	}
+	return &legacy.ListUserTeamsResult{
+		Items:    items,
+		Continue: 0,
+	}, nil
+}
+
+func (f *fakeIdentityStore) ListTeams(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListTeamQuery) (*legacy.ListTeamResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateTeams(f.teams, query.Pagination), nil
+}
+
+func (f *fakeIdentityStore) ListServiceAccounts(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListServiceAccountsQuery) (*legacy.ListServiceAccountResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateServiceAccounts(f.serviceAccounts, query.Pagination), nil
+}
+
+func (f *fakeIdentityStore) ListUsers(ctx context.Context, namespace types.NamespaceInfo, query legacy.ListUserQuery) (*legacy.ListUserResult, error) {
+	if ns, ok := request.NamespaceFrom(ctx); !f.disableNsCheck && (!ok || ns != namespace.Value) {
+		return nil, fmt.Errorf("namespace mismatch")
+	}
+	f.calls++
+	if f.err {
+		return nil, fmt.Errorf("identity store error")
+	}
+	if query.Pagination.Limit < 1 && f.pageSize > 0 {
+		query.Pagination.Limit = int64(f.pageSize)
+	}
+	return paginateUsers(f.users, query.Pagination), nil
+}
+
+// paginateTeams simulates cursor-based pagination over a slice of teams.
+func paginateTeams(items []team.Team, p common.Pagination) *legacy.ListTeamResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items) // no limit = return all
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, t := range items {
+			if t.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListTeamResult{Teams: items[start:]}
+	}
+	return &legacy.ListTeamResult{
+		Teams:    items[start:end],
+		Continue: items[end].ID,
+	}
+}
+
+// paginateServiceAccounts simulates cursor-based pagination over a slice of service accounts.
+func paginateServiceAccounts(items []legacy.ServiceAccount, p common.Pagination) *legacy.ListServiceAccountResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items)
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, sa := range items {
+			if sa.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListServiceAccountResult{Items: items[start:]}
+	}
+	return &legacy.ListServiceAccountResult{
+		Items:    items[start:end],
+		Continue: items[end].ID,
+	}
+}
+
+// paginateUsers simulates cursor-based pagination over a slice of users.
+func paginateUsers(items []common.UserWithRole, p common.Pagination) *legacy.ListUserResult {
+	limit := int(p.Limit)
+	if limit < 1 {
+		limit = len(items)
+	}
+	start := 0
+	if p.Continue > 0 {
+		for i, u := range items {
+			if u.ID >= p.Continue {
+				start = i
+				break
+			}
+		}
+	}
+	end := start + limit
+	if end >= len(items) {
+		return &legacy.ListUserResult{Items: items[start:]}
+	}
+	return &legacy.ListUserResult{
+		Items:    items[start:end],
+		Continue: items[end].ID,
+	}
+}

--- a/pkg/services/authz/zanzana/server/rbac_parity_test.go
+++ b/pkg/services/authz/zanzana/server/rbac_parity_test.go
@@ -1,0 +1,675 @@
+package server
+
+// Parity harness: one RBAC grant fixture is fed to both authorization engines
+// and the two answers are compared.
+//
+//	permissions ([]accesscontrol.Permission) + folder tree
+//	   ├─► RBAC:    rbac.NewTestService -> Service.Check / Service.List
+//	   └─► Zanzana: common.TranslateToResourceTuple -> OpenFGA tuples -> Server.Check / Server.List
+//
+// Both engines are driven through their public entry points, so a difference
+// here is a real behavioural difference and not an artefact of the harness.
+//
+// A case has one of two modes:
+//
+//   - Enforced (the default). The engines agree today, so any divergence fails
+//     the test. This is what stops a regression from landing.
+//   - Open gap. The engines already disagree; the case records Zanzana's current
+//     answer in zanzanaToday plus a divergence note, and is reported rather than
+//     failed. These are bugs to fix, but a permanently red suite gets ignored,
+//     so they stay green until someone closes them.
+//
+// Closing a gap means deleting zanzanaToday and divergence, which flips the case
+// to enforced. The runner logs RESOLVED when it notices a gap has closed, so it
+// tells you when that is possible.
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/authz/rbac"
+	rbacstore "github.com/grafana/grafana/pkg/services/authz/rbac/store"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+const (
+	paritySubject = "user:test-uid"
+	parityUserUID = "test-uid"
+)
+
+// ---------------------------------------------------------------------------
+// Check parity
+// ---------------------------------------------------------------------------
+
+type checkParityCase struct {
+	name        string
+	permissions []accesscontrol.Permission
+	folders     []rbacstore.Folder
+	req         *authzv1.CheckRequest
+
+	// expected is what the RBAC service answers.
+	expected bool
+	// zanzanaToday, when set, marks this case as an open gap and records what
+	// Zanzana answers while the gap is open. Reported, not asserted.
+	zanzanaToday *bool
+	// divergence explains the gap. Required whenever zanzanaToday is set.
+	divergence string
+}
+
+func TestIntegrationRBACParityCheck(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	testCases := []checkParityCase{
+		// -- direct resource grants -----------------------------------------
+		{
+			name:        "dashboard get with matching uid grant",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:dash1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", ""),
+			expected:    true,
+		},
+		{
+			name:        "dashboard get with grant on a different uid",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:dash2"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", ""),
+			expected:    false,
+		},
+		{
+			name:        "dashboard get with uid wildcard grant",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:*"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", ""),
+			expected:    true,
+		},
+		{
+			name:        "dashboard delete via dashboards:admin action set on the object",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:admin", Scope: "dashboards:uid:dash1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbDelete, "dash1", ""),
+			expected:    true,
+		},
+
+		// -- folder inheritance ---------------------------------------------
+		{
+			name:        "dashboard get via grant on its parent folder",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", "folder1"),
+			expected:    true,
+		},
+		{
+			name:        "dashboard get with grant on an unrelated folder",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}, {UID: "folder2"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", "folder2"),
+			expected:    false,
+		},
+		{
+			name:        "dashboard get inherits down the folder tree",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:parent"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}, {UID: "child", ParentUID: parityStrPtr("parent")}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", "child"),
+			expected:    true,
+		},
+		{
+			name:        "dashboard get does not inherit up the folder tree",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:child"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}, {UID: "child", ParentUID: parityStrPtr("parent")}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", "parent"),
+			expected:    false,
+		},
+		{
+			name:        "dashboard get via folders:view action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", "folder1"),
+			expected:    true,
+		},
+		{
+			name:        "dashboard update via folders:edit action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbUpdate, "dash1", "folder1"),
+			expected:    true,
+		},
+		{
+			name:        "dashboard update denied by folders:view action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbUpdate, "dash1", "folder1"),
+			expected:    false,
+		},
+
+		// -- create and the general folder ----------------------------------
+		{
+			name:        "dashboard create in a folder",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbCreate, "", "folder1"),
+			expected:    true,
+		},
+		{
+			name:        "dashboard create at the root maps the empty parent to general",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:general"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbCreate, "", ""),
+			expected:    true,
+		},
+		{
+			name:        "dashboard get at the root does not map the empty parent to general",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:general"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbGet, "dash1", ""),
+			expected:    false,
+		},
+
+		// -- folders ---------------------------------------------------------
+		{
+			name:        "folder get with direct grant",
+			permissions: []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbGet, "folder1", ""),
+			expected:    true,
+		},
+		{
+			name:        "folder get on a child via a grant on the parent",
+			permissions: []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:parent"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}, {UID: "child", ParentUID: parityStrPtr("parent")}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbGet, "child", "parent"),
+			expected:    true,
+		},
+		{
+			name:        "folder create at the root",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:general"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbCreate, "", ""),
+			expected:    true,
+		},
+		{
+			name:        "subfolder create under the parent folder",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:parent"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbCreate, "", "parent"),
+			expected:    true,
+		},
+		{
+			name:        "folder delete denied by folders:view action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbDelete, "folder1", ""),
+			expected:    false,
+		},
+		{
+			name:        "folder set_permissions via folders:admin action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:admin", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbSetPermissions, "folder1", ""),
+			expected:    true,
+		},
+		{
+			name:        "folder get_permissions denied by folders:edit action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(folderGroup, folderResource, "", utils.VerbGetPermissions, "folder1", ""),
+			expected:    false,
+		},
+
+		// -- variables: the empty-parent special case ------------------------
+		{
+			name:        "variable get inside a folder",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, "variables", "", utils.VerbGet, "region", "folder1"),
+			expected:    true,
+		},
+		{
+			name:        "variable create at the root maps the empty parent to general",
+			permissions: []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:general"}},
+			req:         parityCheckReq(dashboardGroup, "variables", "", utils.VerbCreate, "region", ""),
+			expected:    true,
+		},
+		{
+			name:         "variable get at the root maps the empty parent to general",
+			permissions:  []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:general"}},
+			req:          parityCheckReq(dashboardGroup, "variables", "", utils.VerbGet, "region", ""),
+			expected:     true,
+			zanzanaToday: parityBoolPtr(false),
+			divergence: "RBAC maps an empty parent to general for variables on every verb, because variables " +
+				"persist with an empty folder annotation while grants use folders:uid:general. Zanzana applies " +
+				"the empty-to-general default on create only, so a root variable read falls through to a " +
+				"direct object check and is denied.",
+		},
+		{
+			name:         "variable update at the root maps the empty parent to general",
+			permissions:  []accesscontrol.Permission{{Action: "folders:edit", Scope: "folders:uid:general"}},
+			req:          parityCheckReq(dashboardGroup, "variables", "", utils.VerbUpdate, "region", ""),
+			expected:     true,
+			zanzanaToday: parityBoolPtr(false),
+			divergence: "Same empty-parent handling as the get case above: RBAC rewrites the parent to general " +
+				"for variables on every verb, Zanzana only on create.",
+		},
+
+		// -- subresources ----------------------------------------------------
+		{
+			name:         "dashboard annotation get via the dashboard-scoped annotation action",
+			permissions:  []accesscontrol.Permission{{Action: "annotations:read", Scope: "dashboards:uid:dash1"}},
+			req:          parityCheckReq(dashboardGroup, dashboardResource, "annotations", utils.VerbGet, "dash1", ""),
+			expected:     true,
+			zanzanaToday: parityBoolPtr(false),
+			divergence: "Zanzana's translation table has no entry for the annotations:* actions, so the grant " +
+				"produces no tuple at all. RBAC maps the annotations subresource onto annotations:read " +
+				"scoped to the dashboard.",
+		},
+		{
+			name:        "dashboard annotation get via folders:view on the parent folder",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "annotations", utils.VerbGet, "dash1", "folder1"),
+			expected:    true,
+		},
+
+		// -- teams (a typed, non-folder resource) ----------------------------
+		{
+			name:        "team get with matching uid grant",
+			permissions: []accesscontrol.Permission{{Action: "teams:read", Scope: "teams:uid:t1"}},
+			req:         parityCheckReq(teamGroup, teamResource, "", utils.VerbGet, "t1", ""),
+			expected:    true,
+		},
+		{
+			name:        "team get with grant on a different uid",
+			permissions: []accesscontrol.Permission{{Action: "teams:read", Scope: "teams:uid:t1"}},
+			req:         parityCheckReq(teamGroup, teamResource, "", utils.VerbGet, "t2", ""),
+			expected:    false,
+		},
+		{
+			name:        "team create needs no scope",
+			permissions: []accesscontrol.Permission{{Action: "teams:create"}},
+			req:         parityCheckReq(teamGroup, teamResource, "", utils.VerbCreate, "", ""),
+			expected:    true,
+		},
+
+		// -- capabilities probes (no name, no folder) ------------------------
+		{
+			name:         "dashboard list with a single object grant",
+			permissions:  []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:dash1"}},
+			req:          parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbList, "", ""),
+			expected:     true,
+			zanzanaToday: parityBoolPtr(false),
+			divergence: "A check with no name is a capabilities probe. RBAC answers \"does the user hold this " +
+				"action on anything\" and allows it, leaving result narrowing to the caller. Zanzana has no " +
+				"equivalent: an empty name only lets it test the group_resource object, which a per-object " +
+				"grant does not satisfy.",
+		},
+		{
+			name:        "dashboard list with a wildcard grant",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:*"}},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbList, "", ""),
+			expected:    true,
+		},
+		{
+			name:        "dashboard list without any grant",
+			permissions: []accesscontrol.Permission{},
+			req:         parityCheckReq(dashboardGroup, dashboardResource, "", utils.VerbList, "", ""),
+			expected:    false,
+		},
+	}
+
+	srv := setupOpenFGAServer(t)
+	gaps := &parityGaps{}
+	defer gaps.report(t, len(testCases))
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.zanzanaToday != nil {
+				require.NotEmpty(t, tc.divergence, "an open gap must document why the engines differ")
+			}
+
+			ns := parityNamespace(i)
+			req := parityWithNamespace(tc.req, ns)
+
+			rbacRes, err := rbac.NewTestService(parityUserUID, tc.permissions, tc.folders).
+				Check(newContextWithNamespace(), req)
+			require.NoError(t, err)
+			gotRBAC := rbacRes.GetAllowed()
+			require.Equal(t, tc.expected, gotRBAC,
+				"RBAC answer changed; update the case before touching the parity expectation")
+
+			writeParityTuples(t, srv, ns, tc.permissions, tc.folders)
+			zanzanaRes, err := srv.Check(newContextWithNamespace(), req)
+			require.NoError(t, err)
+
+			compareEngines(t, gaps, tc.name, tc.expected, tc.zanzanaToday, tc.divergence,
+				zanzanaRes.GetAllowed(), gotRBAC)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// List parity
+// ---------------------------------------------------------------------------
+
+type listParityCase struct {
+	name        string
+	permissions []accesscontrol.Permission
+	folders     []rbacstore.Folder
+	req         *authzv1.ListRequest
+
+	// expected is what the RBAC service answers.
+	expected parityListResult
+	// zanzanaToday, when set, marks this case as an open gap and records what
+	// Zanzana answers while the gap is open. Reported, not asserted.
+	zanzanaToday *parityListResult
+	// divergence explains the gap. Required whenever zanzanaToday is set.
+	divergence string
+}
+
+type parityListResult struct {
+	All     bool
+	Items   []string
+	Folders []string
+}
+
+func TestIntegrationRBACParityList(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	testCases := []listParityCase{
+		{
+			name: "dashboards with object and folder grants",
+			permissions: []accesscontrol.Permission{
+				{Action: "dashboards:read", Scope: "dashboards:uid:dash1"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:dash2"},
+				{Action: "dashboards:read", Scope: "folders:uid:folder1"},
+			},
+			folders:  []rbacstore.Folder{{UID: "folder1"}},
+			req:      parityListReq(dashboardGroup, dashboardResource, "", utils.VerbGet),
+			expected: parityListResult{Items: []string{"dash1", "dash2"}, Folders: []string{"folder1"}},
+		},
+		{
+			name:        "dashboards folder grant expands to descendants",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "folders:uid:parent"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}, {UID: "child", ParentUID: parityStrPtr("parent")}},
+			req:         parityListReq(dashboardGroup, dashboardResource, "", utils.VerbGet),
+			expected:    parityListResult{Folders: []string{"parent", "child"}},
+		},
+		{
+			name:        "dashboards via folders:view action set",
+			permissions: []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:folder1"}},
+			folders:     []rbacstore.Folder{{UID: "folder1"}},
+			req:         parityListReq(dashboardGroup, dashboardResource, "", utils.VerbGet),
+			expected:    parityListResult{Folders: []string{"folder1"}},
+		},
+		{
+			name:        "dashboards with a wildcard grant",
+			permissions: []accesscontrol.Permission{{Action: "dashboards:read", Scope: "dashboards:uid:*"}},
+			req:         parityListReq(dashboardGroup, dashboardResource, "", utils.VerbGet),
+			expected:    parityListResult{All: true},
+		},
+		{
+			name:        "dashboards without any grant",
+			permissions: []accesscontrol.Permission{},
+			req:         parityListReq(dashboardGroup, dashboardResource, "", utils.VerbGet),
+			expected:    parityListResult{},
+		},
+		{
+			name:        "folders grant expands to descendants",
+			permissions: []accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:parent"}},
+			folders:     []rbacstore.Folder{{UID: "parent"}, {UID: "child", ParentUID: parityStrPtr("parent")}},
+			req:         parityListReq(folderGroup, folderResource, "", utils.VerbGet),
+			expected:    parityListResult{Items: []string{"parent", "child"}},
+		},
+		{
+			name:         "variables with a grant on general",
+			permissions:  []accesscontrol.Permission{{Action: "folders:view", Scope: "folders:uid:general"}},
+			req:          parityListReq(dashboardGroup, "variables", "", utils.VerbList),
+			expected:     parityListResult{Folders: []string{"general", ""}},
+			zanzanaToday: &parityListResult{Folders: []string{"general"}},
+			divergence: "RBAC aliases the root folder sentinels for variables, returning both general and the " +
+				"empty string so variables persisted with an empty folder annotation match. Zanzana returns " +
+				"only the folder UIDs it holds tuples for.",
+		},
+	}
+
+	srv := setupOpenFGAServer(t)
+	gaps := &parityGaps{}
+	defer gaps.report(t, len(testCases))
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.zanzanaToday != nil {
+				require.NotEmpty(t, tc.divergence, "an open gap must document why the engines differ")
+			}
+
+			ns := parityNamespace(i)
+			req := parityWithNamespace(tc.req, ns)
+
+			rbacRes, err := rbac.NewTestService(parityUserUID, tc.permissions, tc.folders).
+				List(newContextWithNamespace(), req)
+			require.NoError(t, err)
+			gotRBAC := toParityListResult(rbacRes)
+			require.Equal(t, normalizeParityList(tc.expected), gotRBAC,
+				"RBAC answer changed; update the case before touching the parity expectation")
+
+			writeParityTuples(t, srv, ns, tc.permissions, tc.folders)
+			zanzanaRes, err := srv.List(newContextWithNamespace(), req)
+			require.NoError(t, err)
+
+			compareEngines(t, gaps, tc.name, normalizeParityList(tc.expected),
+				normalizeParityListPtr(tc.zanzanaToday), tc.divergence,
+				toParityListResult(zanzanaRes), gotRBAC)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// compareEngines enforces the cases where the engines agree today and reports
+// the ones where they do not. See the file header for why open gaps are
+// reported rather than failed.
+func compareEngines[T any](t *testing.T, gaps *parityGaps, name string, expected T, zanzanaToday *T, divergence string, gotZanzana, gotRBAC T) {
+	t.Helper()
+
+	if zanzanaToday == nil {
+		assert.Equal(t, expected, gotZanzana,
+			"enforced case: zanzana diverges from RBAC (RBAC=%v). Either fix the divergence or, if it is "+
+				"intended, record it as an open gap with a divergence note.", gotRBAC)
+		return
+	}
+
+	switch {
+	case assert.ObjectsAreEqual(gotZanzana, gotRBAC):
+		t.Logf("RESOLVED: zanzana now agrees with RBAC. Delete zanzanaToday and divergence to enforce "+
+			"this case.\n  was: %s", divergence)
+		gaps.resolved = append(gaps.resolved, name)
+
+	case assert.ObjectsAreEqual(gotZanzana, *zanzanaToday):
+		t.Logf("OPEN GAP: rbac=%v zanzana=%v\n  %s", gotRBAC, gotZanzana, divergence)
+		gaps.open = append(gaps.open, fmt.Sprintf("%s (rbac=%v zanzana=%v)", name, gotRBAC, gotZanzana))
+
+	default:
+		t.Logf("GAP MOVED: zanzana answers %v, which is neither RBAC's %v nor the recorded %v. Update "+
+			"zanzanaToday.\n  %s", gotZanzana, gotRBAC, *zanzanaToday, divergence)
+		gaps.moved = append(gaps.moved, fmt.Sprintf("%s (rbac=%v zanzana=%v recorded=%v)",
+			name, gotRBAC, gotZanzana, *zanzanaToday))
+	}
+}
+
+// parityGaps collects the open-gap cases so the parent test can print an
+// inventory once every case has run. Subtests here are sequential, so no lock.
+type parityGaps struct {
+	open     []string
+	resolved []string
+	moved    []string
+}
+
+// report prints the inventory. Run with -v to see it on a green build.
+func (g *parityGaps) report(t *testing.T, total int) {
+	t.Helper()
+
+	enforced := total - len(g.open) - len(g.resolved) - len(g.moved)
+	t.Logf("parity: %d/%d cases enforced, %d open gaps, %d resolved, %d moved",
+		enforced, total, len(g.open), len(g.resolved), len(g.moved))
+	for _, name := range g.open {
+		t.Logf("  open gap: %s", name)
+	}
+	for _, name := range g.resolved {
+		t.Logf("  resolved: %s -- delete zanzanaToday/divergence to enforce it", name)
+	}
+	for _, name := range g.moved {
+		t.Logf("  moved:    %s", name)
+	}
+}
+
+// parityNamespace gives every case its own namespace. Zanzana keys its OpenFGA
+// store by namespace, so this is what keeps one case's tuples out of the next.
+// The RBAC service is rebuilt per case, so it needs no such isolation.
+func parityNamespace(i int) string {
+	return fmt.Sprintf("org-%d", i+2)
+}
+
+func writeParityTuples(t *testing.T, srv *Server, ns string, permissions []accesscontrol.Permission, folders []rbacstore.Folder) {
+	t.Helper()
+
+	tuples := make([]*openfgav1.TupleKey, 0, len(permissions)+len(folders))
+	for _, f := range folders {
+		if f.ParentUID != nil {
+			tuples = append(tuples, common.NewFolderParentTuple(f.UID, *f.ParentUID))
+		}
+	}
+	for _, p := range permissions {
+		tuple, ok := permissionToTuple(paritySubject, p)
+		if !ok {
+			// Zanzana has no translation for this action. That is itself a
+			// divergence, and the case's expectation records it.
+			continue
+		}
+		tuples = append(tuples, tuple)
+	}
+	if len(tuples) == 0 {
+		return
+	}
+
+	ctx := context.Background()
+	storeInf, err := srv.getStoreInfo(ctx, ns)
+	require.NoError(t, err)
+
+	_, err = srv.openFGAClient.Write(ctx, &openfgav1.WriteRequest{
+		StoreId:              storeInf.ID,
+		AuthorizationModelId: storeInf.ModelID,
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys:   tuples,
+			OnDuplicate: "ignore",
+		},
+	})
+	require.NoError(t, err)
+}
+
+// permissionToTuple mirrors what the reconciler does when it syncs RBAC rows
+// into Zanzana: split the scope into kind + identifier and hand both to the
+// shared translation table.
+func permissionToTuple(subject string, perm accesscontrol.Permission) (*openfgav1.TupleKey, bool) {
+	kind, identifier := perm.Kind, perm.Identifier
+	if kind == "" && perm.Scope != "" {
+		kind, _, identifier = accesscontrol.SplitScope(perm.Scope)
+	}
+
+	// Grants with no scope (stack roles) or a bare "*" carry no kind, so recover
+	// it from the action. Ordering matters: the folders table also maps the
+	// dashboard/notebook actions, and for an unscoped grant the resource's own
+	// table is the right one.
+	if kind == "" || kind == "*" {
+		for _, candidate := range []string{
+			common.KindDashboards,
+			common.KindNotebooks,
+			common.KindTeams,
+			common.KindUsers,
+			common.KindFolders,
+		} {
+			if tuple, ok := common.TranslateToResourceTuple(subject, perm.Action, candidate, "*"); ok {
+				return tuple, true
+			}
+		}
+		return nil, false
+	}
+
+	if identifier == "" {
+		identifier = "*"
+	}
+	return common.TranslateToResourceTuple(subject, perm.Action, kind, identifier)
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+func parityCheckReq(group, resource, subresource, verb, name, folder string) *authzv1.CheckRequest {
+	return &authzv1.CheckRequest{
+		Subject:     paritySubject,
+		Group:       group,
+		Resource:    resource,
+		Subresource: subresource,
+		Verb:        verb,
+		Name:        name,
+		Folder:      folder,
+	}
+}
+
+func parityListReq(group, resource, subresource, verb string) *authzv1.ListRequest {
+	return &authzv1.ListRequest{
+		Subject:     paritySubject,
+		Group:       group,
+		Resource:    resource,
+		Subresource: subresource,
+		Verb:        verb,
+	}
+}
+
+// parityWithNamespace copies the request so the two engines cannot observe each
+// other's mutations (the RBAC check path rewrites the parent folder in place).
+func parityWithNamespace[T proto.Message](req T, ns string) T {
+	out := proto.Clone(req).(T)
+	switch r := any(out).(type) {
+	case *authzv1.CheckRequest:
+		r.Namespace = ns
+	case *authzv1.ListRequest:
+		r.Namespace = ns
+	}
+	return out
+}
+
+func toParityListResult(res *authzv1.ListResponse) parityListResult {
+	return normalizeParityList(parityListResult{
+		All:     res.GetAll(),
+		Items:   res.GetItems(),
+		Folders: res.GetFolders(),
+	})
+}
+
+func normalizeParityList(l parityListResult) parityListResult {
+	out := parityListResult{
+		All:     l.All,
+		Items:   append([]string{}, l.Items...),
+		Folders: append([]string{}, l.Folders...),
+	}
+	sort.Strings(out.Items)
+	sort.Strings(out.Folders)
+	return out
+}
+
+func normalizeParityListPtr(l *parityListResult) *parityListResult {
+	if l == nil {
+		return nil
+	}
+	out := normalizeParityList(*l)
+	return &out
+}
+
+func parityStrPtr(s string) *string { return &s }
+
+func parityBoolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
### Why

Zanzana and RBAC MT are meant to answer the same authorization question identically, but nothing checks that. Divergences surface one at a time during manual investigation, and there is no guard stopping new ones from landing.

### What

A parity suite in `pkg/services/authz/zanzana/server/rbac_parity_test.go` runs 40 scenarios (33 `Check`, 7 `List`) through both engines' public entry points from one fixture — a set of RBAC permissions plus a folder tree, projected once into the RBAC store and once into OpenFGA tuples.

Sharing that fixture required moving `setupService` and the store/identity fakes out of `rbac/service_test.go` into `rbac/testinfra.go`, exposed as `rbac.NewTestService`. The fakes stay unexported; only the constructor is public, so nothing else in `rbac` changes.

### How a case runs

1. Fixture into the RBAC store, then assert RBAC answers `expected`. This guards the fixture itself, so a fixture bug can't masquerade as a Zanzana bug.
2. Same fixture into OpenFGA tuples, under a namespace unique to the case.
3. Same request into Zanzana, then compare.

Comparison has two modes, selected by one field:

- **Enforced** (35 cases) — the engines agree today, so any difference fails the test.
- **Open gap** (5 cases) — the engines already disagree. The case records Zanzana's current answer in `zanzanaToday` alongside a `divergence` note, and is logged rather than failed, because a permanently red suite stops being read.

Deleting those two fields is the whole act of promoting a case to enforced, and the runner logs `RESOLVED` when it notices a gap has closed, so it tells you when that is possible. It logs `GAP MOVED` when Zanzana's answer is neither RBAC's nor the recorded one, which is how a stale note announces itself.

### Divergences the suite found

| Case | RBAC | Zanzana |
|---|---|---|
| Variable `get`/`update` at the root | allow | deny |
| Dashboard annotations subresource | allow | deny |
| Capabilities probe (check with no name) | allow | deny |
| `List` variables granted on `general` | `["", "general"]` | `["general"]` |

The first two share a root cause: RBAC rewrites an empty parent to `general` for variables on every verb, since variables persist with an empty folder annotation while grants use `folders:uid:general`. Zanzana applies that default on `create` only. The annotations gap is a missing entry in Zanzana's translation table, so the grant produces no tuple at all.

### Tricky parts

- RBAC mutates `ParentFolder` on the request in place, so each engine gets a `proto.Clone` of the request.
- The OpenFGA store is shared across the suite, hence the per-case namespace.
- The inventory is emitted via `t.Log`, so a green run needs `-v` to show it.
