### PR TITLE
Resolve search document builder on first use

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1999,14 +1999,36 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 
 	logger := s.log.New("namespace", nsr.Namespace, "group", nsr.Group, "resource", nsr.Resource)
 
-	builder, err := s.builders.get(ctx, nsr)
-	if err != nil {
-		return nil, err
+	// For dashboards this reads the namespace's usage insights data, and an index
+	// served from a snapshot never calls the callbacks that need it. Kept once
+	// resolved: the cache entry expires while updaterFn keeps running, so asking
+	// again would re-read the insights data.
+	var (
+		builderMu sync.Mutex
+		builder   DocumentBuilder
+	)
+	getBuilder := func(ctx context.Context) (DocumentBuilder, error) {
+		builderMu.Lock()
+		defer builderMu.Unlock()
+		if builder != nil {
+			return builder, nil
+		}
+		b, err := s.builders.get(ctx, nsr)
+		if err != nil {
+			return nil, err
+		}
+		builder = b
+		return builder, nil
 	}
 
 	builderFn := func(index ResourceIndex) (int64, error) {
 		span := trace.SpanFromContext(ctx)
 		span.AddEvent("building index", trace.WithAttributes(attribute.Int64("size", size), attribute.String("reason", indexBuildReason)))
+
+		builder, err := getBuilder(ctx)
+		if err != nil {
+			return 0, err
+		}
 
 		phases := newBuildPhaseRecorder(s.indexMetrics, IndexPathBuild, nsr)
 		// Report whatever was accumulated even when the build gives up early, and
@@ -2115,6 +2137,11 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	updaterFn := func(ctx context.Context, index ResourceIndex, sinceRV int64) (int64, int, error) {
 		span := trace.SpanFromContext(ctx)
 		span.AddEvent("updating index", trace.WithAttributes(attribute.Int64("sinceRV", sinceRV)))
+
+		builder, err := getBuilder(ctx)
+		if err != nil {
+			return 0, 0, err
+		}
 
 		// If we're calling with the same sinceRV as last time, pass the timestamp
 		// of our last call so the backend can skip the lookback window when safe.

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -2270,5 +2271,116 @@ func TestDeletedDocumentsAreRemovedWhenIndexCannotHoldMarkers(t *testing.T) {
 	t.Run("an index with the markers but not the trash fields", func(t *testing.T) {
 		index := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: []IndexFeature{IndexFeatureDeletedMarker}}}
 		require.False(t, server.keepsDeletedDocuments(index, log.NewNopLogger()))
+	})
+}
+
+// Counts builder resolutions, the step that reads usage insights data for real
+// dashboards. Only namespaced builders go through it.
+type countingBuilderSupplier struct {
+	resolved atomic.Int32
+}
+
+func (s *countingBuilderSupplier) GetDocumentBuilders(_ *SearchFieldsRegistry) ([]DocumentBuilderInfo, error) {
+	return []DocumentBuilderInfo{{
+		GroupResource: schema.GroupResource{Group: "group", Resource: "resource"},
+		Namespaced: func(_ context.Context, _ string, _ BlobSupport) (DocumentBuilder, error) {
+			s.resolved.Add(1)
+			return &testDocumentBuilder{}, nil
+		},
+	}}, nil
+}
+
+// Stands in for an index served from a remote snapshot: ready without either
+// callback running.
+type snapshotSearchBackend struct {
+	mockSearchBackend
+}
+
+func (m *snapshotSearchBackend) BuildIndex(_ context.Context, key NamespacedResource, size int64, _ string, _ BuildFn, updater UpdateFn, _ bool, _ time.Time, _ time.Duration) (ResourceIndex, error) {
+	index := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: IndexFeaturesForNewIndex(m.keepsDeletedDocuments)}}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lastUpdater = updater
+	if m.cache == nil {
+		m.cache = make(map[NamespacedResource]ResourceIndex)
+	}
+	m.cache[key] = index
+	m.buildIndexCalls = append(m.buildIndexCalls, buildIndexCall{key: key, size: size})
+
+	return index, nil
+}
+
+// Resolving a builder is expensive, so a build must not do it until something
+// actually needs to index documents.
+func TestBuildResolvesDocumentBuilderOnFirstUse(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+
+	t.Run("an index served from a snapshot never resolves the builder", func(t *testing.T) {
+		supplier := &countingBuilderSupplier{}
+		search := &snapshotSearchBackend{}
+		server, err := newSearchServer(SearchOptions{
+			Backend:   search,
+			Resources: supplier,
+		}, &mockStorageBackend{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		_, err = server.build(t.Context(), key, 1, "test", false, time.Time{})
+		require.NoError(t, err)
+
+		require.Len(t, search.buildIndexCalls, 1, "the index should still have been built")
+		require.Zero(t, supplier.resolved.Load(), "no callback ran, so the builder should never have been resolved")
+	})
+
+	t.Run("a build that indexes documents resolves the builder", func(t *testing.T) {
+		supplier := &countingBuilderSupplier{}
+		search := &mockSearchBackend{keepsDeletedDocuments: true}
+		storage := &trashStorageBackend{trash: []trashEntry{
+			{name: "gone", rv: 10, value: testObjectJSON("gone", "Gone")},
+		}}
+		server, err := newSearchServer(SearchOptions{
+			Backend:   search,
+			Resources: supplier,
+		}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		built, err := server.build(t.Context(), key, 1, "test", false, time.Time{})
+		require.NoError(t, err)
+
+		require.Len(t, built.(*MockResourceIndex).indexedItems(), 1)
+		require.Equal(t, int32(1), supplier.resolved.Load(), "the build callback needs a builder")
+	})
+
+	// The cache entry expires while the updater keeps running, so resolving per
+	// call would re-read the insights data on most updates.
+	t.Run("the builder is resolved once for a build and every later update", func(t *testing.T) {
+		supplier := &countingBuilderSupplier{}
+		search := &mockSearchBackend{keepsDeletedDocuments: true}
+		storage := &trashStorageBackend{
+			trash:    []trashEntry{{name: "gone", rv: 10, value: testObjectJSON("gone", "Gone")}},
+			modified: []*ModifiedResource{{Action: resourcepb.WatchEvent_ADDED, Key: resourcepb.ResourceKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource, Name: "added"}, ResourceVersion: 11, Value: testObjectJSON("added", "Added")}},
+		}
+		server, err := newSearchServer(SearchOptions{
+			Backend:   search,
+			Resources: supplier,
+		}, storage, nil, nil, nil, nil, nil, nil, nil, nil)
+		require.NoError(t, err)
+
+		_, err = server.build(t.Context(), key, 1, "test", false, time.Time{})
+		require.NoError(t, err)
+
+		search.mu.Lock()
+		updater := search.lastUpdater
+		search.mu.Unlock()
+		require.NotNil(t, updater)
+
+		for i := range 3 {
+			index := &MockResourceIndex{buildInfo: IndexBuildInfo{Features: IndexFeaturesForNewIndex(true)}}
+			_, docs, err := updater(t.Context(), index, int64(11+i))
+			require.NoError(t, err)
+			require.Equal(t, 1, docs)
+		}
+
+		require.Equal(t, int32(1), supplier.resolved.Load(), "the builder resolved for the build should be reused by every update")
 	})
 }


### PR DESCRIPTION
Getting the document builder for dashboards reads the whole namespace's usage insights data. That data is only needed by the callbacks that build or update documents, and neither callback runs when `BuildIndex` serves the index from a downloaded remote snapshot, so the read was frequently wasted.

We saw this in a dev cell: pods spent around 80 minutes and 333 pages of insights data before reaching the snapshot download, then loaded the snapshot and never touched the builder. Ten pods reading the same database at once pushed page latency from 1.9s to 40s.

The builder is now resolved the first time a callback asks for one, and then kept for the life of the index. Keeping it matters: the builder cache entry expires after a couple of minutes, while the updater keeps running for as long as the index is open, so asking the cache on every call would re-read the insights data on most updates and be worse than the original problem.

### Behaviour change on the rebuild path

On the rebuild path we clear the cached builder for dashboards, with a comment saying this is to pick up the latest usage insights data. Previously the builder was resolved just before that clear, so the rebuild used whatever was already cached and the clear only affected some later call. Now that resolution happens later, the clear takes effect and a rebuild that indexes documents really does read fresh insights data.

That is what the comment always said it did, so this looks like a fix rather than a regression. The cost is that such a rebuild can no longer be served by a cached builder, but rebuilds are hours apart, so a cache hit was already unlikely. Worth a second opinion from whoever added that clear.
