### PR TITLE
Alerting: Add optional 'replace' param to newSearchQuery

### DIFF
--- a/public/app/features/alerting/unified/hooks/useFilteredRules.ts
+++ b/public/app/features/alerting/unified/hooks/useFilteredRules.ts
@@ -54,8 +54,8 @@ export function useRulesFilter() {
   );
 
   const setSearchQuery = useCallback(
-    (newSearchQuery: string | undefined) => {
-      updateQueryParams({ search: newSearchQuery });
+    (newSearchQuery: string | undefined, options?: { replace?: boolean }) => {
+      updateQueryParams({ search: newSearchQuery }, options?.replace);
     },
     [updateQueryParams]
   );


### PR DESCRIPTION
Add an optional `replace` parameter to `useRulesFilter`'s `setSearchQuery`. It lets callers that write to the search query frequently (e.g. debounced search-as-you-type) avoid pushing a new browser history entry per update.