### PR TITLE
Chore: Route go.mod reviews by module owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,8 @@
 /.github/workflows/sbom-on-release.yml @grafana/security
 
 # Backend code
-# go.mod reviewers come from // @team comments via .github/workflows/modowners-reviewers.yml
+# Reviewers come from // @team comments via .github/workflows/modowners-reviewers.yml.
+# Empty owners so GitHub does not request a squad. Same pattern as the generated API clients below.
 /go.mod
 /go.sum
 /go.work @grafana/grafana-app-platform-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,8 +66,9 @@
 /.github/workflows/sbom-on-release.yml @grafana/security
 
 # Backend code
-/go.mod @grafana/grafana-backend-services-squad
-/go.sum @grafana/grafana-backend-services-squad
+# go.mod reviewers come from // @team comments via .github/workflows/modowners-reviewers.yml
+/go.mod
+/go.sum
 /go.work @grafana/grafana-app-platform-squad
 /go.work.sum @grafana/grafana-app-platform-squad
 /.citools @grafana/grafana-backend-services-squad
@@ -1326,6 +1327,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/release-pr.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/release-comms.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/migrate-prs.yml @grafana/grafana-backend-services-squad
+/.github/workflows/modowners-reviewers.yml @grafana/grafana-backend-services-squad
 /.github/workflows/create-next-release-branch.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/create-release-branch.yml @grafana/grafana-operator-experience-squad
 /.github/workflows/create-security-branch.yml @grafana/grafana-backend-services-squad

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -38,7 +38,7 @@ jobs:
           not_owned_checker_skip_patterns: ""
 
           # Specifies whether CODEOWNERS may have unowned files. For example, `/infra/oncall-rotator/oncall-config.yml` doesn't have owner and this is not reported.
-          owner_checker_allow_unowned_patterns: "false"
+          owner_checker_allow_unowned_patterns: "true"
 
           # Specifies whether only teams are allowed as owners of files.
           owner_checker_owners_must_be_teams: "false"

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -38,7 +38,7 @@ jobs:
           not_owned_checker_skip_patterns: ""
 
           # Specifies whether CODEOWNERS may have unowned files. For example, `/infra/oncall-rotator/oncall-config.yml` doesn't have owner and this is not reported.
-          owner_checker_allow_unowned_patterns: "true"
+          owner_checker_allow_unowned_patterns: "false"
 
           # Specifies whether only teams are allowed as owners of files.
           owner_checker_owners_must_be_teams: "false"

--- a/.github/workflows/modowners-reviewers.yml
+++ b/.github/workflows/modowners-reviewers.yml
@@ -1,0 +1,58 @@
+name: Modowners reviewers
+
+on:
+  pull_request:
+    paths:
+      - go.mod
+      - scripts/modowners/**
+      - .github/workflows/modowners-reviewers.yml
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  request:
+    name: Request go.mod reviewers
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-arm64-small
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: go.mod
+          sparse-checkout-cone-mode: false
+          path: _modowners_base
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          cache-build: 'false'
+          go-version-file: scripts/modowners/go.mod
+      - name: Request module owners
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          slugs=$(go run scripts/modowners/modowners.go reviewers _modowners_base/go.mod go.mod)
+          if [ -z "$slugs" ]; then
+            echo "No module-owner reviewers to request"
+            exit 0
+          fi
+          echo "Requesting: $slugs"
+          while IFS= read -r slug; do
+            [ -z "$slug" ] && continue
+            if ! jq -n --arg slug "$slug" '{reviewers: [], team_reviewers: [$slug]}' |
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input -; then
+              echo "::warning::Could not request @grafana/${slug}"
+            fi
+          done <<< "$slugs"

--- a/.policy.yml
+++ b/.policy.yml
@@ -24,6 +24,7 @@ policy:
             - Workflow .github/workflows/govulncheck.yml succeeded or skipped
             - Workflow .github/workflows/i18n-verify.yml succeeded or skipped
             - Workflow .github/workflows/lint-build-docs.yml succeeded or skipped
+            - Workflow .github/workflows/modowners-reviewers.yml succeeded or skipped
             - Workflow .github/workflows/policybot.yml succeeded or skipped
             - Workflow .github/workflows/pr-build-grafana.yml succeeded or skipped
             - Workflow .github/workflows/pr-bundle-size.yml succeeded or skipped
@@ -362,6 +363,24 @@ approval_rules:
             - success
           workflows:
             - .github/workflows/lint-build-docs.yml
+  - name: Workflow .github/workflows/modowners-reviewers.yml succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - ^go\.mod$
+          - ^scripts\/modowners\/(?:(?:[^/]*(?:/|$))*)$
+          - ^\.github\/workflows\/modowners-reviewers\.yml$
+      file_not_deleted:
+        paths:
+          - ^\.github\/workflows\/modowners-reviewers\.yml$
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - skipped
+            - success
+          workflows:
+            - .github/workflows/modowners-reviewers.yml
   - name: Workflow .github/workflows/policybot.yml succeeded or skipped
     if:
       changed_files:

--- a/go.mod
+++ b/go.mod
@@ -151,8 +151,8 @@ require (
 	github.com/nats-io/nats.go v1.52.0 // @grafana/grafana-search-and-storage
 	github.com/oklog/ulid/v2 v2.1.2 // @grafana/grafana-search-and-storage
 	github.com/olekukonko/tablewriter v1.1.4 // @grafana/grafana-backend-group
-	github.com/open-feature/go-sdk v1.17.2 // @grafana/grafana-backend-group
-	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.7 // @grafana/grafana-backend-group
+	github.com/open-feature/go-sdk v1.17.2 // @grafana/grafana-backend-services-squad
+	github.com/open-feature/go-sdk-contrib/providers/ofrep v0.1.7 // @grafana/grafana-backend-services-squad
 	github.com/openai/openai-go/v3 v3.16.0 // @grafana/grafana-search-and-storage
 	github.com/openfga/api/proto v0.0.0-20260319214821-f153694bfc20 // @grafana/identity-access-team
 	github.com/openfga/language/pkg/go v0.3.2-0.20260730144454-83fedf8a4e70 // @grafana/identity-access-team
@@ -179,7 +179,7 @@ require (
 	github.com/spyzhov/ajson v0.9.6 // @grafana/grafana-sharing-squad
 	github.com/stretchr/testify v1.12.1 // @grafana/grafana-backend-group
 	github.com/testcontainers/testcontainers-go v0.43.0 //@grafana/grafana-app-platform-squad
-	github.com/thomaspoignant/go-feature-flag v1.42.0 // @grafana/grafana-backend-group
+	github.com/thomaspoignant/go-feature-flag v1.42.0 // @grafana/grafana-backend-services-squad
 	github.com/tjhop/slog-gokit v0.2.0 // @grafana/grafana-app-platform-squad
 	github.com/ua-parser/uap-go v0.0.0-20251207011819-db9adb27a0b8 // @grafana/grafana-backend-group
 	github.com/urfave/cli/v2 v2.27.7 // @grafana/grafana-backend-group

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics
 	github.com/grafana/dataplane/sdata v0.0.9 // @grafana/observability-metrics
 	github.com/grafana/dskit v0.0.0-20260814134254-4a836a70f745 // @grafana/grafana-backend-group
-	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f // @grafana-app-platform-squad
+	github.com/grafana/e2e v0.1.2-0.20260309174126-b5393d4e610f // @grafana/grafana-app-platform-squad
 	github.com/grafana/gofpdf v0.0.0-20250307124105-3b9c5d35577f // @grafana/sharing-squad
 	github.com/grafana/gomemcache v0.0.0-20260728143316-9448343bd654 // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana-api-golang-client v0.27.0 // @grafana/alerting-backend
@@ -175,7 +175,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // @grafana/grafana-datasources-core-services
 	github.com/sony/gobreaker/v2 v2.4.0 // @grafana/grafana-app-platform-squad
 	github.com/spf13/cobra v1.10.2 // @grafana/grafana-app-platform-squad
-	github.com/spf13/pflag v1.0.10 // @grafana-app-platform-squad
+	github.com/spf13/pflag v1.0.10 // @grafana/grafana-app-platform-squad
 	github.com/spyzhov/ajson v0.9.6 // @grafana/grafana-sharing-squad
 	github.com/stretchr/testify v1.12.1 // @grafana/grafana-backend-group
 	github.com/testcontainers/testcontainers-go v0.43.0 //@grafana/grafana-app-platform-squad

--- a/scripts/modowners/README.md
+++ b/scripts/modowners/README.md
@@ -4,9 +4,9 @@
 
 Modowners is a way to ensure that each Go dependency has at least one team responsible for maintaining and upgrading it.
 
-The `validate-modfile` drone step checks `go.mod` and will pass if every dependency has an owner. When adding a new dependency, add the responsible team in a line comment.
+The Backend Code Checks workflow runs `modowners check`. It fails if a direct dependency has no owner. When adding a new dependency, add the responsible team in a line comment.
 
-Currently `validate-modfile` is non-blocking, but will eventually become a blocking step. All newly added dependencies will require an assigned owner.
+Pull requests that change `go.mod` get review requests for the teams on the changed require lines. That is the `reviewers` command, run by `.github/workflows/modowners-reviewers.yml`. GitHub CODEOWNERS does not own `go.mod`.
 
 ### Example of ownership assignment
 
@@ -60,6 +60,21 @@ Example output:
 @grafana/grafana-backend-group
 ```
 
+### `reviewers`
+
+Print GitHub team slugs that should review a `go.mod` diff. Compares two files and prints one slug per line. Indirect requires are ignored. Owners must be `@grafana/<team-slug>`.
+
+Example CLI command:
+
+`go run scripts/modowners/modowners.go reviewers go.mod.base go.mod`
+
+Example output:
+
+```
+alerting-backend
+grafana-backend-services-squad
+```
+
 ### `module`
 
 List all dependencies of given owner(s).
@@ -87,4 +102,4 @@ filippo.io/age@v1.1.1
 For existing dependencies, please review and update ownership of your team’s dependencies in `go.mod`.
 
 - If any assignments are incorrect, you can replace your team name with the correct team in `go.mod`.
-- If you don’t know who the correct team is, you can reassign the dependency back to backend platform. Afterwards, open a PR and assign backend platform as reviewers.
+- If you don’t know who the correct team is, you can reassign the dependency to `@grafana/grafana-backend-group`. The reviewers workflow will request that team.

--- a/scripts/modowners/modowners.go
+++ b/scripts/modowners/modowners.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"log"
+	"slices"
 	"strings"
 
 	"os"
@@ -16,12 +17,14 @@ import (
 
 type Module struct {
 	Name     string
+	Path     string
+	Version  string
 	Owners   []string
 	Indirect bool
 }
 
 func parseModule(mod *modfile.Require) Module {
-	m := Module{Name: mod.Mod.String()}
+	m := Module{Name: mod.Mod.String(), Path: mod.Mod.Path, Version: mod.Mod.Version}
 
 	// For each require, access the comment.
 	for _, comment := range mod.Syntax.Comments.Suffix {
@@ -162,6 +165,95 @@ func hasCommonElement(a []string, b []string) bool {
 	return false
 }
 
+func teamSlug(owner string) (string, bool) {
+	owner = strings.TrimPrefix(owner, "@")
+	const prefix = "grafana/"
+	if !strings.HasPrefix(owner, prefix) {
+		return "", false
+	}
+	slug := strings.TrimPrefix(owner, prefix)
+	if slug == "" || strings.Contains(slug, "/") {
+		return "", false
+	}
+	return slug, true
+}
+
+func indexDirect(mods []Module) map[string]Module {
+	byPath := make(map[string]Module, len(mods))
+	for _, mod := range mods {
+		if mod.Indirect {
+			continue
+		}
+		byPath[mod.Path] = mod
+	}
+	return byPath
+}
+
+func sameOwners(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	slices.Sort(as)
+	slices.Sort(bs)
+	return slices.Equal(as, bs)
+}
+
+func changedReviewers(oldMods, newMods []Module) []string {
+	oldByPath := indexDirect(oldMods)
+	newByPath := indexDirect(newMods)
+	slugs := map[string]struct{}{}
+	add := func(mods ...Module) {
+		for _, mod := range mods {
+			for _, owner := range mod.Owners {
+				if slug, ok := teamSlug(owner); ok {
+					slugs[slug] = struct{}{}
+				}
+			}
+		}
+	}
+	for path, neu := range newByPath {
+		old, ok := oldByPath[path]
+		if !ok {
+			add(neu)
+			continue
+		}
+		if old.Version != neu.Version || !sameOwners(old.Owners, neu.Owners) {
+			add(old, neu)
+		}
+	}
+	for path, old := range oldByPath {
+		if _, ok := newByPath[path]; !ok {
+			add(old)
+		}
+	}
+	out := make([]string, 0, len(slugs))
+	for slug := range slugs {
+		out = append(out, slug)
+	}
+	slices.Sort(out)
+	return out
+}
+
+func reviewers(fileSystem fs.FS, logger *log.Logger, args []string) error {
+	if len(args) != 2 {
+		return errors.New("usage: modowners reviewers <old-go.mod> <new-go.mod>")
+	}
+	oldMods, err := parseGoMod(fileSystem, args[0])
+	if err != nil {
+		return err
+	}
+	newMods, err := parseGoMod(fileSystem, args[1])
+	if err != nil {
+		return err
+	}
+	for _, slug := range changedReviewers(oldMods, newMods) {
+		logger.Println(slug)
+	}
+	return nil
+}
+
 func main() {
 	log.SetFlags(0)
 	log.SetOutput(os.Stdout)
@@ -170,7 +262,7 @@ func main() {
 		os.Exit(1)
 	}
 	type CmdFunc func(fs.FS, *log.Logger, []string) error
-	cmds := map[string]CmdFunc{"check": check, "owners": owners, "modules": modules}
+	cmds := map[string]CmdFunc{"check": check, "owners": owners, "modules": modules, "reviewers": reviewers}
 	if f, ok := cmds[os.Args[1]]; !ok {
 		log.Fatal("invalid command")
 	} else if err := f(os.DirFS("."), log.Default(), os.Args[2:]); err != nil {

--- a/scripts/modowners/modowners_test.go
+++ b/scripts/modowners/modowners_test.go
@@ -101,3 +101,174 @@ func TestModules(t *testing.T) {
 		t.Error(expectedResults)
 	}
 }
+
+func TestTeamSlug(t *testing.T) {
+	for _, test := range []struct {
+		owner string
+		slug  string
+		ok    bool
+	}{
+		{"@grafana/grafana-backend-services-squad", "grafana-backend-services-squad", true},
+		{"@grafana/alerting-backend", "alerting-backend", true},
+		{"@grafana-app-platform-squad", "", false},
+		{"@delivery", "", false},
+		{"grafana/grafana-backend-group", "grafana-backend-group", true},
+		{"", "", false},
+	} {
+		slug, ok := teamSlug(test.owner)
+		if slug != test.slug || ok != test.ok {
+			t.Errorf("%q: got (%q, %v), want (%q, %v)", test.owner, slug, ok, test.slug, test.ok)
+		}
+	}
+}
+
+func TestReviewers(t *testing.T) {
+	oldMod := `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana/grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`
+	for _, test := range []struct {
+		description string
+		oldContents string
+		newContents string
+		want        string
+	}{
+		{
+			description: "version bump requests current owner",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.30.1 // @grafana/grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "grafana-backend-group\n",
+		},
+		{
+			description: "added module requests new owner",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana/grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+	github.com/open-feature/go-sdk v1.17.2 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "grafana-backend-services-squad\n",
+		},
+		{
+			description: "removed module requests old owner",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana/grafana-backend-group
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "grafana-as-code\n",
+		},
+		{
+			description: "owner comment change requests both teams",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana/grafana-backend-services-squad
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "grafana-backend-group\ngrafana-backend-services-squad\n",
+		},
+		{
+			description: "unchanged go.mod requests nobody",
+			oldContents: oldMod,
+			newContents: oldMod,
+			want:        "",
+		},
+		{
+			description: "indirect version bump is ignored",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana/grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v66.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "",
+		},
+		{
+			description: "malformed owner is skipped",
+			oldContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.28.1 // @grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+)
+`,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.30.1 // @grafana-backend-group
+	cuelang.org/go v0.5.0 // @grafana/grafana-as-code
+)
+`,
+			want: "",
+		},
+		{
+			description: "two bumps request both owners once",
+			oldContents: oldMod,
+			newContents: `
+module example.com/grafana
+
+require (
+	cloud.google.com/go/storage v1.30.1 // @grafana/grafana-backend-group
+	cuelang.org/go v0.6.0 // @grafana/grafana-as-code
+	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect, @grafana/data-sources-plugins
+	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-services-squad
+)
+`,
+			want: "grafana-as-code\ngrafana-backend-group\n",
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			logger := log.New(buf, "", 0)
+			filesystem := fstest.MapFS{
+				"old.mod": &fstest.MapFile{Data: []byte(test.oldContents)},
+				"new.mod": &fstest.MapFile{Data: []byte(test.newContents)},
+			}
+			if err := reviewers(filesystem, logger, []string{"old.mod", "new.mod"}); err != nil {
+				t.Fatal(err)
+			}
+			if buf.String() != test.want {
+				t.Errorf("got %q, want %q", buf.String(), test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Review requests for `go.mod` now go to the team marked on the changed require line, not to GBS for every bump.

**Why do we need this feature?**

CODEOWNERS listed GBS on the whole file. Dependabot and other dep PRs all landed on that squad.

**Special notes for your reviewer:**

OpenFeature modules (`go-feature-flag`, `go-sdk`, `ofrep`) are retagged to GBS. `GITHUB_TOKEN` team review requests have failed in this repo before; this PR is the first real test.