### PR TITLE
Text: Remove row limit option

### DIFF
--- a/packages/grafana-schema/src/raw/composable/text/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/text/panelcfg/x/types.gen.ts
@@ -62,10 +62,6 @@ export interface Options {
    * Index of the selected frame, when the query returns more than one
    */
   frameIndex?: number;
-  /**
-   * How many rows of query data the content template may render. Unset renders every row.
-   */
-  maxRows?: number;
   mode: TextMode;
   renderMode?: RenderMode;
 }

--- a/public/app/plugins/panel/text/panelcfg.cue
+++ b/public/app/plugins/panel/text/panelcfg.cue
@@ -39,8 +39,6 @@ composableKinds: PanelCfg: {
 					mode:        TextMode & (*"markdown" | _)
 					renderMode?: RenderMode & (*"once" | _)
 					code?:       CodeOptions
-					// How many rows of query data the content template may render. Unset renders every row.
-					maxRows?: number
 					content: string | *"""
 						# Title
 

--- a/public/app/plugins/panel/text/panelcfg.gen.ts
+++ b/public/app/plugins/panel/text/panelcfg.gen.ts
@@ -60,10 +60,6 @@ export interface Options {
    * Index of the selected frame, when the query returns more than one
    */
   frameIndex?: number;
-  /**
-   * How many rows of query data the content template may render. Unset renders every row.
-   */
-  maxRows?: number;
   mode: TextMode;
   renderMode?: RenderMode;
 }

--- a/public/app/plugins/panel/text/v2/TextNGPanel.tsx
+++ b/public/app/plugins/panel/text/v2/TextNGPanel.tsx
@@ -92,7 +92,6 @@ export function TextNGPanel(props: Props) {
       options.content,
       options.mode,
       options.renderMode,
-      options.maxRows,
       options.code?.language,
       series,
       replaceVariables,
@@ -112,7 +111,6 @@ export function TextNGPanel(props: Props) {
         showLineNumbers={options.code?.showLineNumbers ?? false}
         codeLanguage={options.code?.language}
         renderMode={options.renderMode}
-        maxRows={options.maxRows}
         series={series}
         replaceVariables={replaceVariables}
         suggestions={suggestions}
@@ -288,7 +286,6 @@ function renderPanelContent(
           mode: options.mode,
           series,
           renderMode: options.renderMode,
-          maxRows: options.maxRows,
           format: getInterpolateFormat(options.mode, options.code?.language),
         },
         replaceVariables,

--- a/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
+++ b/public/app/plugins/panel/text/v2/editor/TextNGEditor.tsx
@@ -37,7 +37,6 @@ export interface TextNGEditorProps {
   showLineNumbers: boolean;
   codeLanguage?: CodeLanguage;
   renderMode?: RenderMode;
-  maxRows?: number;
   series?: DataFrame[];
   replaceVariables: InterpolateFunction;
   suggestions?: VariableSuggestion[];
@@ -70,7 +69,6 @@ export function TextNGEditor({
   showLineNumbers,
   codeLanguage,
   renderMode,
-  maxRows,
   series,
   replaceVariables,
   suggestions,
@@ -139,10 +137,10 @@ export function TextNGEditor({
     () =>
       catchTemplateError(() =>
         showPreview
-          ? interpolateTemplate({ content: previewSource, mode, series, renderMode, maxRows, format }, replaceVariables)
+          ? interpolateTemplate({ content: previewSource, mode, series, renderMode, format }, replaceVariables)
           : ''
       ),
-    [showPreview, previewSource, mode, series, renderMode, maxRows, format, replaceVariables]
+    [showPreview, previewSource, mode, series, renderMode, format, replaceVariables]
   );
 
   const previewHtml = useMemo(

--- a/public/app/plugins/panel/text/v2/module.test.ts
+++ b/public/app/plugins/panel/text/v2/module.test.ts
@@ -6,7 +6,6 @@ import { getAllOptionEditors, getAllStandardFieldConfigs } from 'app/core/compon
 import { type Options, RenderMode } from '../panelcfg.gen';
 
 import { textNGPanelOptions } from './module';
-import { MAX_RENDERED_ROWS } from './renderContent';
 
 beforeEach(() => {
   setTestFlags({ [FlagKeys.TextNewFeatures]: true });
@@ -34,24 +33,11 @@ function getItem(path: string) {
 }
 
 /** The options pane shows only these; everything else is edited in the panel itself. */
-const paneOptions = ['renderMode', 'maxRows'];
+const paneOptions = ['renderMode'];
 
 describe('textNGPanelOptions', () => {
   it('registers renderMode with a default that preserves a single render', () => {
     expect(getItem('renderMode').defaultValue).toBe(RenderMode.Once);
-  });
-
-  it('leaves maxRows unset, so an empty field renders every row', () => {
-    expect(getItem('maxRows').defaultValue).toBeUndefined();
-    expect(getItem('maxRows').settings).toMatchObject({ placeholder: String(MAX_RENDERED_ROWS) });
-  });
-
-  it('bounds the maxRows input by the hard ceiling', () => {
-    expect(getItem('maxRows').settings).toMatchObject({ min: 1, max: MAX_RENDERED_ROWS, integer: true });
-  });
-
-  it('warns in the maxRows description that raising it costs performance', () => {
-    expect(getItem('maxRows').description).toMatch(/slow the panel/i);
   });
 
   it('are the only options visible in the pane', () => {

--- a/public/app/plugins/panel/text/v2/module.tsx
+++ b/public/app/plugins/panel/text/v2/module.tsx
@@ -5,7 +5,7 @@ import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import { defaultCodeOptions, defaultOptions, type Options, RenderMode } from '../panelcfg.gen';
 
 import { TextNGPanel } from './TextNGPanel';
-import { hasRenderableData, MAX_RENDERED_ROWS } from './renderContent';
+import { hasRenderableData } from './renderContent';
 import { textPanelMigrationHandler } from './textPanelMigrationHandler';
 
 function newFeaturesEnabled(): boolean {
@@ -53,18 +53,6 @@ export const textNGPanelOptions: PanelOptionsSupplier<Options> = (builder) => {
         },
       ],
     },
-    showIf: showForData,
-  });
-
-  builder.addNumberInput({
-    path: 'maxRows',
-    name: t('textng.options.max-rows', 'Row limit'),
-    description: t(
-      'textng.options.max-rows-description',
-      'Rows of query data to render. High values can slow the panel, especially with complex HTML.'
-    ),
-    category: dataCategory,
-    settings: { min: 1, max: MAX_RENDERED_ROWS, integer: true, placeholder: String(MAX_RENDERED_ROWS) },
     showIf: showForData,
   });
 };

--- a/public/app/plugins/panel/text/v2/renderContent.test.ts
+++ b/public/app/plugins/panel/text/v2/renderContent.test.ts
@@ -80,15 +80,9 @@ function interpolate(
   content: string,
   series: DataFrame[] | undefined,
   renderMode: RenderMode | undefined,
-  mode = TextMode.Markdown,
-  maxRows?: number
+  mode = TextMode.Markdown
 ) {
-  return interpolateTemplate({ content, series, renderMode, mode, maxRows }, createReplaceVariables());
-}
-
-/** `interpolate` with an explicit row limit, in markdown mode. */
-function withLimit(content: string, series: DataFrame[], renderMode: RenderMode, maxRows?: number) {
-  return interpolate(content, series, renderMode, TextMode.Markdown, maxRows);
+  return interpolateTemplate({ content, series, renderMode, mode }, createReplaceVariables());
 }
 
 const theme = createTheme();
@@ -239,41 +233,19 @@ describe('interpolateTemplate', () => {
       );
     });
 
-    it('renders at most the requested number of rows', () => {
-      const blocks = withLimit('${__data.fields.n}', [numberedFrame(50)], RenderMode.PerRow, 10).split('\n\n');
-
-      expect(blocks).toHaveLength(10);
-      expect(blocks[9]).toBe('9');
+    it('renders every row of a frame smaller than the hard ceiling', () => {
+      expect(interpolate('${__data.fields.n}', [numberedFrame(3)], RenderMode.PerRow)).toBe('0\n\n1\n\n2');
     });
 
-    it('renders every row when the limit is never reached', () => {
-      expect(withLimit('${__data.fields.n}', [numberedFrame(3)], RenderMode.PerRow, 10)).toBe('0\n\n1\n\n2');
-    });
-
-    it.each([
-      ['unset, on a panel saved before the option existed', undefined],
-      ['zero', 0],
-      ['not a number', NaN],
-    ])('renders every row up to the hard ceiling when the limit is %s', (_name, maxRows) => {
+    it('renders every row up to the hard ceiling', () => {
       const series = [numberedFrame(MAX_RENDERED_ROWS + 10)];
-      const blocks = withLimit('${__data.fields.n}', series, RenderMode.PerRow, maxRows).split('\n\n');
+      const blocks = interpolate('${__data.fields.n}', series, RenderMode.PerRow).split('\n\n');
 
       expect(blocks).toHaveLength(MAX_RENDERED_ROWS);
       expect(blocks[MAX_RENDERED_ROWS - 1]).toBe(String(MAX_RENDERED_ROWS - 1));
     });
 
-    it.each([
-      ['above the hard ceiling', MAX_RENDERED_ROWS + 500, MAX_RENDERED_ROWS],
-      ['below one', -5, 1],
-    ])('clamps a row limit %s', (_name, maxRows, expected) => {
-      const series = [numberedFrame(MAX_RENDERED_ROWS + 10)];
-      const blocks = withLimit('${__data.fields.n}', series, RenderMode.PerRow, maxRows).split('\n\n');
-
-      expect(blocks).toHaveLength(expected);
-      expect(blocks[expected - 1]).toBe(String(expected - 1));
-    });
-
-    it('stops at the size backstop before reaching the row limit', () => {
+    it('stops at the size backstop before reaching the hard ceiling', () => {
       const rendered = interpolate('x'.repeat(1000), [numberedFrame(MAX_RENDERED_ROWS)], RenderMode.PerRow);
 
       expect(rendered.length).toBeLessThanOrEqual(MAX_RENDERED_CHARS);
@@ -371,13 +343,6 @@ describe('interpolateTemplate', () => {
       const rendered = interpolate('{{#each data}}{{n}},{{/each}}', series, RenderMode.Once);
 
       expect(rendered.split(',').filter(Boolean)).toHaveLength(MAX_RENDERED_ROWS);
-    });
-
-    it('applies the row limit to Once as well, so both modes see the same rows', () => {
-      const template = '{{#each data}}{{n}},{{/each}}';
-      const rendered = withLimit(template, [numberedFrame(50)], RenderMode.Once, 10);
-
-      expect(rendered.split(',').filter(Boolean)).toHaveLength(10);
     });
 
     it('truncates a Once template that passes the size backstop', () => {

--- a/public/app/plugins/panel/text/v2/renderContent.ts
+++ b/public/app/plugins/panel/text/v2/renderContent.ts
@@ -17,7 +17,7 @@ import { RenderMode, TextMode } from '../panelcfg.gen';
 import { buildAllRowsContext, buildRows, type CompiledTemplate, compileTemplate } from './handlebars';
 import { transformContent } from './utils';
 
-/** Ceiling for the `maxRows` option, so a typed value cannot hang the panel. */
+/** Hard ceiling on the rows a single render pass may cover, so a large query cannot hang the panel. */
 export const MAX_RENDERED_ROWS = 1000;
 
 /** Render cost follows output size, not row count, and markdown-it degrades superlinearly. */
@@ -33,7 +33,6 @@ export interface TextTemplate {
   series?: DataFrame[];
   renderMode?: RenderMode;
   format?: string;
-  maxRows?: number;
 }
 
 /** A finished render pass, or the error that stopped it. */
@@ -65,21 +64,15 @@ function handlebarsEnabled(): boolean {
   return getFeatureFlagClient().getBooleanValue('text.newFeatures', false);
 }
 
-// A cleared or zeroed field falls back to the ceiling.
-function resolveMaxRows(maxRows?: number): number {
-  return maxRows ? Math.max(1, Math.min(Math.floor(maxRows), MAX_RENDERED_ROWS)) : MAX_RENDERED_ROWS;
-}
-
 export function interpolateTemplate(template: TextTemplate, replaceVariables: InterpolateFunction): string {
   const { content, mode, series = [], renderMode, format } = template;
-  const maxRows = resolveMaxRows(template.maxRows);
 
   // Code mode shows the source verbatim, and Handlebars' HTML escaping would mangle it.
   const compiled =
     handlebarsEnabled() && mode !== TextMode.Code ? compileTemplate(content, replaceVariables) : undefined;
 
   if (renderMode === RenderMode.PerRow && hasRenderableData(series)) {
-    return interpolateEveryRow(template, series, replaceVariables, maxRows, compiled);
+    return interpolateEveryRow(template, series, replaceVariables, compiled);
   }
 
   const scopedVars = buildOnceContext(series);
@@ -88,9 +81,9 @@ export function interpolateTemplate(template: TextTemplate, replaceVariables: In
     return replaceVariables(content, scopedVars, format);
   }
 
-  const rendered = replaceVariables(compiled(buildAllRowsContext(series, maxRows)), scopedVars, format);
+  const rendered = replaceVariables(compiled(buildAllRowsContext(series, MAX_RENDERED_ROWS)), scopedVars, format);
 
-  // A Once template emits one string, so the row limit cannot bound its size.
+  // A Once template emits one string, so the row ceiling cannot bound its size.
   return cutToMaxChars(rendered);
 }
 
@@ -150,7 +143,6 @@ function interpolateEveryRow(
   template: TextTemplate,
   series: DataFrame[],
   replaceVariables: InterpolateFunction,
-  maxRows: number,
   compiled?: CompiledTemplate
 ): string {
   const { content, mode, format } = template;
@@ -163,7 +155,7 @@ function interpolateEveryRow(
       continue;
     }
 
-    const rowCount = Math.min(frame.length, maxRows - blocks.length);
+    const rowCount = Math.min(frame.length, MAX_RENDERED_ROWS - blocks.length);
     const rows = compiled ? buildRows(frame, series, rowCount) : [];
 
     for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
@@ -181,7 +173,7 @@ function interpolateEveryRow(
       }
     }
 
-    if (renderedChars >= MAX_RENDERED_CHARS || blocks.length >= maxRows) {
+    if (renderedChars >= MAX_RENDERED_CHARS || blocks.length >= MAX_RENDERED_ROWS) {
       break;
     }
   }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -16631,8 +16631,6 @@
       "label": "Query"
     },
     "options": {
-      "max-rows": "Row limit",
-      "max-rows-description": "Rows of query data to render. High values can slow the panel, especially with complex HTML.",
       "render-mode": "Render mode"
     },
     "render": {


### PR DESCRIPTION
This PR removes the `Row limit` option from Text v2.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
