### PR TITLE
Plugins: Add retry with backoff to install sync

### DIFF
--- a/apps/plugins/pkg/app/install/registrar.go
+++ b/apps/plugins/pkg/app/install/registrar.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -31,6 +32,10 @@ const (
 	// solely as dependencies of other plugins.
 	DependencyPluginVersion = "latest"
 )
+
+// ErrSyncDidNotConverge indicates that storage hooks kept changing plugin
+// records through every reconciliation pass.
+var ErrSyncDidNotConverge = errors.New("plugin install sync did not converge")
 
 type Source = string
 
@@ -240,7 +245,7 @@ func (r *InstallRegistrar) register(ctx context.Context, namespace string, insta
 	existing, err := client.Get(ctx, identifier)
 	if err != nil && !errorsK8s.IsNotFound(err) {
 		logger.Error("Failed to get existing plugin", "error", err)
-		metrics.RegistrationOperationsTotal.WithLabelValues("register", "error").Inc()
+		metrics.RegistrationOperationsTotal.WithLabelValues("register", outcomeForError(err)).Inc()
 		return false, err
 	}
 
@@ -254,7 +259,7 @@ func (r *InstallRegistrar) register(ctx context.Context, namespace string, insta
 					return true, nil
 				}
 				logger.Error("Failed to update plugin", "error", err)
-				metrics.RegistrationOperationsTotal.WithLabelValues("register", "error").Inc()
+				metrics.RegistrationOperationsTotal.WithLabelValues("register", outcomeForError(err)).Inc()
 				return false, err
 			}
 			metrics.RegistrationOperationsTotal.WithLabelValues("register", "success").Inc()
@@ -272,11 +277,23 @@ func (r *InstallRegistrar) register(ctx context.Context, namespace string, insta
 			return true, nil
 		}
 		logger.Error("Failed to create plugin", "error", err)
-		metrics.RegistrationOperationsTotal.WithLabelValues("register", "error").Inc()
+		metrics.RegistrationOperationsTotal.WithLabelValues("register", outcomeForError(err)).Inc()
 		return false, err
 	}
 	metrics.RegistrationOperationsTotal.WithLabelValues("register", "success").Inc()
 	return true, nil
+}
+
+// outcomeForError classifies transient API failures separately from generic
+// errors so fleet-wide rate limiting and unavailability remain distinguishable.
+func outcomeForError(err error) string {
+	if errorsK8s.IsTooManyRequests(err) {
+		return "rate_limited"
+	}
+	if errorsK8s.IsServiceUnavailable(err) || errorsK8s.IsServerTimeout(err) || errorsK8s.IsTimeout(err) {
+		return "unavailable"
+	}
+	return "error"
 }
 
 // maxSyncNamespacePasses bounds SyncNamespace's passes. A namespace still
@@ -303,8 +320,10 @@ func (r *InstallRegistrar) SyncNamespace(ctx context.Context, namespace string, 
 	for pass := range maxSyncNamespacePasses {
 		existing, err := client.ListAll(ctx, namespace, resource.ListOptions{})
 		if err != nil {
+			metrics.RegistrationOperationsTotal.WithLabelValues("list", outcomeForError(err)).Inc()
 			return err
 		}
+		metrics.RegistrationOperationsTotal.WithLabelValues("list", "success").Inc()
 
 		written = written[:0]
 
@@ -360,7 +379,7 @@ func (r *InstallRegistrar) SyncNamespace(ctx context.Context, namespace string, 
 		}
 	}
 
-	return fmt.Errorf("plugin install sync did not converge after %d passes, still writing: %v", maxSyncNamespacePasses, written)
+	return fmt.Errorf("%w after %d passes, still writing: %v", ErrSyncDidNotConverge, maxSyncNamespacePasses, written)
 }
 
 // unregisterIsNoOp reports whether the listed record proves Unregister would
@@ -402,7 +421,7 @@ func (r *InstallRegistrar) unregister(ctx context.Context, namespace string, nam
 	existing, err := client.Get(ctx, identifier)
 	if err != nil && !errorsK8s.IsNotFound(err) {
 		logger.Error("Failed to get existing plugin", "error", err)
-		metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "error").Inc()
+		metrics.RegistrationOperationsTotal.WithLabelValues("unregister", outcomeForError(err)).Inc()
 		return false, err
 	}
 	// if the plugin doesn't exist, nothing to unregister
@@ -437,7 +456,7 @@ func (r *InstallRegistrar) unregister(ctx context.Context, namespace string, nam
 				return true, nil
 			}
 			logger.Error("Failed to demote plugin to dependency install", "error", err)
-			metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "error").Inc()
+			metrics.RegistrationOperationsTotal.WithLabelValues("unregister", outcomeForError(err)).Inc()
 			return false, err
 		}
 		metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "success").Inc()
@@ -446,7 +465,7 @@ func (r *InstallRegistrar) unregister(ctx context.Context, namespace string, nam
 	err = client.Delete(ctx, identifier, resource.DeleteOptions{})
 	if err != nil {
 		logger.Error("Failed to delete plugin", "error", err)
-		metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "error").Inc()
+		metrics.RegistrationOperationsTotal.WithLabelValues("unregister", outcomeForError(err)).Inc()
 		return false, err
 	}
 	metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "success").Inc()

--- a/apps/plugins/pkg/app/install/registrar_test.go
+++ b/apps/plugins/pkg/app/install/registrar_test.go
@@ -810,6 +810,120 @@ func TestInstallRegistrar_Register_ErrorCases(t *testing.T) {
 	}
 }
 
+func TestInstallRegistrar_OperationErrorMetrics(t *testing.T) {
+	t.Run("register counts a 429 as rate limited, not error", func(t *testing.T) {
+		ctx := t.Context()
+		fakeClient := &fakePluginInstallClient{
+			getFunc: func(context.Context, resource.Identifier) (*pluginsv0alpha1.Plugin, error) {
+				return nil, errorsK8s.NewNotFound(pluginGroupResource(), "plugin-1")
+			},
+			createFunc: func(context.Context, *pluginsv0alpha1.Plugin, resource.CreateOptions) (*pluginsv0alpha1.Plugin, error) {
+				return nil, errorsK8s.NewTooManyRequests("throttled", 5)
+			},
+		}
+		registrar := NewInstallRegistrar(&logging.NoOpLogger{}, &fakeClientGenerator{client: fakeClient})
+
+		errBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "error"))
+		rateLimitedBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "rate_limited"))
+
+		err := registrar.Register(ctx, "org-1", &PluginInstall{ID: "plugin-1", Version: "1.0.0", Source: SourcePluginStore})
+		require.Error(t, err)
+
+		require.Equal(t, errBefore, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "error")))
+		require.Equal(t, rateLimitedBefore+1, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "rate_limited")))
+	})
+
+	t.Run("register still counts a generic error as error", func(t *testing.T) {
+		ctx := t.Context()
+		fakeClient := &fakePluginInstallClient{
+			getFunc: func(context.Context, resource.Identifier) (*pluginsv0alpha1.Plugin, error) {
+				return nil, errorsK8s.NewNotFound(pluginGroupResource(), "plugin-1")
+			},
+			createFunc: func(context.Context, *pluginsv0alpha1.Plugin, resource.CreateOptions) (*pluginsv0alpha1.Plugin, error) {
+				return nil, errors.New("boom")
+			},
+		}
+		registrar := NewInstallRegistrar(&logging.NoOpLogger{}, &fakeClientGenerator{client: fakeClient})
+
+		errBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "error"))
+		rateLimitedBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "rate_limited"))
+
+		err := registrar.Register(ctx, "org-1", &PluginInstall{ID: "plugin-1", Version: "1.0.0", Source: SourcePluginStore})
+		require.Error(t, err)
+
+		require.Equal(t, errBefore+1, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "error")))
+		require.Equal(t, rateLimitedBefore, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("register", "rate_limited")))
+	})
+
+	t.Run("unregister counts a 503 as unavailable, not error", func(t *testing.T) {
+		ctx := t.Context()
+		fakeClient := &fakePluginInstallClient{
+			getFunc: func(context.Context, resource.Identifier) (*pluginsv0alpha1.Plugin, error) {
+				return &pluginsv0alpha1.Plugin{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:   "org-1",
+						Name:        "plugin-1",
+						Annotations: map[string]string{PluginInstallSourceAnnotation: SourcePluginStore},
+					},
+					Spec: pluginsv0alpha1.PluginSpec{Id: "plugin-1"},
+				}, nil
+			},
+			deleteFunc: func(context.Context, resource.Identifier, resource.DeleteOptions) error {
+				return errorsK8s.NewServiceUnavailable("unavailable")
+			},
+		}
+		registrar := NewInstallRegistrar(&logging.NoOpLogger{}, &fakeClientGenerator{client: fakeClient})
+
+		errBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "error"))
+		unavailableBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "unavailable"))
+
+		err := registrar.Unregister(ctx, "org-1", "plugin-1", SourcePluginStore)
+		require.Error(t, err)
+
+		require.Equal(t, errBefore, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "error")))
+		require.Equal(t, unavailableBefore+1, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("unregister", "unavailable")))
+	})
+
+	t.Run("sync counts a rate-limited list request", func(t *testing.T) {
+		fakeClient := &fakePluginInstallClient{
+			listAllFunc: func(context.Context, string, resource.ListOptions) (*pluginsv0alpha1.PluginList, error) {
+				return nil, errorsK8s.NewTooManyRequests("throttled", 5)
+			},
+		}
+		registrar := NewInstallRegistrar(&logging.NoOpLogger{}, &fakeClientGenerator{client: fakeClient})
+
+		errBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("list", "error"))
+		rateLimitedBefore := testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("list", "rate_limited"))
+
+		err := registrar.SyncNamespace(t.Context(), "org-1", SourcePluginStore, nil)
+		require.Error(t, err)
+
+		require.Equal(t, errBefore, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("list", "error")))
+		require.Equal(t, rateLimitedBefore+1, testutil.ToFloat64(metrics.RegistrationOperationsTotal.WithLabelValues("list", "rate_limited")))
+	})
+}
+
+func TestOutcomeForError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		outcome string
+	}{
+		{name: "too many requests", err: errorsK8s.NewTooManyRequests("throttled", 5), outcome: "rate_limited"},
+		{name: "service unavailable", err: errorsK8s.NewServiceUnavailable("unavailable"), outcome: "unavailable"},
+		{name: "server timeout", err: errorsK8s.NewServerTimeout(pluginGroupResource(), "list", 5), outcome: "unavailable"},
+		{name: "timeout", err: errorsK8s.NewTimeoutError("timeout", 5), outcome: "unavailable"},
+		{name: "generic error", err: errors.New("boom"), outcome: "error"},
+		{name: "bad request", err: errorsK8s.NewBadRequest("bad request"), outcome: "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.outcome, outcomeForError(tt.err))
+		})
+	}
+}
+
 func TestInstallRegistrar_Unregister(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -1213,6 +1327,7 @@ func TestInstallRegistrar_SyncNamespace(t *testing.T) {
 		registrar := NewInstallRegistrar(&logging.NoOpLogger{}, &fakeClientGenerator{client: fakeClient})
 
 		err := registrar.SyncNamespace(context.Background(), "org-1", SourcePluginStore, nil)
+		require.ErrorIs(t, err, ErrSyncDidNotConverge)
 		require.ErrorContains(t, err, "did not converge")
 		require.ErrorContains(t, err, "plugin-gone")
 		require.Equal(t, maxSyncNamespacePasses, c.lists)

--- a/pkg/services/pluginsintegration/installsync/syncer.go
+++ b/pkg/services/pluginsintegration/installsync/syncer.go
@@ -4,18 +4,23 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana-app-sdk/resource"
+	errorsK8s "k8s.io/apimachinery/pkg/api/errors"
 
 	pluginsv0alpha1 "github.com/grafana/grafana/apps/plugins/pkg/apis/plugins/v0alpha1"
 	"github.com/grafana/grafana/apps/plugins/pkg/app/install"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/configprovider"
+	infraserverlock "github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
@@ -32,6 +37,17 @@ const (
 
 var (
 	lockTimeout = 10 * time.Minute
+
+	// defaultBackoffConfig controls retries between failed Sync attempts.
+	// Retries are infinite: Sync only ever runs once at process startup, so
+	// there is no other trigger to resync a stack whose sync failed (e.g.
+	// because the API server was throttling requests during a fleet-wide
+	// restart) until the process restarts.
+	defaultBackoffConfig = backoff.Config{
+		MinBackoff: 5 * time.Second,
+		MaxBackoff: 5 * time.Minute,
+		MaxRetries: 0,
+	}
 )
 
 // Syncer is the interface for syncing plugin installations to the Kubernetes-style API.
@@ -55,6 +71,7 @@ type syncer struct {
 	serverLock          ServerLock
 	restConfigProvider  apiserver.RestConfigProvider
 	pluginsStoreService pluginstore.Store
+	backoffConfig       backoff.Config
 }
 
 var _ Syncer = (*syncer)(nil)
@@ -80,6 +97,7 @@ func newSyncer(
 		serverLock:          serverLock,
 		restConfigProvider:  restConfigProvider,
 		pluginsStoreService: pluginsStoreService,
+		backoffConfig:       defaultBackoffConfig,
 	}
 	s.NamedService = services.NewBasicService(nil, s.running, nil).WithName(ServiceName)
 	return &s
@@ -142,11 +160,106 @@ func (s *syncer) running(ctx context.Context) error {
 		ctxLog.Warn("Failed to wait for plugin API availability, skipping plugin sync", "error", err)
 	}
 
-	if err := s.Sync(ctx, install.SourcePluginStore, s.pluginsStoreService.Plugins(ctx)); err != nil {
-		ctxLog.Warn("Failed to sync plugins", "error", err)
-	}
+	s.syncWithRetry(ctx, func(ctx context.Context) error {
+		return s.Sync(ctx, install.SourcePluginStore, s.pluginsStoreService.Plugins(ctx))
+	})
 	<-ctx.Done()
 	return nil
+}
+
+// syncWithRetry calls attempt, retrying with backoff on failure until it
+// succeeds, fails with a non-retryable error, or ctx is done. A single failed
+// attempt (e.g. the API server throttling requests during a fleet-wide
+// restart) must not strand this stack's plugin state until the process
+// restarts, since Sync only ever runs once at startup otherwise.
+func (s *syncer) syncWithRetry(ctx context.Context, attempt func(ctx context.Context) error) {
+	ctxLog := logging.FromContext(ctx)
+	bo := backoff.New(ctx, s.backoffConfig)
+	for {
+		err := attempt(ctx)
+		if err == nil {
+			return
+		}
+		if isServerLockExistsError(err) {
+			ctxLog.Debug("Another instance is running plugin sync, skipping this instance")
+			return
+		}
+		if !isRetryableSyncError(err) {
+			ctxLog.Error("Plugin sync failed with a non-retryable error, giving up", "error", err)
+			return
+		}
+		if !bo.Ongoing() {
+			ctxLog.Warn("Giving up on plugin sync", "error", err, "attempts", bo.NumRetries()+1)
+			return
+		}
+		ctxLog.Warn("Failed to sync plugins, retrying", "error", err, "attempt", bo.NumRetries()+1)
+		bo.Wait()
+	}
+}
+
+func isServerLockExistsError(err error) bool {
+	_, ok := errors.AsType[*infraserverlock.ServerLockExistsError](err)
+	return ok
+}
+
+type joinedError interface {
+	error
+	Unwrap() []error
+}
+
+type apiStatusError interface {
+	error
+	errorsK8s.APIStatus
+}
+
+// isRetryableSyncError reports whether err is a known transient failure.
+// Unknown errors are not retried because retries are otherwise infinite.
+func isRetryableSyncError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	// Reconciliation already made the maximum safe number of passes. Never
+	// restart that write loop, even when another namespace had a transient
+	// failure in the same attempt.
+	if errors.Is(err, install.ErrSyncDidNotConverge) {
+		return false
+	}
+
+	// Kubernetes predicates select the first APIStatus in an error tree. Walk
+	// joined namespace errors individually so their order cannot change whether
+	// a transient failure is retried.
+	if joined, ok := errors.AsType[joinedError](err); ok {
+		for _, joinedErr := range joined.Unwrap() {
+			if isRetryableSyncError(joinedErr) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Some app-sdk errors both expose their own Kubernetes status and unwrap
+	// to a lower-level transport error. Preserve the status classification
+	// before classifying an error from their transport error chain.
+	if apiStatus, ok := errors.AsType[apiStatusError](err); ok {
+		return isRetryableKubernetesError(apiStatus)
+	}
+
+	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+		return true
+	}
+	if _, ok := errors.AsType[*net.OpError](err); ok {
+		return true
+	}
+
+	return false
+}
+
+func isRetryableKubernetesError(err apiStatusError) bool {
+	return errorsK8s.IsTooManyRequests(err) ||
+		errorsK8s.IsServiceUnavailable(err) ||
+		errorsK8s.IsServerTimeout(err) ||
+		errorsK8s.IsTimeout(err) ||
+		err.Status().Code == http.StatusBadGateway
 }
 
 func (s *syncer) Sync(ctx context.Context, source install.Source, installedPlugins []pluginstore.Plugin) error {

--- a/pkg/services/pluginsintegration/installsync/syncer_test.go
+++ b/pkg/services/pluginsintegration/installsync/syncer_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
+	sdkK8s "github.com/grafana/grafana-app-sdk/k8s"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/stretchr/testify/require"
@@ -16,12 +21,189 @@ import (
 
 	pluginsv0alpha1 "github.com/grafana/grafana/apps/plugins/pkg/apis/plugins/v0alpha1"
 	"github.com/grafana/grafana/apps/plugins/pkg/app/install"
+	infraserverlock "github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 )
+
+func testBackoffConfig(maxRetries int) backoff.Config {
+	return backoff.Config{
+		MinBackoff: time.Millisecond,
+		MaxBackoff: 2 * time.Millisecond,
+		MaxRetries: maxRetries,
+	}
+}
+
+func TestSyncer_syncWithRetry(t *testing.T) {
+	t.Run("succeeds without retrying when the first attempt succeeds", func(t *testing.T) {
+		s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+		s.backoffConfig = testBackoffConfig(3)
+
+		var calls int
+		s.syncWithRetry(t.Context(), func(context.Context) error {
+			calls++
+			return nil
+		})
+
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("retries after a failure and stops once an attempt succeeds", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+			s.backoffConfig = testBackoffConfig(5)
+
+			var calls int
+			s.syncWithRetry(t.Context(), func(context.Context) error {
+				calls++
+				if calls < 3 {
+					return errorsK8s.NewTooManyRequests("throttled", 5)
+				}
+				return nil
+			})
+
+			require.Equal(t, 3, calls)
+		})
+	})
+
+	t.Run("retries a request deadline while the retry context remains active", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+			s.backoffConfig = testBackoffConfig(3)
+
+			var calls int
+			s.syncWithRetry(t.Context(), func(context.Context) error {
+				calls++
+				if calls == 1 {
+					return context.DeadlineExceeded
+				}
+				return nil
+			})
+
+			require.Equal(t, 2, calls)
+		})
+	})
+
+	t.Run("gives up after the configured number of retries", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+			s.backoffConfig = testBackoffConfig(2)
+
+			var calls int
+			s.syncWithRetry(t.Context(), func(context.Context) error {
+				calls++
+				return errorsK8s.NewTooManyRequests("still throttled", 5)
+			})
+
+			// dskit/backoff counts retries after the initial attempt, so
+			// MaxRetries=2 allows 1 initial try + 2 retries = 3 calls.
+			require.Equal(t, 3, calls)
+		})
+	})
+
+	t.Run("stops promptly when the context is cancelled mid-retry", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			time.AfterFunc(5*time.Millisecond, cancel)
+			s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+			s.backoffConfig = backoff.Config{MinBackoff: 10 * time.Millisecond, MaxBackoff: 10 * time.Millisecond, MaxRetries: 0}
+
+			var calls int
+			s.syncWithRetry(ctx, func(context.Context) error {
+				calls++
+				return errorsK8s.NewTooManyRequests("throttled", 5)
+			})
+
+			require.Equal(t, 2, calls)
+		})
+	})
+
+	t.Run("stops immediately without retrying on a non-retryable error", func(t *testing.T) {
+		s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+		s.backoffConfig = testBackoffConfig(3)
+
+		var calls int
+		s.syncWithRetry(t.Context(), func(context.Context) error {
+			calls++
+			return errorsK8s.NewBadRequest("malformed plugin install")
+		})
+
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("stops immediately without retrying an unknown error", func(t *testing.T) {
+		s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+		s.backoffConfig = testBackoffConfig(3)
+
+		var calls int
+		s.syncWithRetry(t.Context(), func(context.Context) error {
+			calls++
+			return errors.New("unknown failure")
+		})
+
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("stops immediately when another instance holds the sync lock", func(t *testing.T) {
+		s := newSyncer(nil, nil, nil, nil, nil, nil, nil)
+		s.backoffConfig = testBackoffConfig(3)
+
+		var calls int
+		s.syncWithRetry(t.Context(), func(context.Context) error {
+			calls++
+			return &infraserverlock.ServerLockExistsError{}
+		})
+
+		require.Equal(t, 1, calls)
+	})
+}
+
+func TestIsRetryableSyncError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		isRetryable bool
+	}{
+		{name: "nil error", err: nil, isRetryable: false},
+		{name: "generic error", err: errors.New("connection refused"), isRetryable: false},
+		{name: "context canceled", err: context.Canceled, isRetryable: false},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded, isRetryable: true},
+		{name: "too many requests", err: errorsK8s.NewTooManyRequests("throttled", 5), isRetryable: true},
+		{name: "service unavailable", err: errorsK8s.NewServiceUnavailable("unavailable"), isRetryable: true},
+		{name: "server timeout", err: errorsK8s.NewServerTimeout(schema.GroupResource{}, "list", 5), isRetryable: true},
+		{name: "timeout", err: errorsK8s.NewTimeoutError("timeout", 5), isRetryable: true},
+		{name: "network timeout", err: &net.DNSError{Err: "timeout", IsTimeout: true}, isRetryable: true},
+		{name: "network operation", err: &net.OpError{Op: "read", Err: errors.New("connection refused")}, isRetryable: true},
+		{name: "bad request", err: errorsK8s.NewBadRequest("bad request"), isRetryable: false},
+		{name: "unauthorized", err: errorsK8s.NewUnauthorized("unauthorized"), isRetryable: false},
+		{name: "forbidden", err: errorsK8s.NewForbidden(schema.GroupResource{}, "plugin-1", errors.New("denied")), isRetryable: false},
+		{name: "invalid", err: errorsK8s.NewInvalid(schema.GroupKind{}, "plugin-1", nil), isRetryable: false},
+		{name: "app SDK forbidden", err: sdkK8s.NewServerResponseError(errors.New("denied"), http.StatusForbidden), isRetryable: false},
+		{name: "app SDK forbidden overrides wrapped network error", err: sdkK8s.NewServerResponseError(&net.OpError{Op: "read", Err: errors.New("connection refused")}, http.StatusForbidden), isRetryable: false},
+		{name: "wrapped app SDK forbidden overrides wrapped network error", err: fmt.Errorf("update plugin: %w", sdkK8s.NewServerResponseError(&net.OpError{Op: "read", Err: errors.New("connection refused")}, http.StatusForbidden)), isRetryable: false},
+		{name: "app SDK too many requests", err: sdkK8s.NewServerResponseError(errors.New("throttled"), http.StatusTooManyRequests), isRetryable: true},
+		{name: "app SDK bad gateway", err: sdkK8s.NewServerResponseError(errors.New("bad gateway"), http.StatusBadGateway), isRetryable: true},
+		{name: "app SDK gateway timeout", err: sdkK8s.NewServerResponseError(errors.New("gateway timeout"), http.StatusGatewayTimeout), isRetryable: true},
+		{name: "app SDK transport failure", err: sdkK8s.ParseKubernetesError(nil, 0, &net.OpError{Op: "read", Err: errors.New("connection refused")}), isRetryable: true},
+		{name: "app SDK request deadline", err: sdkK8s.ParseKubernetesError(nil, 0, context.DeadlineExceeded), isRetryable: true},
+		{name: "wrapped too many requests", err: fmt.Errorf("list plugins: %w", errorsK8s.NewTooManyRequests("throttled", 5)), isRetryable: true},
+		{name: "non-converging sync", err: fmt.Errorf("namespace: %w", install.ErrSyncDidNotConverge), isRetryable: false},
+		{name: "non-converging sync overrides a joined retryable error", err: errors.Join(install.ErrSyncDidNotConverge, errorsK8s.NewTooManyRequests("throttled", 5)), isRetryable: false},
+		{name: "joined non-retryable errors", err: errors.Join(errorsK8s.NewBadRequest("bad request"), errorsK8s.NewUnauthorized("unauthorized")), isRetryable: false},
+		{name: "non-retryable then retryable joined errors", err: errors.Join(errorsK8s.NewForbidden(schema.GroupResource{}, "plugin-1", errors.New("denied")), errorsK8s.NewTooManyRequests("throttled", 5)), isRetryable: true},
+		{name: "retryable then non-retryable joined errors", err: errors.Join(errorsK8s.NewTooManyRequests("throttled", 5), errorsK8s.NewForbidden(schema.GroupResource{}, "plugin-1", errors.New("denied"))), isRetryable: true},
+		{name: "wrapped joined errors", err: fmt.Errorf("sync namespaces: %w", errors.Join(errorsK8s.NewForbidden(schema.GroupResource{}, "plugin-1", errors.New("denied")), errorsK8s.NewTooManyRequests("throttled", 5))), isRetryable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.isRetryable, isRetryableSyncError(tt.err))
+		})
+	}
+}
 
 func TestSyncer_Sync(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds retry with randomized exponential backoff to the startup plugin install API sync. It retries transient API server, gateway, and transport failures while continuing to process independent namespaces.

**Why do we need this feature?**

The sync runs only once at startup, so a transient timeout, rate limit, or API outage can leave plugin install records stale until Grafana restarts. Retrying allows the sync to recover automatically when the API becomes available again.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
