### PR TITLE
Chore: Request go.mod reviewers with grafana-pr-automation

### DIFF
--- a/.github/workflows/modowners-reviewers.yml
+++ b/.github/workflows/modowners-reviewers.yml
@@ -54,11 +54,38 @@ jobs:
             exit 0
           fi
           echo "Requesting: $slugs"
-          assigned=$(jq -n --arg slugs "$slugs" '{reviewers: [], team_reviewers: ($slugs | split("\n") | map(select(length > 0)))}' |
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input - |
-            jq -r '.requested_teams[].slug')
-          echo "Assigned: $assigned"
-          if [ -z "$assigned" ]; then
-            echo "::error::GitHub accepted the request but assigned no teams"
-            exit 1
-          fi
+          # GitHub caps reviewers + team_reviewers at 15 per request.
+          # requested_teams is the PR's full current set, so check each slug we asked for.
+          failed=0
+          batch=""
+          n=0
+          request_batch() {
+            local assigned slug
+            [ -z "$batch" ] && return 0
+            assigned=$(jq -n --arg slugs "$batch" '{reviewers: [], team_reviewers: ($slugs | split("\n") | map(select(length > 0)))}' |
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input - |
+              jq -r '.requested_teams[].slug')
+            echo "Assigned: $assigned"
+            while IFS= read -r slug; do
+              [ -z "$slug" ] && continue
+              if ! grep -Fxq "$slug" <<< "$assigned"; then
+                echo "::error::Did not assign @grafana/${slug}"
+                failed=1
+              fi
+            done <<< "$batch"
+            batch=""
+            n=0
+          }
+          while IFS= read -r slug; do
+            [ -z "$slug" ] && continue
+            if [ -n "$batch" ]; then
+              batch+=$'\n'
+            fi
+            batch+="$slug"
+            n=$((n + 1))
+            if [ "$n" -eq 15 ]; then
+              request_batch
+            fi
+          done <<< "$slugs"
+          request_batch
+          exit "$failed"

--- a/.github/workflows/modowners-reviewers.yml
+++ b/.github/workflows/modowners-reviewers.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Request module owners
         env:
           GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          GOWORK: 'off'
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
@@ -54,38 +55,25 @@ jobs:
             exit 0
           fi
           echo "Requesting: $slugs"
-          # GitHub caps reviewers + team_reviewers at 15 per request.
-          # requested_teams is the PR's full current set, so check each slug we asked for.
+          # One team per call so a 422 names the team. requested_teams is the
+          # PR's full current set, so check the slug we asked for.
           failed=0
-          batch=""
-          n=0
-          request_batch() {
-            local assigned slug
-            [ -z "$batch" ] && return 0
-            assigned=$(jq -n --arg slugs "$batch" '{reviewers: [], team_reviewers: ($slugs | split("\n") | map(select(length > 0)))}' |
-              gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input - |
-              jq -r '.requested_teams[].slug')
-            echo "Assigned: $assigned"
-            while IFS= read -r slug; do
-              [ -z "$slug" ] && continue
-              if ! grep -Fxq "$slug" <<< "$assigned"; then
-                echo "::error::Did not assign @grafana/${slug}"
-                failed=1
-              fi
-            done <<< "$batch"
-            batch=""
-            n=0
-          }
           while IFS= read -r slug; do
             [ -z "$slug" ] && continue
-            if [ -n "$batch" ]; then
-              batch+=$'\n'
+            err=$(mktemp)
+            if ! assigned=$(jq -n --arg slug "$slug" '{reviewers: [], team_reviewers: [$slug]}' |
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input - 2>"$err" |
+              jq -r '.requested_teams[].slug'); then
+              echo "::error::Request @grafana/${slug} failed: $(cat "$err")"
+              failed=1
+              rm -f "$err"
+              continue
             fi
-            batch+="$slug"
-            n=$((n + 1))
-            if [ "$n" -eq 15 ]; then
-              request_batch
+            rm -f "$err"
+            echo "Assigned after @grafana/${slug}: $assigned"
+            if ! grep -Fxq "$slug" <<< "$assigned"; then
+              echo "::error::Did not assign @grafana/${slug}"
+              failed=1
             fi
           done <<< "$slugs"
-          request_batch
           exit "$failed"

--- a/.github/workflows/modowners-reviewers.yml
+++ b/.github/workflows/modowners-reviewers.yml
@@ -20,8 +20,13 @@ jobs:
     runs-on: ubuntu-arm64-small
     permissions:
       contents: read
-      pull-requests: write
+      id-token: write
     steps:
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: grafana-pr-automation
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -39,7 +44,7 @@ jobs:
           go-version-file: scripts/modowners/go.mod
       - name: Request module owners
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
@@ -49,10 +54,11 @@ jobs:
             exit 0
           fi
           echo "Requesting: $slugs"
-          while IFS= read -r slug; do
-            [ -z "$slug" ] && continue
-            if ! jq -n --arg slug "$slug" '{reviewers: [], team_reviewers: [$slug]}' |
-              gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input -; then
-              echo "::warning::Could not request @grafana/${slug}"
-            fi
-          done <<< "$slugs"
+          assigned=$(jq -n --arg slugs "$slugs" '{reviewers: [], team_reviewers: ($slugs | split("\n") | map(select(length > 0)))}' |
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --input - |
+            jq -r '.requested_teams[].slug')
+          echo "Assigned: $assigned"
+          if [ -z "$assigned" ]; then
+            echo "::error::GitHub accepted the request but assigned no teams"
+            exit 1
+          fi

--- a/go.mod
+++ b/go.mod
@@ -143,7 +143,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // @grafana/grafana-backend-group
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // @grafana/alerting-backend
 	github.com/migueleliasweb/go-github-mock v1.5.0 // @grafana/grafana-git-ui-sync-team
-	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c //@grafana/identity-access-team
+	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // @grafana/identity-access-team
 	github.com/mocktools/go-smtp-mock/v2 v2.5.4 // @grafana/grafana-backend-group
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // @grafana/alerting-backend
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // @grafana/grafana-operator-experience-squad
@@ -178,7 +178,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // @grafana/grafana-app-platform-squad
 	github.com/spyzhov/ajson v0.9.6 // @grafana/grafana-sharing-squad
 	github.com/stretchr/testify v1.12.1 // @grafana/grafana-backend-group
-	github.com/testcontainers/testcontainers-go v0.43.0 //@grafana/grafana-app-platform-squad
+	github.com/testcontainers/testcontainers-go v0.43.0 // @grafana/grafana-app-platform-squad
 	github.com/thomaspoignant/go-feature-flag v1.42.0 // @grafana/grafana-backend-services-squad
 	github.com/tjhop/slog-gokit v0.2.0 // @grafana/grafana-app-platform-squad
 	github.com/ua-parser/uap-go v0.0.0-20251207011819-db9adb27a0b8 // @grafana/grafana-backend-group

--- a/scripts/modowners/modowners.go
+++ b/scripts/modowners/modowners.go
@@ -166,7 +166,7 @@ func hasCommonElement(a []string, b []string) bool {
 }
 
 func teamSlug(owner string) (string, bool) {
-	owner = strings.TrimPrefix(owner, "@")
+	owner = strings.TrimLeft(owner, "/@")
 	const prefix = "grafana/"
 	if !strings.HasPrefix(owner, prefix) {
 		return "", false

--- a/scripts/modowners/modowners_test.go
+++ b/scripts/modowners/modowners_test.go
@@ -110,6 +110,7 @@ func TestTeamSlug(t *testing.T) {
 	}{
 		{"@grafana/grafana-backend-services-squad", "grafana-backend-services-squad", true},
 		{"@grafana/alerting-backend", "alerting-backend", true},
+		{"//@grafana/grafana-app-platform-squad", "grafana-app-platform-squad", true},
 		{"@grafana-app-platform-squad", "", false},
 		{"@delivery", "", false},
 		{"grafana/grafana-backend-group", "grafana-backend-group", true},


### PR DESCRIPTION
**What is this feature?**

#132189 routes `go.mod` reviews by module owner, but `GITHUB_TOKEN` cannot assign org teams (422). This uses `grafana-pr-automation`, same as levitate.

Also accepts `//@grafana/…` owner comments.

**Why do we need this feature?**

Without it, the workflow picks the right squads and nobody gets requested.

**Special notes for your reviewer:**

Watch the first `go.mod` PR after merge. Levitate has seen this app return 201 and still assign no team; the job now fails if `requested_teams` is empty.