### PR TITLE
Provisioning: report folders blocking repository deletion

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -186,6 +187,37 @@ func (f *finalizer) processResourceItems(ctx context.Context, items []*provision
 // preserving the order within each group.
 var splitItems = resources.SplitItems
 
+type nonEmptyFoldersError struct {
+	folders []*provisioning.ResourceListItem
+}
+
+func (e *nonEmptyFoldersError) Error() string {
+	labels := make([]string, 0, len(e.folders))
+	for _, folder := range e.folders {
+		label := folder.Name
+		if folder.Title != "" && folder.Title != folder.Name {
+			label = fmt.Sprintf("%q (UID: %s)", folder.Title, folder.Name)
+		}
+		labels = append(labels, label)
+	}
+	slices.Sort(labels)
+
+	const limit = 10
+	more := len(labels) - limit
+	if more > 0 {
+		labels = labels[:limit]
+	}
+
+	message := fmt.Sprintf(
+		"Repository deletion is blocked because these folders contain resources not managed by this repository:\n\n- %s",
+		strings.Join(labels, "\n- "),
+	)
+	if more > 0 {
+		message += fmt.Sprintf("\n(+ %d more)", more)
+	}
+	return message + "\n\nRemove or move the remaining resources from these folders. Grafana will retry automatically."
+}
+
 // deleteExistingItems removes all resources managed by the repository.
 // Non-folder resources are deleted concurrently first, then folders are
 // deleted sequentially deepest-first so they are empty before removal.
@@ -214,10 +246,20 @@ func (f *finalizer) deleteExistingItems(
 		return count, err
 	}
 
-	n, err := f.processFolderItems(ctx, folderItems, process)
-	count += n
-	if err != nil {
-		return count, err
+	blockedFolders := make([]*provisioning.ResourceListItem, 0)
+	for _, folder := range folderItems {
+		err := process(ctx, folder)
+		if resources.IsFolderNotEmptyAPIError(err) {
+			blockedFolders = append(blockedFolders, folder)
+			continue
+		}
+		if err != nil {
+			return count, err
+		}
+		count++
+	}
+	if len(blockedFolders) > 0 {
+		return count, &nonEmptyFoldersError{folders: blockedFolders}
 	}
 
 	logger.Info("deleted items", "items", count)

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -733,6 +733,72 @@ func TestDeleteExistingItems_ResourcesBeforeFolders(t *testing.T) {
 	assert.Equal(t, []string{"folder-nested", "folder-root"}, order[2:], "folders should be deleted deepest first")
 }
 
+func TestDeleteExistingItems_ReportsAllNonEmptyFolders(t *testing.T) {
+	items := provisioning.ResourceList{Items: []provisioning.ResourceListItem{
+		{Group: folders.GroupVersion.Group, Resource: "folders", Name: "shared-folder", Title: "Shared folder", Path: "shared"},
+		{Group: folders.GroupVersion.Group, Resource: "folders", Name: "nested-folder", Title: "Nested folder", Path: "shared/nested", Folder: "shared-folder"},
+		{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "managed-dashboard", Path: "shared/nested/dashboard.json", Folder: "nested-folder"},
+	}}
+	resourceLister := resources.NewMockResourceLister(t)
+	resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+	clientFactory := resources.NewMockClientFactory(t)
+	clients := resources.NewMockResourceClients(t)
+	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+	var deleted []string
+	client := &mockDynamicClient{
+		deleteFunc: func(_ context.Context, name string, _ metav1.DeleteOptions, _ ...string) error {
+			deleted = append(deleted, name)
+			if name == "managed-dashboard" {
+				return nil
+			}
+			return &apierrors.StatusError{ErrStatus: metav1.Status{
+				Code: http.StatusBadRequest, Details: &metav1.StatusDetails{UID: "folder.not-empty"},
+			}}
+		},
+	}
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group: folders.GroupVersion.Group, Resource: "folders",
+	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group: "dashboard.grafana.app", Resource: "dashboards",
+	}).Return(client, schema.GroupVersionKind{}, nil).Once()
+
+	f := &finalizer{
+		lister: resourceLister, clientFactory: clientFactory,
+		metrics:    func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers: 1,
+	}
+	count, err := f.deleteExistingItems(context.Background(), &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, []string{"managed-dashboard", "nested-folder", "shared-folder"}, deleted)
+	assert.ErrorContains(t, err, `"Nested folder" (UID: nested-folder)`)
+	assert.ErrorContains(t, err, `"Shared folder" (UID: shared-folder)`)
+	assert.ErrorContains(t, err, "Grafana will retry automatically")
+}
+
+func TestNonEmptyFoldersErrorLimitsFolderList(t *testing.T) {
+	items := make([]provisioning.ResourceListItem, 12)
+	folders := make([]*provisioning.ResourceListItem, 12)
+	for i := range items {
+		items[i].Name = fmt.Sprintf("folder-%02d", i)
+		items[i].Title = fmt.Sprintf("Folder %02d", i)
+		folders[i] = &items[i]
+	}
+
+	message := (&nonEmptyFoldersError{folders: folders}).Error()
+	assert.Contains(t, message, "Repository deletion is blocked because these folders contain resources not managed by this repository:\n\n- \"Folder 00\" (UID: folder-00)")
+	assert.Contains(t, message, "- \"Folder 09\" (UID: folder-09)\n(+ 2 more)")
+	assert.NotContains(t, message, "Folder 10")
+	assert.NotContains(t, message, "Folder 11")
+	assert.Contains(t, message, "\n\nRemove or move the remaining resources from these folders. Grafana will retry automatically.")
+}
+
 func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 	var order []string
 	var mu sync.Mutex

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -875,21 +875,12 @@ func (rc *RepositoryController) process(key string) (repoType string, err error)
 			return repoType, nil
 		}
 
-		// Surface the delete failure on status regardless of its cause. A stuck
-		// deletion is otherwise invisible to users (status.deleteError is not
-		// rendered anywhere) while it keeps showing the "Deleting" spinner, and a
-		// permanent failure re-logs at ERROR on every resync. Recording it on
-		// health -- with a reason classified the same way health-check failures are
-		// -- gives users the reason instead. The per-finalizer error metric is
-		// recorded inside finalizer.process independently of this return, so metric
-		// visibility on deletion errors is preserved either way.
-		// TODO: Write to a dedicated delete status once one is surfaced to users.
 		logger.Warn("unable to delete repository", "error", err)
 		deleteHealthStatus := provisioning.HealthStatus{
 			Healthy: false,
 			Error:   provisioning.HealthFailureHealth,
 			Checked: time.Now().UnixMilli(),
-			Message: []string{fmt.Sprintf("unable to delete repository: %s", err)},
+			Message: []string{"Repository deletion error"},
 		}
 		patchOps := rc.healthPatchIfChanged(obj, deleteHealthStatus)
 		// handleDelete builds the repository to run its finalizers, so the failure

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -473,6 +473,12 @@ func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provision
 }
 
 func (rc *RepositoryController) updateDeleteStatus(ctx context.Context, obj *provisioning.Repository, err error) error {
+	var folderErr *nonEmptyFoldersError
+	if errors.As(err, &folderErr) {
+		// nonEmptyFoldersError is ready for users; omit internal operation prefixes.
+		err = folderErr
+	}
+
 	// Skip the patch when the recorded error is unchanged: it bumps the
 	// resourceVersion, which the informer's UpdateFunc turns straight back into a
 	// re-enqueue, so rewriting the same deleteError on every failed pass would

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -642,6 +642,20 @@ func TestRepositoryController_updateDeleteStatus_UsesAddOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRepositoryController_updateDeleteStatus_UsesNonEmptyFoldersError(t *testing.T) {
+	folderErr := &nonEmptyFoldersError{
+		folders: []*provisioning.ResourceListItem{{Name: "folder-1", Title: "Folder one"}},
+	}
+	patcher := mocks.NewStatusPatcher(t)
+	patcher.On("Patch", mock.Anything, mock.AnythingOfType("*v0alpha1.Repository"), mock.MatchedBy(func(op map[string]interface{}) bool {
+		return op["value"] == folderErr.Error()
+	})).Once().Return(nil)
+
+	c := &RepositoryController{statusPatcher: patcher}
+	err := c.updateDeleteStatus(context.Background(), &provisioning.Repository{}, fmt.Errorf("remove finalizers: %w", folderErr))
+	require.NoError(t, err)
+}
+
 func TestShouldUseIncrementalSync(t *testing.T) {
 	versioned := repository.NewMockVersioned(t)
 	obj := &provisioning.Repository{

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1633,9 +1633,7 @@ func TestRepositoryController_process_UserCausedDeleteFailure(t *testing.T) {
 	health, ok := healthPatch["value"].(provisioning.HealthStatus)
 	require.True(t, ok)
 	assert.False(t, health.Healthy)
-	require.Len(t, health.Message, 1)
-	assert.Contains(t, health.Message[0], "unable to delete repository")
-	assert.Contains(t, health.Message[0], "permission denied")
+	assert.Equal(t, []string{"Repository deletion error"}, health.Message)
 
 	condOp, ok := patcher.findPatchOp("/status/conditions")
 	require.True(t, ok, "Ready must be patched too, or a previously-ready repo would keep reporting Ready=True while stuck deleting")
@@ -1704,8 +1702,7 @@ func TestRepositoryController_process_NonUserCausedDeleteFailureSurfacedOnStatus
 	health, ok := healthPatch["value"].(provisioning.HealthStatus)
 	require.True(t, ok)
 	assert.False(t, health.Healthy)
-	require.Len(t, health.Message, 1)
-	assert.Contains(t, health.Message[0], "unable to delete repository")
+	assert.Equal(t, []string{"Repository deletion error"}, health.Message)
 
 	condOp, ok := patcher.findPatchOp("/status/conditions")
 	require.True(t, ok, "Ready must be patched too, or a previously-ready repo would keep reporting Ready=True while stuck deleting")

--- a/pkg/registry/apis/provisioning/jobs/deleteresources/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/deleteresources/worker_test.go
@@ -27,7 +27,6 @@ var _ dynamic.ResourceInterface = (*fakeDynamicClient)(nil)
 type fakeDynamicClient struct {
 	deleteCalls []string
 	deleteErr   error
-	deleteErrs  map[string]error
 }
 
 func (f *fakeDynamicClient) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
@@ -41,9 +40,6 @@ func (f *fakeDynamicClient) UpdateStatus(context.Context, *unstructured.Unstruct
 }
 func (f *fakeDynamicClient) Delete(_ context.Context, name string, _ metav1.DeleteOptions, _ ...string) error {
 	f.deleteCalls = append(f.deleteCalls, name)
-	if err, ok := f.deleteErrs[name]; ok {
-		return err
-	}
 	return f.deleteErr
 }
 func (f *fakeDynamicClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
@@ -128,49 +124,6 @@ func TestWorker_Process(t *testing.T) {
 	err := w.Process(ctx, nil, job, progress)
 	require.NoError(t, err)
 	require.Equal(t, []string{"dash-1", "folder-1"}, fakeClient.deleteCalls)
-}
-
-func TestWorker_Process_ReportsEveryNonEmptyFolder(t *testing.T) {
-	ctx := context.Background()
-	lister := resources.NewMockResourceLister(t)
-	clientFactory := resources.NewMockClientFactory(t)
-	mockClients := resources.NewMockResourceClients(t)
-	folderNotEmpty := &apierrors.StatusError{ErrStatus: metav1.Status{
-		Code: 400, Details: &metav1.StatusDetails{UID: "folder.not-empty"},
-	}}
-	fakeClient := &fakeDynamicClient{deleteErrs: map[string]error{
-		"shared-folder": folderNotEmpty,
-		"nested-folder": folderNotEmpty,
-	}}
-	w := NewWorker(lister, clientFactory, 1)
-	job := provisioning.Job{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
-		Spec:       provisioning.JobSpec{Action: provisioning.JobActionDeleteResources, Repository: "my-repo"},
-	}
-	items := &provisioning.ResourceList{Items: []provisioning.ResourceListItem{
-		{Name: "shared-folder", Group: "folder.grafana.app", Resource: "folders", Path: "shared"},
-		{Name: "nested-folder", Group: "folder.grafana.app", Resource: "folders", Path: "shared/nested", Folder: "shared-folder"},
-		{Name: "managed-dashboard", Group: "dashboard.grafana.app", Resource: "dashboards", Path: "shared/nested/dashboard.json", Folder: "nested-folder"},
-	}}
-
-	lister.EXPECT().List(mock.Anything, "default", "my-repo").Return(items, nil)
-	clientFactory.EXPECT().Clients(mock.Anything, "default").Return(mockClients, nil)
-	mockClients.EXPECT().ForResource(mock.Anything, mock.Anything).Return(fakeClient, schema.GroupVersionKind{}, nil).Times(3)
-
-	progress := jobs.NewMockJobProgressRecorder(t)
-	progress.On("SetTotal", mock.Anything, 3).Return()
-	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
-	progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return result.Name() == "managed-dashboard" && result.Action() == repository.FileActionDeleted && result.Error() == nil
-	})).Return().Once()
-	progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
-		return (result.Name() == "nested-folder" || result.Name() == "shared-folder") && result.Error() != nil
-	})).Return().Twice()
-	progress.On("TooManyErrors").Return(nil).Times(3)
-
-	err := w.Process(ctx, nil, job, progress)
-	require.NoError(t, err)
-	require.Equal(t, []string{"managed-dashboard", "nested-folder", "shared-folder"}, fakeClient.deleteCalls)
 }
 
 func TestWorker_Process_EmptyResourceList(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/deleteresources/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/deleteresources/worker_test.go
@@ -27,6 +27,7 @@ var _ dynamic.ResourceInterface = (*fakeDynamicClient)(nil)
 type fakeDynamicClient struct {
 	deleteCalls []string
 	deleteErr   error
+	deleteErrs  map[string]error
 }
 
 func (f *fakeDynamicClient) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
@@ -40,6 +41,9 @@ func (f *fakeDynamicClient) UpdateStatus(context.Context, *unstructured.Unstruct
 }
 func (f *fakeDynamicClient) Delete(_ context.Context, name string, _ metav1.DeleteOptions, _ ...string) error {
 	f.deleteCalls = append(f.deleteCalls, name)
+	if err, ok := f.deleteErrs[name]; ok {
+		return err
+	}
 	return f.deleteErr
 }
 func (f *fakeDynamicClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
@@ -124,6 +128,49 @@ func TestWorker_Process(t *testing.T) {
 	err := w.Process(ctx, nil, job, progress)
 	require.NoError(t, err)
 	require.Equal(t, []string{"dash-1", "folder-1"}, fakeClient.deleteCalls)
+}
+
+func TestWorker_Process_ReportsEveryNonEmptyFolder(t *testing.T) {
+	ctx := context.Background()
+	lister := resources.NewMockResourceLister(t)
+	clientFactory := resources.NewMockClientFactory(t)
+	mockClients := resources.NewMockResourceClients(t)
+	folderNotEmpty := &apierrors.StatusError{ErrStatus: metav1.Status{
+		Code: 400, Details: &metav1.StatusDetails{UID: "folder.not-empty"},
+	}}
+	fakeClient := &fakeDynamicClient{deleteErrs: map[string]error{
+		"shared-folder": folderNotEmpty,
+		"nested-folder": folderNotEmpty,
+	}}
+	w := NewWorker(lister, clientFactory, 1)
+	job := provisioning.Job{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec:       provisioning.JobSpec{Action: provisioning.JobActionDeleteResources, Repository: "my-repo"},
+	}
+	items := &provisioning.ResourceList{Items: []provisioning.ResourceListItem{
+		{Name: "shared-folder", Group: "folder.grafana.app", Resource: "folders", Path: "shared"},
+		{Name: "nested-folder", Group: "folder.grafana.app", Resource: "folders", Path: "shared/nested", Folder: "shared-folder"},
+		{Name: "managed-dashboard", Group: "dashboard.grafana.app", Resource: "dashboards", Path: "shared/nested/dashboard.json", Folder: "nested-folder"},
+	}}
+
+	lister.EXPECT().List(mock.Anything, "default", "my-repo").Return(items, nil)
+	clientFactory.EXPECT().Clients(mock.Anything, "default").Return(mockClients, nil)
+	mockClients.EXPECT().ForResource(mock.Anything, mock.Anything).Return(fakeClient, schema.GroupVersionKind{}, nil).Times(3)
+
+	progress := jobs.NewMockJobProgressRecorder(t)
+	progress.On("SetTotal", mock.Anything, 3).Return()
+	progress.On("SetMessage", mock.Anything, mock.Anything).Return()
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Name() == "managed-dashboard" && result.Action() == repository.FileActionDeleted && result.Error() == nil
+	})).Return().Once()
+	progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return (result.Name() == "nested-folder" || result.Name() == "shared-folder") && result.Error() != nil
+	})).Return().Twice()
+	progress.On("TooManyErrors").Return(nil).Times(3)
+
+	err := w.Process(ctx, nil, job, progress)
+	require.NoError(t, err)
+	require.Equal(t, []string{"managed-dashboard", "nested-folder", "shared-folder"}, fakeClient.deleteCalls)
 }
 
 func TestWorker_Process_EmptyResourceList(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -432,6 +433,25 @@ func (e *FolderValidationError) Unwrap() []error {
 // can detect the validation rejection via errors.As.
 func NewFolderValidationError(path string, err error) *FolderValidationError {
 	return &FolderValidationError{Path: path, Err: err}
+}
+
+// IsFolderNotEmptyAPIError reports whether the folder API rejected deletion because the folder contains resources.
+func IsFolderNotEmptyAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, foldermodel.ErrFolderNotEmpty) {
+		return true
+	}
+
+	var statusErr apierrors.APIStatus
+	if errors.As(err, &statusErr) {
+		status := statusErr.Status()
+		return status.Code == http.StatusBadRequest && status.Details != nil && status.Details.UID == "folder.not-empty"
+	}
+
+	return false
 }
 
 // IsFolderValidationAPIError reports whether err is a 4xx rejection from the

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -617,6 +617,23 @@ func TestFolderValidationError(t *testing.T) {
 	})
 }
 
+func TestIsFolderNotEmptyAPIError(t *testing.T) {
+	statusErr := &apierrors.StatusError{
+		ErrStatus: metav1.Status{
+			Code: 400,
+			Details: &metav1.StatusDetails{
+				UID: "folder.not-empty",
+			},
+		},
+	}
+
+	require.True(t, IsFolderNotEmptyAPIError(statusErr))
+	require.True(t, IsFolderNotEmptyAPIError(fmt.Errorf("delete folder: %w", statusErr)))
+	require.True(t, IsFolderNotEmptyAPIError(foldermodel.ErrFolderNotEmpty.Errorf("folder contains a dashboard")))
+	require.False(t, IsFolderNotEmptyAPIError(apierrors.NewBadRequest("bad request")))
+	require.False(t, IsFolderNotEmptyAPIError(nil))
+}
+
 func TestIsFolderValidationAPIError(t *testing.T) {
 	t.Run("nil returns false", func(t *testing.T) {
 		require.False(t, IsFolderValidationAPIError(nil))


### PR DESCRIPTION
**What is this feature?**

Repository deletion now reports every managed folder that cannot be deleted because it contains resources not managed by the repository. The repository remains in `Terminating` until those resources are removed or moved.

The detailed message is stored in `status.deleteError`. Repository health uses the concise message `Repository deletion error`.

Frontend PR: https://github.com/grafana/grafana/pull/132412

**Why do we need this feature?**

Selective migration can create mixed ownership within a folder. Cleanup deletes the repository's managed non-folder resources, but the folder API prevents deletion while unmanaged resources remain. Previously, cleanup reported only the first blocked folder.

Cleanup does not delete or release unmanaged resources.

**Who is this feature for?**

Git Sync users deleting repositories with unmanaged resources inside some of the folders.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1338

Reproduction: https://gist.github.com/amalavet/f31d1ca7eead2d1b42780b16577102a8

_<sub>PR description generated with openai-codex:gpt-5.6-sol</sub>_

