### PR TITLE
Plugins: classify canceled CallResource gRPC requests as client cancellations

### DIFF
--- a/pkg/plugins/manager/client/client.go
+++ b/pkg/plugins/manager/client/client.go
@@ -155,6 +155,10 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request canceled: %w", err)
 		}
 
+		if s, ok := grpcstatus.FromError(err); ok && s.Code() == grpccodes.Canceled {
+			return plugins.ErrPluginRequestCanceledErrorBase.Errorf("client: call resource request canceled: %w", err)
+		}
+
 		return plugins.ErrPluginRequestFailureErrorBase.Errorf("client: failed to call resources: %w", err)
 	}
 

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/require"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
@@ -443,6 +445,54 @@ func TestCallResource(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCallResourceErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		pluginErr     error
+		expectedError error
+	}{
+		{
+			name:          "context cancellation",
+			pluginErr:     context.Canceled,
+			expectedError: plugins.ErrPluginRequestCanceledErrorBase,
+		},
+		{
+			name:          "gRPC cancellation",
+			pluginErr:     grpcstatus.Error(grpccodes.Canceled, "context canceled"),
+			expectedError: plugins.ErrPluginRequestCanceledErrorBase,
+		},
+		{
+			name:          "plugin failure",
+			pluginErr:     errors.New("plugin failure"),
+			expectedError: plugins.ErrPluginRequestFailureErrorBase,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := pluginfakes.NewFakePluginRegistry()
+			p := &plugins.Plugin{
+				JSONData: plugins.JSONData{ID: "pid"},
+			}
+			p.RegisterClient(&fakePluginBackend{
+				crr: func(context.Context, *backend.CallResourceRequest, backend.CallResourceResponseSender) error {
+					return tt.pluginErr
+				},
+			})
+			require.NoError(t, registry.Add(context.Background(), p))
+
+			client := ProvideService(registry)
+			err := client.CallResource(
+				context.Background(),
+				&backend.CallResourceRequest{PluginContext: backend.PluginContext{PluginID: "pid"}},
+				backend.CallResourceResponseSenderFunc(func(*backend.CallResourceResponse) error { return nil }),
+			)
+
+			require.ErrorIs(t, err, tt.expectedError)
+		})
+	}
 }
 
 type fakePluginBackend struct {


### PR DESCRIPTION
## Summary

Treat gRPC `codes.Canceled` errors returned from plugin `CallResource` calls as client-canceled requests instead of plugin request failures.

This makes `CallResource` consistent with the existing `QueryData` behavior and allows Grafana's HTTP response handling and `logger=context` instrumentation to classify an abandoned plugin-resource request as 499 rather than 500.

## Why

When an HTTP client abandons `/api/plugins/:pluginId/resources/*`, cancellation propagates through Grafana to the plugin gRPC stream. The gRPC client can return:

```text
rpc error: code = Canceled desc = context canceled
```

That error does not unwrap to Go's `context.Canceled` sentinel. `CallResource` currently checks only `errors.Is(err, context.Canceled)`, so it wraps the error as `plugin.requestFailureError`, which is handled as HTTP 500 and recorded as `logger=context status=500 ...`.

`QueryData` already handles both forms of cancellation. This change applies the same gRPC status check to `CallResource`, returning `ErrPluginRequestCanceledErrorBase` so the existing HTTP error handling selects 499 (`Client Closed Request`).

Although an abandoned client will not receive the response, the corrected logger=context logs can then correctly attribute 4XX status rather than 5XX.
