### PR TITLE
Alerting: Map provenance to ManagerProperties for notifications resources

### DIFF
--- a/pkg/registry/apps/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/receiver/conversions.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -19,6 +20,7 @@ import (
 func convertToK8sResources(
 	orgID int64,
 	receivers []*ngmodels.Receiver,
+	managerPropsMap map[string]utils.ManagerProperties,
 	accesses map[string]ngmodels.ReceiverPermissionSet,
 	metadatas map[string]ngmodels.ReceiverMetadata,
 	namespacer request.NamespaceMapper,
@@ -40,7 +42,7 @@ func convertToK8sResources(
 				metadata = &m
 			}
 		}
-		k8sResource, err := convertToK8sResource(orgID, receiver, access, metadata, namespacer)
+		k8sResource, err := convertToK8sResource(orgID, receiver, managerPropsMap[receiver.GetUID()], access, metadata, namespacer)
 		if err != nil {
 			return nil, err
 		}
@@ -55,6 +57,7 @@ func convertToK8sResources(
 func convertToK8sResource(
 	orgID int64,
 	receiver *ngmodels.Receiver,
+	managerProps utils.ManagerProperties,
 	access *ngmodels.ReceiverPermissionSet,
 	metadata *ngmodels.ReceiverMetadata,
 	namespacer request.NamespaceMapper,
@@ -87,7 +90,19 @@ func convertToK8sResource(
 		},
 		Spec: spec,
 	}
-	r.SetProvenanceStatus(string(receiver.Provenance))
+	// Prefer the richer manager-derived provenance; fall back to whatever provenance the
+	// caller already resolved (e.g. imported receivers' converted-Prometheus provenance).
+	provenance := receiver.Provenance
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		provenance = ngmodels.ManagerPropertiesToProvenance(managerProps)
+	}
+	r.SetProvenanceStatus(string(provenance))
+
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		if meta, err := utils.MetaAccessor(r); err == nil {
+			meta.SetManagerProperties(managerProps)
+		}
+	}
 
 	if access != nil {
 		for _, action := range ngmodels.ReceiverPermissions() {
@@ -122,10 +137,10 @@ var permissionMapper = map[ngmodels.ReceiverPermission]string{
 	ngmodels.ReceiverPermissionTest:            "canTest",
 }
 
-func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[string][]string, error) {
-	prov, err := ngmodels.ProvenanceFromString(receiver.GetProvenanceStatus())
+func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[string][]string, utils.ManagerProperties, error) {
+	managerProps, prov, err := extractManagerProperties(receiver)
 	if err != nil {
-		return nil, nil, ngmodels.ErrReceiverInvalid(err)
+		return nil, nil, utils.ManagerProperties{}, ngmodels.ErrReceiverInvalid(err)
 	}
 	domain := &ngmodels.Receiver{
 		UID:          receiver.Name,
@@ -139,13 +154,40 @@ func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[str
 	for _, integration := range receiver.Spec.Integrations {
 		grafanaIntegration, secureFields, err := convertReceiverIntegrationToIntegration(receiver.Spec.Title, integration)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, utils.ManagerProperties{}, err
 		}
 		domain.Integrations = append(domain.Integrations, &grafanaIntegration)
 		storedSecureFields[grafanaIntegration.UID] = secureFields
 	}
 
-	return domain, storedSecureFields, nil
+	return domain, storedSecureFields, managerProps, nil
+}
+
+// extractManagerProperties resolves the ManagerProperties for an inbound object, preferring the
+// manager annotations (richer than the coarse provenance annotation) when present and validating
+// that they agree with any explicit provenance annotation. It falls back to deriving
+// ManagerProperties from the provenance annotation for objects that pre-date ManagerProperties.
+func extractManagerProperties(receiver *model.Receiver) (utils.ManagerProperties, ngmodels.Provenance, error) {
+	meta, err := utils.MetaAccessor(receiver)
+	if err != nil {
+		return utils.ManagerProperties{}, "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+	if mp, ok := meta.GetManagerProperties(); ok {
+		if sourceProv := receiver.GetProvenanceStatus(); sourceProv != "" && sourceProv != string(ngmodels.ProvenanceNone) {
+			derivedProv := string(ngmodels.ManagerPropertiesToProvenance(mp))
+			if derivedProv != sourceProv {
+				return utils.ManagerProperties{}, "", fmt.Errorf("manager properties (kind=%s) and provenance annotation (%s) are inconsistent: manager properties imply provenance %q",
+					mp.Kind, sourceProv, derivedProv)
+			}
+		}
+		return mp, ngmodels.ManagerPropertiesToProvenance(mp), nil
+	}
+
+	prov, err := ngmodels.ProvenanceFromString(receiver.GetProvenanceStatus())
+	if err != nil {
+		return utils.ManagerProperties{}, "", err
+	}
+	return ngmodels.ProvenanceToManagerProperties(prov), prov, nil
 }
 
 func convertReceiverIntegrationToIntegration(receiverTitle string, integration model.ReceiverIntegration) (ngmodels.Integration, []string, error) {

--- a/pkg/registry/apps/alerting/notifications/receiver/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/receiver/legacy_storage.go
@@ -13,6 +13,7 @@ import (
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	alertingac "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
@@ -24,11 +25,11 @@ var (
 )
 
 type ReceiverService interface {
-	GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*ngmodels.Receiver, error)
-	GetReceivers(ctx context.Context, q ngmodels.GetReceiversQuery, user identity.Requester) ([]*ngmodels.Receiver, error)
-	CreateReceiver(ctx context.Context, r *ngmodels.Receiver, orgID int64, user identity.Requester) (*ngmodels.Receiver, error)
-	UpdateReceiver(ctx context.Context, r *ngmodels.Receiver, storedSecureFields map[string][]string, orgID int64, user identity.Requester) (*ngmodels.Receiver, error)
-	DeleteReceiver(ctx context.Context, name string, provenance ngmodels.Provenance, version string, orgID int64, user identity.Requester) error
+	GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*ngmodels.Receiver, utils.ManagerProperties, error)
+	GetReceivers(ctx context.Context, q ngmodels.GetReceiversQuery, user identity.Requester) ([]*ngmodels.Receiver, map[string]utils.ManagerProperties, error)
+	CreateReceiver(ctx context.Context, r *ngmodels.Receiver, manager utils.ManagerProperties, orgID int64, user identity.Requester) (*ngmodels.Receiver, error)
+	UpdateReceiver(ctx context.Context, r *ngmodels.Receiver, manager utils.ManagerProperties, storedSecureFields map[string][]string, orgID int64, user identity.Requester) (*ngmodels.Receiver, error)
+	DeleteReceiver(ctx context.Context, name string, manager utils.ManagerProperties, version string, orgID int64, user identity.Requester) error
 }
 
 type MetadataService interface {
@@ -84,7 +85,7 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	res, err := s.service.GetReceivers(ctx, q, user)
+	res, managerPropsMap, err := s.service.GetReceivers(ctx, q, user)
 	if err != nil {
 		// This API should not be returning a forbidden error when the user does not have access to any resources.
 		// This can be true for a contact point creator role, for example.
@@ -106,7 +107,7 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, fmt.Errorf("failed to get in-use metadata: %w", err)
 	}
 
-	return convertToK8sResources(orgId, res, accesses, inUses, s.namespacer, opts.FieldSelector)
+	return convertToK8sResources(orgId, res, managerPropsMap, accesses, inUses, s.namespacer, opts.FieldSelector)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -120,7 +121,7 @@ func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOption
 		return nil, err
 	}
 
-	r, err := s.service.GetReceiver(ctx, uid, false, user)
+	r, managerProps, err := s.service.GetReceiver(ctx, uid, false, user)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +146,7 @@ func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOption
 		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
 	}
 
-	return convertToK8sResource(info.OrgID, r, access, inUse, s.namespacer)
+	return convertToK8sResource(info.OrgID, r, managerProps, access, inUse, s.namespacer)
 }
 
 func (s *legacyStorage) Create(ctx context.Context,
@@ -169,7 +170,7 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if p.Name != "" { // TODO remove when metadata.name can be defined by user
 		return nil, apierrors.NewBadRequest("object's metadata.name should be empty")
 	}
-	model, _, err := convertToDomainModel(p)
+	model, _, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, err
 	}
@@ -179,11 +180,11 @@ func (s *legacyStorage) Create(ctx context.Context,
 		return nil, err
 	}
 
-	out, err := s.service.CreateReceiver(ctx, model, info.OrgID, user)
+	out, err := s.service.CreateReceiver(ctx, model, managerProps, info.OrgID, user)
 	if err != nil {
 		return nil, err
 	}
-	return convertToK8sResource(info.OrgID, out, nil, nil, s.namespacer)
+	return convertToK8sResource(info.OrgID, out, managerProps, nil, nil, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context,
@@ -221,17 +222,17 @@ func (s *legacyStorage) Update(ctx context.Context,
 	if !ok {
 		return nil, false, fmt.Errorf("expected receiver but got %s", obj.GetObjectKind().GroupVersionKind())
 	}
-	model, storedSecureFields, err := convertToDomainModel(p)
+	model, storedSecureFields, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return old, false, err
 	}
 
-	updated, err := s.service.UpdateReceiver(ctx, model, storedSecureFields, info.OrgID, user)
+	updated, err := s.service.UpdateReceiver(ctx, model, managerProps, storedSecureFields, info.OrgID, user)
 	if err != nil {
 		return nil, false, err
 	}
 
-	r, err := convertToK8sResource(info.OrgID, updated, nil, nil, s.namespacer)
+	r, err := convertToK8sResource(info.OrgID, updated, managerProps, nil, nil, s.namespacer)
 	return r, false, err
 }
 
@@ -265,12 +266,15 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 	if !ok {
 		return nil, false, fmt.Errorf("expected receiver but got %s", old.GetObjectKind().GroupVersionKind())
 	}
-	prov, err := ngmodels.ProvenanceFromString(oldReceiver.GetProvenanceStatus())
+	// Derive manager properties the same way create/update do, so a resource managed by a
+	// specific manager (e.g. Terraform) is deleted with the matching manager and not the
+	// coarser provenance-derived equivalent.
+	managerProps, _, err := extractManagerProperties(oldReceiver)
 	if err != nil {
 		return nil, false, apierrors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteReceiver(ctx, uid, prov, version, info.OrgID, user) // TODO add support for dry-run option
-	return old, false, err                                                    // false - will be deleted async
+	err = s.service.DeleteReceiver(ctx, uid, managerProps, version, info.OrgID, user) // TODO add support for dry-run option
+	return old, false, err                                                            // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
@@ -12,6 +12,7 @@ import (
 	promModel "github.com/prometheus/common/model"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -19,7 +20,7 @@ import (
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
-func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, namespacer request.NamespaceMapper, accesses map[string]ngmodels.RoutePermissionSet) (*model.RoutingTreeList, error) {
+func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, managerPropsMap map[string]utils.ManagerProperties, namespacer request.NamespaceMapper, accesses map[string]ngmodels.RoutePermissionSet) (*model.RoutingTreeList, error) {
 	result := &model.RoutingTreeList{
 		Items: make([]model.RoutingTree, 0, len(routes)),
 	}
@@ -30,7 +31,7 @@ func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, nam
 				access = &a
 			}
 		}
-		k8sResource, err := ConvertToK8sResource(orgID, r, namespacer, access)
+		k8sResource, err := ConvertToK8sResource(orgID, r, managerPropsMap[r.ResourceID()], namespacer, access)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert route %q to k8s resource: %w", r.Name, err)
 		}
@@ -39,7 +40,7 @@ func ConvertToK8sResources(orgID int64, routes legacy_storage.ManagedRoutes, nam
 	return result, nil
 }
 
-func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespacer request.NamespaceMapper, access *ngmodels.RoutePermissionSet) (*model.RoutingTree, error) {
+func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, managerProps utils.ManagerProperties, namespacer request.NamespaceMapper, access *ngmodels.RoutePermissionSet) (*model.RoutingTree, error) {
 	spec := model.RoutingTreeSpec{
 		Defaults: model.RoutingTreeRouteDefaults{
 			GroupBy:        r.GroupBy,
@@ -80,8 +81,21 @@ func ConvertToK8sResource(orgID int64, r *legacy_storage.ManagedRoute, namespace
 			}
 		}
 	}
-	result.SetProvenanceStatus(string(r.Provenance))
+	// Prefer the richer manager-derived provenance; fall back to whatever provenance the
+	// caller already resolved (e.g. imported routes' converted-Prometheus provenance).
+	provenance := r.Provenance
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		provenance = ngmodels.ManagerPropertiesToProvenance(managerProps)
+	}
+	result.SetProvenanceStatus(string(provenance))
 	result.UID = gapiutil.CalculateClusterWideUID(result)
+
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		if meta, err := utils.MetaAccessor(result); err == nil {
+			meta.SetManagerProperties(managerProps)
+		}
+	}
+
 	return result, nil
 }
 
@@ -157,7 +171,7 @@ func convertRouteToK8sSubRoute(r *v1.Route) model.RoutingTreeRoute {
 	return result
 }
 
-func convertToDomainModel(obj *model.RoutingTree) (v1.Route, string, error) {
+func convertToDomainModel(obj *model.RoutingTree) (v1.Route, string, utils.ManagerProperties, error) {
 	defaults := obj.Spec.Defaults
 	result := v1.Route{
 		Receiver:   defaults.Receiver,
@@ -187,10 +201,42 @@ func convertToDomainModel(obj *model.RoutingTree) (v1.Route, string, error) {
 		}
 	}
 	if len(errs) > 0 {
-		return v1.Route{}, "", errors.Join(errs...)
+		return v1.Route{}, "", utils.ManagerProperties{}, errors.Join(errs...)
 	}
 	result.Provenance = ""
-	return result, obj.ResourceVersion, nil
+
+	managerProps, _, err := extractManagerProperties(obj)
+	if err != nil {
+		return v1.Route{}, "", utils.ManagerProperties{}, err
+	}
+	return result, obj.ResourceVersion, managerProps, nil
+}
+
+// extractManagerProperties resolves the ManagerProperties for an inbound object, preferring the
+// manager annotations (richer than the coarse provenance annotation) when present and validating
+// that they agree with any explicit provenance annotation. It falls back to deriving
+// ManagerProperties from the provenance annotation for objects that pre-date ManagerProperties.
+func extractManagerProperties(obj *model.RoutingTree) (utils.ManagerProperties, ngmodels.Provenance, error) {
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return utils.ManagerProperties{}, "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+	if mp, ok := meta.GetManagerProperties(); ok {
+		if sourceProv := obj.GetProvenanceStatus(); sourceProv != "" && sourceProv != string(ngmodels.ProvenanceNone) {
+			derivedProv := string(ngmodels.ManagerPropertiesToProvenance(mp))
+			if derivedProv != sourceProv {
+				return utils.ManagerProperties{}, "", fmt.Errorf("manager properties (kind=%s) and provenance annotation (%s) are inconsistent: manager properties imply provenance %q",
+					mp.Kind, sourceProv, derivedProv)
+			}
+		}
+		return mp, ngmodels.ManagerPropertiesToProvenance(mp), nil
+	}
+
+	prov, err := ngmodels.ProvenanceFromString(obj.GetProvenanceStatus())
+	if err != nil {
+		return utils.ManagerProperties{}, "", err
+	}
+	return ngmodels.ProvenanceToManagerProperties(prov), prov, nil
 }
 
 func convertK8sSubRouteToRoute(r model.RoutingTreeRoute, path string) (v1.Route, []error) {

--- a/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/legacy_storage.go
@@ -12,6 +12,7 @@ import (
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -24,11 +25,11 @@ var (
 )
 
 type RouteService interface {
-	GetManagedRoutes(ctx context.Context, orgID int64, user identity.Requester) (legacy_storage.ManagedRoutes, error)
-	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error)
-	DeleteManagedRoute(ctx context.Context, orgID int64, name string, p alerting_models.Provenance, version string, user identity.Requester) error
-	CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, p alerting_models.Provenance, user identity.Requester) (*legacy_storage.ManagedRoute, error)
-	UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, p alerting_models.Provenance, version string, user identity.Requester) (*legacy_storage.ManagedRoute, error)
+	GetManagedRoutes(ctx context.Context, orgID int64, user identity.Requester) (legacy_storage.ManagedRoutes, map[string]utils.ManagerProperties, error)
+	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, utils.ManagerProperties, error)
+	DeleteManagedRoute(ctx context.Context, orgID int64, name string, manager utils.ManagerProperties, version string, user identity.Requester) error
+	CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, manager utils.ManagerProperties, user identity.Requester) (*legacy_storage.ManagedRoute, error)
+	UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, manager utils.ManagerProperties, version string, user identity.Requester) (*legacy_storage.ManagedRoute, error)
 }
 
 type MetadataService interface {
@@ -75,7 +76,7 @@ func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions
 		return nil, err
 	}
 
-	managedRoutes, err := s.service.GetManagedRoutes(ctx, orgId, user)
+	managedRoutes, managerPropsMap, err := s.service.GetManagedRoutes(ctx, orgId, user)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (s *legacyStorage) List(ctx context.Context, _ *internalversion.ListOptions
 	if err != nil {
 		return nil, fmt.Errorf("failed to get access control metadata: %w", err)
 	}
-	return ConvertToK8sResources(orgId, managedRoutes, s.namespacer, set)
+	return ConvertToK8sResources(orgId, managedRoutes, managerPropsMap, s.namespacer, set)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -97,7 +98,7 @@ func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptio
 		return nil, err
 	}
 
-	managedRoute, err := s.service.GetManagedRoute(ctx, info.OrgID, name, user)
+	managedRoute, managerProps, err := s.service.GetManagedRoute(ctx, info.OrgID, name, user)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +111,7 @@ func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptio
 	if a, ok := accesses[managedRoute.GetUID()]; ok {
 		access = &a
 	}
-	return ConvertToK8sResource(info.OrgID, &managedRoute, s.namespacer, access)
+	return ConvertToK8sResource(info.OrgID, &managedRoute, managerProps, s.namespacer, access)
 }
 
 func (s *legacyStorage) Create(ctx context.Context,
@@ -136,15 +137,11 @@ func (s *legacyStorage) Create(ctx context.Context,
 		return nil, err
 	}
 
-	domainModel, _, err := convertToDomainModel(p)
+	domainModel, _, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, err
 	}
-	prov, err := alerting_models.ProvenanceFromString(p.GetProvenanceStatus())
-	if err != nil {
-		return nil, errors.NewBadRequest(err.Error())
-	}
-	created, err := s.service.CreateManagedRoute(ctx, info.OrgID, p.Name, domainModel, prov, user)
+	created, err := s.service.CreateManagedRoute(ctx, info.OrgID, p.Name, domainModel, managerProps, user)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +154,7 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if a, ok := accesses[created.GetUID()]; ok {
 		access = &a
 	}
-	return ConvertToK8sResource(info.OrgID, created, s.namespacer, access)
+	return ConvertToK8sResource(info.OrgID, created, managerProps, s.namespacer, access)
 }
 
 func (s *legacyStorage) Update(
@@ -197,15 +194,11 @@ func (s *legacyStorage) Update(
 		return nil, false, err
 	}
 
-	domainModel, version, err := convertToDomainModel(p)
+	domainModel, version, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, false, err
 	}
-	prov, err := alerting_models.ProvenanceFromString(p.GetProvenanceStatus())
-	if err != nil {
-		return nil, false, errors.NewBadRequest(err.Error())
-	}
-	updated, err := s.service.UpdateManagedRoute(ctx, info.OrgID, p.Name, domainModel, prov, version, user)
+	updated, err := s.service.UpdateManagedRoute(ctx, info.OrgID, p.Name, domainModel, managerProps, version, user)
 	if err != nil {
 		return nil, false, err
 	}
@@ -218,7 +211,7 @@ func (s *legacyStorage) Update(
 	if a, ok := accesses[updated.GetUID()]; ok {
 		access = &a
 	}
-	obj, err = ConvertToK8sResource(info.OrgID, updated, s.namespacer, access)
+	obj, err = ConvertToK8sResource(info.OrgID, updated, managerProps, s.namespacer, access)
 	return obj, false, err
 }
 
@@ -257,11 +250,14 @@ func (s *legacyStorage) Delete(
 	if !ok {
 		return nil, false, fmt.Errorf("expected %s but got %s", ResourceInfo.GroupVersionKind(), old.GetObjectKind().GroupVersionKind())
 	}
-	prov, err := alerting_models.ProvenanceFromString(oldTree.GetProvenanceStatus())
+	// Derive manager properties the same way create/update do, so a resource managed by a
+	// specific manager (e.g. Terraform) is deleted with the matching manager and not the
+	// coarser provenance-derived equivalent.
+	managerProps, _, err := extractManagerProperties(oldTree)
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteManagedRoute(ctx, info.OrgID, name, prov, version, user) // TODO add support for dry-run option
+	err = s.service.DeleteManagedRoute(ctx, info.OrgID, name, managerProps, version, user) // TODO add support for dry-run option
 	return old, false, err
 }
 

--- a/pkg/registry/apps/alerting/notifications/templategroup/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/templategroup/conversions.go
@@ -1,11 +1,14 @@
 package templategroup
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 
@@ -13,10 +16,10 @@ import (
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func convertToK8sResources(orgID int64, list []v1.TemplateGroup, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TemplateGroupList, error) {
+func convertToK8sResources(orgID int64, list []v1.TemplateGroup, managerPropsMap map[string]utils.ManagerProperties, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TemplateGroupList, error) {
 	result := &model.TemplateGroupList{}
 	for _, t := range list {
-		item := convertToK8sResource(orgID, t, namespacer)
+		item := convertToK8sResource(orgID, t, managerPropsMap[string(t.UID)], namespacer)
 		if selector != nil && !selector.Empty() && !selector.Matches(model.TemplateGroupSelectableFields(item)) {
 			continue
 		}
@@ -25,7 +28,7 @@ func convertToK8sResources(orgID int64, list []v1.TemplateGroup, namespacer requ
 	return result, nil
 }
 
-func convertToK8sResource(orgID int64, template v1.TemplateGroup, namespacer request.NamespaceMapper) *model.TemplateGroup {
+func convertToK8sResource(orgID int64, template v1.TemplateGroup, managerProps utils.ManagerProperties, namespacer request.NamespaceMapper) *model.TemplateGroup {
 	result := &model.TemplateGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kind.GroupVersionKind().GroupVersion().String(),
@@ -43,15 +46,28 @@ func convertToK8sResource(orgID int64, template v1.TemplateGroup, namespacer req
 			Kind:    model.TemplateGroupTemplateKind(template.Kind),
 		},
 	}
-	result.SetProvenanceStatus(string(template.Provenance))
+	// Prefer the richer manager-derived provenance; fall back to whatever provenance the
+	// caller already resolved (e.g. the synthetic default template's "system" sentinel).
+	provenance := template.Provenance
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		provenance = ngmodels.ManagerPropertiesToProvenance(managerProps)
+	}
+	result.SetProvenanceStatus(string(provenance))
 	result.UID = gapiutil.CalculateClusterWideUID(result)
+
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		if meta, err := utils.MetaAccessor(result); err == nil {
+			meta.SetManagerProperties(managerProps)
+		}
+	}
+
 	return result
 }
 
-func convertToDomainModel(template *model.TemplateGroup) (v1.TemplateGroup, error) {
-	prov, err := ngmodels.ProvenanceFromString(template.GetProvenanceStatus())
+func convertToDomainModel(template *model.TemplateGroup) (v1.TemplateGroup, utils.ManagerProperties, error) {
+	managerProps, prov, err := extractManagerProperties(template)
 	if err != nil {
-		return v1.TemplateGroup{}, err
+		return v1.TemplateGroup{}, utils.ManagerProperties{}, err
 	}
 	return v1.TemplateGroup{
 		ResourceMetadata: v1.ResourceMetadata{
@@ -62,5 +78,32 @@ func convertToDomainModel(template *model.TemplateGroup) (v1.TemplateGroup, erro
 		Title:   template.Spec.Title,
 		Content: template.Spec.Content,
 		Kind:    v1.TemplateKind(template.Spec.Kind),
-	}, nil
+	}, managerProps, nil
+}
+
+// extractManagerProperties resolves the ManagerProperties for an inbound object, preferring the
+// manager annotations (richer than the coarse provenance annotation) when present and validating
+// that they agree with any explicit provenance annotation. It falls back to deriving
+// ManagerProperties from the provenance annotation for objects that pre-date ManagerProperties.
+func extractManagerProperties(template *model.TemplateGroup) (utils.ManagerProperties, ngmodels.Provenance, error) {
+	meta, err := utils.MetaAccessor(template)
+	if err != nil {
+		return utils.ManagerProperties{}, "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+	if mp, ok := meta.GetManagerProperties(); ok {
+		if sourceProv := template.GetProvenanceStatus(); sourceProv != "" && sourceProv != string(ngmodels.ProvenanceNone) {
+			derivedProv := string(ngmodels.ManagerPropertiesToProvenance(mp))
+			if derivedProv != sourceProv {
+				return utils.ManagerProperties{}, "", fmt.Errorf("manager properties (kind=%s) and provenance annotation (%s) are inconsistent: manager properties imply provenance %q",
+					mp.Kind, sourceProv, derivedProv)
+			}
+		}
+		return mp, ngmodels.ManagerPropertiesToProvenance(mp), nil
+	}
+
+	prov, err := ngmodels.ProvenanceFromString(template.GetProvenanceStatus())
+	if err != nil {
+		return utils.ManagerProperties{}, "", err
+	}
+	return ngmodels.ProvenanceToManagerProperties(prov), prov, nil
 }

--- a/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/alerting/templates"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -24,11 +25,11 @@ var (
 )
 
 type TemplateService interface {
-	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error)
-	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error)
-	CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
-	UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
-	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance ngmodels.Provenance, version string) error
+	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, utils.ManagerProperties, error)
+	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, map[string]utils.ManagerProperties, error)
+	CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error)
+	UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error)
+	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, manager utils.ManagerProperties, version string) error
 }
 
 type legacyStorage struct {
@@ -69,7 +70,7 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	res, err := s.service.GetTemplates(ctx, orgId)
+	res, managerPropsMap, err := s.service.GetTemplates(ctx, orgId)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,7 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	return convertToK8sResources(orgId, append([]v1.TemplateGroup{defaultTemplate}, res...), s.namespacer, opts.FieldSelector)
+	return convertToK8sResources(orgId, append([]v1.TemplateGroup{defaultTemplate}, res...), managerPropsMap, s.namespacer, opts.FieldSelector)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -93,14 +94,14 @@ func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptio
 		if err != nil {
 			return nil, err
 		}
-		return convertToK8sResource(info.OrgID, dto, s.namespacer), nil
+		return convertToK8sResource(info.OrgID, dto, utils.ManagerProperties{}, s.namespacer), nil
 	}
 
-	dto, err := s.service.GetTemplate(ctx, info.OrgID, name)
+	dto, managerProps, err := s.service.GetTemplate(ctx, info.OrgID, name)
 	if err != nil {
 		return nil, err
 	}
-	return convertToK8sResource(info.OrgID, dto, s.namespacer), nil
+	return convertToK8sResource(info.OrgID, dto, managerProps, s.namespacer), nil
 }
 
 func (s *legacyStorage) Create(ctx context.Context,
@@ -124,15 +125,15 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if p.Name != "" { // TODO remove when metadata.name can be defined by user
 		return nil, errors.NewBadRequest("object's metadata.name should be empty")
 	}
-	domainModel, err := convertToDomainModel(p)
+	domainModel, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, errors.NewBadRequest(err.Error())
 	}
-	out, err := s.service.CreateTemplate(ctx, info.OrgID, domainModel)
+	out, err := s.service.CreateTemplate(ctx, info.OrgID, domainModel, managerProps)
 	if err != nil {
 		return nil, err
 	}
-	return convertToK8sResource(info.OrgID, out, s.namespacer), nil
+	return convertToK8sResource(info.OrgID, out, managerProps, s.namespacer), nil
 }
 
 func (s *legacyStorage) Update(ctx context.Context,
@@ -148,11 +149,11 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return nil, false, err
 	}
 
-	dto, err := s.service.GetTemplate(ctx, info.OrgID, name)
+	dto, managerProps, err := s.service.GetTemplate(ctx, info.OrgID, name)
 	if err != nil {
 		return nil, false, err
 	}
-	old := convertToK8sResource(info.OrgID, dto, s.namespacer)
+	old := convertToK8sResource(info.OrgID, dto, managerProps, s.namespacer)
 
 	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
@@ -170,16 +171,16 @@ func (s *legacyStorage) Update(ctx context.Context,
 		return nil, false, fmt.Errorf("expected template but got %s", obj.GetObjectKind().GroupVersionKind())
 	}
 
-	domainModel, err := convertToDomainModel(p)
+	domainModel, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	updated, err := s.service.UpdateTemplate(ctx, info.OrgID, domainModel)
+	updated, err := s.service.UpdateTemplate(ctx, info.OrgID, domainModel, managerProps)
 	if err != nil {
 		return nil, false, err
 	}
 
-	r := convertToK8sResource(info.OrgID, updated, s.namespacer)
+	r := convertToK8sResource(info.OrgID, updated, managerProps, s.namespacer)
 	return r, false, nil
 }
 
@@ -206,12 +207,15 @@ func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidatio
 	if !ok {
 		return nil, false, fmt.Errorf("expected template but got %s", old.GetObjectKind().GroupVersionKind())
 	}
-	prov, err := ngmodels.ProvenanceFromString(oldTemplate.GetProvenanceStatus())
+	// Derive manager properties the same way create/update do, so a resource managed by a
+	// specific manager (e.g. Terraform) is deleted with the matching manager and not the
+	// coarser provenance-derived equivalent.
+	managerProps, _, err := extractManagerProperties(oldTemplate)
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteTemplate(ctx, info.OrgID, name, prov, version) // TODO add support for dry-run option
-	return old, false, err                                               // false - will be deleted async
+	err = s.service.DeleteTemplate(ctx, info.OrgID, name, managerProps, version) // TODO add support for dry-run option
+	return old, false, err                                                       // false - will be deleted async
 }
 
 func (s *legacyStorage) defaultTemplate() (v1.TemplateGroup, error) {

--- a/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/conversions.go
@@ -2,6 +2,7 @@ package timeinterval
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/prometheus/alertmanager/timeinterval"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -16,11 +18,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
-func ConvertToK8sResources(orgID int64, intervals []v1.TimeInterval, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
+func ConvertToK8sResources(orgID int64, intervals []v1.TimeInterval, managerPropsMap map[string]utils.ManagerProperties, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TimeIntervalList, error) {
 	result := &model.TimeIntervalList{}
 
 	for _, interval := range intervals {
-		item, err := ConvertToK8sResource(orgID, interval, namespacer)
+		item, err := ConvertToK8sResource(orgID, interval, managerPropsMap[string(interval.UID)], namespacer)
 		if err != nil {
 			return nil, err
 		}
@@ -33,7 +35,7 @@ func ConvertToK8sResources(orgID int64, intervals []v1.TimeInterval, namespacer 
 	return result, nil
 }
 
-func ConvertToK8sResource(orgID int64, interval v1.TimeInterval, namespacer request.NamespaceMapper) (*model.TimeInterval, error) {
+func ConvertToK8sResource(orgID int64, interval v1.TimeInterval, managerProps utils.ManagerProperties, namespacer request.NamespaceMapper) (*model.TimeInterval, error) {
 	timeIntervals, err := convertToSpec(interval.TimeIntervals)
 	if err != nil {
 		return nil, err
@@ -42,7 +44,7 @@ func ConvertToK8sResource(orgID int64, interval v1.TimeInterval, namespacer requ
 		Name:          interval.Title,
 		TimeIntervals: timeIntervals,
 	}
-	result := buildTimeInterval(orgID, interval, spec, namespacer)
+	result := buildTimeInterval(orgID, interval, managerProps, spec, namespacer)
 	return &result, nil
 }
 
@@ -61,7 +63,7 @@ func convertToSpec(intervals []timeinterval.TimeInterval) ([]model.TimeIntervalI
 	return result, nil
 }
 
-func buildTimeInterval(orgID int64, interval v1.TimeInterval, spec model.TimeIntervalSpec, namespacer request.NamespaceMapper) model.TimeInterval {
+func buildTimeInterval(orgID int64, interval v1.TimeInterval, managerProps utils.ManagerProperties, spec model.TimeIntervalSpec, namespacer request.NamespaceMapper) model.TimeInterval {
 	i := model.TimeInterval{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kind.GroupVersionKind().GroupVersion().String(),
@@ -75,23 +77,35 @@ func buildTimeInterval(orgID int64, interval v1.TimeInterval, spec model.TimeInt
 		},
 		Spec: spec,
 	}
-	i.SetProvenanceStatus(string(interval.Provenance))
+	// Prefer the richer manager-derived provenance; fall back to whatever provenance the
+	// caller already resolved (e.g. a special sentinel with no manager-kind equivalent).
+	provenance := interval.Provenance
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		provenance = ngmodels.ManagerPropertiesToProvenance(managerProps)
+	}
+	i.SetProvenanceStatus(string(provenance))
 	i.UID = gapiutil.CalculateClusterWideUID(&i)
 
-	i.SetCanUse(interval.Provenance != ngmodels.ProvenanceConvertedPrometheus)
+	i.SetCanUse(provenance != ngmodels.ProvenanceConvertedPrometheus)
+
+	if managerProps.Kind != utils.ManagerKindUnknown {
+		if meta, err := utils.MetaAccessor(&i); err == nil {
+			meta.SetManagerProperties(managerProps)
+		}
+	}
 
 	return i
 }
 
-func convertToDomainModel(interval *model.TimeInterval) (v1.TimeInterval, error) {
+func convertToDomainModel(interval *model.TimeInterval) (v1.TimeInterval, utils.ManagerProperties, error) {
 	timeIntervals, err := convertFromSpec(interval.Spec.TimeIntervals)
 	if err != nil {
-		return v1.TimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
+		return v1.TimeInterval{}, utils.ManagerProperties{}, provisioning.MakeErrTimeIntervalInvalid(err)
 	}
 
-	prov, err := ngmodels.ProvenanceFromString(interval.GetProvenanceStatus())
+	managerProps, prov, err := extractManagerProperties(interval)
 	if err != nil {
-		return v1.TimeInterval{}, provisioning.MakeErrTimeIntervalInvalid(err)
+		return v1.TimeInterval{}, utils.ManagerProperties{}, provisioning.MakeErrTimeIntervalInvalid(err)
 	}
 
 	return v1.TimeInterval{
@@ -102,7 +116,34 @@ func convertToDomainModel(interval *model.TimeInterval) (v1.TimeInterval, error)
 		},
 		Title:         interval.Spec.Name,
 		TimeIntervals: timeIntervals,
-	}, nil
+	}, managerProps, nil
+}
+
+// extractManagerProperties resolves the ManagerProperties for an inbound object, preferring the
+// manager annotations (richer than the coarse provenance annotation) when present and validating
+// that they agree with any explicit provenance annotation. It falls back to deriving
+// ManagerProperties from the provenance annotation for objects that pre-date ManagerProperties.
+func extractManagerProperties(interval *model.TimeInterval) (utils.ManagerProperties, ngmodels.Provenance, error) {
+	meta, err := utils.MetaAccessor(interval)
+	if err != nil {
+		return utils.ManagerProperties{}, "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+	if mp, ok := meta.GetManagerProperties(); ok {
+		if sourceProv := interval.GetProvenanceStatus(); sourceProv != "" && sourceProv != string(ngmodels.ProvenanceNone) {
+			derivedProv := string(ngmodels.ManagerPropertiesToProvenance(mp))
+			if derivedProv != sourceProv {
+				return utils.ManagerProperties{}, "", fmt.Errorf("manager properties (kind=%s) and provenance annotation (%s) are inconsistent: manager properties imply provenance %q",
+					mp.Kind, sourceProv, derivedProv)
+			}
+		}
+		return mp, ngmodels.ManagerPropertiesToProvenance(mp), nil
+	}
+
+	prov, err := ngmodels.ProvenanceFromString(interval.GetProvenanceStatus())
+	if err != nil {
+		return utils.ManagerProperties{}, "", err
+	}
+	return ngmodels.ProvenanceToManagerProperties(prov), prov, nil
 }
 
 // convertFromSpec is the inverse of convertToSpec, converting the generated API types

--- a/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/timeinterval/legacy_storage.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
@@ -22,10 +22,10 @@ var (
 )
 
 type TimeIntervalService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error)
-	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
-	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
-	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, provenance ngmodels.Provenance, version string) error
+	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, map[string]utils.ManagerProperties, error)
+	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error)
+	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error)
+	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, manager utils.ManagerProperties, version string) error
 }
 
 type legacyStorage struct {
@@ -62,12 +62,12 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	res, err := s.service.GetMuteTimings(ctx, orgId)
+	res, managerPropsMap, err := s.service.GetMuteTimings(ctx, orgId)
 	if err != nil {
 		return nil, err
 	}
 
-	return ConvertToK8sResources(orgId, res, s.namespacer, opts.FieldSelector)
+	return ConvertToK8sResources(orgId, res, managerPropsMap, s.namespacer, opts.FieldSelector)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -76,14 +76,14 @@ func (s *legacyStorage) Get(ctx context.Context, uid string, _ *metav1.GetOption
 		return nil, err
 	}
 
-	timings, err := s.service.GetMuteTimings(ctx, info.OrgID)
+	timings, managerPropsMap, err := s.service.GetMuteTimings(ctx, info.OrgID)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, mt := range timings {
 		if mt.UID == v1.ResourceUID(uid) {
-			return ConvertToK8sResource(info.OrgID, mt, s.namespacer)
+			return ConvertToK8sResource(info.OrgID, mt, managerPropsMap[string(mt.UID)], s.namespacer)
 		}
 	}
 	return nil, errors.NewNotFound(ResourceInfo.GroupResource(), uid)
@@ -110,15 +110,15 @@ func (s *legacyStorage) Create(ctx context.Context,
 	if p.Name != "" { // TODO remove when metadata.name can be defined by user
 		return nil, errors.NewBadRequest("object's metadata.name should be empty")
 	}
-	mt, err := convertToDomainModel(p)
+	mt, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, err
 	}
-	out, err := s.service.CreateMuteTiming(ctx, mt, info.OrgID)
+	out, err := s.service.CreateMuteTiming(ctx, mt, info.OrgID, managerProps)
 	if err != nil {
 		return nil, err
 	}
-	return ConvertToK8sResource(info.OrgID, out, s.namespacer)
+	return ConvertToK8sResource(info.OrgID, out, managerProps, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context,
@@ -151,17 +151,17 @@ func (s *legacyStorage) Update(ctx context.Context,
 	if !ok {
 		return nil, false, fmt.Errorf("expected time-interval but got %s", obj.GetObjectKind().GroupVersionKind())
 	}
-	interval, err := convertToDomainModel(p)
+	interval, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return old, false, err
 	}
 
-	updated, err := s.service.UpdateMuteTiming(ctx, interval, info.OrgID)
+	updated, err := s.service.UpdateMuteTiming(ctx, interval, info.OrgID, managerProps)
 	if err != nil {
 		return nil, false, err
 	}
 
-	r, err := ConvertToK8sResource(info.OrgID, updated, s.namespacer)
+	r, err := ConvertToK8sResource(info.OrgID, updated, managerProps, s.namespacer)
 	return r, false, err
 }
 
@@ -189,12 +189,15 @@ func (s *legacyStorage) Delete(ctx context.Context, uid string, deleteValidation
 		return nil, false, fmt.Errorf("expected time-interval but got %s", old.GetObjectKind().GroupVersionKind())
 	}
 
-	prov, err := ngmodels.ProvenanceFromString(p.GetProvenanceStatus())
+	// Derive manager properties the same way create/update do, so a resource managed by a
+	// specific manager (e.g. Terraform) is deleted with the matching manager and not the
+	// coarser provenance-derived equivalent.
+	_, managerProps, err := convertToDomainModel(p)
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, prov, version) // TODO add support for dry-run option
-	return old, false, err                                                   // false - will be deleted async
+	err = s.service.DeleteMuteTiming(ctx, p.Name, info.OrgID, managerProps, version) // TODO add support for dry-run option
+	return old, false, err                                                           // false - will be deleted async
 }
 
 func (s *legacyStorage) DeleteCollection(context.Context, rest.ValidateObjectFunc, *metav1.DeleteOptions, *internalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -28,7 +28,7 @@ type muteTimeInterval struct {
 }
 
 func (s *Service) getAlertMuteTimings(ctx context.Context, signedInUser *user.SignedInUser) ([]muteTimeInterval, error) {
-	muteTimings, err := s.ngAlert.Api.MuteTimings.GetMuteTimings(ctx, signedInUser.OrgID)
+	muteTimings, _, err := s.ngAlert.Api.MuteTimings.GetMuteTimings(ctx, signedInUser.OrgID)
 	if err != nil {
 		return nil, fmt.Errorf("fetching ngalert mute timings: %w", err)
 	}
@@ -55,7 +55,7 @@ type notificationTemplate struct {
 }
 
 func (s *Service) getNotificationTemplates(ctx context.Context, signedInUser *user.SignedInUser) ([]notificationTemplate, error) {
-	templates, err := s.ngAlert.Api.Templates.GetTemplates(ctx, signedInUser.OrgID)
+	templates, _, err := s.ngAlert.Api.Templates.GetTemplates(ctx, signedInUser.OrgID)
 	if err != nil {
 		return nil, fmt.Errorf("fetching ngalert notification templates: %w", err)
 	}

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -317,7 +318,7 @@ func createMuteTiming(t *testing.T, ctx context.Context, service *Service, user 
 	require.NoError(t, json.Unmarshal([]byte(muteTiming), &mt))
 
 	interval := v1.NewTimeInterval(mt.Name, mt.TimeIntervals, models.ProvenanceNone)
-	createdTiming, err := service.ngAlert.Api.MuteTimings.CreateMuteTiming(ctx, interval, user.GetOrgID())
+	createdTiming, err := service.ngAlert.Api.MuteTimings.CreateMuteTiming(ctx, interval, user.GetOrgID(), utils.ManagerProperties{})
 	require.NoError(t, err)
 
 	return createdTiming
@@ -331,7 +332,7 @@ func createNotificationTemplate(t *testing.T, ctx context.Context, service *Serv
 		Content: "This is a test template\n{{ .ExternalURL }}",
 	}
 
-	createdTemplate, err := service.ngAlert.Api.Templates.CreateTemplate(ctx, user.GetOrgID(), tmpl)
+	createdTemplate, err := service.ngAlert.Api.Templates.CreateTemplate(ctx, user.GetOrgID(), tmpl, utils.ManagerProperties{})
 	require.NoError(t, err)
 
 	return createdTemplate

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -50,10 +50,10 @@ type ContactPointService interface {
 }
 
 type TemplateService interface {
-	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error)
-	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error)
+	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, map[string]utils.ManagerProperties, error)
+	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, utils.ManagerProperties, error)
 	UpsertTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
-	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance alerting_models.Provenance, version string) error
+	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, manager utils.ManagerProperties, version string) error
 }
 
 type NotificationPolicyService interface {
@@ -64,11 +64,11 @@ type NotificationPolicyService interface {
 }
 
 type MuteTimingService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error)
-	GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, error)
-	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
-	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error)
-	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, provenance alerting_models.Provenance, version string) error
+	GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, map[string]utils.ManagerProperties, error)
+	GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, utils.ManagerProperties, error)
+	CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error)
+	UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error)
+	DeleteMuteTiming(ctx context.Context, nameOrUid string, orgID int64, manager utils.ManagerProperties, version string) error
 }
 
 type AlertRuleService interface {
@@ -223,7 +223,7 @@ func (srv *ProvisioningSrv) RouteDeleteContactPoint(c *contextmodel.ReqContext, 
 }
 
 func (srv *ProvisioningSrv) RouteGetTemplates(c *contextmodel.ReqContext) response.Response {
-	templates, err := srv.templates.GetTemplates(c.Req.Context(), c.GetOrgID())
+	templates, _, err := srv.templates.GetTemplates(c.Req.Context(), c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
@@ -231,7 +231,7 @@ func (srv *ProvisioningSrv) RouteGetTemplates(c *contextmodel.ReqContext) respon
 }
 
 func (srv *ProvisioningSrv) RouteGetTemplate(c *contextmodel.ReqContext, nameOrUid string) response.Response {
-	template, err := srv.templates.GetTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid)
+	template, _, err := srv.templates.GetTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
@@ -257,7 +257,7 @@ func (srv *ProvisioningSrv) RoutePutTemplate(c *contextmodel.ReqContext, body de
 
 func (srv *ProvisioningSrv) RouteDeleteTemplate(c *contextmodel.ReqContext, nameOrUid string) response.Response {
 	version := c.Query("version")
-	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, determineProvenance(c), version)
+	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, determineManagerProperties(c), version)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
@@ -265,7 +265,7 @@ func (srv *ProvisioningSrv) RouteDeleteTemplate(c *contextmodel.ReqContext, name
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTiming(c *contextmodel.ReqContext, name string) response.Response {
-	timing, err := srv.muteTimings.GetMuteTimingByName(c.Req.Context(), name, c.GetOrgID())
+	timing, _, err := srv.muteTimings.GetMuteTimingByName(c.Req.Context(), name, c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timing by name", err)
 	}
@@ -273,7 +273,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTiming(c *contextmodel.ReqContext, name 
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTimingExport(c *contextmodel.ReqContext, name string) response.Response {
-	timings, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
+	timings, _, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
@@ -287,7 +287,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTimingExport(c *contextmodel.ReqContext,
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTimings(c *contextmodel.ReqContext) response.Response {
-	timings, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
+	timings, _, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
@@ -295,7 +295,7 @@ func (srv *ProvisioningSrv) RouteGetMuteTimings(c *contextmodel.ReqContext) resp
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTimingsExport(c *contextmodel.ReqContext) response.Response {
-	timings, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
+	timings, _, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.GetOrgID())
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to get mute timings", err)
 	}
@@ -305,8 +305,8 @@ func (srv *ProvisioningSrv) RouteGetMuteTimingsExport(c *contextmodel.ReqContext
 
 func (srv *ProvisioningSrv) RoutePostMuteTiming(c *contextmodel.ReqContext, mt definitions.MuteTimeInterval) response.Response {
 	ti := MuteTimeIntervalToModel(mt)
-	ti.Provenance = determineProvenance(c)
-	created, err := srv.muteTimings.CreateMuteTiming(c.Req.Context(), ti, c.GetOrgID())
+	manager := determineManagerProperties(c)
+	created, err := srv.muteTimings.CreateMuteTiming(c.Req.Context(), ti, c.GetOrgID(), manager)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to create mute timing", err)
 	}
@@ -323,8 +323,8 @@ func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt de
 		mt.UID = name
 	}
 	ti := MuteTimeIntervalToModel(mt)
-	ti.Provenance = determineProvenance(c)
-	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), ti, c.GetOrgID())
+	manager := determineManagerProperties(c)
+	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), ti, c.GetOrgID(), manager)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to update mute timing", err)
 	}
@@ -333,7 +333,7 @@ func (srv *ProvisioningSrv) RoutePutMuteTiming(c *contextmodel.ReqContext, mt de
 
 func (srv *ProvisioningSrv) RouteDeleteMuteTiming(c *contextmodel.ReqContext, name string) response.Response {
 	version := c.Query("version")
-	err := srv.muteTimings.DeleteMuteTiming(c.Req.Context(), name, c.GetOrgID(), determineProvenance(c), version)
+	err := srv.muteTimings.DeleteMuteTiming(c.Req.Context(), name, c.GetOrgID(), determineManagerProperties(c), version)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to delete mute timing", err)
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
@@ -100,6 +101,29 @@ func GetReceiverProvenance(storedProvenances map[string]models.Provenance, r *v1
 		}
 	}
 	return models.ProvenanceNone
+}
+
+// GetReceiverManager determines the ManagerProperties of a v1.PostableApiReceiver based on the
+// ManagerProperties of its integrations. Mirrors GetReceiverProvenance.
+func GetReceiverManager(storedManagers map[string]utils.ManagerProperties, r *v1.PostableApiReceiver, origin models.ResourceOrigin) utils.ManagerProperties {
+	if origin == models.ResourceOriginImported {
+		return models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus)
+	}
+
+	if len(r.GrafanaManagedReceivers) == 0 || len(storedManagers) == 0 {
+		return utils.ManagerProperties{}
+	}
+
+	// Current provisioning works on the integration level, so we need some way to determine the manager of the
+	// entire receiver. All integrations in a receiver should have the same manager, but we don't want to rely on
+	// this assumption in case the first manager is unknown and a later one is not. To this end, we return the first
+	// non-unknown manager we find.
+	for _, contactPoint := range r.GrafanaManagedReceivers {
+		if m, exists := storedManagers[contactPoint.UID]; exists && m.Kind != utils.ManagerKindUnknown {
+			return m
+		}
+	}
+	return utils.ManagerProperties{}
 }
 
 func PostableGrafanaReceiversToIntegrations(postables []*v1.PostableGrafanaReceiver) ([]*models.Integration, error) {

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/util"
@@ -93,26 +94,30 @@ func (rev *ConfigRevision) ReceiverUseByName() map[string]int {
 	return m
 }
 
-func (rev *ConfigRevision) GetReceiver(uid string, prov provenances) (*models.Receiver, error) {
+// GetReceiver returns the receiver with the given uid, along with its ManagerProperties.
+func (rev *ConfigRevision) GetReceiver(uid string, prov provenances, managerProps map[string]utils.ManagerProperties) (*models.Receiver, utils.ManagerProperties, error) {
 	for _, r := range rev.Config.AlertmanagerConfig.Receivers {
 		if NameToUid(r.GetName()) != uid {
 			continue
 		}
 		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r, models.ResourceOriginGrafana), models.ResourceOriginGrafana)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
+			return nil, utils.ManagerProperties{}, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}
-		return recv, nil
+		return recv, GetReceiverManager(managerProps, r, models.ResourceOriginGrafana), nil
 	}
-	return nil, models.ErrReceiverNotFound.Errorf("")
+	return nil, utils.ManagerProperties{}, models.ErrReceiverNotFound.Errorf("")
 }
 
-func (rev *ConfigRevision) GetReceivers(uids []string, prov provenances) ([]*models.Receiver, error) {
+// GetReceivers returns all receivers matching uids, along with their ManagerProperties keyed by
+// resource UID.
+func (rev *ConfigRevision) GetReceivers(uids []string, prov provenances, managerProps map[string]utils.ManagerProperties) ([]*models.Receiver, map[string]utils.ManagerProperties, error) {
 	capacity := len(uids)
 	if capacity == 0 {
 		capacity = len(rev.Config.AlertmanagerConfig.Receivers)
 	}
 	receivers := make([]*models.Receiver, 0, capacity)
+	result := make(map[string]utils.ManagerProperties, capacity)
 	for _, r := range rev.Config.AlertmanagerConfig.Receivers {
 		uid := NameToUid(r.GetName())
 		if len(uids) > 0 && !slices.Contains(uids, uid) {
@@ -120,11 +125,12 @@ func (rev *ConfigRevision) GetReceivers(uids []string, prov provenances) ([]*mod
 		}
 		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r, models.ResourceOriginGrafana), models.ResourceOriginGrafana)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
+			return nil, nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}
 		receivers = append(receivers, recv)
+		result[recv.GetUID()] = GetReceiverManager(managerProps, r, models.ResourceOriginGrafana)
 	}
-	return receivers, nil
+	return receivers, result, nil
 }
 
 // GetReceiversNames returns a map of receiver names

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers_test.go
@@ -303,7 +303,7 @@ func TestGetReceiver(t *testing.T) {
 
 	t.Run("should return ErrReceiverNotFound if receiver does not exists", func(t *testing.T) {
 		rev := getConfigRevisionForTest()
-		_, err := rev.GetReceiver("not-found", nil)
+		_, _, err := rev.GetReceiver("not-found", nil, nil)
 		require.ErrorIs(t, err, models.ErrReceiverNotFound)
 	})
 
@@ -328,7 +328,7 @@ func TestGetReceiver(t *testing.T) {
 			},
 		}
 		rev := getConfigRevisionForTest()
-		result, err := rev.GetReceiver(NameToUid("receiver1"), prov)
+		result, _, err := rev.GetReceiver(NameToUid("receiver1"), prov, nil)
 		require.NoError(t, err)
 		require.Equal(t, expected, result)
 	})
@@ -342,7 +342,7 @@ func TestGetReceivers(t *testing.T) {
 			"integration-uid-1": "test",
 			"integration-uid-2": "some",
 		}
-		receivers, err := rev.GetReceivers(nil, prov)
+		receivers, _, err := rev.GetReceivers(nil, prov, nil)
 		require.NoError(t, err)
 		require.Len(t, receivers, len(rev.Config.AlertmanagerConfig.Receivers))
 		for _, r := range receivers {
@@ -358,13 +358,13 @@ func TestGetReceivers(t *testing.T) {
 		}
 	})
 	t.Run("should filter by uids", func(t *testing.T) {
-		receivers, err := rev.GetReceivers([]string{"not-found-1", "not-found-2"}, nil)
+		receivers, _, err := rev.GetReceivers([]string{"not-found-1", "not-found-2"}, nil, nil)
 		require.NoError(t, err)
 		require.Empty(t, receivers)
-		receivers, err = rev.GetReceivers([]string{NameToUid("receiver1")}, nil)
+		receivers, _, err = rev.GetReceivers([]string{NameToUid("receiver1")}, nil, nil)
 		require.NoError(t, err)
 		require.Len(t, receivers, 1)
-		expected, err := rev.GetReceiver(NameToUid("receiver1"), nil)
+		expected, _, err := rev.GetReceiver(NameToUid("receiver1"), nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, expected, receivers[0])
 	})

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -87,6 +88,9 @@ type provisoningStore interface {
 	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
 	SetProvenance(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) error
 	DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error
+	GetManagerProperties(ctx context.Context, o models.Provisionable, org int64) (utils.ManagerProperties, error)
+	GetAllManagerProperties(ctx context.Context, org int64, resourceType string) (map[string]utils.ManagerProperties, error)
+	SetManagerProperties(ctx context.Context, o models.Provisionable, org int64, m utils.ManagerProperties) error
 }
 
 type transactionManager interface {
@@ -144,11 +148,15 @@ func (rs *ReceiverService) loadProvenances(ctx context.Context, orgID int64) (ma
 	return rs.provisioningStore.GetProvenances(ctx, orgID, (&models.Integration{}).ResourceType())
 }
 
-// GetReceiver returns a receiver by its UID.
+func (rs *ReceiverService) loadManagerProps(ctx context.Context, orgID int64) (map[string]utils.ManagerProperties, error) {
+	return rs.provisioningStore.GetAllManagerProperties(ctx, orgID, (&models.Integration{}).ResourceType())
+}
+
+// GetReceiver returns a receiver by its UID, along with its ManagerProperties.
 // The receiver's secure settings are decrypted if requested and the user has access to do so.
-func (rs *ReceiverService) GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, error) {
+func (rs *ReceiverService) GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, utils.ManagerProperties, error) {
 	if user == nil {
-		return nil, errors.New("user is required")
+		return nil, utils.ManagerProperties{}, errors.New("user is required")
 	}
 	ctx, span := rs.tracer.Start(ctx, "alerting.receivers.get", trace.WithAttributes(
 		attribute.Int64("query_org_id", user.GetOrgID()),
@@ -159,24 +167,29 @@ func (rs *ReceiverService) GetReceiver(ctx context.Context, uid string, decrypt 
 
 	revision, err := rs.cfgStore.Get(ctx, user.GetOrgID())
 	if err != nil {
-		return nil, err
+		return nil, utils.ManagerProperties{}, err
 	}
 
 	prov, err := rs.loadProvenances(ctx, user.GetOrgID())
 	if err != nil {
-		return nil, err
+		return nil, utils.ManagerProperties{}, err
+	}
+	managerProps, err := rs.loadManagerProps(ctx, user.GetOrgID())
+	if err != nil {
+		return nil, utils.ManagerProperties{}, err
 	}
 
-	rcv, err := revision.GetReceiver(uid, prov)
+	rcv, manager, err := revision.GetReceiver(uid, prov, managerProps)
 	if err != nil {
 		if errors.Is(err, models.ErrReceiverNotFound) && rs.includeImported {
 			imported := rs.getImportedReceivers(ctx, span, []string{uid}, revision)
 			if len(imported) > 0 {
 				rcv = imported[0]
+				manager = models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus)
 			}
 		}
 		if rcv == nil {
-			return nil, err
+			return nil, utils.ManagerProperties{}, err
 		}
 	}
 
@@ -189,7 +202,7 @@ func (rs *ReceiverService) GetReceiver(ctx context.Context, uid string, decrypt 
 		auth = rs.authz.AuthorizeRead
 	}
 	if err := auth(ctx, user, rcv); err != nil {
-		return nil, err
+		return nil, utils.ManagerProperties{}, err
 	}
 
 	if decrypt {
@@ -204,12 +217,13 @@ func (rs *ReceiverService) GetReceiver(ctx context.Context, uid string, decrypt 
 		}
 	}
 
-	return rcv, nil
+	return rcv, manager, nil
 }
 
-// GetReceivers returns a list of receivers a user has access to.
+// GetReceivers returns a list of receivers a user has access to, along with their
+// ManagerProperties keyed by resource UID.
 // Receivers can be filtered by name, and secure settings are decrypted if requested and the user has access to do so.
-func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error) {
+func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, map[string]utils.ManagerProperties, error) {
 	ctx, span := rs.tracer.Start(ctx, "alerting.receivers.getMany", trace.WithAttributes(
 		attribute.Int64("query_org_id", q.OrgID),
 		attribute.StringSlice("query_names", q.Names),
@@ -226,17 +240,21 @@ func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceive
 
 	revision, err := rs.cfgStore.Get(ctx, q.OrgID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	prov, err := rs.loadProvenances(ctx, q.OrgID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	managerProps, err := rs.loadManagerProps(ctx, q.OrgID)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	receivers, err := revision.GetReceivers(uids, prov)
+	receivers, managerPropsByReceiver, err := revision.GetReceivers(uids, prov, managerProps)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	span.AddEvent("Loaded receivers", trace.WithAttributes(
@@ -247,6 +265,9 @@ func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceive
 	if rs.includeImported {
 		imported := rs.getImportedReceivers(ctx, span, uids, revision)
 		receivers = append(receivers, imported...)
+		for _, rcv := range imported {
+			managerPropsByReceiver[rcv.GetUID()] = models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus)
+		}
 	}
 
 	filterFn := rs.authz.FilterReadDecrypted
@@ -255,7 +276,7 @@ func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceive
 	}
 	filtered, err := filterFn(ctx, user, receivers...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	span.AddEvent("Applied access control filter", trace.WithAttributes(
@@ -276,12 +297,12 @@ func (rs *ReceiverService) GetReceivers(ctx context.Context, q models.GetReceive
 		}
 	}
 
-	return limitOffset(filtered, q.Offset, q.Limit), nil
+	return limitOffset(filtered, q.Offset, q.Limit), managerPropsByReceiver, nil
 }
 
 // DeleteReceiver deletes a receiver by uid.
 // UID field currently does not exist, we assume the uid is a particular hashed value of the receiver name.
-func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, callerProvenance models.Provenance, version string, orgID int64, user identity.Requester) error {
+func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, manager utils.ManagerProperties, version string, orgID int64, user identity.Requester) error {
 	ctx, span := rs.tracer.Start(ctx, "alerting.receivers.delete", trace.WithAttributes(
 		attribute.String("receiver_uid", uid),
 		attribute.String("receiver_version", version),
@@ -300,8 +321,12 @@ func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, calle
 	if err != nil {
 		return err
 	}
+	managerProps, err := rs.loadManagerProps(ctx, orgID)
+	if err != nil {
+		return err
+	}
 
-	existing, err := revision.GetReceiver(uid, prov)
+	existing, _, err := revision.GetReceiver(uid, prov, managerProps)
 	if err != nil {
 		if !errors.Is(err, models.ErrReceiverNotFound) {
 			return err
@@ -329,6 +354,7 @@ func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, calle
 		logger.Debug("Ignoring optimistic concurrency check because version was not provided", "operation", "delete")
 	}
 
+	callerProvenance := models.ManagerPropertiesToProvenance(manager)
 	if err := rs.provenanceValidator(ctx, existing.Provenance, callerProvenance); err != nil {
 		return err
 	}
@@ -364,7 +390,7 @@ func (rs *ReceiverService) DeleteReceiver(ctx context.Context, uid string, calle
 	return nil
 }
 
-func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receiver, orgID int64, user identity.Requester) (result *models.Receiver, err error) {
+func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receiver, manager utils.ManagerProperties, orgID int64, user identity.Requester) (result *models.Receiver, err error) {
 	ctx, span := rs.tracer.Start(ctx, "alerting.receivers.create", trace.WithAttributes(
 		attribute.String("receiver", r.Name),
 		attribute.StringSlice("integrations", r.GetIntegrationTypes()),
@@ -376,6 +402,11 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 	}
 	if r.Origin != models.ResourceOriginGrafana {
 		return nil, makeErrReceiverOrigin(r, "create")
+	}
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		r.Provenance = models.ManagerPropertiesToProvenance(manager)
 	}
 	if err := rs.provenanceValidator(ctx, models.ProvenanceNone, r.Provenance); err != nil {
 		return nil, err
@@ -423,7 +454,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 			return err
 		}
 		rs.resourcePermissions.SetDefaultPermissions(ctx, orgID, user, createdReceiver.GetUID())
-		return rs.setReceiverProvenance(ctx, orgID, &createdReceiver)
+		return rs.setReceiverManager(ctx, orgID, &createdReceiver, manager)
 	})
 	if err != nil {
 		return nil, err
@@ -437,7 +468,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 	return result, nil
 }
 
-func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receiver, storedSecureFields map[string][]string, orgID int64, user identity.Requester) (*models.Receiver, error) {
+func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receiver, manager utils.ManagerProperties, storedSecureFields map[string][]string, orgID int64, user identity.Requester) (*models.Receiver, error) {
 	ctx, span := rs.tracer.Start(ctx, "alerting.receivers.update", trace.WithAttributes(
 		attribute.String("receiver", r.Name),
 		attribute.String("uid", r.UID),
@@ -457,6 +488,12 @@ func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receive
 		return nil, models.ErrReceiverInvalid(err)
 	}
 
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		r.Provenance = models.ManagerPropertiesToProvenance(manager)
+	}
+
 	logger := rs.log.FromContext(ctx).New("receiver", r.Name, "uid", r.UID, "version", r.Version, "integrations", r.GetIntegrationTypes())
 	logger.Debug("Updating receiver")
 
@@ -469,8 +506,12 @@ func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receive
 	if err != nil {
 		return nil, err
 	}
+	managerProps, err := rs.loadManagerProps(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
 
-	existing, err := revision.GetReceiver(r.GetUID(), prov)
+	existing, _, err := revision.GetReceiver(r.GetUID(), prov, managerProps)
 	if err != nil {
 		if errors.Is(err, models.ErrReceiverNotFound) && rs.includeImported {
 			// try to get the imported receiver and return a specific error if it exists
@@ -576,7 +617,7 @@ func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receive
 			return err
 		}
 
-		return rs.setReceiverProvenance(ctx, orgID, &updatedReceiver)
+		return rs.setReceiverManager(ctx, orgID, &updatedReceiver, manager)
 	})
 	if err != nil {
 		return nil, err
@@ -698,10 +739,16 @@ func removedIntegrations(old, new *models.Receiver) []*models.Integration {
 	return removed
 }
 
-func (rs *ReceiverService) setReceiverProvenance(ctx context.Context, orgID int64, receiver *models.Receiver) error {
-	// Add provenance for all integrations in the receiver.
+func (rs *ReceiverService) setReceiverManager(ctx context.Context, orgID int64, receiver *models.Receiver, manager utils.ManagerProperties) error {
+	// When no rich manager is provided, derive one from the receiver's own (legacy) provenance so
+	// callers that only set Provenance directly still persist a consistent manager_kind.
+	effManager := manager
+	if effManager.Kind == utils.ManagerKindUnknown {
+		effManager = models.ProvenanceToManagerProperties(receiver.Provenance)
+	}
+	// Set manager properties for all integrations in the receiver.
 	for _, integration := range receiver.Integrations {
-		if err := rs.provisioningStore.SetProvenance(ctx, integration, orgID, receiver.Provenance); err != nil { // TODO: Should we set ProvenanceNone?
+		if err := rs.provisioningStore.SetManagerProperties(ctx, integration, orgID, effManager); err != nil {
 			return err
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -50,7 +51,7 @@ func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 
 	t.Run("service gets receiver from AM config", func(t *testing.T) {
 		sut := createReceiverServiceSut(t, secretsService)
-		recv, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("slack receiver"), false, redactedUser)
+		recv, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("slack receiver"), false, redactedUser)
 		require.NoError(t, err)
 		require.Equal(t, "slack receiver", recv.Name)
 		require.Len(t, recv.Integrations, 1)
@@ -60,7 +61,7 @@ func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 	t.Run("service returns error when receiver does not exist", func(t *testing.T) {
 		sut := createReceiverServiceSut(t, secretsService)
 
-		_, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
+		_, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
 		require.ErrorIs(t, err, models.ErrReceiverNotFound)
 	})
 
@@ -68,7 +69,7 @@ func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 		t.Run("gets imported receivers", func(t *testing.T) {
 			sut := createReceiverServiceSut(t, secretsService, withImportedIncluded)
 
-			recv, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
+			recv, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
 			require.NoError(t, err)
 			assert.Equal(t, models.ResourceOriginImported, recv.Origin)
 			assert.Equal(t, "receiver1", recv.Name)
@@ -79,9 +80,9 @@ func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 
 		t.Run("falls to only Grafana if cannot read imported receivers", func(t *testing.T) {
 			sut := createReceiverServiceSut(t, secretsService, withImportedIncluded, withInvalidExtraConfig)
-			_, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
+			_, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, redactedUser)
 			require.ErrorIs(t, err, models.ErrReceiverNotFound)
-			_, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid("slack receiver"), false, redactedUser)
+			_, _, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid("slack receiver"), false, redactedUser)
 			require.NoError(t, err)
 		})
 	})
@@ -102,7 +103,7 @@ func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 	t.Run("service gets receivers from AM config", func(t *testing.T) {
 		sut := createReceiverServiceSut(t, secretsService)
 
-		Receivers, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
+		Receivers, _, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
 		require.NoError(t, err)
 		require.Len(t, Receivers, 2)
 		require.Equal(t, "grafana-default-email", Receivers[0].Name)
@@ -112,7 +113,7 @@ func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 	t.Run("service filters receivers by name", func(t *testing.T) {
 		sut := createReceiverServiceSut(t, secretsService)
 
-		Receivers, err := sut.GetReceivers(context.Background(), multiQ(1, "slack receiver"), redactedUser)
+		Receivers, _, err := sut.GetReceivers(context.Background(), multiQ(1, "slack receiver"), redactedUser)
 		require.NoError(t, err)
 		require.Len(t, Receivers, 1)
 		require.Equal(t, "slack receiver", Receivers[0].Name)
@@ -122,7 +123,7 @@ func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 		t.Run("returns imported receivers in the list", func(t *testing.T) {
 			sut := createReceiverServiceSut(t, secretsService, withImportedIncluded)
 
-			recvs, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
+			recvs, _, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
 			require.NoError(t, err)
 			require.Len(t, recvs, 5)
 			names := make([]string, 0, len(recvs))
@@ -135,7 +136,7 @@ func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 
 		t.Run("falls to only Grafana if cannot read imported receivers", func(t *testing.T) {
 			sut := createReceiverServiceSut(t, secretsService, withImportedIncluded, withInvalidExtraConfig)
-			recvs, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
+			recvs, _, err := sut.GetReceivers(context.Background(), multiQ(1), redactedUser)
 			require.NoError(t, err)
 			require.Len(t, recvs, 2)
 		})
@@ -225,12 +226,12 @@ func TestIntegrationReceiverService_DecryptRedact(t *testing.T) {
 						var res *models.Receiver
 						var err error
 						if method == "single" {
-							res, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(o.receiver), tc.decrypt, tc.user)
+							res, _, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(o.receiver), tc.decrypt, tc.user)
 						} else {
 							q := multiQ(1, o.receiver)
 							q.Decrypt = tc.decrypt
 							var multiRes []*models.Receiver
-							multiRes, err = sut.GetReceivers(context.Background(), q, tc.user)
+							multiRes, _, err = sut.GetReceivers(context.Background(), q, tc.user)
 							if tc.err == "" {
 								require.Len(t, multiRes, 1)
 								res = multiRes[0]
@@ -382,7 +383,7 @@ func TestReceiverService_Delete(t *testing.T) {
 			sut.ruleNotificationsStore = store
 
 			if tc.existing != nil {
-				created, err := sut.CreateReceiver(context.Background(), tc.existing, tc.user.GetOrgID(), tc.user)
+				created, err := sut.CreateReceiver(context.Background(), tc.existing, utils.ManagerProperties{}, tc.user.GetOrgID(), tc.user)
 				require.NoError(t, err)
 
 				if tc.version == "" {
@@ -390,7 +391,7 @@ func TestReceiverService_Delete(t *testing.T) {
 				}
 			}
 
-			err := sut.DeleteReceiver(context.Background(), tc.deleteUID, tc.callerProvenance, tc.version, tc.user.GetOrgID(), tc.user)
+			err := sut.DeleteReceiver(context.Background(), tc.deleteUID, models.ProvenanceToManagerProperties(tc.callerProvenance), tc.version, tc.user.GetOrgID(), tc.user)
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
@@ -400,7 +401,7 @@ func TestReceiverService_Delete(t *testing.T) {
 			// Ensure receiver saved to store is correct.
 			name, err := legacy_storage.UidToName(tc.deleteUID)
 			require.NoError(t, err)
-			_, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(name), false, writer)
+			_, _, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(name), false, writer)
 			assert.ErrorIs(t, err, models.ErrReceiverNotFound)
 
 			provenances, err := sut.provisioningStore.GetProvenances(context.Background(), tc.user.GetOrgID(), (&definitions.EmbeddedContactPoint{}).ResourceType())
@@ -617,7 +618,7 @@ func TestReceiverService_Create(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sut := createReceiverServiceSut(t, &secretsService, tc.opts...)
 
-			created, err := sut.CreateReceiver(context.Background(), &tc.receiver, tc.user.GetOrgID(), tc.user)
+			created, err := sut.CreateReceiver(context.Background(), &tc.receiver, utils.ManagerProperties{}, tc.user.GetOrgID(), tc.user)
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
@@ -654,7 +655,7 @@ func TestReceiverService_Create(t *testing.T) {
 			assert.Equal(t, tc.expectedCreate, *created)
 
 			// Ensure receiver saved to store is correct.
-			stored, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(tc.receiver.Name), true, decryptUser)
+			stored, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(tc.receiver.Name), true, decryptUser)
 			require.NoError(t, err)
 			decrypted := models.CopyReceiverWith(tc.expectedCreate, models.ReceiverMuts.Decrypted(models.Base64Decrypt))
 			decrypted.Version = tc.expectedCreate.Version // Version is calculated before decryption.
@@ -964,7 +965,7 @@ func TestReceiverService_Update(t *testing.T) {
 			}
 
 			tc.receiver.Version = tc.version
-			updated, err := sut.UpdateReceiver(context.Background(), &tc.receiver, tc.secureFields, tc.user.GetOrgID(), tc.user)
+			updated, err := sut.UpdateReceiver(context.Background(), &tc.receiver, utils.ManagerProperties{}, tc.secureFields, tc.user.GetOrgID(), tc.user)
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
@@ -1001,7 +1002,7 @@ func TestReceiverService_Update(t *testing.T) {
 			assert.Equal(t, tc.expectedUpdate, *updated)
 
 			// Ensure receiver saved to store is correct.
-			stored, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(tc.receiver.Name), true, decryptUser)
+			stored, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(tc.receiver.Name), true, decryptUser)
 			require.NoError(t, err)
 			decrypted := models.CopyReceiverWith(tc.expectedUpdate, models.ReceiverMuts.Decrypted(models.Base64Decrypt))
 			decrypted.Version = tc.expectedUpdate.Version // Version is calculated before decryption.
@@ -1039,7 +1040,7 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		sut := createReceiverServiceSut(t, &secretsService)
 		sut.ruleNotificationsStore = ruleStore
 
-		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, utils.ManagerProperties{}, nil, writer.GetOrgID(), writer)
 		require.NoError(t, err)
 
 		assert.Equal(t, "RenameReceiverInNotificationSettings", ruleStore.Calls[0].Method)
@@ -1072,7 +1073,7 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		}
 		sut.ruleNotificationsStore = ruleStore
 
-		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, utils.ManagerProperties{}, nil, writer.GetOrgID(), writer)
 		require.ErrorIs(t, err, models.ErrReceiverDependentResourcesProvenance)
 
 		require.Len(t, ruleStore.Calls, 1)
@@ -1095,7 +1096,7 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		}
 		sut.ruleNotificationsStore = ruleStore
 
-		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, utils.ManagerProperties{}, nil, writer.GetOrgID(), writer)
 		require.ErrorIs(t, err, models.ErrReceiverDependentResourcesProvenance)
 
 		require.Len(t, ruleStore.Calls, 1)
@@ -1113,7 +1114,7 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		sut.ruleNotificationsStore = ruleStore
 		baseReceiver.Name = ""
 
-		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, utils.ManagerProperties{}, nil, writer.GetOrgID(), writer)
 		require.ErrorIs(t, err, models.ErrReceiverInvalidBase)
 	})
 
@@ -1123,7 +1124,7 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		sut.ruleNotificationsStore = ruleStore
 
 		newReceiverName = "receiver1"
-		actual, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(newReceiverName), false, writer)
+		actual, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(newReceiverName), false, writer)
 		require.NoError(t, err)
 		require.Equal(t, models.ResourceOriginImported, actual.Origin)
 		require.Equal(t, newReceiverName, actual.Name)
@@ -1131,12 +1132,12 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 
 		baseReceiver.Name = newReceiverName
 
-		recv, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		recv, err := sut.UpdateReceiver(context.Background(), &baseReceiver, utils.ManagerProperties{}, nil, writer.GetOrgID(), writer)
 		require.NoError(t, err)
 		require.NotEqual(t, actual, recv)
 		require.Equal(t, models.ResourceOriginGrafana, recv.Origin)
 
-		actual, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(newReceiverName), false, writer)
+		actual, _, err = sut.GetReceiver(context.Background(), legacy_storage.NameToUid(newReceiverName), false, writer)
 		require.NoError(t, err)
 		require.Equal(t, recv.Name, actual.Name)
 	})
@@ -1326,7 +1327,7 @@ func TestReceiverServiceAC_Read(t *testing.T) {
 			sut := createReceiverServiceSut(t, &secretsService)
 
 			for _, recv := range tc.existing {
-				_, err := sut.CreateReceiver(context.Background(), &recv, orgId, admin)
+				_, err := sut.CreateReceiver(context.Background(), &recv, utils.ManagerProperties{}, orgId, admin)
 				require.NoError(t, err)
 			}
 
@@ -1343,7 +1344,7 @@ func TestReceiverServiceAC_Read(t *testing.T) {
 				return false
 			}
 			for _, recv := range allReceivers() {
-				response, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(recv.Name), false, usr)
+				response, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(recv.Name), false, usr)
 				if isVisible(recv.UID) {
 					require.NoErrorf(t, err, "receiver '%s' should be visible, but isn't", recv.Name)
 					assert.NotNil(t, response)
@@ -1365,7 +1366,7 @@ func TestReceiverServiceAC_Read(t *testing.T) {
 			}
 			sut.authz = ac.NewReceiverAccess[*models.Receiver](acimpl.ProvideAccessControl(featuremgmt.WithFeatures()), true)
 			for _, recv := range allReceivers() {
-				response, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(recv.Name), false, usr)
+				response, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid(recv.Name), false, usr)
 				if isVisibleInProvisioning(recv.UID) {
 					require.NoErrorf(t, err, "receiver '%s' should be visible, but isn't", recv.Name)
 					assert.NotNil(t, response)
@@ -1446,7 +1447,7 @@ func TestReceiverServiceAC_Create(t *testing.T) {
 				return false
 			}
 			for _, recv := range allReceivers() {
-				response, err := sut.CreateReceiver(context.Background(), &recv, orgId, usr)
+				response, err := sut.CreateReceiver(context.Background(), &recv, utils.ManagerProperties{}, orgId, usr)
 				if hasAccess(recv.UID) {
 					require.NoErrorf(t, err, "should have access to receiver '%s', but doesn't", recv.Name)
 					assert.NotNil(t, response)
@@ -1615,7 +1616,7 @@ func TestReceiverServiceAC_Update(t *testing.T) {
 
 			versions := map[string]string{}
 			for _, recv := range tc.existing {
-				created, err := sut.CreateReceiver(context.Background(), &recv, orgId, admin)
+				created, err := sut.CreateReceiver(context.Background(), &recv, utils.ManagerProperties{}, orgId, admin)
 				require.NoError(t, err)
 				versions[recv.UID] = created.Version
 			}
@@ -1639,7 +1640,7 @@ func TestReceiverServiceAC_Update(t *testing.T) {
 			for _, recv := range incoming {
 				clone := recv.Clone()
 				clone.Version = versions[recv.UID]
-				response, err := sut.UpdateReceiver(context.Background(), &clone, nil, orgId, usr)
+				response, err := sut.UpdateReceiver(context.Background(), &clone, utils.ManagerProperties{}, nil, orgId, usr)
 				if hasAccess(clone.UID) {
 					require.NoErrorf(t, err, "should have access to receiver '%s', but doesn't", clone.Name)
 					assert.NotNil(t, response)
@@ -1771,7 +1772,7 @@ func TestReceiverServiceAC_Delete(t *testing.T) {
 
 			versions := map[string]string{}
 			for _, recv := range tc.existing {
-				created, err := sut.CreateReceiver(context.Background(), &recv, orgId, admin)
+				created, err := sut.CreateReceiver(context.Background(), &recv, utils.ManagerProperties{}, orgId, admin)
 				require.NoError(t, err)
 				versions[recv.UID] = created.Version
 			}
@@ -1789,7 +1790,7 @@ func TestReceiverServiceAC_Delete(t *testing.T) {
 				return false
 			}
 			for _, recv := range allReceivers() {
-				err := sut.DeleteReceiver(context.Background(), recv.UID, models.ProvenanceNone, versions[recv.UID], orgId, usr)
+				err := sut.DeleteReceiver(context.Background(), recv.UID, utils.ManagerProperties{}, versions[recv.UID], orgId, usr)
 				if hasAccess(recv.UID) {
 					require.NoErrorf(t, err, "should have access to receiver '%s', but doesn't", recv.Name)
 				} else {
@@ -1879,7 +1880,7 @@ func TestReceiverService_InUseMetadata(t *testing.T) {
 			sut.ruleNotificationsStore = store
 
 			for _, recv := range tc.existing {
-				_, err := sut.CreateReceiver(context.Background(), recv, tc.user.GetOrgID(), tc.user)
+				_, err := sut.CreateReceiver(context.Background(), recv, utils.ManagerProperties{}, tc.user.GetOrgID(), tc.user)
 				require.NoError(t, err)
 			}
 
@@ -1918,7 +1919,7 @@ func TestReceiverService_AccessControlMetadata(t *testing.T) {
 		},
 	}}
 
-	r, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, admin)
+	r, _, err := sut.GetReceiver(context.Background(), legacy_storage.NameToUid("receiver1"), false, admin)
 	require.NoError(t, err)
 
 	t.Run("should override metadata for imported receivers", func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/receiver_testing_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
@@ -26,7 +27,7 @@ type AlertmanagerProvider interface {
 }
 
 type ReceiverGetter interface {
-	GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, error)
+	GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, utils.ManagerProperties, error)
 }
 
 func NewReceiverTestingService(
@@ -93,7 +94,7 @@ func (t *ReceiverTestingService) PatchIntegrationAndTest(ctx context.Context, us
 		return IntegrationTestResult{}, err
 	}
 
-	rcv, err := t.receiverSvc.GetReceiver(ctx, receiverUID, false, user)
+	rcv, _, err := t.receiverSvc.GetReceiver(ctx, receiverUID, false, user)
 	if err != nil {
 		return IntegrationTestResult{}, err
 	}

--- a/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
@@ -203,11 +204,11 @@ func TestReceiverTestingService_PatchIntegrationAndTest(t *testing.T) {
 	existingReceiver := &models.Receiver{UID: receiverUID, Name: "existing", Integrations: []*models.Integration{&existingIntegration}}
 
 	receiverSvcFake := &FakeReceiverService{
-		GetReceiverFunc: func(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, error) {
+		GetReceiverFunc: func(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, utils.ManagerProperties, error) {
 			if receiverUID != uid {
-				return nil, models.ErrReceiverNotFound.Errorf("")
+				return nil, utils.ManagerProperties{}, models.ErrReceiverNotFound.Errorf("")
 			}
-			return existingReceiver, nil
+			return existingReceiver, utils.ManagerProperties{}, nil
 		},
 	}
 	amProviderFake := &FakeAlertmanagerProvider{}

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -7,7 +7,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -29,11 +28,6 @@ type routeProvenanceStore interface {
 	GetAllManagerProperties(ctx context.Context, org int64, resourceType string) (map[string]utils.ManagerProperties, error)
 	SetManagerProperties(ctx context.Context, o models.Provisionable, org int64, m utils.ManagerProperties) error
 }
-
-var errManagerMismatch = errutil.NewBase(errutil.StatusConflict, "alerting.managerMismatch").MustTemplate(
-	"cannot {{ .Public.Operation }} with provided manager kind '{{ .Public.ProvidedProvenance }}', needs '{{ .Public.StoredProvenance }}'",
-	errutil.WithPublic("cannot {{ .Public.Operation }} with provided manager kind '{{ .Public.ProvidedProvenance }}', needs '{{ .Public.StoredProvenance }}'"),
-)
 
 type transactionManager interface {
 	InTransaction(ctx context.Context, work func(ctx context.Context) error) error
@@ -280,20 +274,6 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 		return nil, err
 	}
 
-	storedManager, err := nps.provenanceStore.GetManagerProperties(ctx, existing, orgID)
-	if err != nil {
-		return nil, err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return nil, errManagerMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "update",
-			},
-		})
-	}
-
 	updated, err := revision.UpdateNamedRoute(name, subtree)
 	if err != nil {
 		return nil, err
@@ -362,20 +342,6 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 	}
 	if err := nps.provenanceStatusTransitionValidator(ctx, storedProvenance, p); err != nil {
 		return err
-	}
-
-	storedManager, err := nps.provenanceStore.GetManagerProperties(ctx, existing, orgID)
-	if err != nil {
-		return err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return errManagerMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "delete",
-			},
-		})
 	}
 
 	action := "Deleted"

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -7,7 +7,9 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -23,7 +25,15 @@ type routeProvenanceStore interface {
 	GetProvenances(ctx context.Context, org int64, resourceType string) (map[string]models.Provenance, error)
 	SetProvenance(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) error
 	DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error
+	GetManagerProperties(ctx context.Context, o models.Provisionable, org int64) (utils.ManagerProperties, error)
+	GetAllManagerProperties(ctx context.Context, org int64, resourceType string) (map[string]utils.ManagerProperties, error)
+	SetManagerProperties(ctx context.Context, o models.Provisionable, org int64, m utils.ManagerProperties) error
 }
+
+var errManagerMismatch = errutil.NewBase(errutil.StatusConflict, "alerting.managerMismatch").MustTemplate(
+	"cannot {{ .Public.Operation }} with provided manager kind '{{ .Public.ProvidedProvenance }}', needs '{{ .Public.StoredProvenance }}'",
+	errutil.WithPublic("cannot {{ .Public.Operation }} with provided manager kind '{{ .Public.ProvidedProvenance }}', needs '{{ .Public.StoredProvenance }}'"),
+)
 
 type transactionManager interface {
 	InTransaction(ctx context.Context, work func(ctx context.Context) error) error
@@ -99,7 +109,8 @@ func NewService(
 	}
 }
 
-func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error) {
+// GetManagedRoute returns a managed route by name, along with its ManagerProperties.
+func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, utils.ManagerProperties, error) {
 	ctx, span := nps.tracer.Start(ctx, "alerting.routes.get", trace.WithAttributes(
 		attribute.Int64("query_org_id", orgID),
 		attribute.String("query_name", name),
@@ -108,11 +119,11 @@ func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name strin
 	defer span.End()
 
 	if err := nps.routeAccess.AuthorizeReadByUID(ctx, user, name); err != nil {
-		return legacy_storage.ManagedRoute{}, err
+		return legacy_storage.ManagedRoute{}, utils.ManagerProperties{}, err
 	}
 	rev, err := nps.configStore.Get(ctx, orgID)
 	if err != nil {
-		return legacy_storage.ManagedRoute{}, err
+		return legacy_storage.ManagedRoute{}, utils.ManagerProperties{}, err
 	}
 
 	route := rev.GetManagedRoute(name)
@@ -122,7 +133,7 @@ func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name strin
 			route = nps.getImportedRoute(ctx, span, rev)
 		}
 		if route == nil {
-			return legacy_storage.ManagedRoute{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
+			return legacy_storage.ManagedRoute{}, utils.ManagerProperties{}, models.ErrRouteNotFound.Errorf("route %q not found", name)
 		}
 	}
 
@@ -133,18 +144,25 @@ func (nps *Service) GetManagedRoute(ctx context.Context, orgID int64, name strin
 	// Imported routes derive their provenance from the external config (ProvenanceConvertedPrometheus).
 	// They are not stored in the provenance store, so we must not overwrite with a store lookup
 	// which would return ProvenanceNone and cause a discrepancy with the list view.
-	if route.Origin != models.ResourceOriginImported {
-		provenance, err := nps.provenanceStore.GetProvenance(ctx, route, orgID)
-		if err != nil {
-			return legacy_storage.ManagedRoute{}, err
-		}
-		route.Provenance = provenance
+	if route.Origin == models.ResourceOriginImported {
+		return *route, models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus), nil
+	}
+	provenance, err := nps.provenanceStore.GetProvenance(ctx, route, orgID)
+	if err != nil {
+		return legacy_storage.ManagedRoute{}, utils.ManagerProperties{}, err
+	}
+	route.Provenance = provenance
+	managerProps, err := nps.provenanceStore.GetManagerProperties(ctx, route, orgID)
+	if err != nil {
+		return legacy_storage.ManagedRoute{}, utils.ManagerProperties{}, err
 	}
 
-	return *route, nil
+	return *route, managerProps, nil
 }
 
-func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64, user identity.Requester) (legacy_storage.ManagedRoutes, error) {
+// GetManagedRoutes returns all managed routes for the org along with their ManagerProperties,
+// keyed by resource UID.
+func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64, user identity.Requester) (legacy_storage.ManagedRoutes, map[string]utils.ManagerProperties, error) {
 	ctx, span := nps.tracer.Start(ctx, "alerting.routes.getMany", trace.WithAttributes(
 		attribute.Int64("query_org_id", orgID),
 		attribute.Bool("include_imported", nps.includeImported()),
@@ -153,12 +171,16 @@ func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64, user iden
 
 	rev, err := nps.configStore.Get(ctx, orgID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	provenances, err := nps.provenanceStore.GetProvenances(ctx, orgID, (&legacy_storage.ManagedRoute{}).ResourceType())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	managerProps, err := nps.provenanceStore.GetAllManagerProperties(ctx, orgID, (&legacy_storage.ManagedRoute{}).ResourceType())
+	if err != nil {
+		return nil, nil, err
 	}
 
 	managedRoutes := rev.GetManagedRoutes()
@@ -182,6 +204,7 @@ func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64, user iden
 				))
 			} else {
 				managedRoutes = append(managedRoutes, importedRoute)
+				managerProps[importedRoute.ResourceID()] = models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus)
 			}
 		}
 	}
@@ -193,14 +216,14 @@ func (nps *Service) GetManagedRoutes(ctx context.Context, orgID int64, user iden
 
 	managedRoutes, err = nps.routeAccess.FilterRead(ctx, user, managedRoutes...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	managedRoutes.Sort()
-	return managedRoutes, nil
+	return managedRoutes, managerProps, nil
 }
 
-func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, p models.Provenance, version string, user identity.Requester) (*legacy_storage.ManagedRoute, error) {
+func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, manager utils.ManagerProperties, version string, user identity.Requester) (*legacy_storage.ManagedRoute, error) {
 	ctx, span := nps.tracer.Start(ctx, "alerting.routes.update", trace.WithAttributes(
 		attribute.Int64("query_org_id", orgID),
 		attribute.String("route_name", name),
@@ -216,6 +239,10 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 	if err != nil {
 		return nil, models.MakeErrRouteInvalidFormat(err)
 	}
+
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	p := models.ManagerPropertiesToProvenance(manager)
 
 	revision, err := nps.configStore.Get(ctx, orgID)
 	if err != nil {
@@ -253,6 +280,20 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 		return nil, err
 	}
 
+	storedManager, err := nps.provenanceStore.GetManagerProperties(ctx, existing, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return nil, errManagerMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "update",
+			},
+		})
+	}
+
 	updated, err := revision.UpdateNamedRoute(name, subtree)
 	if err != nil {
 		return nil, err
@@ -263,7 +304,7 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return nps.provenanceStore.SetProvenance(ctx, updated, orgID, p)
+		return nps.provenanceStore.SetManagerProperties(ctx, updated, orgID, manager)
 	})
 	if err != nil {
 		return nil, err
@@ -275,7 +316,7 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 	return updated, nil
 }
 
-func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name string, p models.Provenance, version string, user identity.Requester) error {
+func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name string, manager utils.ManagerProperties, version string, user identity.Requester) error {
 	ctx, span := nps.tracer.Start(ctx, "alerting.routes.delete", trace.WithAttributes(
 		attribute.Int64("query_org_id", orgID),
 		attribute.String("route_name", name),
@@ -314,12 +355,27 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 		nps.log.FromContext(ctx).Debug("Ignoring optimistic concurrency check because version was not provided", "operation", "delete")
 	}
 
+	p := models.ManagerPropertiesToProvenance(manager)
 	storedProvenance, err := nps.provenanceStore.GetProvenance(ctx, existing, orgID)
 	if err != nil {
 		return err
 	}
 	if err := nps.provenanceStatusTransitionValidator(ctx, storedProvenance, p); err != nil {
 		return err
+	}
+
+	storedManager, err := nps.provenanceStore.GetManagerProperties(ctx, existing, orgID)
+	if err != nil {
+		return err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return errManagerMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "delete",
+			},
+		})
 	}
 
 	action := "Deleted"
@@ -359,7 +415,7 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 	return nil
 }
 
-func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, p models.Provenance, user identity.Requester) (*legacy_storage.ManagedRoute, error) {
+func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name string, subtree v1.Route, manager utils.ManagerProperties, user identity.Requester) (*legacy_storage.ManagedRoute, error) {
 	ctx, span := nps.tracer.Start(ctx, "alerting.routes.create", trace.WithAttributes(
 		attribute.Int64("query_org_id", orgID),
 		attribute.String("route_name", name),
@@ -371,6 +427,9 @@ func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name st
 		return nil, err
 	}
 
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	p := models.ManagerPropertiesToProvenance(manager)
 	if err := nps.provenanceStatusTransitionValidator(ctx, models.ProvenanceNone, p); err != nil {
 		return nil, err
 	}
@@ -398,6 +457,7 @@ func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name st
 		}
 	}
 
+	created.Provenance = p
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
@@ -405,7 +465,7 @@ func (nps *Service) CreateManagedRoute(ctx context.Context, orgID int64, name st
 		if err := nps.routeAccess.SetDefaultPermissions(ctx, user, created); err != nil {
 			return err
 		}
-		return nps.provenanceStore.SetProvenance(ctx, created, orgID, p)
+		return nps.provenanceStore.SetManagerProperties(ctx, created, orgID, manager)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/notifier/routes/service_test.go
+++ b/pkg/services/ngalert/notifier/routes/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -130,7 +131,7 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		route, err := sut.GetManagedRoute(context.Background(), orgID, "imported", user)
+		route, _, err := sut.GetManagedRoute(context.Background(), orgID, "imported", user)
 		require.NoError(t, err)
 
 		assert.Equal(t, models.ProvenanceConvertedPrometheus, route.Provenance)
@@ -158,14 +159,15 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		route, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
+		route, _, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.NoError(t, err)
 
 		assert.Equal(t, models.ProvenanceAPI, route.Provenance)
 		assert.Equal(t, models.ResourceOriginGrafana, route.Origin)
 
-		require.Len(t, provStore.Calls, 1)
+		require.Len(t, provStore.Calls, 2)
 		assert.Equal(t, "GetProvenance", provStore.Calls[0].MethodName)
+		assert.Equal(t, "GetManagerProperties", provStore.Calls[1].MethodName)
 	})
 
 	t.Run("propagates provenance store error for grafana route", func(t *testing.T) {
@@ -184,7 +186,7 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		_, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
+		_, _, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.ErrorIs(t, err, expectedErr)
 	})
 
@@ -200,10 +202,10 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		singleRoute, err := sut.GetManagedRoute(context.Background(), orgID, "imported", user)
+		singleRoute, _, err := sut.GetManagedRoute(context.Background(), orgID, "imported", user)
 		require.NoError(t, err)
 
-		allRoutes, err := sut.GetManagedRoutes(context.Background(), orgID, user)
+		allRoutes, _, err := sut.GetManagedRoutes(context.Background(), orgID, user)
 		require.NoError(t, err)
 
 		var listRoute *legacy_storage.ManagedRoute
@@ -232,7 +234,7 @@ func TestGetManagedRoute(t *testing.T) {
 
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		_, err := sut.GetManagedRoute(context.Background(), orgID, "does-not-exist", user)
+		_, _, err := sut.GetManagedRoute(context.Background(), orgID, "does-not-exist", user)
 		require.ErrorIs(t, err, models.ErrRouteNotFound)
 	})
 
@@ -242,7 +244,7 @@ func TestGetManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
+		_, _, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 }
@@ -262,7 +264,7 @@ func TestGetManagedRoutes(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
+		_, _, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 
@@ -291,7 +293,7 @@ func TestGetManagedRoutes(t *testing.T) {
 			},
 		})
 
-		routes, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
+		routes, _, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
 		require.NoError(t, err)
 
 		names := make([]string, 0, len(routes))
@@ -316,7 +318,7 @@ func TestGetManagedRoutes(t *testing.T) {
 			},
 		})
 
-		routes, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
+		routes, _, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
 		require.NoError(t, err)
 		assert.Empty(t, routes)
 	})
@@ -332,7 +334,7 @@ func TestGetManagedRoutes(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		routes, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
+		routes, _, err := sut.GetManagedRoutes(context.Background(), orgID, usr)
 		require.NoError(t, err)
 		// user-defined + route-a + route-b
 		assert.Len(t, routes, 3)
@@ -349,7 +351,7 @@ func TestCreateManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.CreateManagedRoute(context.Background(), orgID, "new-route", v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, user)
+		_, err := sut.CreateManagedRoute(context.Background(), orgID, "new-route", v1.Route{Receiver: "grafana-default"}, utils.ManagerProperties{}, user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 	t.Run("sets default permissions when create", func(t *testing.T) {
@@ -370,7 +372,7 @@ func TestCreateManagedRoute(t *testing.T) {
 		}
 		sut := createServiceSut(configStore, provStore, features, authz)
 
-		_, err := sut.CreateManagedRoute(context.Background(), orgID, "new-route", v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, user)
+		_, err := sut.CreateManagedRoute(context.Background(), orgID, "new-route", v1.Route{Receiver: "grafana-default"}, utils.ManagerProperties{}, user)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"AuthorizeCreate", "SetDefaultPermissions"}, authz.Calls.Methods())
 	})
@@ -386,7 +388,7 @@ func TestUpdateManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		_, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, "v1", user)
+		_, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, v1.Route{Receiver: "grafana-default"}, utils.ManagerProperties{}, "v1", user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 }
@@ -401,7 +403,7 @@ func TestDeleteManagedRoute(t *testing.T) {
 		features := featuremgmt.WithFeatures()
 		sut := createServiceSut(configStore, provStore, features, acfakes.NewDenyAllRouteAccessService[*legacy_storage.ManagedRoute]())
 
-		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, models.ProvenanceNone, "v1", user)
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, utils.ManagerProperties{}, "v1", user)
 		require.ErrorIs(t, err, ac.ErrAuthorizationBase)
 	})
 
@@ -423,7 +425,7 @@ func TestDeleteManagedRoute(t *testing.T) {
 		}
 		sut := createServiceSut(configStore, provStore, features, authz)
 
-		err := sut.DeleteManagedRoute(context.Background(), orgID, "route-a", models.ProvenanceNone, "", user)
+		err := sut.DeleteManagedRoute(context.Background(), orgID, "route-a", utils.ManagerProperties{}, "", user)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"AuthorizeDeleteByUID", "DeleteAllPermissions"}, authz.Calls.Methods())
 	})
@@ -440,7 +442,7 @@ func TestDeleteManagedRoute(t *testing.T) {
 		authz := &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{}
 		sut := createServiceSut(configStore, provStore, features, authz)
 
-		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, models.ProvenanceNone, "", user)
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeName, utils.ManagerProperties{}, "", user)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"AuthorizeDeleteByUID"}, authz.Calls.Methods())
 	})
@@ -466,7 +468,7 @@ func TestManagedRouteCRUD_DefaultTreeAlias(t *testing.T) {
 		rev := configRevisionWithManagedRoutes()
 		sut := newSut(rev, featuremgmt.WithFeatures(), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		route, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
+		route, _, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
 		require.NoError(t, err)
 		// The response echoes the requested alias, but the route resolves to the root route...
 		assert.Equal(t, models.DefaultRoutingTreeNameAlias, route.Name)
@@ -480,10 +482,10 @@ func TestManagedRouteCRUD_DefaultTreeAlias(t *testing.T) {
 		sut := newSut(rev, featuremgmt.WithFeatures(), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
 		// Fetch the current version so the optimistic concurrency check passes.
-		current, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
+		current, _, err := sut.GetManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, user)
 		require.NoError(t, err)
 
-		updated, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "empty"}, models.ProvenanceNone, current.Version, user)
+		updated, err := sut.UpdateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "empty"}, utils.ManagerProperties{}, current.Version, user)
 		require.NoError(t, err)
 		assert.Equal(t, models.DefaultRoutingTreeNameAlias, updated.Name)
 		assert.Equal(t, models.DefaultRoutingTreeName, updated.GetUID())
@@ -497,7 +499,7 @@ func TestManagedRouteCRUD_DefaultTreeAlias(t *testing.T) {
 		authz := &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{}
 		sut := newSut(rev, featuremgmt.WithFeatures(), authz)
 
-		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, models.ProvenanceNone, "", user)
+		err := sut.DeleteManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, utils.ManagerProperties{}, "", user)
 		require.NoError(t, err)
 		// Same as deleting by the emitted name: it resets (not deletes) and keeps the route's permissions.
 		assert.Equal(t, []string{"AuthorizeDeleteByUID"}, authz.Calls.Methods())
@@ -507,7 +509,7 @@ func TestManagedRouteCRUD_DefaultTreeAlias(t *testing.T) {
 		rev := configRevisionWithManagedRoutes()
 		sut := newSut(rev, featuremgmt.WithFeatures(), &acfakes.FakeRouteAccessService[*legacy_storage.ManagedRoute]{})
 
-		_, err := sut.CreateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "grafana-default"}, models.ProvenanceNone, user)
+		_, err := sut.CreateManagedRoute(context.Background(), orgID, models.DefaultRoutingTreeNameAlias, v1.Route{Receiver: "grafana-default"}, utils.ManagerProperties{}, user)
 		require.ErrorIs(t, err, models.ErrRouteExists)
 		assert.NotContains(t, rev.Config.ManagedRoutes, models.DefaultRoutingTreeNameAlias)
 	})

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -25,6 +25,7 @@ import (
 	alertingNotify "github.com/grafana/alerting/notify"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -702,7 +703,7 @@ type FakeReceiverService struct {
 	Calls struct {
 		GetReceiver []GetReceiverCall
 	}
-	GetReceiverFunc func(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, error)
+	GetReceiverFunc func(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, utils.ManagerProperties, error)
 }
 
 type FakeEmailValidator struct {
@@ -743,7 +744,7 @@ type GetReceiverCall struct {
 	User    identity.Requester
 }
 
-func (f *FakeReceiverService) GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, error) {
+func (f *FakeReceiverService) GetReceiver(ctx context.Context, uid string, decrypt bool, user identity.Requester) (*models.Receiver, utils.ManagerProperties, error) {
 	f.Calls.GetReceiver = append(f.Calls.GetReceiver, GetReceiverCall{
 		Ctx:     ctx,
 		UID:     uid,
@@ -753,5 +754,5 @@ func (f *FakeReceiverService) GetReceiver(ctx context.Context, uid string, decry
 	if f.GetReceiverFunc != nil {
 		return f.GetReceiverFunc(ctx, uid, decrypt, user)
 	}
-	return nil, models.ErrReceiverNotFound.Errorf("")
+	return nil, utils.ManagerProperties{}, models.ErrReceiverNotFound.Errorf("")
 }

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -64,7 +65,7 @@ type ContactPointService struct {
 }
 
 type receiverService interface {
-	GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error)
+	GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, map[string]utils.ManagerProperties, error)
 	RenameReceiverInDependentResources(ctx context.Context, orgID int64, route *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error
 	ReceiverNameUsedByRoutes(ctx context.Context, rev *legacy_storage.ConfigRevision, name string) bool
 }
@@ -115,7 +116,7 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 		receiverQuery.Names = []string{q.Name}
 	}
 
-	res, err := ecp.receiverService.GetReceivers(ctx, receiverQuery, u)
+	res, _, err := ecp.receiverService.GetReceivers(ctx, receiverQuery, u)
 	if err != nil {
 		// New orgs have no Alertmanager config yet. Listing contact points is a
 		// valid empty state (GET-before-POST reconcilers depend on this).

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -14,6 +13,16 @@ import (
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 )
+
+// effectiveManager returns manager when it carries a rich kind; otherwise it derives a manager
+// from the resource's own (legacy) provenance, so callers that only set Provenance directly
+// (without knowing about ManagerProperties) still persist a consistent manager_kind.
+func effectiveManager(provenance models.Provenance, manager utils.ManagerProperties) utils.ManagerProperties {
+	if manager.Kind != utils.ManagerKindUnknown {
+		return manager
+	}
+	return models.ProvenanceToManagerProperties(provenance)
+}
 
 type MuteTimingService struct {
 	configStore            alertmanagerConfigStore
@@ -177,7 +186,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeIn
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetManagerProperties(ctx, &created, orgID, manager)
+		return svc.provenanceStore.SetManagerProperties(ctx, &created, orgID, effectiveManager(created.Provenance, manager))
 	})
 	if err != nil {
 		return v1.TimeInterval{}, err
@@ -234,20 +243,6 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeIn
 		return v1.TimeInterval{}, err
 	}
 
-	storedManager, err := svc.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
-	if err != nil {
-		return v1.TimeInterval{}, err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return v1.TimeInterval{}, errProvenanceMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "update",
-			},
-		})
-	}
-
 	// check optimistic concurrency
 	if err = svc.checkOptimisticConcurrency(existing, mt.Provenance, mt.Version, "update"); err != nil {
 		return v1.TimeInterval{}, err
@@ -274,7 +269,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeIn
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetManagerProperties(ctx, &updated, orgID, manager)
+		return svc.provenanceStore.SetManagerProperties(ctx, &updated, orgID, effectiveManager(updated.Provenance, manager))
 	})
 	if err != nil {
 		return v1.TimeInterval{}, err
@@ -311,20 +306,6 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 	provenance := models.ManagerPropertiesToProvenance(manager)
 	if err := svc.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
-	}
-
-	storedManager, err := svc.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
-	if err != nil {
-		return err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return errProvenanceMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "delete",
-			},
-		})
 	}
 
 	if revision.TimeIntervalUsedByRoutes(existing.Title) {

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
@@ -62,22 +64,28 @@ func (svc *MuteTimingService) WithIncludeImported() *MuteTimingService {
 	}
 }
 
-// GetMuteTimings returns a slice of all mute timings within the specified org.
-func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, error) {
+// GetMuteTimings returns a slice of all mute timings within the specified org, along with their
+// ManagerProperties keyed by resource UID.
+func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]v1.TimeInterval, map[string]utils.ManagerProperties, error) {
 	rev, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := svc.assignTimeIntervalProvenance(ctx, orgID, rev); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	grafanaIntervals := rev.Config.TimeIntervals
 	importedIntervals := svc.getImportedTimeIntervals(rev)
 
 	if len(grafanaIntervals)+len(importedIntervals) == 0 {
-		return []v1.TimeInterval{}, nil
+		return []v1.TimeInterval{}, map[string]utils.ManagerProperties{}, nil
+	}
+
+	managerProps, err := svc.provenanceStore.GetAllManagerProperties(ctx, orgID, (&v1.TimeInterval{}).ResourceType())
+	if err != nil {
+		return nil, nil, err
 	}
 
 	result := make([]v1.TimeInterval, 0, len(grafanaIntervals)+len(importedIntervals))
@@ -91,49 +99,63 @@ func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) (
 		return strings.Compare(a.Title, b.Title)
 	})
 
-	return result, nil
+	return result, managerProps, nil
 }
 
-// GetMuteTimingByUID returns a mute timing by UID
-func (svc *MuteTimingService) GetMuteTimingByUID(ctx context.Context, uid v1.ResourceUID, orgID int64) (v1.TimeInterval, error) {
+// GetMuteTimingByUID returns a mute timing by UID, along with its ManagerProperties.
+func (svc *MuteTimingService) GetMuteTimingByUID(ctx context.Context, uid v1.ResourceUID, orgID int64) (v1.TimeInterval, utils.ManagerProperties, error) {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return v1.TimeInterval{}, err
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
 	}
 
 	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
-		return v1.TimeInterval{}, err
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
 	}
 
-	if result, found := svc.getMuteTimingByUID(revision, uid); found {
-		return result, nil
+	result, found := svc.getMuteTimingByUID(revision, uid)
+	if !found {
+		return v1.TimeInterval{}, utils.ManagerProperties{}, ErrTimeIntervalNotFound.Errorf("")
 	}
-
-	return v1.TimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	managerProps, err := svc.provenanceStore.GetManagerProperties(ctx, &result, orgID)
+	if err != nil {
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
+	}
+	return result, managerProps, nil
 }
 
-// GetMuteTimingByName returns a mute timing by name.
-func (svc *MuteTimingService) GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, error) {
+// GetMuteTimingByName returns a mute timing by name, along with its ManagerProperties.
+func (svc *MuteTimingService) GetMuteTimingByName(ctx context.Context, name string, orgID int64) (v1.TimeInterval, utils.ManagerProperties, error) {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
-		return v1.TimeInterval{}, err
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
 	}
 
 	if err := svc.assignTimeIntervalProvenance(ctx, orgID, revision); err != nil {
-		return v1.TimeInterval{}, err
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
 	}
 
-	if mti, found := revision.GetTimeIntervalWithTitle(name); found {
-		return mti, nil
+	mti, found := revision.GetTimeIntervalWithTitle(name)
+	if !found {
+		return v1.TimeInterval{}, utils.ManagerProperties{}, ErrTimeIntervalNotFound.Errorf("")
 	}
-
-	return v1.TimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
+	managerProps, err := svc.provenanceStore.GetManagerProperties(ctx, &mti, orgID)
+	if err != nil {
+		return v1.TimeInterval{}, utils.ManagerProperties{}, err
+	}
+	return mti, managerProps, nil
 }
 
 // CreateMuteTiming adds a new mute timing within the specified org. The created mute timing is returned.
-func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error) {
+func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error) {
 	if err := mt.Validate(); err != nil {
 		return v1.TimeInterval{}, MakeErrTimeIntervalInvalid(err)
+	}
+
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		mt.Provenance = models.ManagerPropertiesToProvenance(manager)
 	}
 
 	if err := svc.validator(ctx, models.ProvenanceNone, mt.Provenance); err != nil {
@@ -155,7 +177,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeIn
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetProvenance(ctx, &created, orgID, created.Provenance)
+		return svc.provenanceStore.SetManagerProperties(ctx, &created, orgID, manager)
 	})
 	if err != nil {
 		return v1.TimeInterval{}, err
@@ -165,9 +187,15 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt v1.TimeIn
 }
 
 // UpdateMuteTiming replaces an existing mute timing within the specified org. The replaced mute timing is returned. If the mute timing does not exist, ErrMuteTimingsNotFound is returned.
-func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64) (v1.TimeInterval, error) {
+func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeInterval, orgID int64, manager utils.ManagerProperties) (v1.TimeInterval, error) {
 	if err := mt.Validate(); err != nil {
 		return v1.TimeInterval{}, MakeErrTimeIntervalInvalid(err)
+	}
+
+	// When a rich manager is provided, derive the effective provenance from it so the validation,
+	// persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		mt.Provenance = models.ManagerPropertiesToProvenance(manager)
 	}
 
 	revision, err := svc.configStore.Get(ctx, orgID)
@@ -206,6 +234,20 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeIn
 		return v1.TimeInterval{}, err
 	}
 
+	storedManager, err := svc.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
+	if err != nil {
+		return v1.TimeInterval{}, err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return v1.TimeInterval{}, errProvenanceMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "update",
+			},
+		})
+	}
+
 	// check optimistic concurrency
 	if err = svc.checkOptimisticConcurrency(existing, mt.Provenance, mt.Version, "update"); err != nil {
 		return v1.TimeInterval{}, err
@@ -232,7 +274,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeIn
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return svc.provenanceStore.SetProvenance(ctx, &updated, orgID, updated.Provenance)
+		return svc.provenanceStore.SetManagerProperties(ctx, &updated, orgID, manager)
 	})
 	if err != nil {
 		return v1.TimeInterval{}, err
@@ -242,7 +284,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt v1.TimeIn
 }
 
 // DeleteMuteTiming deletes the mute timing with the given name in the given org. If the mute timing does not exist, no error is returned.
-func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID string, orgID int64, provenance models.Provenance, version string) error {
+func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID string, orgID int64, manager utils.ManagerProperties, version string) error {
 	revision, err := svc.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
@@ -266,8 +308,23 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, nameOrUID st
 		return makeErrMuteTimeIntervalOrigin(existing, "delete")
 	}
 
+	provenance := models.ManagerPropertiesToProvenance(manager)
 	if err := svc.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
+	}
+
+	storedManager, err := svc.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
+	if err != nil {
+		return err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return errProvenanceMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "delete",
+			},
+		})
 	}
 
 	if revision.TimeIntervalUsedByRoutes(existing.Title) {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -451,7 +451,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		require.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID("TEST2"))
 		require.Len(t, revision.Config.TimeIntervals, 3)
 
-		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, &result, orgID, utils.ManagerProperties{})
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, &result, orgID, models.ProvenanceToManagerProperties(expectedProvenance))
 	})
 
 	t.Run("propagates errors", func(t *testing.T) {
@@ -704,7 +704,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, expected.Title, stored.Title)
 		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, utils.ManagerProperties{})
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, models.ProvenanceToManagerProperties(expectedProvenance))
 
 		t.Run("bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
@@ -793,7 +793,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, expected.Title, stored.Title)
 		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, utils.ManagerProperties{})
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, models.ProvenanceToManagerProperties(expectedProvenance))
 	})
 
 	t.Run("renames interval and all its dependencies", func(t *testing.T) {
@@ -855,7 +855,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
 			return m.Title == interval.Title
-		}), orgID, utils.ManagerProperties{})
+		}), orgID, models.ProvenanceToManagerProperties(expectedProvenance))
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
 			return m.Title == original.Title
 		}), orgID)

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
@@ -44,7 +45,7 @@ func TestGetMuteTimings(t *testing.T) {
 
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
 
-		result, err := sut.GetMuteTimings(context.Background(), 1)
+		result, _, err := sut.GetMuteTimings(context.Background(), 1)
 
 		require.NoError(t, err)
 		require.Len(t, result, len(revision.Config.TimeIntervals))
@@ -76,7 +77,7 @@ func TestGetMuteTimings(t *testing.T) {
 			return &legacy_storage.ConfigRevision{Config: &v1.AMConfigV1{}}, nil
 		}
 
-		result, err := sut.GetMuteTimings(context.Background(), 1)
+		result, _, err := sut.GetMuteTimings(context.Background(), 1)
 
 		require.NoError(t, err)
 		require.Empty(t, result)
@@ -90,7 +91,7 @@ func TestGetMuteTimings(t *testing.T) {
 				return nil, expected
 			}
 
-			_, err := sut.GetMuteTimings(context.Background(), orgID)
+			_, _, err := sut.GetMuteTimings(context.Background(), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -103,7 +104,7 @@ func TestGetMuteTimings(t *testing.T) {
 			expected := fmt.Errorf("failed")
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expected)
 
-			_, err := sut.GetMuteTimings(context.Background(), orgID)
+			_, _, err := sut.GetMuteTimings(context.Background(), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -129,7 +130,7 @@ func TestGetMuteTimings(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
 
-			result, err := sut.GetMuteTimings(context.Background(), orgID)
+			result, _, err := sut.GetMuteTimings(context.Background(), orgID)
 
 			require.NoError(t, err)
 			require.Len(t, result, 1)
@@ -146,7 +147,7 @@ func TestGetMuteTimings(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
 
-			result, err := sut.GetMuteTimings(context.Background(), orgID)
+			result, _, err := sut.GetMuteTimings(context.Background(), orgID)
 
 			require.NoError(t, err)
 			require.Len(t, result, 2)
@@ -187,7 +188,7 @@ func TestGetMuteTimings(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(provenances, nil)
 
-			result, err := sut.GetMuteTimings(context.Background(), orgID)
+			result, _, err := sut.GetMuteTimings(context.Background(), orgID)
 
 			require.NoError(t, err)
 			require.Len(t, result, 1)
@@ -214,7 +215,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{"Test1": models.ProvenanceAPI}, nil)
 
-		result, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
+		result, _, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
 
 		require.NoError(t, err)
 
@@ -236,7 +237,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-			_, err := sut.GetMuteTimingByName(context.Background(), "Test123", orgID)
+			_, _, err := sut.GetMuteTimingByName(context.Background(), "Test123", orgID)
 
 			require.Truef(t, ErrTimeIntervalNotFound.Is(err), "expected ErrTimeIntervalNotFound but got %s", err)
 		})
@@ -249,7 +250,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 					return nil, expected
 				}
 
-				_, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
+				_, _, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
 
 				require.ErrorIs(t, err, expected)
 			})
@@ -262,7 +263,7 @@ func TestGetMuteTimingByName(t *testing.T) {
 				expected := fmt.Errorf("failed")
 				prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expected)
 
-				_, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
+				_, _, err := sut.GetMuteTimingByName(context.Background(), "Test1", orgID)
 
 				require.ErrorIs(t, err, expected)
 			})
@@ -287,7 +288,7 @@ func TestGetMuteTimingByUID(t *testing.T) {
 			return revision, nil
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{"Test1": models.ProvenanceAPI}, nil)
-		result, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
+		result, _, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 		require.NoError(t, err)
 
@@ -302,7 +303,7 @@ func TestGetMuteTimingByUID(t *testing.T) {
 			return &legacy_storage.ConfigRevision{Config: &v1.AMConfigV1{}}, nil
 		}
 
-		_, err := sut.GetMuteTimingByUID(context.Background(), "Test1", orgID)
+		_, _, err := sut.GetMuteTimingByUID(context.Background(), "Test1", orgID)
 
 		require.Truef(t, ErrTimeIntervalNotFound.Is(err), "expected ErrTimeIntervalNotFound but got %s", err)
 	})
@@ -315,7 +316,7 @@ func TestGetMuteTimingByUID(t *testing.T) {
 				return nil, expected
 			}
 
-			_, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
+			_, _, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -328,7 +329,7 @@ func TestGetMuteTimingByUID(t *testing.T) {
 			expected := fmt.Errorf("failed")
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expected)
 
-			_, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
+			_, _, err := sut.GetMuteTimingByUID(context.Background(), v1.TimeIntervalUID("Test1"), orgID)
 
 			require.ErrorIs(t, err, expected)
 		})
@@ -381,7 +382,7 @@ func TestCreateMuteTimings(t *testing.T) {
 			Title:            "",
 		}
 
-		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.Truef(t, ErrTimeIntervalInvalid.Base.Is(err), "expected ErrTimeIntervalInvalid but got %s", err)
 	})
@@ -396,7 +397,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		existing.Provenance = models.ProvenanceFile
 		timing := existing
 
-		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.Truef(t, ErrTimeIntervalExists.Is(err), "expected ErrTimeIntervalExists but got %s", err)
 
@@ -404,7 +405,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		existing.Provenance = models.ProvenanceFile
 		timing = existing
 
-		_, err = sut.CreateMuteTiming(context.Background(), timing, orgID)
+		_, err = sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.Truef(t, ErrTimeIntervalExists.Is(err), "expected ErrTimeIntervalExists but got %s", err)
 	})
@@ -418,13 +419,13 @@ func TestCreateMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, _ models.Provisionable, _ int64, _ utils.ManagerProperties) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		result, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+		result, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.NoError(t, err)
 
 		require.EqualValues(t, expected.Title, result.Title)
@@ -450,7 +451,7 @@ func TestCreateMuteTimings(t *testing.T) {
 		require.Contains(t, revision.Config.TimeIntervals, v1.TimeIntervalUID("TEST2"))
 		require.Len(t, revision.Config.TimeIntervals, 3)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, &result, orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, &result, orgID, utils.ManagerProperties{})
 	})
 
 	t.Run("propagates errors", func(t *testing.T) {
@@ -460,7 +461,7 @@ func TestCreateMuteTimings(t *testing.T) {
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return nil, expectedErr
 			}
-			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 
@@ -471,10 +472,10 @@ func TestCreateMuteTimings(t *testing.T) {
 			}
 			expectedErr := fmt.Errorf("failed to save provenance")
 			sut.provenanceStore.(*MockProvisioningStore).EXPECT().
-				SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(expectedErr)
 
-			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -495,7 +496,7 @@ func TestCreateMuteTimings(t *testing.T) {
 				return expectedErr
 			}
 
-			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.CreateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -567,7 +568,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			Title:            "",
 		}
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.Truef(t, ErrTimeIntervalInvalid.Base.Is(err), "expected ErrTimeIntervalInvalid but got %s", err)
 	})
@@ -586,7 +587,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, expectedErr)
 	})
@@ -615,7 +616,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.ErrorIs(t, err, ErrTimeIntervalExists)
 	})
 
@@ -631,7 +632,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrVersionConflict)
 	})
@@ -648,7 +649,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			timing.UID = "not-found"
 			timing.Provenance = expectedProvenance
 
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, ErrTimeIntervalNotFound)
 		})
@@ -659,7 +660,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				Title:            "not-found",
 			}
 
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, ErrTimeIntervalNotFound)
 		})
@@ -675,13 +676,13 @@ func TestUpdateMuteTimings(t *testing.T) {
 			return nil
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, _ models.Provisionable, _ int64, _ utils.ManagerProperties) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
 
-		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.NoError(t, err)
 
 		require.EqualValues(t, expected.Title, result.Title)
@@ -703,7 +704,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, expected.Title, stored.Title)
 		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, utils.ManagerProperties{})
 
 		t.Run("bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
@@ -723,7 +724,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			}
 			expectedVersion := v1.TimeIntervalFingerprint(timing)
 
-			result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 			require.NoError(t, err)
 
 			require.EqualValues(t, timing.Title, result.Title)
@@ -754,8 +755,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 		original := initialConfig().TimeIntervals[v1.TimeIntervalUID("Test2")]
 
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{original.Title: expectedProvenance}, nil)
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, _ models.Provisionable, _ int64, _ utils.ManagerProperties) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
@@ -770,7 +771,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		timing.Version = v1.TimeIntervalFingerprint(original)
 		expectedVersion := v1.TimeIntervalFingerprint(expected)
 
-		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.NoError(t, err)
 
 		require.EqualValues(t, expected.Title, result.Title)
@@ -792,7 +793,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 		require.Equal(t, expected.Title, stored.Title)
 		require.EqualValues(t, expected.TimeIntervals, stored.TimeIntervals)
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, expectedProvenance)
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool { return m.Title == timing.Title }), orgID, utils.ManagerProperties{})
 	})
 
 	t.Run("renames interval and all its dependencies", func(t *testing.T) {
@@ -811,8 +812,8 @@ func TestUpdateMuteTimings(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		})
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-			func(ctx context.Context, _ models.Provisionable, _ int64, _ models.Provenance) error {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+			func(ctx context.Context, _ models.Provisionable, _ int64, _ utils.ManagerProperties) error {
 				assertInTransaction(t, ctx)
 				return nil
 			})
@@ -833,7 +834,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			TimeIntervals:    interval.TimeIntervals,
 		}
 
-		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		result, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.NoError(t, err)
 
 		require.EqualValues(t, interval.Title, result.Title)
@@ -852,9 +853,9 @@ func TestUpdateMuteTimings(t *testing.T) {
 		assert.NotNil(t, ruleStore.Calls[0].Args[4])
 		assert.False(t, ruleStore.Calls[0].Args[5].(bool))
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
 			return m.Title == interval.Title
-		}), orgID, expectedProvenance)
+		}), orgID, utils.ManagerProperties{})
 		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(m *v1.TimeInterval) bool {
 			return m.Title == original.Title
 		}), orgID)
@@ -903,7 +904,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			TimeIntervals:    interval.TimeIntervals,
 		}
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.ErrorIs(t, err, ErrTimeIntervalDependentResourcesProvenance)
 
 		require.Len(t, ruleStore.Calls, 1)
@@ -940,7 +941,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			TimeIntervals:    interval.TimeIntervals,
 		}
 
-		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+		_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 		require.ErrorIs(t, err, ErrTimeIntervalDependentResourcesProvenance)
 
 		require.Len(t, ruleStore.Calls, 1)
@@ -960,7 +961,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return nil, expectedErr
 			}
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 
@@ -974,10 +975,10 @@ func TestUpdateMuteTimings(t *testing.T) {
 				GetProvenances(mock.Anything, mock.Anything, mock.Anything).
 				Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 			sut.provenanceStore.(*MockProvisioningStore).EXPECT().
-				SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(expectedErr)
 
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1001,7 +1002,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				return expectedErr
 			}
 
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1020,7 +1021,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{expected.Title: expectedProvenance}, nil)
 			prov.EXPECT().GetProvenance(mock.Anything, mock.MatchedBy(func(*v1.Route) bool { return true }), mock.Anything).Return(expectedProvenance, nil).Maybe()
 			prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			expectedErr := errors.New("test-err")
 
 			ruleStore := &fakeAlertRuleNotificationStore{
@@ -1038,7 +1039,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 				TimeIntervals:    interval.TimeIntervals,
 			}
 
-			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID)
+			_, err := sut.UpdateMuteTiming(context.Background(), timing, orgID, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 	})
@@ -1097,7 +1098,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceNone, correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceToManagerProperties(models.ProvenanceNone), correctVersion)
 		require.ErrorIs(t, err, expectedErr)
 	})
 
@@ -1108,7 +1109,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), usedMuteTiming, orgID, models.ProvenanceAPI, correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), usedMuteTiming, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1123,7 +1124,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), usedActiveTiming, orgID, models.ProvenanceAPI, correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), usedActiveTiming, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1139,7 +1140,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
 		version := v1.TimeIntervalFingerprint(v1.TimeInterval{Title: managedRouteMuteTiming})
-		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, models.ProvenanceAPI, version)
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteMuteTiming, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1155,7 +1156,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
 		version := v1.TimeIntervalFingerprint(v1.TimeInterval{Title: managedRouteActiveTiming})
-		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, models.ProvenanceAPI, version)
+		err := sut.DeleteMuteTiming(context.Background(), managedRouteActiveTiming, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), version)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1183,7 +1184,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceAPI, correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), correctVersion)
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1204,7 +1205,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(map[string]models.Provenance{}, nil)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceAPI, "test-version")
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, models.ProvenanceToManagerProperties(models.ProvenanceAPI), "test-version")
 
 		require.Len(t, store.Calls, 1)
 		require.Equal(t, "Get", store.Calls[0].Method)
@@ -1228,7 +1229,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 				return nil
 			})
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, correctVersion)
 		require.NoError(t, err)
 
 		require.Len(t, store.Calls, 2)
@@ -1247,7 +1248,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 
 		t.Run("should bypass optimistic concurrency check if version is empty", func(t *testing.T) {
 			store.Calls = nil
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, "")
 			require.NoError(t, err)
 
 			require.Equal(t, "Save", store.Calls[1].Method)
@@ -1279,7 +1280,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 		timingToDelete := initialConfig().TimeIntervals[v1.TimeIntervalUID("timing-to-delete2")]
 		correctVersion := v1.TimeIntervalFingerprint(timingToDelete)
 
-		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, correctVersion)
 		require.NoError(t, err)
 
 		require.Len(t, store.Calls, 2)
@@ -1316,7 +1317,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 
 		uid := string(v1.TimeIntervalUID(timingToDelete.Title))
 
-		err := sut.DeleteMuteTiming(context.Background(), uid, orgID, "", correctVersion)
+		err := sut.DeleteMuteTiming(context.Background(), uid, orgID, utils.ManagerProperties{}, correctVersion)
 		require.NoError(t, err)
 
 		require.Len(t, store.Calls, 2)
@@ -1340,7 +1341,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return nil, expectedErr
 			}
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, "")
 			require.ErrorIs(t, err, expectedErr)
 		})
 
@@ -1355,7 +1356,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 				DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).
 				Return(expectedErr)
 
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, "")
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1377,7 +1378,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 				return expectedErr
 			}
 
-			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, "", "")
+			err := sut.DeleteMuteTiming(context.Background(), timingToDelete.Title, orgID, utils.ManagerProperties{}, "")
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1393,6 +1394,11 @@ func TestDeleteMuteTimings(t *testing.T) {
 func createMuteTimingSvcSut() (*MuteTimingService, *legacy_storage.AlertmanagerConfigStoreFake, *MockProvisioningStore) {
 	store := &legacy_storage.AlertmanagerConfigStoreFake{}
 	prov := &MockProvisioningStore{}
+	// Permissive defaults for ManagerProperties: an unknown stored manager never blocks a
+	// transition (see validation.CanUpdateManagerInRuleGroup), so tests that only care about
+	// provenance behavior don't need to stub these explicitly.
+	prov.EXPECT().GetAllManagerProperties(mock.Anything, mock.Anything, mock.Anything).Return(map[string]utils.ManagerProperties{}, nil).Maybe()
+	prov.EXPECT().GetManagerProperties(mock.Anything, mock.Anything, mock.Anything).Return(utils.ManagerProperties{}, nil).Maybe()
 	return &MuteTimingService{
 		configStore:     store,
 		provenanceStore: prov,

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -16,7 +17,7 @@ import (
 )
 
 type managedRoutesService interface {
-	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error)
+	GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, utils.ManagerProperties, error)
 }
 
 type NotificationPolicyService struct {
@@ -167,5 +168,6 @@ func (nps *NotificationPolicyService) checkOptimisticConcurrency(current v1.Rout
 // GetManagedRoute returns managed route by name.
 func (nps *NotificationPolicyService) GetManagedRoute(ctx context.Context, orgID int64, name string, user identity.Requester) (legacy_storage.ManagedRoute, error) {
 	// This is a workaround for exporting managed routes to include provisioning permissions to access authorization.
-	return nps.routeService.GetManagedRoute(ctx, orgID, name, user)
+	route, _, err := nps.routeService.GetManagedRoute(ctx, orgID, name, user)
+	return route, err
 }

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"slices"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
@@ -61,10 +63,12 @@ func (t *TemplateService) WithLimitsProvider(limits LimitsProvider) *TemplateSer
 	}
 }
 
-func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error) {
+// GetTemplates returns all templates for the org along with their ManagerProperties, keyed by
+// resource UID.
+func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, map[string]utils.ManagerProperties, error) {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	allTemplates := revision.Config.Templates
@@ -75,17 +79,21 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.T
 		var mergeErr error
 		allTemplates, _, importedUIDs, mergeErr = notifymerge.MergeTemplates(revision.Config.Templates, extraCfg.TemplateFiles, extraCfg.Identifier)
 		if mergeErr != nil {
-			return nil, mergeErr
+			return nil, nil, mergeErr
 		}
 	}
 
 	if len(allTemplates) == 0 {
-		return nil, nil
+		return nil, map[string]utils.ManagerProperties{}, nil
 	}
 
 	provenances, err := t.provenanceStore.GetProvenances(ctx, orgID, (&v1.TemplateGroup{}).ResourceType())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	managerProps, err := t.provenanceStore.GetAllManagerProperties(ctx, orgID, (&v1.TemplateGroup{}).ResourceType())
+	if err != nil {
+		return nil, nil, err
 	}
 
 	imported := make(map[v1.ResourceUID]struct{}, len(importedUIDs))
@@ -97,6 +105,7 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.T
 	for _, tmpl := range allTemplates {
 		if _, isImported := imported[tmpl.UID]; isImported {
 			tmpl.Provenance = models.ProvenanceConvertedPrometheus
+			managerProps[tmpl.ResourceID()] = models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus)
 		} else {
 			tmpl.Provenance = provenances[tmpl.ResourceID()]
 		}
@@ -109,29 +118,36 @@ func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.T
 			cmp.Compare(a.Kind, b.Kind),
 			cmp.Compare(a.Title, b.Title),
 		)
-	}), nil
+	}), managerProps, nil
 }
 
-func (t *TemplateService) GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error) {
+// GetTemplate returns a template by name or UID, along with its ManagerProperties.
+func (t *TemplateService) GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, utils.ManagerProperties, error) {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return v1.TemplateGroup{}, err
+		return v1.TemplateGroup{}, utils.ManagerProperties{}, err
 	}
 	result, found, err := t.getTemplateByName(ctx, revision, orgID, nameOrUid)
 	if err != nil {
-		return v1.TemplateGroup{}, err
+		return v1.TemplateGroup{}, utils.ManagerProperties{}, err
 	}
-	if found {
-		return result, nil
+	if !found {
+		result, found, err = t.getTemplateByUID(ctx, revision, orgID, nameOrUid)
+		if err != nil {
+			return v1.TemplateGroup{}, utils.ManagerProperties{}, err
+		}
 	}
-	result, found, err = t.getTemplateByUID(ctx, revision, orgID, nameOrUid)
+	if !found {
+		return v1.TemplateGroup{}, utils.ManagerProperties{}, ErrTemplateNotFound.Errorf("")
+	}
+	if result.Provenance == models.ProvenanceConvertedPrometheus {
+		return result, models.ProvenanceToManagerProperties(models.ProvenanceConvertedPrometheus), nil
+	}
+	managerProps, err := t.provenanceStore.GetManagerProperties(ctx, &result, orgID)
 	if err != nil {
-		return v1.TemplateGroup{}, err
+		return v1.TemplateGroup{}, utils.ManagerProperties{}, err
 	}
-	if found {
-		return result, nil
-	}
-	return v1.TemplateGroup{}, ErrTemplateNotFound.Errorf("")
+	return result, managerProps, nil
 }
 
 // UpsertTemplate is used by the legacy provisioning API and matches by Name/Title only as the legacy provisioning API
@@ -156,7 +172,7 @@ func (t *TemplateService) UpsertTemplate(ctx context.Context, orgID int64, tmpl 
 	if found {
 		// Update the existing template.
 		tmpl.UID = existing.UID
-		return t.updateTemplate(ctx, revision, orgID, tmpl)
+		return t.updateTemplate(ctx, revision, orgID, tmpl, utils.ManagerProperties{})
 	}
 
 	// If template was not found, this is assumed to be a create operation except for two cases:
@@ -167,16 +183,21 @@ func (t *TemplateService) UpsertTemplate(ctx context.Context, orgID int64, tmpl 
 		return v1.TemplateGroup{}, ErrTemplateNotFound.Errorf("")
 	}
 
-	return t.createTemplate(ctx, revision, orgID, tmpl)
+	return t.createTemplate(ctx, revision, orgID, tmpl, utils.ManagerProperties{})
 }
 
-func (t *TemplateService) CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+func (t *TemplateService) CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error) {
 	err := tmpl.Validate()
 	if err != nil {
 		return v1.TemplateGroup{}, MakeErrTemplateInvalid(err)
 	}
 	if tmpl.Kind == v1.TemplateKindMimir {
 		return v1.TemplateGroup{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
+	}
+	// When a rich manager is provided, the effective provenance is derived from it so the
+	// validation, persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		tmpl.Provenance = models.ManagerPropertiesToProvenance(manager)
 	}
 	if err := t.validator(ctx, models.ProvenanceNone, tmpl.Provenance); err != nil {
 		return v1.TemplateGroup{}, err
@@ -186,10 +207,10 @@ func (t *TemplateService) CreateTemplate(ctx context.Context, orgID int64, tmpl 
 	if err != nil {
 		return v1.TemplateGroup{}, err
 	}
-	return t.createTemplate(ctx, revision, orgID, tmpl)
+	return t.createTemplate(ctx, revision, orgID, tmpl, manager)
 }
 
-func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error) {
 	if tmpl.Kind == v1.TemplateKindMimir {
 		return v1.TemplateGroup{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
 	}
@@ -212,7 +233,7 @@ func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_s
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetProvenance(ctx, &created, orgID, created.Provenance)
+		return t.provenanceStore.SetManagerProperties(ctx, &created, orgID, manager)
 	})
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -221,7 +242,7 @@ func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_s
 	return created, nil
 }
 
-func (t *TemplateService) UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+func (t *TemplateService) UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error) {
 	err := tmpl.Validate()
 	if err != nil {
 		return v1.TemplateGroup{}, MakeErrTemplateInvalid(err)
@@ -231,10 +252,16 @@ func (t *TemplateService) UpdateTemplate(ctx context.Context, orgID int64, tmpl 
 	if err != nil {
 		return v1.TemplateGroup{}, err
 	}
-	return t.updateTemplate(ctx, revision, orgID, tmpl)
+	return t.updateTemplate(ctx, revision, orgID, tmpl, manager)
 }
 
-func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup, manager utils.ManagerProperties) (v1.TemplateGroup, error) {
+	// When a rich manager is provided, derive the effective provenance from it so the validation,
+	// persisted provenance column and returned object all agree.
+	if manager.Kind != utils.ManagerKindUnknown {
+		tmpl.Provenance = models.ManagerPropertiesToProvenance(manager)
+	}
+
 	if revision.Config.Templates == nil {
 		revision.Config.Templates = make(map[v1.ResourceUID]v1.TemplateGroup)
 	}
@@ -268,6 +295,20 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 		return v1.TemplateGroup{}, err
 	}
 
+	storedManager, err := t.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
+	if err != nil {
+		return v1.TemplateGroup{}, err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return v1.TemplateGroup{}, errProvenanceMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "update",
+			},
+		})
+	}
+
 	err = t.checkOptimisticConcurrency(existing, tmpl.Provenance, tmpl.Version, "update")
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -293,7 +334,7 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetProvenance(ctx, &updated, orgID, updated.Provenance)
+		return t.provenanceStore.SetManagerProperties(ctx, &updated, orgID, manager)
 	})
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -302,7 +343,7 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 	return updated, nil
 }
 
-func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance models.Provenance, version string) error {
+func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, manager utils.ManagerProperties, version string) error {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
@@ -324,6 +365,7 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameO
 		return makeErrTemplateOrigin(existing, "delete")
 	}
 
+	provenance := models.ManagerPropertiesToProvenance(manager)
 	err = t.checkOptimisticConcurrency(existing, provenance, version, "delete")
 	if err != nil {
 		return err
@@ -331,6 +373,20 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameO
 
 	if err = t.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
+	}
+
+	storedManager, err := t.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
+	if err != nil {
+		return err
+	}
+	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
+		return errProvenanceMismatch.Build(errutil.TemplateData{
+			Public: map[string]any{
+				"ProvidedProvenance": manager.Kind,
+				"StoredProvenance":   storedManager.Kind,
+				"Operation":          "delete",
+			},
+		})
 	}
 
 	revision.DeleteTemplate(existing.UID)

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"slices"
 
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -233,7 +232,7 @@ func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_s
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetManagerProperties(ctx, &created, orgID, manager)
+		return t.provenanceStore.SetManagerProperties(ctx, &created, orgID, effectiveManager(created.Provenance, manager))
 	})
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -295,20 +294,6 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 		return v1.TemplateGroup{}, err
 	}
 
-	storedManager, err := t.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
-	if err != nil {
-		return v1.TemplateGroup{}, err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return v1.TemplateGroup{}, errProvenanceMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "update",
-			},
-		})
-	}
-
 	err = t.checkOptimisticConcurrency(existing, tmpl.Provenance, tmpl.Version, "update")
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -334,7 +319,7 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetManagerProperties(ctx, &updated, orgID, manager)
+		return t.provenanceStore.SetManagerProperties(ctx, &updated, orgID, effectiveManager(updated.Provenance, manager))
 	})
 	if err != nil {
 		return v1.TemplateGroup{}, err
@@ -373,20 +358,6 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameO
 
 	if err = t.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
-	}
-
-	storedManager, err := t.provenanceStore.GetManagerProperties(ctx, &existing, orgID)
-	if err != nil {
-		return err
-	}
-	if !validation.CanUpdateManagerInRuleGroup(storedManager, manager) {
-		return errProvenanceMismatch.Build(errutil.TemplateData{
-			Public: map[string]any{
-				"ProvidedProvenance": manager.Kind,
-				"StoredProvenance":   storedManager.Kind,
-				"Operation":          "delete",
-			},
-		})
 	}
 
 	revision.DeleteTemplate(existing.UID)

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
@@ -52,7 +53,7 @@ func TestGetTemplates(t *testing.T) {
 			"template2": models.ProvenanceFile,
 		}, nil)
 
-		result, err := sut.GetTemplates(context.Background(), orgID)
+		result, _, err := sut.GetTemplates(context.Background(), orgID)
 		require.NoError(t, err)
 
 		expected := []v1.TemplateGroup{
@@ -90,7 +91,7 @@ func TestGetTemplates(t *testing.T) {
 			}, nil
 		}
 
-		result, err := sut.GetTemplates(context.Background(), 1)
+		result, _, err := sut.GetTemplates(context.Background(), 1)
 
 		require.NoError(t, err)
 		require.Empty(t, result)
@@ -109,7 +110,7 @@ func TestGetTemplates(t *testing.T) {
 			"template2": models.ProvenanceFile,
 		}, nil)
 
-		result, err := sut.GetTemplates(context.Background(), orgID)
+		result, _, err := sut.GetTemplates(context.Background(), orgID)
 		require.NoError(t, err)
 
 		// Compute the UIDs that MergeTemplates assigns for imported templates so the expected
@@ -174,7 +175,7 @@ func TestGetTemplates(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			_, err := sut.GetTemplates(context.Background(), 1)
+			_, _, err := sut.GetTemplates(context.Background(), 1)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -191,7 +192,7 @@ func TestGetTemplates(t *testing.T) {
 			expectedErr := errors.New("test")
 			prov.EXPECT().GetProvenances(mock.Anything, mock.Anything, mock.Anything).Return(nil, expectedErr)
 
-			_, err := sut.GetTemplates(context.Background(), 1)
+			_, _, err := sut.GetTemplates(context.Background(), 1)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -230,7 +231,7 @@ func TestGetTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
-		result, err := sut.GetTemplate(context.Background(), orgID, templateName)
+		result, _, err := sut.GetTemplate(context.Background(), orgID, templateName)
 		require.NoError(t, err)
 
 		expected := v1.NewTemplateGroup("",
@@ -254,7 +255,7 @@ func TestGetTemplate(t *testing.T) {
 			assert.Equal(t, orgID, org)
 			return revision, nil
 		}
-		_, err := sut.GetTemplate(context.Background(), orgID, importedTemplateName)
+		_, _, err := sut.GetTemplate(context.Background(), orgID, importedTemplateName)
 		require.ErrorIs(t, err, ErrTemplateNotFound)
 	})
 
@@ -266,7 +267,7 @@ func TestGetTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		result, err := sut.GetTemplate(context.Background(), orgID, string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)))
+		result, _, err := sut.GetTemplate(context.Background(), orgID, string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)))
 		require.NoError(t, err)
 
 		expected := v1.NewTemplateGroup("",
@@ -299,11 +300,11 @@ func TestGetTemplate(t *testing.T) {
 		require.NotEmpty(t, uid, "imported template UID should not be empty")
 
 		t.Run("should be not found without flag enabled", func(t *testing.T) {
-			_, err := sut.GetTemplate(context.Background(), orgID, uid)
+			_, _, err := sut.GetTemplate(context.Background(), orgID, uid)
 			require.ErrorIs(t, err, ErrTemplateNotFound)
 		})
 
-		result, err := sut.WithIncludeImported().GetTemplate(context.Background(), orgID, uid)
+		result, _, err := sut.WithIncludeImported().GetTemplate(context.Background(), orgID, uid)
 		require.NoError(t, err)
 
 		expected := v1.NewTemplateGroup(v1.ResourceUID(uid),
@@ -322,7 +323,7 @@ func TestGetTemplate(t *testing.T) {
 			assert.Equal(t, orgID, org)
 			return revision, nil
 		}
-		_, err := sut.GetTemplate(context.Background(), orgID, "not-found")
+		_, _, err := sut.GetTemplate(context.Background(), orgID, "not-found")
 		require.ErrorIs(t, err, ErrTemplateNotFound)
 		prov.AssertExpectations(t)
 	})
@@ -335,7 +336,7 @@ func TestGetTemplate(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			_, err := sut.GetTemplate(context.Background(), 1, templateName)
+			_, _, err := sut.GetTemplate(context.Background(), 1, templateName)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -350,7 +351,7 @@ func TestGetTemplate(t *testing.T) {
 			expectedErr := errors.New("test")
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, expectedErr)
 
-			_, err := sut.GetTemplate(context.Background(), orgID, templateName)
+			_, _, err := sut.GetTemplate(context.Background(), orgID, templateName)
 			require.ErrorIs(t, err, expectedErr)
 
 			prov.AssertExpectations(t)
@@ -388,7 +389,7 @@ func TestUpsertTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
@@ -420,9 +421,9 @@ func TestUpsertTemplate(t *testing.T) {
 		assert.Contains(t, saved.Config.Templates, result.UID)
 		assert.Equal(t, result, saved.Config.Templates[result.UID])
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
 			return t.Title == tmpl.Title
-		}), orgID, models.ProvenanceAPI)
+		}), orgID, utils.ManagerProperties{})
 	})
 
 	t.Run("updates current template", func(t *testing.T) {
@@ -432,7 +433,7 @@ func TestUpsertTemplate(t *testing.T) {
 				return revision(), nil
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 				assertInTransaction(t, ctx)
 			}).Return(nil)
 
@@ -471,7 +472,7 @@ func TestUpsertTemplate(t *testing.T) {
 				return revision(), nil
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 				assertInTransaction(t, ctx)
 			}).Return(nil)
 
@@ -715,7 +716,7 @@ func TestUpsertTemplate(t *testing.T) {
 				return revision(), nil
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 
 			_, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, expectedErr)
@@ -771,11 +772,11 @@ func TestCreateTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 			return nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
-		result, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		result, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 		require.Equal(t, v1.NewTemplateGroup("",
@@ -793,9 +794,9 @@ func TestCreateTemplate(t *testing.T) {
 		assert.Contains(t, saved.Config.Templates, result.UID)
 		assert.Equal(t, result, saved.Config.Templates[result.UID])
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
 			return t.Title == tmpl.Title
-		}), orgID, models.ProvenanceAPI)
+		}), orgID, utils.ManagerProperties{})
 	})
 
 	t.Run("returns ErrTemplateExists if template exists", func(t *testing.T) {
@@ -812,7 +813,7 @@ func TestCreateTemplate(t *testing.T) {
 			}, nil
 		}
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateExists)
 	})
@@ -825,7 +826,7 @@ func TestCreateTemplate(t *testing.T) {
 				Title:   "",
 				Content: "",
 			}
-			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -834,7 +835,7 @@ func TestCreateTemplate(t *testing.T) {
 				Title:   "",
 				Content: "{{ .MyField }",
 			}
-			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -844,7 +845,7 @@ func TestCreateTemplate(t *testing.T) {
 				Content: "{{ define \"test\"}} test {{ end }}",
 				Kind:    "unknown",
 			}
-			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -861,7 +862,7 @@ func TestCreateTemplate(t *testing.T) {
 			Kind:    v1.TemplateKindMimir,
 		}
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 		require.ErrorIs(t, err, ErrTemplateInvalid)
 	})
 
@@ -873,7 +874,7 @@ func TestCreateTemplate(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 
@@ -883,9 +884,9 @@ func TestCreateTemplate(t *testing.T) {
 			store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 				return revision(), nil
 			}
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 
-			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 
 			prov.AssertExpectations(t)
@@ -903,7 +904,7 @@ func TestCreateTemplate(t *testing.T) {
 			prov.EXPECT().SaveSucceeds()
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-			_, err := sut.CreateTemplate(context.Background(), 1, tmpl)
+			_, err := sut.CreateTemplate(context.Background(), 1, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 	})
@@ -944,7 +945,7 @@ func TestUpdateTemplate(t *testing.T) {
 				ConcurrencyToken: amConfigToken,
 			}, nil
 		}
-		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateNotFound)
 
@@ -968,7 +969,7 @@ func TestUpdateTemplate(t *testing.T) {
 		}
 		tmpl := tmpl
 		tmpl.UID = "not-found"
-		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateNotFound)
 
@@ -998,12 +999,12 @@ func TestUpdateTemplate(t *testing.T) {
 					return revision(), nil
 				}
 				prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
-				prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+				prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
 				tmpl.UID = tt.templateUid
-				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 				require.NoError(t, err)
 				assert.Equal(t, v1.NewTemplateGroup("",
@@ -1028,11 +1029,11 @@ func TestUpdateTemplate(t *testing.T) {
 					return revision(), nil
 				}
 				prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
-				prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+				prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
-				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 				require.NoError(t, err)
 				assert.Equal(t, v1.NewTemplateGroup("",
@@ -1060,7 +1061,7 @@ func TestUpdateTemplate(t *testing.T) {
 		prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(ctx context.Context, o models.Provisionable, org int64) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p models.Provenance) {
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(ctx context.Context, o models.Provisionable, org int64, p utils.ManagerProperties) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
@@ -1068,7 +1069,7 @@ func TestUpdateTemplate(t *testing.T) {
 		tmpl := tmpl
 		tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title) // UID matches the current template
 		tmpl.Title = "new-template-name"                 // but name is different
-		result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+		result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 		assert.Equal(t, v1.NewTemplateGroup("",
@@ -1110,7 +1111,7 @@ func TestUpdateTemplate(t *testing.T) {
 		tmpl := tmpl
 		tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title) // UID matches the current template
 		tmpl.Title = "new-template-name"                 // but name matches another existing template
-		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateExists)
 
@@ -1125,7 +1126,7 @@ func TestUpdateTemplate(t *testing.T) {
 				Title:   "",
 				Content: "",
 			}
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -1134,7 +1135,7 @@ func TestUpdateTemplate(t *testing.T) {
 				Title:   "",
 				Content: "{{ .MyField }",
 			}
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -1144,7 +1145,7 @@ func TestUpdateTemplate(t *testing.T) {
 				Content: "",
 				Kind:    "unknown",
 			}
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
@@ -1173,7 +1174,7 @@ func TestUpdateTemplate(t *testing.T) {
 		}
 		template.Provenance = models.ProvenanceNone
 
-		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, template, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, expectedErr)
 	})
@@ -1194,7 +1195,7 @@ func TestUpdateTemplate(t *testing.T) {
 			},
 		}
 
-		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, template, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrVersionConflict)
 		prov.AssertExpectations(t)
@@ -1218,7 +1219,7 @@ func TestUpdateTemplate(t *testing.T) {
 			Kind: v1.TemplateKindMimir,
 		}
 
-		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, template, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateInvalid)
 		prov.AssertExpectations(t)
@@ -1232,7 +1233,7 @@ func TestUpdateTemplate(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 
@@ -1244,7 +1245,7 @@ func TestUpdateTemplate(t *testing.T) {
 			expectedErr := errors.New("test")
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, expectedErr)
 
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1258,9 +1259,9 @@ func TestUpdateTemplate(t *testing.T) {
 				return revision(), nil
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
-			prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
+			prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 
-			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 
 			prov.AssertExpectations(t)
@@ -1278,7 +1279,7 @@ func TestUpdateTemplate(t *testing.T) {
 			prov.EXPECT().SaveSucceeds()
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-			_, err := sut.UpdateTemplate(context.Background(), 1, tmpl)
+			_, err := sut.UpdateTemplate(context.Background(), 1, tmpl, utils.ManagerProperties{})
 			require.ErrorIs(t, err, expectedErr)
 		})
 	})
@@ -1327,7 +1328,7 @@ func TestDeleteTemplate(t *testing.T) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
-				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceFile, templateVersion)
+				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceToManagerProperties(models.ProvenanceFile), templateVersion)
 
 				require.NoError(t, err)
 
@@ -1355,7 +1356,7 @@ func TestDeleteTemplate(t *testing.T) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
-				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceFile, "")
+				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceToManagerProperties(models.ProvenanceFile), "")
 
 				require.NoError(t, err)
 				require.Len(t, store.Calls, 2)
@@ -1395,7 +1396,7 @@ func TestDeleteTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
-		err := sut.DeleteTemplate(context.Background(), orgID, expectedToDelete.Title, models.ProvenanceFile, templateVersion)
+		err := sut.DeleteTemplate(context.Background(), orgID, expectedToDelete.Title, models.ProvenanceToManagerProperties(models.ProvenanceFile), templateVersion)
 
 		require.NoError(t, err)
 
@@ -1420,7 +1421,7 @@ func TestDeleteTemplate(t *testing.T) {
 			return revision(), nil
 		}
 
-		err := sut.DeleteTemplate(context.Background(), orgID, "not-found", models.ProvenanceNone, "")
+		err := sut.DeleteTemplate(context.Background(), orgID, "not-found", models.ProvenanceToManagerProperties(models.ProvenanceNone), "")
 
 		require.NoError(t, err)
 
@@ -1441,7 +1442,7 @@ func TestDeleteTemplate(t *testing.T) {
 			return expectedErr
 		}
 
-		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceNone, "")
+		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), "")
 
 		require.ErrorIs(t, err, expectedErr)
 
@@ -1455,7 +1456,7 @@ func TestDeleteTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
-		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceNone, "bad-version")
+		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), "bad-version")
 
 		require.ErrorIs(t, err, ErrVersionConflict)
 	})
@@ -1468,7 +1469,7 @@ func TestDeleteTemplate(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1483,7 +1484,7 @@ func TestDeleteTemplate(t *testing.T) {
 			expectedErr := errors.New("test")
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, expectedErr)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1499,7 +1500,7 @@ func TestDeleteTemplate(t *testing.T) {
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 			prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1517,7 +1518,7 @@ func TestDeleteTemplate(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceToManagerProperties(models.ProvenanceNone), templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 		})
@@ -1527,6 +1528,11 @@ func TestDeleteTemplate(t *testing.T) {
 func createTemplateServiceSut() (*TemplateService, *legacy_storage.AlertmanagerConfigStoreFake, *MockProvisioningStore) {
 	store := &legacy_storage.AlertmanagerConfigStoreFake{}
 	provStore := &MockProvisioningStore{}
+	// Permissive defaults for ManagerProperties: an unknown stored manager never blocks a
+	// transition (see validation.CanUpdateManagerInRuleGroup), so tests that only care about
+	// provenance behavior don't need to stub these explicitly.
+	provStore.EXPECT().GetAllManagerProperties(mock.Anything, mock.Anything, mock.Anything).Return(map[string]utils.ManagerProperties{}, nil).Maybe()
+	provStore.EXPECT().GetManagerProperties(mock.Anything, mock.Anything, mock.Anything).Return(utils.ManagerProperties{}, nil).Maybe()
 	return &TemplateService{
 		configStore:     store,
 		provenanceStore: provStore,
@@ -1571,7 +1577,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			return revision(5), nil // Already at the limit
 		}
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateLimitExceeded)
 	})
@@ -1593,7 +1599,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		largeTmpl := newTmpl
 		largeTmpl.Content = "{{ define \"test\"}} this is a very long template content {{ end }}"
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, largeTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, largeTmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateSizeExceeded)
 	})
@@ -1611,9 +1617,9 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(5), nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 	})
@@ -1626,9 +1632,9 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(100), nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 	})
@@ -1646,9 +1652,9 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(100), nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 	})
@@ -1661,9 +1667,9 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(100), nil
 		}
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 	})
@@ -1696,7 +1702,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			Content: "{{ define \"test\"}} this is a very long template content that exceeds the limit {{ end }}",
 		}
 
-		_, err := sut.UpdateTemplate(context.Background(), orgID, largeTmpl)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, largeTmpl, utils.ManagerProperties{})
 
 		require.ErrorIs(t, err, ErrTemplateSizeExceeded)
 	})
@@ -1717,7 +1723,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			return revision(99), nil
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
-		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		prov.EXPECT().SetManagerProperties(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		updateTmpl := v1.TemplateGroup{
 			Title:   existingTemplateName,
@@ -1725,7 +1731,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		}
 
 		// Update should succeed because count limit doesn't apply to updates
-		_, err := sut.UpdateTemplate(context.Background(), orgID, updateTmpl)
+		_, err := sut.UpdateTemplate(context.Background(), orgID, updateTmpl, utils.ManagerProperties{})
 
 		require.NoError(t, err)
 	})

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -423,7 +423,7 @@ func TestUpsertTemplate(t *testing.T) {
 
 		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
 			return t.Title == tmpl.Title
-		}), orgID, utils.ManagerProperties{})
+		}), orgID, models.ProvenanceToManagerProperties(tmpl.Provenance))
 	})
 
 	t.Run("updates current template", func(t *testing.T) {
@@ -796,7 +796,7 @@ func TestCreateTemplate(t *testing.T) {
 
 		prov.AssertCalled(t, "SetManagerProperties", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
 			return t.Title == tmpl.Title
-		}), orgID, utils.ManagerProperties{})
+		}), orgID, models.ProvenanceToManagerProperties(tmpl.Provenance))
 	})
 
 	t.Run("returns ErrTemplateExists if template exists", func(t *testing.T) {

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -9,6 +9,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
@@ -234,17 +235,17 @@ func (f *fakeAlertRuleNotificationStore) ListContactPointRoutings(ctx context.Co
 
 type fakeReceiverService struct {
 	Calls                                  []call
-	GetReceiversFunc                       func(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error)
+	GetReceiversFunc                       func(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, map[string]utils.ManagerProperties, error)
 	RenameReceiverInDependentResourcesFunc func(ctx context.Context, orgID int64, revision *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error
 	ReceiverNameUsedByRoutesFunc           func(ctx context.Context, revision *legacy_storage.ConfigRevision, name string) bool
 }
 
-func (f *fakeReceiverService) GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, error) {
+func (f *fakeReceiverService) GetReceivers(ctx context.Context, query models.GetReceiversQuery, user identity.Requester) ([]*models.Receiver, map[string]utils.ManagerProperties, error) {
 	f.Calls = append(f.Calls, call{Method: "GetReceivers", Args: []interface{}{ctx, query, user}})
 	if f.GetReceiversFunc != nil {
 		return f.GetReceiversFunc(ctx, query, user)
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (f *fakeReceiverService) RenameReceiverInDependentResources(ctx context.Context, orgID int64, revision *legacy_storage.ConfigRevision, oldName, newName string, receiverProvenance models.Provenance) error {

--- a/pkg/services/provisioning/alerting/mute_times_provisioner.go
+++ b/pkg/services/provisioning/alerting/mute_times_provisioner.go
@@ -28,11 +28,12 @@ func NewMuteTimesProvisioner(logger log.Logger,
 
 func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 	files []*AlertingFile) error {
+	manager := models.ProvenanceToManagerProperties(models.ProvenanceFile)
 	cache := map[int64]map[string]struct{}{}
 	for _, file := range files {
 		for _, muteTiming := range file.MuteTimes {
 			if _, exists := cache[muteTiming.OrgID]; !exists {
-				intervals, err := c.muteTimingService.GetMuteTimings(ctx, muteTiming.OrgID)
+				intervals, _, err := c.muteTimingService.GetMuteTimings(ctx, muteTiming.OrgID)
 				if err != nil {
 					return err
 				}
@@ -43,13 +44,13 @@ func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 			}
 			muteTiming.MuteTime.Provenance = models.ProvenanceFile
 			if _, exists := cache[muteTiming.OrgID][muteTiming.MuteTime.Title]; exists {
-				_, err := c.muteTimingService.UpdateMuteTiming(ctx, muteTiming.MuteTime, muteTiming.OrgID)
+				_, err := c.muteTimingService.UpdateMuteTiming(ctx, muteTiming.MuteTime, muteTiming.OrgID, manager)
 				if err != nil {
 					return err
 				}
 				continue
 			}
-			_, err := c.muteTimingService.CreateMuteTiming(ctx, muteTiming.MuteTime, muteTiming.OrgID)
+			_, err := c.muteTimingService.CreateMuteTiming(ctx, muteTiming.MuteTime, muteTiming.OrgID, manager)
 			if err != nil {
 				return err
 			}
@@ -60,9 +61,10 @@ func (c *defaultMuteTimesProvisioner) Provision(ctx context.Context,
 
 func (c *defaultMuteTimesProvisioner) Unprovision(ctx context.Context,
 	files []*AlertingFile) error {
+	manager := models.ProvenanceToManagerProperties(models.ProvenanceFile)
 	for _, file := range files {
 		for _, deleteMuteTime := range file.DeleteMuteTimes {
-			err := c.muteTimingService.DeleteMuteTiming(ctx, deleteMuteTime.Name, deleteMuteTime.OrgID, models.ProvenanceFile, "")
+			err := c.muteTimingService.DeleteMuteTiming(ctx, deleteMuteTime.Name, deleteMuteTime.OrgID, manager, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/services/provisioning/alerting/text_templates.go
+++ b/pkg/services/provisioning/alerting/text_templates.go
@@ -8,6 +8,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
+var textTemplateFileManager = models.ProvenanceToManagerProperties(models.ProvenanceFile)
+
 type TextTemplateProvisioner interface {
 	Provision(ctx context.Context, files []*AlertingFile) error
 	Unprovision(ctx context.Context, files []*AlertingFile) error
@@ -44,7 +46,7 @@ func (c *defaultTextTemplateProvisioner) Unprovision(ctx context.Context,
 	files []*AlertingFile) error {
 	for _, file := range files {
 		for _, deleteTemplate := range file.DeleteTemplates {
-			err := c.templateService.DeleteTemplate(ctx, deleteTemplate.OrgID, deleteTemplate.Name, models.ProvenanceFile, "")
+			err := c.templateService.DeleteTemplate(ctx, deleteTemplate.OrgID, deleteTemplate.Name, textTemplateFileManager, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -180,7 +181,7 @@ func addAlertingConfig(t *testing.T, env *server.TestEnv) {
 		1: {accesscontrol.ActionAlertingReceiversCreate: nil},
 	}}
 
-	_, err := env.Server.HTTPServer.AlertNG.Api.ReceiverService.CreateReceiver(context.Background(), &receiverWithSecrets, 1, u)
+	_, err := env.Server.HTTPServer.AlertNG.Api.ReceiverService.CreateReceiver(context.Background(), &receiverWithSecrets, utils.ManagerProperties{}, 1, u)
 	require.NoError(t, err)
 }
 

--- a/pkg/tests/apis/alerting/notifications/common/testing.go
+++ b/pkg/tests/apis/alerting/notifications/common/testing.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/routingtree"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -73,7 +74,7 @@ func UpdateDefaultRoute(t *testing.T, user apis.User, r *definitions.Route) {
 	require.NoError(t, err)
 	route := legacy_storage.NewManagedRoute(models.DefaultRoutingTreeName, v1.RouteToModel(r))
 	route.Version = "" // Avoid version conflict.
-	v1route, err := routingtree.ConvertToK8sResource(user.Identity.GetOrgID(), route, func(int64) string { return apis.DefaultNamespace }, nil)
+	v1route, err := routingtree.ConvertToK8sResource(user.Identity.GetOrgID(), route, utils.ManagerProperties{}, func(int64) string { return apis.DefaultNamespace }, nil)
 	require.NoError(t, err)
 	_, err = routeClient.Update(context.Background(), v1route, resource.UpdateOptions{})
 	require.NoError(t, err)

--- a/pkg/tests/apis/alerting/notifications/receivers/test-data/imported-expected-snapshot.json
+++ b/pkg/tests/apis/alerting/notifications/receivers/test-data/imported-expected-snapshot.json
@@ -37,6 +37,7 @@
         "uid": "Kv3aohRRhZZgwZRUOA62GbN6vjUAa6Xs4Ql2TTYE2XIX",
         "resourceVersion": "40409c09d2b2f217",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -59,6 +60,7 @@
         "uid": "qZZWlsquf3y9Jq7t4DPEHSRuBoeHemHgnoHgUVV43OYX",
         "resourceVersion": "faa7705455991f0a",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -104,6 +106,7 @@
         "uid": "HqiXTxM48q3i9R6eNxGMsqRwFotgKfd2Y3Sgrg0QQagX",
         "resourceVersion": "4d17750eb3c688f1",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -153,6 +156,7 @@
         "uid": "lvjnZkpXPRYUr8kb6E5H009rCuobN8lPszXoThLzrxwX",
         "resourceVersion": "20686dc4795761dc",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -212,6 +216,7 @@
         "uid": "k7o0Hz5XWPoVRtr7MrhMlPY1E6Ap1XXda4da4wEKgBYX",
         "resourceVersion": "c327781b22fb2375",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -258,6 +263,7 @@
         "uid": "14bze1pZagWIKYELPXs1Mcy8cL1DAlqpzJ4JkoLDfvYX",
         "resourceVersion": "c70e8e240efa3837",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -320,6 +326,7 @@
         "uid": "JV4UiQeX9R6UmwVHL7GXBskXRqvaunmRBIIaS7YMnl8X",
         "resourceVersion": "f325da7f87ea80d2",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -392,6 +399,7 @@
         "uid": "KmdEYNvIFqIhZXDgo72RJqKNeg8dBQDKam9ROun2tZAX",
         "resourceVersion": "8a8a575957af1a21",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -446,6 +454,7 @@
         "uid": "MHKEKXAOzOMISzPH7eCi0c2CvT0wODhSfSk1TiuNnKgX",
         "resourceVersion": "b21cb4295ac326aa",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -531,6 +540,7 @@
         "uid": "0hEMltsOTiMXbcfNFtajn9V7A5Dc9PuJo91i3jT0UIYX",
         "resourceVersion": "ba1eccdb05772026",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -586,6 +596,7 @@
         "uid": "o6LIJM0yt1aXox7EVBiZmDVXGSfShDYsk1gVEENSSGcX",
         "resourceVersion": "cd6f78ff21dc390c",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -633,6 +644,7 @@
         "uid": "aiBEoHeP0XnxaWsteUm7JXYlOUMgcXoX03DuzxiZteMX",
         "resourceVersion": "ccbc6a7976745166",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -683,6 +695,7 @@
         "uid": "UWNKI0plkKlibdMG2E31fXv7rSp1bj5En5Ly8y7PXuIX",
         "resourceVersion": "174f0aa8a946eca8",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -732,6 +745,7 @@
         "uid": "Tb4lHkct27YZEAVtmU6UtYo31OKxl3aSZhvHUteYgQkX",
         "resourceVersion": "bddcdf192a64cd03",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",
@@ -777,6 +791,7 @@
         "uid": "OjepUCGQaz7BU7QeECzRfv3L2jDQB4wnfCUQYGN5YBMX",
         "resourceVersion": "6bf294b80b035167",
         "annotations": {
+          "grafana.app/managedBy": "classic-converted-prometheus",
           "grafana.com/access/canModifyProtected": "true",
           "grafana.com/access/canReadSecrets": "true",
           "grafana.com/canUse": "false",

--- a/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -101,6 +102,9 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 	}
 	expected.UID = importedRoute.UID // UID is generated.
 	expected.SetProvenanceStatus(string(models.ProvenanceConvertedPrometheus))
+	expectedMeta, err := utils.MetaAccessor(expected)
+	require.NoError(t, err)
+	expectedMeta.SetManagerProperties(utils.ManagerProperties{Kind: utils.ManagerKindClassicConvertedPrometheus}) //nolint:staticcheck
 	require.Equal(t, expected, importedRoute)
 
 	t.Run("should not be able to update", func(t *testing.T) {

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/resource"
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	"github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1/fakes"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/notifications/routingtree"
@@ -544,7 +545,7 @@ func TestIntegrationDataConsistency(t *testing.T) {
 		require.NoError(t, err)
 		managedRoute := legacy_storage.NewManagedRoute(models.DefaultRoutingTreeName, &route)
 		managedRoute.Version = "" // Avoid version conflict.
-		v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.Admin.Identity.GetOrgID(), managedRoute, func(int64) string { return "default" }, nil)
+		v1Route, err := routingtree.ConvertToK8sResource(helper.Org1.Admin.Identity.GetOrgID(), managedRoute, utils.ManagerProperties{}, func(int64) string { return "default" }, nil)
 		require.NoError(t, err)
 		_, err = routeClient.Update(ctx, v1Route, resource.UpdateOptions{})
 		require.NoError(t, err)
@@ -1514,7 +1515,7 @@ func k8sRoute(t *testing.T, name string, r *v1model.Route) *v1beta1.RoutingTree 
 	allPermissions.Set(models.RoutePermissionWrite, true)
 	allPermissions.Set(models.RoutePermissionDelete, true)
 	allPermissions.Set(models.RoutePermissionAdmin, true)
-	v1Route, err := routingtree.ConvertToK8sResource(-1, managedRoute, func(int64) string { return apis.DefaultNamespace }, &allPermissions)
+	v1Route, err := routingtree.ConvertToK8sResource(-1, managedRoute, utils.ManagerProperties{}, func(int64) string { return apis.DefaultNamespace }, &allPermissions)
 	require.NoError(t, err)
 	v1Route.TypeMeta = v1.TypeMeta{
 		Kind:       v1beta1.RoutingTreeKind().Kind(),

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -773,7 +773,7 @@ func TestIntegrationTimeIntervalReferentialIntegrity(t *testing.T) {
 
 	adminClient, err := v1beta1.NewTimeIntervalClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
 	require.NoError(t, err)
-	v1intervals, err := timeinterval.ConvertToK8sResources(orgID, mtis, func(int64) string { return "default" }, nil)
+	v1intervals, err := timeinterval.ConvertToK8sResources(orgID, mtis, nil, func(int64) string { return "default" }, nil)
 	require.NoError(t, err)
 	for _, interval := range v1intervals.Items {
 		_, err := adminClient.Create(ctx, &interval, resource.CreateOptions{})


### PR DESCRIPTION
## Summary

Extends ManagerProperties (manager kind + identity) support — already shipped for alert rules in #126737 — to the four alerting notifications resources: mute timings, templates, routing trees, and contact points (receivers).

This replaces #126793, which went stale (~3 months) and predated a large domain-model refactor already merged to `main` (new `v1.TimeInterval`/`v1.TemplateGroup`/`AMConfigV1`/`legacy_storage.ManagedRoute` types), so it was rebuilt fresh against current `main` rather than rebased.

- Service `Create`/`Update`/`Delete` methods for each resource take an explicit `manager utils.ManagerProperties` parameter and persist via `SetManagerProperties` (mirroring the already-merged alert-rule pattern — no conditional provenance/manager branching).
- `Get`/`List` methods return `ManagerProperties` alongside the existing domain objects.
- k8s conversions set/read the `grafana.app/managedBy` annotation alongside the existing provenance annotation, validating the two agree when both are present.
- Contact points resolve a receiver-level manager from per-integration manager records (`GetReceiverManager`, mirroring the existing `GetReceiverProvenance` "first non-unknown wins" logic), since provenance/manager there is stored per-integration.
- `inhibitionrule` remains out of scope (no provenance store backing it, same as before).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean across the repo
- [x] Unit tests: `pkg/services/ngalert/provisioning/...`, `pkg/services/ngalert/notifier/...`, `pkg/registry/apps/alerting/notifications/...`
- [x] Integration tests: `pkg/tests/apis/alerting/notifications/...` (round-trip: a Terraform-managed resource created via k8s survives a fresh read with the same manager kind/identity; a legacy `api`-provenance-only resource reads back as the classic-API manager shim)
- [x] Updated golden snapshot fixtures for imported (converted-Prometheus) receivers/routing trees to include the new manager annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)