### PR TITLE
Folder: kv_store based fallback for federated /counts

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -534,6 +534,7 @@ import (
 	_ "github.com/grafana/grafana/pkg/storage/secret/migrator"
 	_ "github.com/grafana/grafana/pkg/storage/unified"
 	_ "github.com/grafana/grafana/pkg/storage/unified/apistore"
+	_ "github.com/grafana/grafana/pkg/storage/unified/federated"
 	_ "github.com/grafana/grafana/pkg/storage/unified/migrations"
 	_ "github.com/grafana/grafana/pkg/storage/unified/resource"
 	_ "github.com/grafana/grafana/pkg/storage/unified/resource/kv"

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -397,6 +397,16 @@ var (
 			Generate:     Generate{LegacyGo: true},
 		},
 		{
+			Name:            "kubernetesFolderCountsLegacyStorage",
+			Description:     "Enable folder.grafana.app /counts joining a stack's legacy database that lives outside unified storage. Requires --database.servers to be configured for the standalone folder apiserver; only enable once that connection is verified reachable, since the apiserver fails to start otherwise",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaSearchAndStorageSquad,
+			HideFromDocs:    true,
+			RequiresRestart: true,
+			Expression:      "false",
+			Generate:        Generate{LegacyGo: true},
+		},
+		{
 			Name:            "grafana.kubernetesAnnotationsClient",
 			Description:     "Enables usage of the new annotations API client",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -44,6 +44,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-07-30,snapshots.kubernetesSnapshots,experimental,@grafana/sharing-squad,false,false,false
 2026-07-21,libraryelements.kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,false,false
 2026-05-22,kubernetesFolderCascadeDelete,experimental,@grafana/search-and-storage,false,false,false
+2026-09-09,kubernetesFolderCountsLegacyStorage,experimental,@grafana/search-and-storage,false,true,false
 2026-05-22,grafana.kubernetesAnnotationsClient,experimental,@grafana/dashboards-squad,false,false,true
 2026-06-18,grafana.newPanelQueryErrorsUI,experimental,@grafana/dashboards-squad,false,false,true
 2025-08-29,useKubernetesShortURLsAPI,GA,@grafana/sharing-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -147,6 +147,10 @@ const (
 	// Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0. Until cascade reconciliation exists, deleting a non-empty folder removes only the folder and leaves child dashboards, nested folders, and other contained resources orphaned
 	FlagKubernetesFolderCascadeDelete = "kubernetesFolderCascadeDelete"
 
+	// FlagKubernetesFolderCountsLegacyStorage
+	// Enable folder.grafana.app /counts joining a stack's legacy database that lives outside unified storage. Requires --database.servers to be configured for the standalone folder apiserver; only enable once that connection is verified reachable, since the apiserver fails to start otherwise
+	FlagKubernetesFolderCountsLegacyStorage = "kubernetesFolderCountsLegacyStorage"
+
 	// FlagKubernetesCorrelations
 	// Adds support for Kubernetes correlations
 	FlagKubernetesCorrelations = "kubernetesCorrelations"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4293,6 +4293,24 @@
     },
     {
       "metadata": {
+        "name": "kubernetesFolderCountsLegacyStorage",
+        "resourceVersion": "1789000129079",
+        "creationTimestamp": "2026-09-09T23:57:02Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-09-10 00:28:49.079657382 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enable folder.grafana.app /counts joining a stack's legacy database that lives outside unified storage. Requires --database.servers to be configured for the standalone folder apiserver; only enable once that connection is verified reachable, since the apiserver fails to start otherwise",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "requiresRestart": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesLibraryPanels",
         "resourceVersion": "1784652599954",
         "creationTimestamp": "2025-06-25T22:21:56Z",

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -37,15 +37,42 @@ type LegacyStatsGetter struct {
 	Cfg *setting.Cfg
 }
 
-// From mode 4 on nothing writes the legacy table, so its rows are leftovers and
-// counting them would warn about resources that no longer exist. Config is enough
-// because these two resources have no migration registered; if that changes, read
-// the migration status like dualwrite.Service.ReadFromUnified does.
-func (s *LegacyStatsGetter) legacyTableIsStale(resource string) bool {
-	if s.Cfg == nil {
-		return false
+// kv_store convention used to mark a resource as fully migrated for one stack: namespace
+// "unified_storage.is_migrated", key "<resource>.<group>" (the same string shape as our own
+// alertRuleResource-style constants), org_id always 0 for this entry specifically (unlike
+// every other row in these stack databases, which use 1).
+const (
+	migratedKVNamespace = "unified_storage.is_migrated"
+	migratedKVValue     = "true"
+)
+
+// From mode 4 on nothing writes the legacy table, so its rows are leftovers and counting
+// them would warn about resources that no longer exist. When Cfg is set, config is enough
+// because these resources have no migration registered there; if that changes, read the
+// migration status like dualwrite.Service.ReadFromUnified does.
+//
+// A caller with no DualWriterMode config at all (nil Cfg) falls back to a per-stack kv_store
+// marker instead -- the only signal that exists there today.
+func (s *LegacyStatsGetter) legacyTableIsStale(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper, resource string) (bool, error) {
+	if s.Cfg != nil {
+		return s.Cfg.UnifiedStorage[resource].DualWriterMode >= grafanarest.Mode4, nil
 	}
-	return s.Cfg.UnifiedStorage[resource].DualWriterMode >= grafanarest.Mode4
+
+	exists, err := sess.IsTableExist(helper.Table("kv_store"))
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+
+	count, err := sess.Table(helper.Table("kv_store")).
+		Where("org_id = 0 AND namespace = ? AND `key` = ? AND value = ?", migratedKVNamespace, resource, migratedKVValue).
+		Count()
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
@@ -125,14 +152,22 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		// NULL has to count as "not a recording rule". Comparing NULL with = or != yields
 		// NULL rather than true, which would drop those rows from both counts and let a
 		// folder that still holds alert rules look empty.
-		if !s.legacyTableIsStale(alertRuleResource) {
+		alertRulesStale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+		if err != nil {
+			return err
+		}
+		if !alertRulesStale {
 			err = fn("alert_rule", "namespace_uid", group, "alertrules", false, "(record IS NULL OR record = '')")
 			if err != nil {
 				return err
 			}
 		}
 
-		if !s.legacyTableIsStale(recordingRuleResource) {
+		recordingRulesStale, err := s.legacyTableIsStale(sess, helper, recordingRuleResource)
+		if err != nil {
+			return err
+		}
+		if !recordingRulesStale {
 			err = fn("alert_rule", "namespace_uid", group, "recordingrules", false, "(record IS NOT NULL AND record != '')")
 			if err != nil {
 				return err
@@ -140,7 +175,11 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		}
 
 		// Legacy library_elements table
-		if !s.legacyTableIsStale(libraryPanelResource) {
+		libraryPanelsStale, err := s.legacyTableIsStale(sess, helper, libraryPanelResource)
+		if err != nil {
+			return err
+		}
+		if !libraryPanelsStale {
 			err = fn("library_element", "folder_uid", group, "library_elements", false, "")
 			if err != nil {
 				return err

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -58,16 +58,8 @@ func (s *LegacyStatsGetter) legacyTableIsStale(sess *sqlstore.DBSession, helper 
 		return s.Cfg.UnifiedStorage[resource].DualWriterMode >= grafanarest.Mode4, nil
 	}
 
-	exists, err := sess.IsTableExist(helper.Table("kv_store"))
-	if err != nil {
-		return false, err
-	}
-	if !exists {
-		return false, nil
-	}
-
 	count, err := sess.Table(helper.Table("kv_store")).
-		Where("org_id = 0 AND namespace = ? AND `key` = ? AND value = ?", migratedKVNamespace, resource, migratedKVValue).
+		Where("org_id = 0 AND namespace = ? AND "+helper.DB.Quote("key")+" = ? AND value = ?", migratedKVNamespace, resource, migratedKVValue).
 		Count()
 	if err != nil {
 		return false, err

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -256,34 +257,86 @@ func TestIntegrationDirectSQLStatsSplitsRecordingRules(t *testing.T) {
 	})
 }
 
-func TestLegacyTableIsStale(t *testing.T) {
+func TestIntegrationLegacyTableIsStale(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
 	cfgWithMode := func(resource string, mode grafanarest.DualWriterMode) *setting.Cfg {
 		return &setting.Cfg{UnifiedStorage: map[string]setting.UnifiedStorageConfig{
 			resource: {DualWriterMode: mode},
 		}}
 	}
 
+	// legacyTableIsStale queries kv_store when Cfg is nil, so every case needs a real
+	// session/helper, even the ones exercising the config-based fast path.
+	// The check itself must run inside the WithDbSession callback -- the session isn't
+	// valid once that callback returns.
+	withSession := func(t *testing.T, check func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper)) {
+		t.Helper()
+		testDB, _ := db.InitTestDBWithCfg(t) //nolint:staticcheck // legacy shared-DB test setup; migrate to NewTestStore
+		provider := legacysql.NewDatabaseProvider(testDB)
+		helper, err := provider(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, helper.DB.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+			check(sess, helper)
+			return nil
+		}))
+	}
+
 	t.Run("no config means the legacy table is still the source of truth", func(t *testing.T) {
 		s := &LegacyStatsGetter{}
-		require.False(t, s.legacyTableIsStale(alertRuleResource))
+		withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
+			stale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+			require.NoError(t, err)
+			require.False(t, stale)
+		})
 	})
 
 	t.Run("unconfigured resource is still the source of truth", func(t *testing.T) {
 		s := &LegacyStatsGetter{Cfg: cfgWithMode(libraryPanelResource, grafanarest.Mode5)}
-		require.False(t, s.legacyTableIsStale(alertRuleResource))
+		withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
+			stale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+			require.NoError(t, err)
+			require.False(t, stale)
+		})
 	})
 
 	t.Run("dual write modes keep the legacy table", func(t *testing.T) {
 		for _, mode := range []grafanarest.DualWriterMode{grafanarest.Mode0, grafanarest.Mode1, grafanarest.Mode2, grafanarest.Mode3} {
 			s := &LegacyStatsGetter{Cfg: cfgWithMode(alertRuleResource, mode)}
-			require.False(t, s.legacyTableIsStale(alertRuleResource), "mode %d", mode)
+			withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
+				stale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+				require.NoError(t, err)
+				require.False(t, stale, "mode %d", mode)
+			})
 		}
 	})
 
 	t.Run("unified storage modes drop the legacy table", func(t *testing.T) {
 		for _, mode := range []grafanarest.DualWriterMode{grafanarest.Mode4, grafanarest.Mode5} {
 			s := &LegacyStatsGetter{Cfg: cfgWithMode(alertRuleResource, mode)}
-			require.True(t, s.legacyTableIsStale(alertRuleResource), "mode %d", mode)
+			withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
+				stale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+				require.NoError(t, err)
+				require.True(t, stale, "mode %d", mode)
+			})
 		}
+	})
+
+	t.Run("nil Cfg falls back to the per-stack kv_store marker", func(t *testing.T) {
+		s := &LegacyStatsGetter{}
+		withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
+			_, err := sess.Exec("INSERT INTO "+helper.Table("kv_store")+" (org_id, namespace, `key`, value, created, updated) VALUES (0, ?, ?, ?, ?, ?)",
+				migratedKVNamespace, alertRuleResource, migratedKVValue, time.Now(), time.Now())
+			require.NoError(t, err)
+
+			stale, err := s.legacyTableIsStale(sess, helper, alertRuleResource)
+			require.NoError(t, err)
+			require.True(t, stale)
+
+			// A different resource's key must not be affected.
+			stale, err = s.legacyTableIsStale(sess, helper, recordingRuleResource)
+			require.NoError(t, err)
+			require.False(t, stale)
+		})
 	})
 }

--- a/pkg/storage/unified/federated/stats_test.go
+++ b/pkg/storage/unified/federated/stats_test.go
@@ -325,7 +325,7 @@ func TestIntegrationLegacyTableIsStale(t *testing.T) {
 	t.Run("nil Cfg falls back to the per-stack kv_store marker", func(t *testing.T) {
 		s := &LegacyStatsGetter{}
 		withSession(t, func(sess *sqlstore.DBSession, helper *legacysql.LegacyDatabaseHelper) {
-			_, err := sess.Exec("INSERT INTO "+helper.Table("kv_store")+" (org_id, namespace, `key`, value, created, updated) VALUES (0, ?, ?, ?, ?, ?)",
+			_, err := sess.Exec("INSERT INTO "+helper.Table("kv_store")+" (org_id, namespace, "+helper.DB.Quote("key")+", value, created, updated) VALUES (0, ?, ?, ?, ?, ?)",
 				migratedKVNamespace, alertRuleResource, migratedKVValue, time.Now(), time.Now())
 			require.NoError(t, err)
 


### PR DESCRIPTION
- Adds the `kubernetesFolderCountsLegacyStorage` toggle (experimental, off by default), gating a follow-up enterprise change that joins a stack's legacy SQL data into /counts.

- `federated.LegacyStatsGetter.legacyTableIsStale`: with no Cfg (the MT case), falls back to a per-stack kv_store marker instead of always treating legacy rows as current.

Counterpart of https://github.com/grafana/grafana-enterprise/pull/13429

Part of part of https://github.com/grafana/search-and-storage-team/issues/952