### PR TITLE
Table: Paint the refreshed header's corners instead of clipping them

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -59,6 +59,19 @@ export const isTableCellStylesKeyEqual = (cacheKey: Key, key: RawKey): boolean =
 // hair of `background.secondary`, the established "one step off white" surface.
 const HEADER_BACKGROUND_EMPHASIS = 0.04;
 
+// Geometry shared by the two header corner masks (see their use in `getGridStyles`). react-data-grid
+// gives every cell `position: relative`, so the pseudo-element anchors to the header cell itself, and
+// `::after` is free — rdg only takes `::before`, on the grid root, for its Firefox scrollbar fix.
+const headerCornerMask = (radius: string) =>
+  ({
+    content: '""',
+    position: 'absolute',
+    insetBlockStart: 0,
+    inlineSize: radius,
+    blockSize: radius,
+    pointerEvents: 'none',
+  }) as const;
+
 export const getGridStyles = memoize(
   (
     theme: GrafanaTheme2,
@@ -89,6 +102,8 @@ export const getGridStyles = memoize(
     // `noPanelPadding` it picks up the same `FIRST_COLUMN_EXTRA_PADDING` inline-start bump as any
     // other first column — `gridNested` below has to know about it to stay flush with that column.
     const nestedGridExpanderPaddingOffset = noPanelPadding ? FIRST_COLUMN_EXTRA_PADDING : 0;
+    // sizes both the masks' boxes and the arc they cut, so the two can't drift
+    const cornerRadius = theme.shape.radius.default;
 
     return {
       grid: css({
@@ -216,13 +231,23 @@ export const getGridStyles = memoize(
           '.rdg-header-row > .rdg-cell.rdg-cell-frozen': {
             backgroundColor: 'var(--rdg-header-background-color)',
           },
-          [`.rdg-header-row > .rdg-cell.${FIRST_COLUMN_CLASS}`]: {
-            borderStartStartRadius: theme.shape.radius.default,
-            overflow: 'hidden',
+          // The header's corners are painted rather than clipped. A corner made by transparency needs
+          // an ancestor clipping at that exact offset: the grid's own radius above is that ancestor
+          // only while the columns reach the panel edge. When every column has a configured width
+          // they can stop short of it (nothing stretches to fill), and the table's real trailing
+          // corner then sits mid-panel with a body cell scrolling under the sticky header behind it.
+          // Filling everything outside the arc with the table's own background — the same colour as
+          // the gap beside the table, and as whatever the table sits on — makes the corner opaque, so
+          // there is nothing left to show through wherever it lands.
+          [`.rdg-header-row > .rdg-cell.${FIRST_COLUMN_CLASS}::after`]: {
+            ...headerCornerMask(cornerRadius),
+            insetInlineStart: 0,
+            background: `radial-gradient(circle at 100% 100%, transparent calc(${cornerRadius} - 0.5px), var(--rdg-background-color) ${cornerRadius})`,
           },
-          [`.rdg-header-row > .rdg-cell.${LAST_COLUMN_CLASS}`]: {
-            borderStartEndRadius: theme.shape.radius.default,
-            overflow: 'hidden',
+          [`.rdg-header-row > .rdg-cell.${LAST_COLUMN_CLASS}::after`]: {
+            ...headerCornerMask(cornerRadius),
+            insetInlineEnd: 0,
+            background: `radial-gradient(circle at 0 100%, transparent calc(${cornerRadius} - 0.5px), var(--rdg-background-color) ${cornerRadius})`,
           },
           // The footer is the last row in the grid, so react-data-grid's per-cell bottom border
           // draws a hairline along the table's own bottom edge with nothing below it to divide.


### PR DESCRIPTION
**What is this feature?**

An experiment: the refreshed header's rounded top corners are painted rather than clipped.

Today the edge header cells round their own corners and rely on something behind them to clip what's underneath. The grid's own radius (added in #131168) is that something — but only while the columns reach the panel edge. The header surface is exactly the summed column tracks: react-data-grid's header row is `display: contents` and paints nothing itself, and when every visible column carries a configured `width` neither sizing path fills the remainder, so the table can stop short of the panel. The table's real trailing corner then sits mid-panel, where nothing clips, and the body cell scrolling under the sticky header shows through the notch — very visible on a coloured (apply-to-row) table.

This fills everything outside the arc with `var(--rdg-background-color)` in a pseudo-element on each edge header cell. That's the colour of the gap beside the table and of whatever the table sits on (including on transparent panels), so the corner reads the same wherever it lands and there is nothing left to show through.

**Why do we need this feature?**

The corner rounding currently only holds when the table happens to fill its panel. Resizing every column persists a width override per column, so a user gets the short case without doing anything unusual.

**Who is this feature for?**

Anyone using the Table panel with `table.refresh` enabled.

**Special notes for your reviewer:**

- The grid-level radius from #131168 stays. It still does the right thing at the container edges — the leading corner, the trailing corner when the columns fill or overflow the panel (where the last column is scrolled out of the DOM and carries no marker class), and the `noHeader` case where body rows reach the top.
- react-data-grid gives every cell `position: relative`, and `::after` is free: rdg only uses `::before`, on the grid root, for its Firefox scrollbar fix.
- Open question: the gradients are physical (`circle at 100% 100%` / `circle at 0 100%`) while the insets are logical, so RTL would mirror the box but not the arc. Worth fixing with a `:dir(rtl)` pair if we keep this.
- No unit test: jsdom doesn't resolve `::after` through `getComputedStyle`. The existing grid-radius test in `TableDataGrid.test.tsx` still covers the container edges. Wants a look in a browser.
- Alternatives considered: stretching the last column to fill would override configured widths; sizing the grid root to the content width would put the existing radius in the right place but risks a measure → resize → measure loop, since `useScrollbarWidth` measures that same element.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
