### PR TITLE
DateTime: Increase parity in luxon-moment-compat wrapper (part 1)

### DIFF
--- a/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
@@ -22,9 +22,9 @@ describe('localized padded L', () => {
 
     expect(date.toFormat(convertMomentToLuxonWithOrdinal('L'))).toBe('03/05/2024');
     expect(date.toFormat(convertMomentToLuxonWithOrdinal('L', 'de'))).toBe('05.03.2024');
-    expect(
-      DateTime.fromFormat('03/05/2024', convertMomentToLuxonForParsing('L'), { zone: 'UTC' }).toISODate()
-    ).toBe('2024-03-05');
+    expect(DateTime.fromFormat('03/05/2024', convertMomentToLuxonForParsing('L'), { zone: 'UTC' }).toISODate()).toBe(
+      '2024-03-05'
+    );
   });
 
   it('keeps cached conversions separate when alternating locales', () => {

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
@@ -1,0 +1,53 @@
+import { convertMomentToLuxonForParsing, convertMomentToLuxonWithOrdinal, formatWithOrdinal } from './format';
+import { DateTime } from './luxon';
+
+describe('localized padded L', () => {
+  it.each([
+    { locale: 'en-US', expected: '03/05/2024' },
+    { locale: 'en-GB', expected: '05/03/2024' },
+    { locale: 'de', expected: '05.03.2024' },
+    { locale: 'ja', expected: '2024/03/05' },
+  ])('formats and parses padded L in $locale', ({ locale, expected }) => {
+    const date = DateTime.utc(2024, 3, 5).setLocale(locale);
+    const formatted = formatWithOrdinal(date, 'L');
+
+    expect(formatted).toBe(expected);
+    expect(
+      DateTime.fromFormat(formatted, convertMomentToLuxonForParsing('L', locale), { locale, zone: 'UTC' }).toISODate()
+    ).toBe('2024-03-05');
+  });
+
+  it('uses the supplied conversion locale and defaults to en-US', () => {
+    const date = DateTime.utc(2024, 3, 5).setLocale('en-US');
+
+    expect(date.toFormat(convertMomentToLuxonWithOrdinal('L'))).toBe('03/05/2024');
+    expect(date.toFormat(convertMomentToLuxonWithOrdinal('L', 'de'))).toBe('05.03.2024');
+    expect(
+      DateTime.fromFormat('03/05/2024', convertMomentToLuxonForParsing('L'), { zone: 'UTC' }).toISODate()
+    ).toBe('2024-03-05');
+  });
+
+  it('keeps cached conversions separate when alternating locales', () => {
+    const date = DateTime.utc(2024, 3, 5);
+    expect(formatWithOrdinal(date.setLocale('en-US'), 'L [cache]')).toBe('03/05/2024 cache');
+    expect(formatWithOrdinal(date.setLocale('de'), 'L [cache]')).toBe('05.03.2024 cache');
+    expect(formatWithOrdinal(date.setLocale('en-US'), 'L [cache]')).toBe('03/05/2024 cache');
+  });
+
+  it.each([
+    { format: '[L yyyyy] L', expected: 'L yyyyy 05.03.2024' },
+    { format: '\\L L', expected: 'L 05.03.2024' },
+    { format: 'L [|] L', expected: '05.03.2024 | 05.03.2024' },
+  ])('preserves literals when converting $format', ({ format, expected }) => {
+    const date = DateTime.utc(2024, 3, 5).setLocale('de');
+    const formatted = formatWithOrdinal(date, format);
+
+    expect(formatted).toBe(expected);
+    expect(
+      DateTime.fromFormat(formatted, convertMomentToLuxonForParsing(format, 'de'), {
+        locale: 'de',
+        zone: 'UTC',
+      }).toISODate()
+    ).toBe('2024-03-05');
+  });
+});

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/format.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/format.ts
@@ -1,4 +1,4 @@
-import type { DateTime } from './luxon';
+import { DateTime } from './luxon';
 
 const LOWER_MERIDIEM_FORMAT = "'__mls__'a'__mle__'";
 const ONE_TO_TWENTY_FOUR_HOUR_FORMAT = "'__khs__'H'__khe__'";
@@ -6,9 +6,8 @@ const PADDED_ONE_TO_TWENTY_FOUR_HOUR_FORMAT = "'__khs__'HH'__khe__'";
 
 const TOKEN_MAP: Record<string, string> = {
   // moment's L* tokens are locale-aware (word order changes per locale), so map them to luxon's
-  // localized macro tokens rather than fixed patterns. `L` and `llll` have no exact luxon macro
-  // (`D` is unpadded while moment's `L` pads, and no macro uses an abbreviated weekday), so they
-  // keep en-US shaped patterns.
+  // localized macro tokens rather than fixed patterns. `L` is expanded separately to pad the date.
+  // No macro uses an abbreviated weekday, so `llll` keeps an en-US shaped pattern.
   LLLL: 'DDDD t',
   LLL: 'DDD t',
   LL: 'DDD',
@@ -91,12 +90,12 @@ interface ConvertedFormat {
 }
 
 // format conversion runs on every format() call in hot paths (table cells, axis ticks) and format
-// strings are highly repetitive, so cache the regex work. Keys only come from config/code-supplied
-// format strings, so the cache stays small for the lifetime of the page.
+// strings are highly repetitive, so cache the regex work. Keys come from config/code-supplied
+// format strings and locales, so the cache stays small for the lifetime of the page.
 const convertedFormatCache = new Map<string, ConvertedFormat>();
 
-function convertFormat(format: string, omitZoneName = false, forParsing = false): ConvertedFormat {
-  const cacheKey = `${forParsing ? 'parse' : 'format'}|${omitZoneName ? 'local' : 'zoned'}|${format}`;
+function convertFormat(format: string, omitZoneName = false, forParsing = false, locale = 'en-US'): ConvertedFormat {
+  const cacheKey = `${forParsing ? 'parse' : 'format'}|${omitZoneName ? 'local' : 'zoned'}|${locale}|${format}`;
   let converted = convertedFormatCache.get(cacheKey);
 
   if (!converted) {
@@ -104,7 +103,7 @@ function convertFormat(format: string, omitZoneName = false, forParsing = false)
     // Normalize `\x` to `[x]` first so we can reuse the existing escaped-text handling.
     const withEscapedLiterals = format.replace(/\\(.)/g, '[$1]');
     const luxonFormat = withEscapedLiterals.replace(TOKEN_PATTERN, (match, escapedText?: string) =>
-      replaceMomentToken(match, escapedText, omitZoneName, forParsing)
+      replaceMomentToken(match, escapedText, omitZoneName, forParsing, locale)
     );
 
     converted = {
@@ -119,7 +118,13 @@ function convertFormat(format: string, omitZoneName = false, forParsing = false)
   return converted;
 }
 
-function replaceMomentToken(match: string, escapedText?: string, omitZoneName = false, forParsing = false): string {
+function replaceMomentToken(
+  match: string,
+  escapedText?: string,
+  omitZoneName = false,
+  forParsing = false,
+  locale = 'en-US'
+): string {
   if (escapedText != null) {
     return toLuxonLiteral(escapedText);
   }
@@ -136,6 +141,16 @@ function replaceMomentToken(match: string, escapedText?: string, omitZoneName = 
     return `d'${ORDINAL_MARKER}'`;
   }
 
+  if (match === 'L') {
+    const localizedFormat = DateTime.parseFormatForOpts(
+      { year: 'numeric', month: '2-digit', day: '2-digit' },
+      { locale }
+    );
+    // Luxon generates a parser-only numeric-year token; adapt only this generated pattern,
+    // not the user's tokens or escaped literals, so the same pattern also formats correctly.
+    return (localizedFormat ?? TOKEN_MAP.L).replace('yyyyy', 'yyyy');
+  }
+
   return (forParsing ? PARSING_TOKEN_MAP : TOKEN_MAP)[match] ?? match;
 }
 
@@ -147,12 +162,12 @@ function toLuxonLiteral(literal: string): string {
     .join("''");
 }
 
-export function convertMomentToLuxonWithOrdinal(format: string): string {
-  return convertFormat(format).luxonFormat;
+export function convertMomentToLuxonWithOrdinal(format: string, locale?: string): string {
+  return convertFormat(format, false, false, locale).luxonFormat;
 }
 
-export function convertMomentToLuxonForParsing(format: string): string {
-  return convertFormat(format, false, true).luxonFormat.split(LOWER_MERIDIEM_FORMAT).join('a');
+export function convertMomentToLuxonForParsing(format: string, locale?: string): string {
+  return convertFormat(format, false, true, locale).luxonFormat.split(LOWER_MERIDIEM_FORMAT).join('a');
 }
 
 function getOrdinal(day: number): string {
@@ -163,7 +178,9 @@ function getOrdinal(day: number): string {
 export function formatWithOrdinal(luxonDateTime: DateTime, momentFormat: string): string {
   const { luxonFormat, hasOrdinal, hasMeridiem, hasOneToTwentyFourHour } = convertFormat(
     momentFormat,
-    luxonDateTime.zone.type === 'system'
+    luxonDateTime.zone.type === 'system',
+    false,
+    luxonDateTime.locale ?? undefined
   );
   // ZZZZ doesnt work
   // https://github.com/moment/luxon/discussions/1041

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
@@ -6,7 +6,6 @@ describe('moment compatibility parity', () => {
   let originalDefaultLocale: typeof Settings.defaultLocale;
   let originalNow: typeof Settings.now;
 
-
   beforeEach(() => {
     originalLocale = moment.locale();
     originalDefaultLocale = Settings.defaultLocale;
@@ -19,7 +18,6 @@ describe('moment compatibility parity', () => {
     moment.locale(originalLocale);
     Settings.defaultLocale = originalDefaultLocale;
     Settings.now = originalNow;
-
   });
 
   describe('shared scalar duration inputs', () => {
@@ -32,7 +30,9 @@ describe('moment compatibility parity', () => {
     it.each([2, '2'])('applies an explicit unit to the numeric input %s', (input) => {
       expect(moment.duration(input, 'hours').asMilliseconds()).toBe(7200000);
       expect(moment.utc('2024-05-06T12:00:00Z').add(input, 'hours').toISOString()).toBe('2024-05-06T14:00:00.000Z');
-      expect(moment.utc('2024-05-06T12:00:00Z').subtract(input, 'hours').toISOString()).toBe('2024-05-06T10:00:00.000Z');
+      expect(moment.utc('2024-05-06T12:00:00Z').subtract(input, 'hours').toISOString()).toBe(
+        '2024-05-06T10:00:00.000Z'
+      );
     });
 
     it('parses a common compound ISO duration without dropping its date or time components', () => {
@@ -288,9 +288,7 @@ describe('moment compatibility parity', () => {
 
   describe('parsing and invalid values', () => {
     it('makes explicit ISO parsing authoritative instead of accepting an RFC fallback', () => {
-      expect(moment.utc('2024-05-06T12:00:00+02:00', moment.ISO_8601).toISOString()).toBe(
-        '2024-05-06T10:00:00.000Z'
-      );
+      expect(moment.utc('2024-05-06T12:00:00+02:00', moment.ISO_8601).toISOString()).toBe('2024-05-06T10:00:00.000Z');
       expect(moment.utc('Mon, 06 May 2024 12:00:00 GMT', moment.ISO_8601).isValid()).toBe(false);
     });
 

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
@@ -1,0 +1,371 @@
+import { DateTime, Settings } from './luxon';
+import moment from './moment';
+
+describe('moment compatibility parity', () => {
+  let originalLocale: string;
+  let originalDefaultLocale: typeof Settings.defaultLocale;
+  let originalNow: typeof Settings.now;
+
+
+  beforeEach(() => {
+    originalLocale = moment.locale();
+    originalDefaultLocale = Settings.defaultLocale;
+    originalNow = Settings.now;
+
+    moment.locale('en');
+  });
+
+  afterEach(() => {
+    moment.locale(originalLocale);
+    Settings.defaultLocale = originalDefaultLocale;
+    Settings.now = originalNow;
+
+  });
+
+  describe('shared scalar duration inputs', () => {
+    it.each([300000, '300000', 'PT5M', '5m'])('uses %s for duration, addition, and subtraction', (input) => {
+      expect(moment.duration(input).asMilliseconds()).toBe(300000);
+      expect(moment.utc('2024-05-06T12:00:00Z').add(input).toISOString()).toBe('2024-05-06T12:05:00.000Z');
+      expect(moment.utc('2024-05-06T12:00:00Z').subtract(input).toISOString()).toBe('2024-05-06T11:55:00.000Z');
+    });
+
+    it.each([2, '2'])('applies an explicit unit to the numeric input %s', (input) => {
+      expect(moment.duration(input, 'hours').asMilliseconds()).toBe(7200000);
+      expect(moment.utc('2024-05-06T12:00:00Z').add(input, 'hours').toISOString()).toBe('2024-05-06T14:00:00.000Z');
+      expect(moment.utc('2024-05-06T12:00:00Z').subtract(input, 'hours').toISOString()).toBe('2024-05-06T10:00:00.000Z');
+    });
+
+    it('parses a common compound ISO duration without dropping its date or time components', () => {
+      expect(moment.duration('P1DT2H30M').asHours()).toBe(26.5);
+      expect(moment.utc('2024-05-06T12:00:00Z').add('P1DT2H30M').toISOString()).toBe('2024-05-07T14:30:00.000Z');
+      expect(moment.utc('2024-05-06T12:00:00Z').subtract('P1DT2H30M').toISOString()).toBe('2024-05-05T09:30:00.000Z');
+    });
+
+    it('treats malformed durations as zero across construction and arithmetic', () => {
+      expect(moment.duration('garbage').asMilliseconds()).toBe(0);
+      expect(moment.utc(0).add('garbage').valueOf()).toBe(0);
+      expect(moment.utc(0).subtract('garbage').valueOf()).toBe(0);
+    });
+
+    it('treats an unknown scalar unit as zero rather than milliseconds', () => {
+      // @ts-expect-error Exercise unsupported units from untyped callers.
+      expect(moment.duration(5, 'fortnights').asMilliseconds()).toBe(0);
+      // @ts-expect-error Exercise unsupported units from untyped callers.
+      expect(moment.utc(0).add(5, 'fortnights').valueOf()).toBe(0);
+      // @ts-expect-error Exercise unsupported units from untyped callers.
+      expect(moment.utc(0).subtract(5, 'fortnights').valueOf()).toBe(0);
+    });
+
+    it.each([NaN, Infinity, -Infinity])('returns invalid results without throwing for %s', (input) => {
+      const duration = moment.duration(input, 'hours');
+      expect(duration.asMilliseconds()).toBeNaN();
+      expect(duration.hours()).toBeNaN();
+      expect(moment.utc(0).add(input, 'hours').isValid()).toBe(false);
+      expect(moment.utc(0).subtract(input, 'hours').isValid()).toBe(false);
+      expect(moment(input).isValid()).toBe(false);
+    });
+
+    it.each([
+      {
+        value: 1.5,
+        addedMonth: '2024-03-31',
+        subtractedMonth: '2023-11-30',
+        addedDay: '2024-02-02',
+        subtractedDay: '2024-01-29',
+      },
+      {
+        value: -1.5,
+        addedMonth: '2023-11-30',
+        subtractedMonth: '2024-03-31',
+        addedDay: '2024-01-29',
+        subtractedDay: '2024-02-02',
+      },
+    ])(
+      'rounds signed fractional calendar units away from zero for $value',
+      ({ value, addedMonth, subtractedMonth, addedDay, subtractedDay }) => {
+        const base = moment.utc('2024-01-31T00:00:00Z');
+        expect(base.clone().add(value, 'month').format('YYYY-MM-DD')).toBe(addedMonth);
+        expect(base.clone().subtract(value, 'month').format('YYYY-MM-DD')).toBe(subtractedMonth);
+        expect(base.clone().add(value, 'day').format('YYYY-MM-DD')).toBe(addedDay);
+        expect(base.clone().subtract(value, 'day').format('YYYY-MM-DD')).toBe(subtractedDay);
+      }
+    );
+
+    it('converts fractional years and weeks to months and days before rounding', () => {
+      const value = moment.utc('2024-01-31');
+      expect(value.clone().add(0.5, 'years').format('YYYY-MM-DD')).toBe('2024-07-31');
+      expect(value.clone().add(0.5, 'weeks').format('YYYY-MM-DD')).toBe('2024-02-04');
+    });
+
+    it('retains fractional days in durations instead of applying calendar arithmetic rounding', () => {
+      expect(moment.duration(1.5, 'days').asHours()).toBe(36);
+      expect(moment.duration(-1.5, 'days').asHours()).toBe(-36);
+    });
+  });
+
+  describe('duration objects', () => {
+    it.each([
+      { form: 'singular', input: { hour: 1, minute: '30' } },
+      { form: 'plural', input: { hours: 1, minutes: '30' } },
+      { form: 'short', input: { h: 1, m: '30' } },
+    ])('accepts $form keys with numeric and numeric-string values', ({ input }) => {
+      expect(moment.duration(input).asMilliseconds()).toBe(5400000);
+    });
+
+    it('uses the last alias in property order instead of accumulating aliases', () => {
+      expect(moment.duration({ hour: 1, hours: 2, h: '3' }).asHours()).toBe(3);
+      expect(moment.duration({ h: '3', hours: 2, hour: 1 }).asHours()).toBe(1);
+      expect(moment.duration({ hour: 'invalid', hours: 2 }).asHours()).toBe(2);
+      expect(moment.duration({ hours: 2, hour: undefined }).asHours()).toBe(0);
+    });
+
+    it('uses mixed units in arithmetic without changing the input or applying an explicit unit', () => {
+      const input = Object.freeze({ hour: 1, hours: 2, minutes: '30' });
+      const value = moment.utc('2024-05-08T12:00:00Z');
+
+      expect(moment.duration(input, 'seconds').asMilliseconds()).toBe(9000000);
+      expect(value.add(input, 'seconds')).toBe(value);
+      expect(value.toISOString()).toBe('2024-05-08T14:30:00.000Z');
+      expect(value.subtract(input).toISOString()).toBe('2024-05-08T12:00:00.000Z');
+    });
+
+    it('preserves calendar months and calendar days across month ends and DST', () => {
+      expect(moment.utc('2024-01-31T12:00:00Z').add({ month: 1, minutes: 30 }).toISOString()).toBe(
+        '2024-02-29T12:30:00.000Z'
+      );
+      expect(moment.tz('2024-03-09T12:00:00', 'America/New_York').add({ day: 1, hours: 2 }).toISOString()).toBe(
+        '2024-03-10T18:00:00.000Z'
+      );
+    });
+
+    it('ignores inherited and unknown keys', () => {
+      const input = Object.assign(Object.create({ hours: 5 }), { minutes: 30, fortnights: 2, toString: 5 });
+      expect(moment.duration(input).asMilliseconds()).toBe(1800000);
+      expect(moment.duration({}).asMilliseconds()).toBe(0);
+    });
+
+    it('validates the final value after aliases overwrite earlier values', () => {
+      expect(moment.duration({ hour: 1, hours: 'invalid' }).asMilliseconds()).toBeNaN();
+    });
+  });
+
+  describe('composite shorthand durations', () => {
+    it.each([
+      { input: '1h30m', milliseconds: 5400000 },
+      { input: '1.5h30m', milliseconds: 7200000 },
+      { input: '2m500ms', milliseconds: 120500 },
+      { input: '1h1h', milliseconds: 7200000 },
+      { input: '-1h30m', milliseconds: -5400000 },
+      { input: '+1h30m', milliseconds: 5400000 },
+    ])('parses $input as an elapsed duration', ({ input, milliseconds }) => {
+      expect(moment.duration(input).asMilliseconds()).toBe(milliseconds);
+    });
+
+    it('keeps calendar months distinct from minutes and ignores an explicit unit', () => {
+      const value = moment.utc('2024-01-31T12:00:00Z');
+      expect(value.add('1M30m', 'seconds')).toBe(value);
+      expect(value.toISOString()).toBe('2024-02-29T12:30:00.000Z');
+
+      expect(moment.duration('1h30m', 'seconds').asMilliseconds()).toBe(5400000);
+    });
+
+    it('adds a calendar day across DST without converting it to 24 elapsed hours', () => {
+      const value = moment.tz('2024-03-09T12:00:00', 'America/New_York');
+      expect(value.add('1d2h').toISOString()).toBe('2024-03-10T18:00:00.000Z');
+    });
+
+    it.each(['1h-30m', '1h+30m', '1h30garbage', '1h30', '1h 30m'])('rejects all of %s', (input) => {
+      expect(moment.duration(input).asMilliseconds()).toBe(0);
+    });
+
+    it('starts each scan independently after a malformed input', () => {
+      expect(moment.duration('1h30garbage').asMilliseconds()).toBe(0);
+      expect(moment.duration('1h30m').asMilliseconds()).toBe(5400000);
+      expect(moment.duration('5m').asMilliseconds()).toBe(300000);
+    });
+  });
+
+  describe('locale and week semantics', () => {
+    it('gets the instance locale without changing it or adopting a later global locale', () => {
+      const value = moment.utc('2024-05-06').locale('de');
+      moment.locale('fr');
+
+      expect(value.locale()).toBe('de');
+      expect(value.format('MMMM')).toBe('Mai');
+      expect(moment.locale()).toBe('fr');
+    });
+
+    it('activates a synthetic locale and retains its parent for Intl after another update', () => {
+      moment.updateLocale('parity-week', { parentLocale: 'de', week: { dow: 2 } });
+
+      expect(moment.locale()).toBe('parity-week');
+      expect(moment.utc('2024-05-08').locale()).toBe('parity-week');
+      expect(moment.utc('2024-05-08').format('MMMM')).toBe('Mai');
+      expect(moment.localeData().firstDayOfWeek()).toBe(2);
+
+      moment.updateLocale('parity-week', { week: { dow: 4 } });
+      expect(moment.utc('2024-05-08').format('MMMM')).toBe('Mai');
+      expect(moment.utc('2024-05-08').startOf('week').toISOString()).toBe('2024-05-02T00:00:00.000Z');
+    });
+
+    it.each([
+      { locale: 'en-US', dow: 0, start: '2024-05-05T00:00:00.000Z', end: '2024-05-11T23:59:59.999Z' },
+      { locale: 'de', dow: 1, start: '2024-05-06T00:00:00.000Z', end: '2024-05-12T23:59:59.999Z' },
+    ])('uses $locale defaults for singular and plural week boundaries', ({ locale, dow, start, end }) => {
+      const value = moment.utc('2024-05-08T12:00:00Z').locale(locale);
+      expect(moment.localeData(locale).firstDayOfWeek()).toBe(dow);
+      expect(value.clone().startOf('week').toISOString()).toBe(start);
+      expect(value.clone().startOf('weeks').toISOString()).toBe(start);
+      expect(value.clone().endOf('week').toISOString()).toBe(end);
+      expect(value.clone().endOf('weeks').toISOString()).toBe(end);
+    });
+
+    it('keeps ISO week boundaries on Monday in a Sunday-first locale', () => {
+      const value = moment.utc('2024-05-08T12:00:00Z').locale('en-US');
+      expect(value.clone().startOf('isoWeek').toISOString()).toBe('2024-05-06T00:00:00.000Z');
+      expect(value.clone().endOf('isoWeek').toISOString()).toBe('2024-05-12T23:59:59.999Z');
+    });
+
+    it('gets and sets weekday relative to the locale rather than Sunday', () => {
+      const value = moment.utc('2024-05-08T12:00:00Z').locale('de');
+      expect(value.day()).toBe(3);
+      expect(value.weekday()).toBe(2);
+      expect(value.clone().weekday(0).toISOString()).toBe('2024-05-06T12:00:00.000Z');
+      expect(value.clone().weekday(-1).toISOString()).toBe('2024-05-05T12:00:00.000Z');
+    });
+  });
+
+  describe('construction and zone conversion', () => {
+    it('preserves the locale and system-zone identity when copying a local instance', () => {
+      const source = moment('2024-05-06T12:00:00').locale('de');
+      moment.locale('fr');
+
+      const copy = moment(source);
+      expect(copy.locale()).toBe('de');
+      expect(copy.format('YYYY-MM-DD HH:mm [zone:]z')).toBe('2024-05-06 12:00 zone:');
+      copy.add(1, 'day');
+      expect(source.format('YYYY-MM-DD HH:mm')).toBe('2024-05-06 12:00');
+    });
+
+    it('preserves a named zone and locale when cloning or copying', () => {
+      const source = moment.tz('2024-05-06T12:00:00', 'America/New_York').locale('de');
+      moment.locale('fr');
+
+      for (const copy of [source.clone(), moment(source)]) {
+        expect(copy.locale()).toBe('de');
+        expect(copy.tz()).toBe('America/New_York');
+        expect(copy.toISOString()).toBe('2024-05-06T16:00:00.000Z');
+      }
+    });
+
+    it('constructs from raw Luxon input and honors an explicit destination zone', () => {
+      const raw = DateTime.fromISO('2024-05-06T12:00:00', { zone: 'America/New_York', locale: 'de' });
+      const copied = moment(raw);
+      expect(copied.locale()).toBe('de');
+      expect(copied.tz()).toBe('America/New_York');
+      expect(copied.toISOString()).toBe('2024-05-06T16:00:00.000Z');
+
+      const converted = moment.tz(raw, 'Asia/Tokyo');
+      expect(converted.tz()).toBe('Asia/Tokyo');
+      expect(converted.format('YYYY-MM-DD HH:mm Z')).toBe('2024-05-07 01:00 +09:00');
+      expect(moment.utc(raw).toISOString()).toBe('2024-05-06T16:00:00.000Z');
+    });
+
+    it('treats the single tz argument as the zone for the current instant', () => {
+      Settings.now = () => 1714996800000;
+      const value = moment.tz('America/New_York');
+      expect(value.tz()).toBe('America/New_York');
+      expect(value.toISOString()).toBe('2024-05-06T12:00:00.000Z');
+      expect(value.format('HH:mm Z')).toBe('08:00 -04:00');
+    });
+
+    it('preserves wall time with local(true), but preserves the instant with local()', () => {
+      const source = moment.tz('2024-05-06T12:00:00', 'America/New_York');
+      expect(source.clone().local(true).format('YYYY-MM-DD HH:mm')).toBe('2024-05-06 12:00');
+      expect(source.clone().local().toISOString()).toBe('2024-05-06T16:00:00.000Z');
+    });
+  });
+
+  describe('parsing and invalid values', () => {
+    it('makes explicit ISO parsing authoritative instead of accepting an RFC fallback', () => {
+      expect(moment.utc('2024-05-06T12:00:00+02:00', moment.ISO_8601).toISOString()).toBe(
+        '2024-05-06T10:00:00.000Z'
+      );
+      expect(moment.utc('Mon, 06 May 2024 12:00:00 GMT', moment.ISO_8601).isValid()).toBe(false);
+    });
+
+    it('does not normalize an impossible ISO date through the native Date fallback', () => {
+      expect(moment.utc('2024-02-30').isValid()).toBe(false);
+      expect(moment.utc('2024-02-30', 'YYYY-MM-DD').isValid()).toBe(false);
+    });
+
+    it('does not discard a mismatched RFC weekday through the native Date fallback', () => {
+      expect(moment.utc('Tue, 06 May 2024 12:00:00 GMT').isValid()).toBe(false);
+    });
+
+    it('returns NaN for diff with an invalid receiver or operand', () => {
+      const valid = moment.utc('2024-05-06');
+      const invalid = moment(null);
+      expect(valid.diff(invalid, 'days')).toBeNaN();
+      expect(invalid.diff(valid, 'days')).toBeNaN();
+      expect(valid.diff(invalid, 'hours', true)).toBeNaN();
+    });
+
+    it('rejects invalid receivers and endpoints even with inclusive bounds', () => {
+      const start = moment.utc('2024-05-06');
+      const end = moment.utc('2024-05-08');
+      const value = moment.utc('2024-05-07');
+      const invalid = moment(null);
+      expect(invalid.isBetween(start, end, 'day', '[]')).toBe(false);
+      expect(value.isBetween(invalid, end, 'day', '[]')).toBe(false);
+      expect(value.isBetween(start, invalid, 'day', '[]')).toBe(false);
+      expect(value.isSame(invalid, 'day')).toBe(false);
+      expect(value.isBefore(invalid, 'day')).toBe(false);
+      expect(value.isAfter(invalid, 'day')).toBe(false);
+    });
+  });
+
+  it('compares day boundaries in the receiver zone rather than each operand zone', () => {
+    const value = moment.tz('2024-05-06T23:30:00', 'America/New_York');
+    const sameDay = moment.utc('2024-05-07T01:00:00Z');
+    const nextDay = moment.utc('2024-05-07T05:00:00Z');
+    const previousDay = moment.utc('2024-05-06T03:00:00Z');
+
+    expect(value.isSame(sameDay, 'day')).toBe(true);
+    expect(value.isBefore(sameDay, 'day')).toBe(false);
+    expect(value.isAfter(sameDay, 'day')).toBe(false);
+    expect(value.isBefore(nextDay, 'day')).toBe(true);
+    expect(value.isAfter(previousDay, 'day')).toBe(true);
+    expect(value.isBetween(sameDay, nextDay, 'day', '[)')).toBe(true);
+    expect(value.isBetween(sameDay, nextDay, 'day', '()')).toBe(false);
+  });
+
+  describe('calendar fields and serialization', () => {
+    it('distinguishes day of week from day of month in get and set', () => {
+      const value = moment.utc('2024-05-08T12:00:00Z');
+      expect(value.get('day')).toBe(3);
+      expect(value.get('date')).toBe(8);
+      expect(value.clone().set('day', 0).toISOString()).toBe('2024-05-05T12:00:00.000Z');
+      expect(value.clone().set('date', 1).toISOString()).toBe('2024-05-01T12:00:00.000Z');
+    });
+
+    it('sets quarter while retaining the month within the quarter and clamping the date', () => {
+      const value = moment.utc('2024-05-31T12:00:00Z');
+      expect(value.get('quarter')).toBe(2);
+      expect(value.set('quarter', 1).toISOString()).toBe('2024-02-29T12:00:00.000Z');
+    });
+
+    it('gets the ISO week across the calendar year boundary', () => {
+      const value = moment.utc('2021-01-01').locale('en-US');
+      expect(value.isoWeek()).toBe(53);
+      expect(value.get('isoWeek')).toBe(53);
+    });
+
+    it('serializes a zoned date as UTC JSON and an invalid date as null', () => {
+      const value = moment.tz('2024-05-06T12:00:00', 'America/New_York');
+      expect(value.toJSON()).toBe('2024-05-06T16:00:00.000Z');
+      expect(JSON.stringify({ at: value })).toBe('{"at":"2024-05-06T16:00:00.000Z"}');
+      expect(moment(null).toJSON()).toBeNull();
+    });
+  });
+});

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
@@ -104,6 +104,26 @@ describe('moment compatibility parity', () => {
   });
 
   describe('duration objects', () => {
+    it('uses duration-instance totals for copies, addition, and subtraction', () => {
+      const duration = moment.duration(5, 'minutes');
+      const value = moment.utc('2024-05-08T12:00:00Z');
+
+      expect(moment.duration(duration).asMilliseconds()).toBe(300000);
+      expect(value.clone().add(duration).toISOString()).toBe('2024-05-08T12:05:00.000Z');
+      expect(value.clone().subtract(duration).toISOString()).toBe('2024-05-08T11:55:00.000Z');
+    });
+
+    it('retains elapsed-millisecond arithmetic for duration instances across DST', () => {
+      const value = moment.tz('2024-03-09T12:00:00', 'America/New_York');
+      expect(value.add(moment.duration(1, 'day')).toISOString()).toBe('2024-03-10T17:00:00.000Z');
+    });
+
+    it('preserves invalid duration-instance totals', () => {
+      const duration = moment.duration(NaN);
+      expect(moment.duration(duration).asMilliseconds()).toBeNaN();
+      expect(moment.utc(0).add(duration).isValid()).toBe(false);
+    });
+
     it.each([
       { form: 'singular', input: { hour: 1, minute: '30' } },
       { form: 'plural', input: { hours: 1, minutes: '30' } },

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
@@ -680,7 +680,7 @@ const FIELD_BY_UNIT: Partial<
 };
 
 function getLocaleFirstDayOfWeek(locale = currentLocale): number {
-  return localeOverrides.get(locale)?.dow ?? (Info.getStartOfWeek({ locale: normalizeLocale(locale) }) % 7);
+  return localeOverrides.get(locale)?.dow ?? Info.getStartOfWeek({ locale: normalizeLocale(locale) }) % 7;
 }
 
 function normalizeZoneName(name: string): string {
@@ -970,7 +970,7 @@ class MomentCompat implements MomentLike {
     if (value == null) {
       return this._locale;
     }
-    this._locale = localeOverrides.has(value) ? value : normalizeLocale(value) ?? DEFAULT_LOCALE;
+    this._locale = localeOverrides.has(value) ? value : (normalizeLocale(value) ?? DEFAULT_LOCALE);
     return this._setDt(this._dt.setLocale(normalizeLocale(value) ?? DEFAULT_LOCALE));
   }
 
@@ -1192,10 +1192,10 @@ function makeMoment(input?: MomentInput, options?: MomentOptions, parseOptions?:
   const normalizedOptions = options?.zone ? { ...options, zone: normalizeZone(options.zone) } : options;
   const dt = normalizeInput(input, normalizedOptions, parseOptions);
   const locale = DateTime.isDateTime(input)
-    ? input.locale ?? DEFAULT_LOCALE
+    ? (input.locale ?? DEFAULT_LOCALE)
     : options?.locale && localeOverrides.has(options.locale)
       ? options.locale
-      : dt.locale ?? DEFAULT_LOCALE;
+      : (dt.locale ?? DEFAULT_LOCALE);
   return new MomentCompat(dt, locale);
 }
 

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
@@ -10,6 +10,7 @@ import {
   Duration,
   FixedOffsetZone,
   IANAZone,
+  Info,
   Settings,
   type Zone,
 } from './luxon';
@@ -44,7 +45,10 @@ export type MomentUnit =
   | 'millisecond'
   | 'ms';
 
-type StartEndUnit = MomentUnit | 'date';
+type ArithmeticUnit = MomentUnit;
+type DiffUnit = Exclude<MomentUnit, 'isoWeek'>;
+type StartEndUnit = MomentUnit | 'isoWeeks' | 'W' | 'date' | 'dates' | 'D' | undefined;
+type Inclusivity = '()' | '[)' | '(]' | '[]';
 
 type InputObject = Partial<{
   year: number;
@@ -64,9 +68,10 @@ interface MomentBuiltinFormat {
 }
 type MomentFormat = string | MomentBuiltinFormat;
 type FormatArg = string | undefined;
-type UnitGetter = MomentUnit | DateTimeUnit | 'date';
+type UnitGetter = Exclude<StartEndUnit, undefined> | 'weekday' | 'weekdays' | 'e' | 'isoWeekday' | 'isoWeekdays' | 'E';
 
-type MomentDurationInput = number | string | undefined | null;
+export type MomentDurationInputObject = Partial<Record<ArithmeticUnit, number | string>>;
+type MomentDurationInput = number | string | MomentDurationInputObject | undefined | null;
 
 interface MomentOptions {
   locale?: string;
@@ -103,15 +108,16 @@ interface UnitAccessor {
 export interface MomentLike {
   _isAMomentObject?: boolean;
 
-  add(value: number, unit?: MomentUnit | string): MomentLike;
-  subtract(value: number, unit?: MomentUnit | string): MomentLike;
+  add(value?: MomentDurationInput, unit?: ArithmeticUnit): MomentLike;
+  subtract(value?: MomentDurationInput, unit?: ArithmeticUnit): MomentLike;
   startOf(unit: StartEndUnit): MomentLike;
   endOf(unit: StartEndUnit): MomentLike;
   set(unit: UnitGetter, value: number): MomentLike;
   get(unit: UnitGetter): number;
+  locale(): string;
   locale(value: string): MomentLike;
   utc(keepLocalTime?: boolean): MomentLike;
-  local(): MomentLike;
+  local(keepLocalTime?: boolean): MomentLike;
   tz(): string | undefined;
   tz(zone: string, keepLocalTime?: boolean): MomentLike;
   clone(): MomentLike;
@@ -138,11 +144,11 @@ export interface MomentLike {
   millisecond: UnitAccessor;
   milliseconds: UnitAccessor;
   isValid(): boolean;
-  isBefore(input: MomentInput, unit?: StartEndUnit): boolean;
-  isAfter(input: MomentInput, unit?: StartEndUnit): boolean;
-  isBetween(a: MomentInput, b: MomentInput, unit?: StartEndUnit, inclusivity?: string): boolean;
-  isSame(input: MomentInput, unit?: StartEndUnit): boolean;
-  diff(input: MomentInput, unit?: MomentUnit, asFloat?: boolean): number;
+  isBefore(input?: MomentInput, unit?: StartEndUnit): boolean;
+  isAfter(input?: MomentInput, unit?: StartEndUnit): boolean;
+  isBetween(a: MomentInput, b: MomentInput, unit?: StartEndUnit, inclusivity?: Inclusivity): boolean;
+  isSame(input?: MomentInput, unit?: StartEndUnit): boolean;
+  diff(input: MomentInput, unit?: DiffUnit, asFloat?: boolean): number;
   toDate(): Date;
   toISOString(keepOffset?: boolean): string | null;
   toJSON(): string | null;
@@ -198,7 +204,7 @@ const UNIT_MAP: Record<MomentUnit, DurationUnit> = {
   ms: 'milliseconds',
 };
 
-const START_END_UNIT_MAP: Record<StartEndUnit, DateTimeUnit> = {
+const START_END_UNIT_MAP: Record<Exclude<StartEndUnit, undefined>, DateTimeUnit> = {
   years: 'year',
   year: 'year',
   y: 'year',
@@ -211,10 +217,14 @@ const START_END_UNIT_MAP: Record<StartEndUnit, DateTimeUnit> = {
   weeks: 'week',
   week: 'week',
   isoWeek: 'week',
+  isoWeeks: 'week',
+  W: 'week',
   w: 'week',
   days: 'day',
   day: 'day',
   date: 'day',
+  dates: 'day',
+  D: 'day',
   d: 'day',
   hours: 'hour',
   hour: 'hour',
@@ -238,7 +248,7 @@ const ISO_8601 = 'ISO_8601' as unknown as MomentBuiltinFormat;
 
 let currentLocale = DEFAULT_LOCALE;
 Settings.defaultLocale = currentLocale;
-const localeWeekStart: Record<string, number> = {};
+const localeOverrides = new Map<string, { locale: string; dow: number }>();
 const intlFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const timeZoneInfoCache = new Map<string, MomentTimeZoneInfo | null>();
 const normalizedLocaleCache = new Map<string, string | undefined>();
@@ -250,6 +260,11 @@ let cachedGuessedZone: string | null = null;
 function normalizeLocale(locale?: string): string | undefined {
   if (locale == null) {
     return undefined;
+  }
+
+  const override = localeOverrides.get(locale);
+  if (override) {
+    return override.locale;
   }
 
   if (normalizedLocaleCache.has(locale)) {
@@ -342,23 +357,95 @@ function getCachedDateTimeFormatter(locale: string, options: Intl.DateTimeFormat
 }
 
 function isMomentUnit(unit: string): unit is MomentUnit {
-  return unit in UNIT_MAP;
+  return Object.prototype.hasOwnProperty.call(UNIT_MAP, unit);
 }
 
 function normalizeUnit(unit: string): DurationUnit {
   return isMomentUnit(unit) ? UNIT_MAP[unit] : 'milliseconds';
 }
 
-function normalizeStartEndUnit(unit: StartEndUnit): DateTimeUnit {
-  return START_END_UNIT_MAP[unit];
+function normalizeStartEndUnit(unit: StartEndUnit): DateTimeUnit | undefined {
+  return unit != null && Object.prototype.hasOwnProperty.call(START_END_UNIT_MAP, unit)
+    ? START_END_UNIT_MAP[unit]
+    : undefined;
 }
 
-function normalizeDurationInput(input: number, unit?: MomentUnit | string): Duration {
-  if (unit == null) {
-    return Duration.fromMillis(input);
+const SHORTHAND_DURATION = /(\d+(?:\.\d*)?|\.\d+)(ms|s|m|h|d|w|M|y)/y;
+
+function durationFromFields(fields: Partial<Record<DurationUnit, number>>): Duration {
+  return Object.values(fields).every(Number.isFinite)
+    ? Duration.fromObject(fields)
+    : Duration.invalid('nonfinite duration');
+}
+
+function parseShorthandDuration(input: string): Duration | undefined {
+  const value = input.trim();
+  const sign = value[0] === '-' ? -1 : 1;
+  let offset = value[0] === '-' || value[0] === '+' ? 1 : 0;
+  if (offset === value.length) {
+    return undefined;
   }
 
-  return Duration.fromObject({ [normalizeUnit(unit)]: input });
+  const fields: Partial<Record<DurationUnit, number>> = {};
+  while (offset < value.length) {
+    // Sticky matching rejects gaps and trailing text instead of accepting a valid prefix.
+    SHORTHAND_DURATION.lastIndex = offset;
+    const part = SHORTHAND_DURATION.exec(value);
+    if (!part || !isMomentUnit(part[2])) {
+      return undefined;
+    }
+    const unit = UNIT_MAP[part[2]];
+    fields[unit] = (fields[unit] ?? 0) + sign * Number(part[1]);
+    offset = SHORTHAND_DURATION.lastIndex;
+  }
+
+  return durationFromFields(fields);
+}
+
+function normalizeDurationInput(input?: MomentDurationInput, unit?: ArithmeticUnit): Duration {
+  if (input == null) {
+    return Duration.fromMillis(0);
+  }
+
+  if (typeof input === 'object') {
+    const fields: Partial<Record<DurationUnit, number>> = {};
+    for (const key of Object.keys(input)) {
+      if (isMomentUnit(key)) {
+        // Object aliases overwrite in property order; unlike shorthand, they do not accumulate.
+        fields[UNIT_MAP[key]] = Number(input[key] ?? 0);
+      }
+    }
+    return durationFromFields(fields);
+  }
+
+  if (typeof input === 'string' && Number.isNaN(Number(input))) {
+    const shorthand = parseShorthandDuration(input);
+    if (shorthand) {
+      return shorthand;
+    }
+    const parsed = Duration.fromISO(input);
+    return parsed.isValid ? parsed : Duration.fromMillis(0);
+  }
+
+  const amount = Number(input);
+  if (!Number.isFinite(amount)) {
+    return Duration.invalid('nonfinite duration');
+  }
+  if (unit != null && !isMomentUnit(unit)) {
+    return Duration.fromMillis(0);
+  }
+  return Duration.fromObject({ [unit == null ? 'milliseconds' : UNIT_MAP[unit]]: amount });
+}
+
+function arithmeticDuration(duration: Duration): Duration {
+  // Calendar fractions round after aggregation; elapsed hours must not become calendar days.
+  const months = duration.years * 12 + duration.quarters * 3 + duration.months;
+  const days = duration.weeks * 7 + duration.days;
+  return Duration.fromObject({
+    months: Math.sign(months) * Math.round(Math.abs(months)),
+    days: Math.sign(days) * Math.round(Math.abs(days)),
+    milliseconds: duration.hours * 3600000 + duration.minutes * 60000 + duration.seconds * 1000 + duration.milliseconds,
+  });
 }
 
 const formatParserCache = new Map<string, TokenParser>();
@@ -397,10 +484,10 @@ function parseWithFormat(value: string, format: MomentFormat, options?: MomentOp
 
   // ISO_8601 is the only non-string MomentFormat member and it is handled above, so this
   // fallback never changes behavior; it only narrows the type for the format conversions below.
-  const fmt = convertMomentToLuxonForParsing(typeof format === 'string' ? format : 'ISO_8601');
+  const fmt = convertMomentToLuxonForParsing(typeof format === 'string' ? format : 'ISO_8601', options?.locale);
 
   const parsed = parseFromCachedFormat(value, fmt, options);
-  if (parsed.isValid) {
+  if (parsed.isValid || parsed.invalidReason !== 'unparsable') {
     return parsed;
   }
 
@@ -423,10 +510,10 @@ function parseWithFormat(value: string, format: MomentFormat, options?: MomentOp
     for (const [permissiveValue, permissiveFormat] of permissiveInputs) {
       const permissiveParsed = parseFromCachedFormat(
         permissiveValue,
-        convertMomentToLuxonForParsing(permissiveFormat),
+        convertMomentToLuxonForParsing(permissiveFormat, options?.locale),
         options
       );
-      if (permissiveParsed.isValid) {
+      if (permissiveParsed.isValid || permissiveParsed.invalidReason !== 'unparsable') {
         return permissiveParsed;
       }
     }
@@ -443,7 +530,7 @@ function parseWithFormat(value: string, format: MomentFormat, options?: MomentOp
     return reparsed.isValid ? reparsed : fallbackParsed;
   }
 
-  return DateTime.invalid('unsupported format input');
+  return fallbackParsed;
 }
 
 function parseWithFallbacks(value: string, options?: MomentOptions): DateTime {
@@ -460,12 +547,12 @@ function parseWithFallbacks(value: string, options?: MomentOptions): DateTime {
 
   for (const parse of parsers) {
     const dt = parse();
-    if (dt.isValid) {
+    if (dt.isValid || dt.invalidReason !== 'unparsable') {
       return dt;
     }
   }
 
-  return DateTime.invalid('unsupported string input');
+  return DateTime.invalid('unparsable');
 }
 
 type RelativeUnit = 'years' | 'months' | 'days' | 'hours' | 'minutes' | 'seconds';
@@ -532,12 +619,24 @@ function toMomentDay(weekday: number): number {
   return weekday % 7;
 }
 
-// canonical field for every get() unit spelling; get() dispatches to the matching accessor so the
-// moment-vs-luxon offset semantics (0-based months, etc.) live in exactly one place. The 'day'
-// family maps to day-of-month (luxon semantics, matching this shim's behavior to date), not
-// moment's weekday.
+// Constructor objects use day-of-month; get/set use Moment's weekday semantics instead.
 const FIELD_BY_UNIT: Partial<
-  Record<UnitGetter, 'year' | 'month' | 'date' | 'week' | 'hour' | 'minute' | 'second' | 'millisecond' | 'quarter'>
+  Record<
+    UnitGetter,
+    | 'year'
+    | 'month'
+    | 'date'
+    | 'day'
+    | 'weekday'
+    | 'isoWeekday'
+    | 'week'
+    | 'isoWeek'
+    | 'hour'
+    | 'minute'
+    | 'second'
+    | 'millisecond'
+    | 'quarter'
+  >
 > = {
   millisecond: 'millisecond',
   milliseconds: 'millisecond',
@@ -551,10 +650,21 @@ const FIELD_BY_UNIT: Partial<
   hour: 'hour',
   hours: 'hour',
   h: 'hour',
-  day: 'date',
-  days: 'date',
-  d: 'date',
+  day: 'day',
+  days: 'day',
+  d: 'day',
   date: 'date',
+  dates: 'date',
+  D: 'date',
+  weekday: 'weekday',
+  weekdays: 'weekday',
+  e: 'weekday',
+  isoWeekday: 'isoWeekday',
+  isoWeekdays: 'isoWeekday',
+  E: 'isoWeekday',
+  isoWeek: 'isoWeek',
+  isoWeeks: 'isoWeek',
+  W: 'isoWeek',
   week: 'week',
   weeks: 'week',
   w: 'week',
@@ -570,7 +680,7 @@ const FIELD_BY_UNIT: Partial<
 };
 
 function getLocaleFirstDayOfWeek(locale = currentLocale): number {
-  return localeWeekStart[locale] ?? 0;
+  return localeOverrides.get(locale)?.dow ?? (Info.getStartOfWeek({ locale: normalizeLocale(locale) }) % 7);
 }
 
 function normalizeZoneName(name: string): string {
@@ -667,7 +777,7 @@ function parseInput(input: MomentInput, options?: MomentOptions, parseOptions?: 
   }
 
   if (DateTime.isDateTime(input)) {
-    return input;
+    return options?.zone ? input.setZone(options.zone) : input;
   }
 
   if (input instanceof Date) {
@@ -676,6 +786,9 @@ function parseInput(input: MomentInput, options?: MomentOptions, parseOptions?: 
   }
 
   if (typeof input === 'number') {
+    if (!Number.isFinite(input)) {
+      return DateTime.invalid('nonfinite timestamp');
+    }
     return DateTime.fromMillis(input, {
       ...options,
       locale,
@@ -689,7 +802,7 @@ function parseInput(input: MomentInput, options?: MomentOptions, parseOptions?: 
         locale,
       });
 
-      if (formatted.isValid) {
+      if (formatted.isValid || parseOptions.format === ISO_8601 || formatted.invalidReason !== 'unparsable') {
         return formatted;
       }
     }
@@ -742,27 +855,23 @@ function weekdayNames(locale: string): string[] {
   return Array.from({ length: 7 }, (_, i) => dateFmt.format(new Date(Date.UTC(2020, 5, 7 + i))));
 }
 
-// millis of `dt` and `other`, truncated to `unit` when given, for comparisons
-function comparableMillis(dt: DateTime, other: MomentInput, unit?: StartEndUnit): [number, number] {
-  const b = normalizeInput(other);
-
-  if (unit) {
-    const normalizedUnit = normalizeStartEndUnit(unit);
-    return [dt.startOf(normalizedUnit).toMillis(), b.startOf(normalizedUnit).toMillis()];
+function unitBoundary(dt: DateTime, unit: StartEndUnit, locale: string, end = false): DateTime {
+  const normalizedUnit = normalizeStartEndUnit(unit);
+  if (normalizedUnit == null) {
+    return dt;
   }
-
-  return [dt.toMillis(), b.toMillis()];
+  if (unit === 'week' || unit === 'weeks' || unit === 'w') {
+    const start = startOfLocaleWeek(dt, locale);
+    return end ? start.plus({ days: 6 }).endOf('day') : start;
+  }
+  return end ? dt.endOf(normalizedUnit) : dt.startOf(normalizedUnit);
 }
 
-function startOfLocaleWeek(dt: DateTime): DateTime {
-  const weekStart = getLocaleFirstDayOfWeek(dt.locale || currentLocale);
+function startOfLocaleWeek(dt: DateTime, locale: string): DateTime {
+  const weekStart = getLocaleFirstDayOfWeek(locale);
   const currentDay = toMomentDay(dt.weekday);
   const daysSinceWeekStart = (currentDay - weekStart + 7) % 7;
   return dt.startOf('day').minus({ days: daysSinceWeekStart });
-}
-
-function endOfLocaleWeek(dt: DateTime): DateTime {
-  return startOfLocaleWeek(dt).plus({ days: 6 }).endOf('day');
 }
 
 function truncateToWholeMilliseconds(dt: DateTime): DateTime {
@@ -784,13 +893,11 @@ function truncateToWholeMilliseconds(dt: DateTime): DateTime {
 class MomentCompat implements MomentLike {
   declare _isAMomentObject: boolean;
 
-  // plural/synonym unit spellings share the canonical unit's prototype method (assigned below the
-  // class): moment treats e.g. minutes() as minute(), and week()/isoWeek() as synonyms.
+  // Plural accessors share the canonical prototype methods without per-instance allocations.
   declare years: UnitAccessor;
   declare months: UnitAccessor;
   declare dates: UnitAccessor;
   declare days: UnitAccessor;
-  declare weekday: UnitAccessor;
   declare weeks: UnitAccessor;
   declare isoWeek: UnitAccessor;
   declare isoWeeks: UnitAccessor;
@@ -800,9 +907,11 @@ class MomentCompat implements MomentLike {
   declare milliseconds: UnitAccessor;
 
   private _dt: DateTime;
+  private _locale: string;
 
-  constructor(dt: DateTime) {
+  constructor(dt: DateTime, locale = dt.locale ?? DEFAULT_LOCALE) {
     this._dt = dt;
+    this._locale = locale;
   }
 
   private _setDt(next: DateTime): MomentLike {
@@ -810,28 +919,26 @@ class MomentCompat implements MomentLike {
     return this;
   }
 
-  add(value: number, unit?: MomentUnit | string): MomentLike {
-    return this._setDt(this._dt.plus(normalizeDurationInput(value, unit)));
+  add(value?: MomentDurationInput, unit?: ArithmeticUnit): MomentLike {
+    const duration = normalizeDurationInput(value, unit);
+    return this._setDt(
+      duration.isValid ? this._dt.plus(arithmeticDuration(duration)) : DateTime.invalid('invalid duration')
+    );
   }
 
-  subtract(value: number, unit?: MomentUnit | string): MomentLike {
-    return this._setDt(this._dt.minus(normalizeDurationInput(value, unit)));
+  subtract(value?: MomentDurationInput, unit?: ArithmeticUnit): MomentLike {
+    const duration = normalizeDurationInput(value, unit);
+    return this._setDt(
+      duration.isValid ? this._dt.minus(arithmeticDuration(duration)) : DateTime.invalid('invalid duration')
+    );
   }
 
   startOf(unit: StartEndUnit): MomentLike {
-    if (unit === 'week' || unit === 'w') {
-      return this._setDt(startOfLocaleWeek(this._dt));
-    }
-
-    return this._setDt(this._dt.startOf(normalizeStartEndUnit(unit)));
+    return this._setDt(unitBoundary(this._dt, unit, this._locale));
   }
 
   endOf(unit: StartEndUnit): MomentLike {
-    if (unit === 'week' || unit === 'w') {
-      return this._setDt(endOfLocaleWeek(this._dt));
-    }
-
-    return this._setDt(this._dt.endOf(normalizeStartEndUnit(unit)));
+    return this._setDt(unitBoundary(this._dt, unit, this._locale, true));
   }
 
   set(unit: UnitGetter, value: number): MomentLike {
@@ -839,22 +946,15 @@ class MomentCompat implements MomentLike {
       return this;
     }
 
-    if (unit === 'week' || unit === 'weeks' || unit === 'w' || unit === 'isoWeek') {
-      return this.week(value);
+    const field = Object.prototype.hasOwnProperty.call(FIELD_BY_UNIT, unit) ? FIELD_BY_UNIT[unit] : undefined;
+    if (field == null) {
+      return this;
     }
-    if (unit === 'month' || unit === 'months' || unit === 'M') {
-      return this._setDt(this._dt.set({ month: value + 1 }));
-    }
-    if (unit === 'date') {
-      return this._setDt(this._dt.set({ day: value }));
-    }
-
-    const normalizedUnit = normalizeUnit(unit);
-    return this._setDt(this._dt.set({ [normalizedUnit]: value }));
+    return field === 'quarter' ? this.month((value - 1) * 3 + (this.month() % 3)) : this[field](value);
   }
 
   get(unit: UnitGetter): number {
-    const field = FIELD_BY_UNIT[unit];
+    const field = Object.prototype.hasOwnProperty.call(FIELD_BY_UNIT, unit) ? FIELD_BY_UNIT[unit] : undefined;
 
     if (field === undefined) {
       return Number.NaN;
@@ -864,7 +964,13 @@ class MomentCompat implements MomentLike {
     return field === 'quarter' ? this._dt.quarter : this[field]();
   }
 
-  locale(value: string): MomentLike {
+  locale(): string;
+  locale(value: string): MomentLike;
+  locale(value?: string): string | MomentLike {
+    if (value == null) {
+      return this._locale;
+    }
+    this._locale = localeOverrides.has(value) ? value : normalizeLocale(value) ?? DEFAULT_LOCALE;
     return this._setDt(this._dt.setLocale(normalizeLocale(value) ?? DEFAULT_LOCALE));
   }
 
@@ -872,8 +978,8 @@ class MomentCompat implements MomentLike {
     return this._setDt(this._dt.setZone('utc', { keepLocalTime }));
   }
 
-  local(): MomentLike {
-    return this._setDt(this._dt.setZone('local'));
+  local(keepLocalTime = false): MomentLike {
+    return this._setDt(this._dt.setZone('local', { keepLocalTime }));
   }
 
   tz(): string | undefined;
@@ -887,7 +993,7 @@ class MomentCompat implements MomentLike {
   }
 
   clone(): MomentLike {
-    return new MomentCompat(this._dt);
+    return new MomentCompat(this._dt, this._locale);
   }
 
   year(): number;
@@ -916,6 +1022,13 @@ class MomentCompat implements MomentLike {
     return value == null
       ? toMomentDay(this._dt.weekday)
       : this._setDt(this._dt.plus({ days: value - toMomentDay(this._dt.weekday) }));
+  }
+
+  weekday(): number;
+  weekday(value: number): MomentLike;
+  weekday(value?: number): number | MomentLike {
+    const day = (this.day() - getLocaleFirstDayOfWeek(this._locale) + 7) % 7;
+    return value == null ? day : this._setDt(this._dt.plus({ days: value - day }));
   }
 
   isoWeekday(): number;
@@ -958,39 +1071,40 @@ class MomentCompat implements MomentLike {
     return this._dt.isValid;
   }
 
-  isBefore(other: MomentInput, unit?: StartEndUnit): boolean {
-    const [a, b] = comparableMillis(this._dt, other, unit);
-    return a < b;
+  isBefore(other?: MomentInput, unit?: StartEndUnit): boolean {
+    return unitBoundary(this._dt, unit, this._locale, true).toMillis() < normalizeInput(other).toMillis();
   }
 
-  isAfter(other: MomentInput, unit?: StartEndUnit): boolean {
-    const [a, b] = comparableMillis(this._dt, other, unit);
-    return a > b;
+  isAfter(other?: MomentInput, unit?: StartEndUnit): boolean {
+    return unitBoundary(this._dt, unit, this._locale).toMillis() > normalizeInput(other).toMillis();
   }
 
-  // like moment, bounds are not reordered (a reversed range is simply never matched) and the
-  // unit truncates the endpoints as well as this instant
-  isBetween(a: MomentInput, b: MomentInput, unit?: StartEndUnit, inclusivity = '()'): boolean {
-    const [value, left] = comparableMillis(this._dt, a, unit);
-    const [, right] = comparableMillis(this._dt, b, unit);
-
-    const afterStart = inclusivity.startsWith('[') ? value >= left : value > left;
-    const beforeEnd = inclusivity.endsWith(']') ? value <= right : value < right;
-
-    return afterStart && beforeEnd;
+  isBetween(a: MomentInput, b: MomentInput, unit?: StartEndUnit, inclusivity: Inclusivity = '()'): boolean {
+    const left = normalizeInput(a);
+    const right = normalizeInput(b);
+    if (!this.isValid() || !left.isValid || !right.isValid) {
+      return false;
+    }
+    return (
+      (inclusivity[0] === '[' ? !this.isBefore(left, unit) : this.isAfter(left, unit)) &&
+      (inclusivity[1] === ']' ? !this.isAfter(right, unit) : this.isBefore(right, unit))
+    );
   }
 
-  isSame(other: MomentInput, unit?: StartEndUnit): boolean {
-    const [a, b] = comparableMillis(this._dt, other, unit);
-    return a === b;
+  isSame(other?: MomentInput, unit?: StartEndUnit): boolean {
+    const value = normalizeInput(other).toMillis();
+    return (
+      unitBoundary(this._dt, unit, this._locale).toMillis() <= value &&
+      value <= unitBoundary(this._dt, unit, this._locale, true).toMillis()
+    );
   }
 
-  diff(other: MomentInput, unit: MomentUnit = 'milliseconds', asFloat = false): number {
+  diff(other: MomentInput, unit: DiffUnit = 'milliseconds', asFloat = false): number {
     const b = normalizeInput(other);
     const normalizedUnit = normalizeUnit(unit);
     const value = this._dt.diff(b, normalizedUnit).as(normalizedUnit);
     // moment truncates toward zero (returning 0, never -0) unless asFloat is passed
-    return asFloat ? value : Math.trunc(value) || 0;
+    return asFloat ? value : Math.trunc(value) + 0;
   }
 
   toDate(): Date {
@@ -1002,7 +1116,7 @@ class MomentCompat implements MomentLike {
   }
 
   toJSON(): string | null {
-    return this._dt.toJSON();
+    return this.toISOString();
   }
 
   toString(): string {
@@ -1060,9 +1174,7 @@ proto.years = proto.year;
 proto.months = proto.month;
 proto.dates = proto.date;
 proto.days = proto.day;
-// moment's weekday() is locale-aware; the shim aliases it to Sunday-based day(), matching the
-// behavior this shim has always had (see the migration notes)
-proto.weekday = proto.day;
+
 proto.weeks = proto.week;
 proto.isoWeek = proto.week;
 proto.isoWeeks = proto.week;
@@ -1072,21 +1184,23 @@ proto.seconds = proto.second;
 proto.milliseconds = proto.millisecond;
 
 function makeMoment(input?: MomentInput, options?: MomentOptions, parseOptions?: ParseOptions): MomentLike {
+  // Custom valueOf implementations retain the generic Moment-like conversion behavior.
+  if (input instanceof MomentCompat && input.valueOf === MomentCompat.prototype.valueOf) {
+    const copy = input.clone();
+    return options?.zone ? copy.tz(typeof options.zone === 'string' ? options.zone : options.zone.name) : copy;
+  }
   const normalizedOptions = options?.zone ? { ...options, zone: normalizeZone(options.zone) } : options;
-  return new MomentCompat(normalizeInput(input, normalizedOptions, parseOptions));
+  const dt = normalizeInput(input, normalizedOptions, parseOptions);
+  const locale = DateTime.isDateTime(input)
+    ? input.locale ?? DEFAULT_LOCALE
+    : options?.locale && localeOverrides.has(options.locale)
+      ? options.locale
+      : dt.locale ?? DEFAULT_LOCALE;
+  return new MomentCompat(dt, locale);
 }
 
-function makeDuration(input?: MomentDurationInput, unit?: MomentUnit): MomentDurationLike {
-  let duration: Duration;
-
-  if (input == null) {
-    duration = Duration.fromMillis(0);
-  } else if (typeof input === 'string') {
-    const parsed = Duration.fromISO(input);
-    duration = parsed.isValid ? parsed : Duration.fromMillis(0);
-  } else {
-    duration = normalizeDurationInput(input, unit);
-  }
+function makeDuration(input?: MomentDurationInput, unit?: ArithmeticUnit): MomentDurationLike {
+  const duration = normalizeDurationInput(input, unit);
 
   // moment's seconds()/minutes()/hours() return integer components (0-59, 0-59, 0-23 with the
   // remainder carried into days), unlike as(unit) which returns the fractional total
@@ -1127,7 +1241,7 @@ export interface MomentFactory {
   (input?: MomentInput, format?: MomentFormat): MomentLike;
   ISO_8601: typeof ISO_8601;
   utc(input?: MomentInput, format?: MomentFormat): MomentLike;
-  duration(input?: MomentDurationInput, unit?: MomentUnit): MomentDurationLike;
+  duration(input?: MomentDurationInput, unit?: ArithmeticUnit): MomentDurationLike;
   isMoment(input: unknown): input is MomentLike;
   locale(locale?: string): string;
   localeData(locale?: string): { firstDayOfWeek: () => number };
@@ -1150,7 +1264,9 @@ const momentTz: MomentTzFactory = Object.assign(
       return makeMoment(input, { zone: formatOrZone, locale: currentLocale });
     }
 
-    return makeMoment(input, { locale: currentLocale });
+    return typeof input === 'string'
+      ? makeMoment(undefined, { zone: input, locale: currentLocale })
+      : makeMoment(input, { locale: currentLocale });
   },
   {
     guess: (ignoreCache = false): string => {
@@ -1177,7 +1293,7 @@ const moment: MomentFactory = Object.assign(
     locale: (locale?: string): string => {
       const normalizedLocale = normalizeLocale(locale);
       if (normalizedLocale != null) {
-        currentLocale = normalizedLocale;
+        currentLocale = locale != null && localeOverrides.has(locale) ? locale : normalizedLocale;
         Settings.defaultLocale = normalizedLocale;
       }
       return currentLocale;
@@ -1189,17 +1305,18 @@ const moment: MomentFactory = Object.assign(
 
     updateLocale: (locale: string, config: { parentLocale?: string; week?: { dow?: number } }): string => {
       const parentLocale = config.parentLocale ?? locale;
-      localeWeekStart[locale] = config.week?.dow ?? getLocaleFirstDayOfWeek(parentLocale);
-      return locale;
+      localeOverrides.set(locale, {
+        locale: normalizeLocale(parentLocale) ?? DEFAULT_LOCALE,
+        dow: config.week?.dow ?? getLocaleFirstDayOfWeek(parentLocale),
+      });
+      return moment.locale(locale);
     },
 
     utc: (input?: MomentInput, format?: MomentFormat): MomentLike => {
-      // the trailing .utc() is load-bearing for raw luxon DateTime inputs, which normalizeInput
-      // passes through with their own zone, ignoring options.zone
-      return makeMoment(input, { zone: 'utc', locale: currentLocale }, { format }).utc();
+      return makeMoment(input, { zone: 'utc', locale: currentLocale }, { format });
     },
 
-    duration: (input?: MomentDurationInput, unit?: MomentUnit): MomentDurationLike => makeDuration(input, unit),
+    duration: (input?: MomentDurationInput, unit?: ArithmeticUnit): MomentDurationLike => makeDuration(input, unit),
 
     isMoment: (input: unknown): input is MomentLike => isMomentLike(input),
 

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
@@ -71,7 +71,13 @@ type FormatArg = string | undefined;
 type UnitGetter = Exclude<StartEndUnit, undefined> | 'weekday' | 'weekdays' | 'e' | 'isoWeekday' | 'isoWeekdays' | 'E';
 
 export type MomentDurationInputObject = Partial<Record<ArithmeticUnit, number | string>>;
-type MomentDurationInput = number | string | MomentDurationInputObject | undefined | null;
+type MomentDurationInput =
+  | number
+  | string
+  | MomentDurationInputObject
+  | Pick<MomentDurationLike, 'asMilliseconds'>
+  | undefined
+  | null;
 
 interface MomentOptions {
   locale?: string;
@@ -408,6 +414,11 @@ function normalizeDurationInput(input?: MomentDurationInput, unit?: ArithmeticUn
   }
 
   if (typeof input === 'object') {
+    if ('asMilliseconds' in input) {
+      // Preserve elapsed-millisecond arithmetic for duration instances, not their component methods.
+      return normalizeDurationInput(input.asMilliseconds());
+    }
+
     const fields: Partial<Record<DurationUnit, number>> = {};
     for (const key of Object.keys(input)) {
       if (isMomentUnit(key)) {

--- a/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
@@ -1,0 +1,74 @@
+describe('Luxon-backed DateTime wrapper', () => {
+  const flagName = '__grafanaUseLuxon';
+  let originalDescriptor: PropertyDescriptor | undefined;
+  let originalLocale: string;
+  let wrapper: typeof import('./moment_wrapper');
+
+  beforeAll(async () => {
+    originalDescriptor = Object.getOwnPropertyDescriptor(window, flagName);
+    Object.defineProperty(window, flagName, { configurable: true, value: true });
+    wrapper = await import('./moment_wrapper');
+    originalLocale = wrapper.getLocale();
+  });
+
+  afterEach(() => {
+    wrapper.setLocale(originalLocale);
+  });
+
+  afterAll(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, flagName, originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, flagName);
+    }
+  });
+
+  it('subtracts shorthand through the public DateTime API without replacing the instance', () => {
+    const value = wrapper.toUtc('2024-05-08T12:00:00Z');
+
+    expect(value.subtract('5m')).toBe(value);
+    expect(value.toISOString()).toBe('2024-05-08T11:55:00.000Z');
+    expect(wrapper.toDuration('5m').asMilliseconds()).toBe(300000);
+    expect(wrapper.toDuration('5', 'minutes').asMilliseconds()).toBe(300000);
+  });
+
+  it('accepts unit objects through the public duration and arithmetic APIs', () => {
+    const input = { hour: 1, hours: 2, minutes: '30' };
+    expect(wrapper.toDuration(input, 'seconds').asMilliseconds()).toBe(9000000);
+
+    const value = wrapper.toUtc('2024-05-08T12:00:00Z');
+    expect(value.add(input)).toBe(value);
+    expect(value.toISOString()).toBe('2024-05-08T14:30:00.000Z');
+    expect(value.subtract({ h: 2, m: 30 }).toISOString()).toBe('2024-05-08T12:00:00.000Z');
+  });
+
+  it('retains the millisecond conversion path for existing duration-like inputs', () => {
+    const source = wrapper.toDuration(90, 'minutes');
+    expect(wrapper.toDuration(source, 'days').asMilliseconds()).toBe(5400000);
+  });
+
+  it('activates the week-start override and resets to the base locale', () => {
+    wrapper.setLocale('de');
+    wrapper.setWeekStart('Sunday');
+
+    expect(wrapper.getLocale()).toBe('de-weekStart');
+    expect(wrapper.getLocaleData().firstDayOfWeek()).toBe(0);
+    expect(wrapper.toUtc('2024-05-08').format('MMMM')).toBe('Mai');
+    expect(wrapper.toUtc('2024-05-08').startOf('weeks').toISOString()).toBe('2024-05-05T00:00:00.000Z');
+
+    wrapper.setWeekStart();
+
+    expect(wrapper.getLocale()).toBe('de');
+    expect(wrapper.getLocaleData().firstDayOfWeek()).toBe(1);
+    expect(wrapper.toUtc('2024-05-08').startOf('week').toISOString()).toBe('2024-05-06T00:00:00.000Z');
+  });
+
+  it('uses the same localized L pattern for public parsing and formatting', () => {
+    wrapper.setLocale('de');
+    const value = wrapper.toUtc('08.05.2024', 'L');
+
+    expect(value.toISOString()).toBe('2024-05-08T00:00:00.000Z');
+    expect(value.format('L')).toBe('08.05.2024');
+    expect(wrapper.toUtc('Wed, 08 May 2024 12:00:00 GMT', wrapper.ISO_8601).isValid()).toBe(false);
+  });
+});

--- a/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
@@ -49,6 +49,14 @@ describe('Luxon-backed DateTime wrapper', () => {
     expect(wrapper.toDuration(source, 'days').asMilliseconds()).toBe(5400000);
   });
 
+  it('accepts toDuration results in public arithmetic', () => {
+    const duration = wrapper.toDuration(5, 'minutes');
+    const value = wrapper.toUtc('2024-05-08T12:00:00Z');
+
+    expect(value.add(duration).toISOString()).toBe('2024-05-08T12:05:00.000Z');
+    expect(value.subtract(duration).toISOString()).toBe('2024-05-08T12:00:00.000Z');
+  });
+
   it('activates the week-start override and resets to the base locale', () => {
     wrapper.setLocale('de');
     wrapper.setWeekStart('Sunday');

--- a/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
@@ -1,8 +1,10 @@
+import type * as MomentWrapper from './moment_wrapper';
+
 describe('Luxon-backed DateTime wrapper', () => {
   const flagName = '__grafanaUseLuxon';
   let originalDescriptor: PropertyDescriptor | undefined;
   let originalLocale: string;
-  let wrapper: typeof import('./moment_wrapper');
+  let wrapper: typeof MomentWrapper;
 
   beforeAll(async () => {
     originalDescriptor = Object.getOwnPropertyDescriptor(window, flagName);

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -35,7 +35,7 @@ export interface DateTimeDuration {
 }
 
 export interface DateTime extends Object {
-  add: (amount?: DateTimeInput | MomentDurationInputObject, unit?: DurationUnit) => DateTime;
+  add: (amount?: DateTimeInput | DurationInput, unit?: DurationUnit) => DateTime;
   set: (unit: DurationUnit | 'date', amount: DateTimeInput) => void;
   diff: (amount: DateTimeInput, unit?: DurationUnit, asFloat?: boolean) => number;
   endOf: (unitOfTime: DurationUnit) => DateTime;
@@ -48,7 +48,7 @@ export interface DateTime extends Object {
   local: () => DateTime;
   locale: (locale: string) => DateTime;
   startOf: (unitOfTime: DurationUnit) => DateTime;
-  subtract: (amount?: DateTimeInput | MomentDurationInputObject, unit?: DurationUnit) => DateTime;
+  subtract: (amount?: DateTimeInput | DurationInput, unit?: DurationUnit) => DateTime;
   toDate: () => Date;
   toISOString: (keepOffset?: boolean) => string;
   isoWeekday: (day?: number | string) => number | string;

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -1,6 +1,11 @@
 import { type TimeZone } from '../types/time';
 
-import { type MomentInput, type MomentLike as Moment, type MomentUnit } from './luxon_moment_compat/moment';
+import {
+  type MomentDurationInputObject,
+  type MomentInput,
+  type MomentLike as Moment,
+  type MomentUnit,
+} from './luxon_moment_compat/moment';
 import moment from './moment_implementation';
 
 export type { Moment };
@@ -12,7 +17,7 @@ export interface DateTimeBuiltinFormat {
 export const ISO_8601: DateTimeBuiltinFormat = moment.ISO_8601;
 export type DateTimeInput = Date | string | number | Array<string | number> | DateTime | null; // | undefined;
 export type FormatInput = string | DateTimeBuiltinFormat | undefined;
-export type DurationInput = string | number | DateTimeDuration;
+export type DurationInput = string | number | DateTimeDuration | MomentDurationInputObject;
 // same member set as the shim's MomentUnit; aliased so the two cannot drift apart
 export type DurationUnit = MomentUnit;
 
@@ -30,9 +35,9 @@ export interface DateTimeDuration {
 }
 
 export interface DateTime extends Object {
-  add: (amount?: DateTimeInput, unit?: DurationUnit) => DateTime;
+  add: (amount?: DateTimeInput | MomentDurationInputObject, unit?: DurationUnit) => DateTime;
   set: (unit: DurationUnit | 'date', amount: DateTimeInput) => void;
-  diff: (amount: DateTimeInput, unit?: DurationUnit, truncate?: boolean) => number;
+  diff: (amount: DateTimeInput, unit?: DurationUnit, asFloat?: boolean) => number;
   endOf: (unitOfTime: DurationUnit) => DateTime;
   format: (formatInput?: FormatInput) => string;
   fromNow: (withoutSuffix?: boolean) => string;
@@ -43,7 +48,7 @@ export interface DateTime extends Object {
   local: () => DateTime;
   locale: (locale: string) => DateTime;
   startOf: (unitOfTime: DurationUnit) => DateTime;
-  subtract: (amount?: DateTimeInput, unit?: DurationUnit) => DateTime;
+  subtract: (amount?: DateTimeInput | MomentDurationInputObject, unit?: DurationUnit) => DateTime;
   toDate: () => Date;
   toISOString: (keepOffset?: boolean) => string;
   isoWeekday: (day?: number | string) => number | string;
@@ -117,9 +122,12 @@ export const toDuration = (input?: DurationInput, unit?: DurationUnit): DateTime
     return moment.duration(input, unit);
   }
 
-  // duration-like objects carry their own magnitude, so `unit` does not apply (same as before,
-  // when the shim took the object's `valueOf()` in milliseconds and ignored the unit).
-  return moment.duration(input.asMilliseconds());
+  // The public duration interface exposes totals, not calendar fields.
+  if ('asMilliseconds' in input) {
+    return moment.duration(input.asMilliseconds());
+  }
+
+  return moment.duration(input, unit);
 };
 
 export const dateTime = (input?: DateTimeInput, formatInput?: FormatInput): DateTime => {


### PR DESCRIPTION
among other things, fixes `dateTime().subtract('5m')`, which is used in the init of the [Hydrolix plugin](https://grafana.com/grafana/plugins/hydrolix-hydrolix-datasource/), causing it to crash during config or use:

https://github.com/hydrolix/grafana-datasource-plugin/blob/ee0234a19f6458f98efb2cc85cafb5ea57062b13/src/defaultConfigs.ts#L12


## Summary

Improve common Moment compatibility in the Luxon shim without expanding into legacy overloads.

- Support numeric, ISO, and shorthand/composite durations (`5m`, `1h30m`) across arithmetic and duration construction.
- Accept singular, plural, and short duration-object keys, with Moment’s last-alias-wins behavior.
- Correct calendar-duration rounding, invalid `diff()` results, and unit-based comparisons.
- Preserve locale and timezone state across copies; correct locale-aware week boundaries and weekday accessors.
- Tighten ISO parsing, serialize JSON in UTC, and improve localized `L` formatting.
- Align public arithmetic types and support `local(keepLocalTime)`.

## Validation

- Added focused parity tests; existing tests remain unchanged.
- Compatibility suite: 125 tests passed.
- Targeted TypeScript 7.0.2 check passed.

---
before:

<img width="2933" height="2064" alt="image" src="https://github.com/user-attachments/assets/0bbc838b-a2c4-4125-853f-42b32ea88a71" />

---
after:

<img width="2933" height="2064" alt="image" src="https://github.com/user-attachments/assets/38de4654-3c0b-42c6-8c2c-01403916ac16" />
