### PR TITLE
API search: support field-value results

### DIFF
--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -529,6 +529,8 @@ type FindPersistedDashboardsQuery struct {
 	Sort       model.SortOption
 	IsDeleted  bool
 
+	UseFieldValueResults bool
+
 	ManagedBy            utils.ManagerKind
 	ManagerIdentity      string
 	SourcePath           string

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -2052,6 +2052,10 @@ func (dr *DashboardServiceImpl) buildDashboardSearchRequest(query *dashboards.Fi
 	request.Page = query.Page
 	request.Offset = (query.Page - 1) * query.Limit // only relevant when running in modes 3+
 	request.Fields = dashboardsearch.IncludeFields
+	if query.UseFieldValueResults {
+		request.ResultFormat = resourcepb.ResourceSearchRequest_FIELD_VALUES
+		request.Fields = slices.Clone(dashboardsearch.APISearchIncludeFields)
+	}
 
 	namespace := dr.k8sclient.GetNamespace(query.OrgId)
 	var err error

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1598,6 +1598,7 @@ func TestSearchDashboardsThroughK8sRaw(t *testing.T) {
 					resource.SEARCH_FIELD_FOLDER,
 					resource.SEARCH_FIELD_DESCRIPTION,
 					resource.SEARCH_FIELD_LEGACY_ID,
+					resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID,
 				}) &&
 				len(req.SortBy) == 1 &&
 				// should be converted to "title" due to ParseSortName

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1570,29 +1570,39 @@ func TestCountInFolders(t *testing.T) {
 }
 
 func TestSearchDashboardsThroughK8sRaw(t *testing.T) {
-	t.Run("can search dashboards", func(t *testing.T) {
-		ctx := context.Background()
+	t.Run("uses unspecified result format by default", func(t *testing.T) {
+		k8sCliMock := new(client.MockK8sHandler)
+		service := &DashboardServiceImpl{k8sclient: k8sCliMock}
+		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
+
+		request, err := service.buildDashboardSearchRequest(&dashboards.FindPersistedDashboardsQuery{OrgId: 1})
+		require.NoError(t, err)
+		assert.Equal(t, resourcepb.ResourceSearchRequest_UNSPECIFIED, request.ResultFormat)
+	})
+
+	t.Run("requests field-value results and accepts a legacy response", func(t *testing.T) {
+		ctx := t.Context()
 		k8sCliMock := new(client.MockK8sHandler)
 		service := &DashboardServiceImpl{k8sclient: k8sCliMock}
 		query := &dashboards.FindPersistedDashboardsQuery{
-			OrgId: 1,
-			Sort:  sort.SortAlphaAsc,
+			OrgId:                1,
+			Sort:                 sort.SortAlphaAsc,
+			UseFieldValueResults: true,
 		}
 		k8sCliMock.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 		k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.MatchedBy(func(req *resourcepb.ResourceSearchRequest) bool {
-			// should include sort field only once
-			titleFieldCount := 0
-			for _, field := range req.Fields {
-				if field == "title" {
-					titleFieldCount++
-				}
-			}
-
-			return len(req.SortBy) == 1 &&
+			return req.ResultFormat == resourcepb.ResourceSearchRequest_FIELD_VALUES &&
+				slices.Equal(req.Fields, []string{
+					resource.SEARCH_FIELD_TITLE,
+					resource.SEARCH_FIELD_TAGS,
+					resource.SEARCH_FIELD_FOLDER,
+					resource.SEARCH_FIELD_DESCRIPTION,
+					resource.SEARCH_FIELD_LEGACY_ID,
+				}) &&
+				len(req.SortBy) == 1 &&
 				// should be converted to "title" due to ParseSortName
 				req.SortBy[0].Field == "title" &&
-				!req.SortBy[0].Desc &&
-				titleFieldCount == 1
+				!req.SortBy[0].Desc
 		})).Return(&resourcepb.ResourceSearchResponse{
 			Results: &resourcepb.ResourceTable{
 				Columns: []*resourcepb.ResourceTableColumnDefinition{

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -33,6 +33,7 @@ var (
 		resource.SEARCH_FIELD_FOLDER,
 		resource.SEARCH_FIELD_DESCRIPTION,
 		resource.SEARCH_FIELD_LEGACY_ID,
+		resource.SEARCH_FIELD_LABELS + "." + resource.SEARCH_FIELD_LEGACY_ID,
 	}
 
 	IncludeFields = []string{

--- a/pkg/services/dashboards/service/search/search.go
+++ b/pkg/services/dashboards/service/search/search.go
@@ -27,6 +27,14 @@ var (
 		resource.SEARCH_FIELD_OWNER_REFERENCES: "",
 	}
 
+	APISearchIncludeFields = []string{
+		resource.SEARCH_FIELD_TITLE,
+		resource.SEARCH_FIELD_TAGS,
+		resource.SEARCH_FIELD_FOLDER,
+		resource.SEARCH_FIELD_DESCRIPTION,
+		resource.SEARCH_FIELD_LEGACY_ID,
+	}
+
 	IncludeFields = []string{
 		resource.SEARCH_FIELD_TITLE,
 		resource.SEARCH_FIELD_TAGS,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2958,6 +2958,14 @@ var (
 			Generate:    Generate{Go: true},
 		},
 		{
+			Name:        "dashboard.apiSearchFieldValueResults",
+			Description: "Uses field-value results for requests from the /api/search endpoint",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSearchAndStorageSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:        "dashboard.vectorSearch",
 			Description: "Exposes the semantic (vector) search endpoint for dashboards under the dashboard API",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -343,6 +343,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-27,grafana.panelEditNextFeedbackEvent,experimental,@grafana/datapro,false,false,true
 2026-06-12,grafana.visualDesignRefresh,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-09-08,dashboard.searchFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
+2026-09-10,dashboard.apiSearchFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
 2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false
 2026-06-25,grafana.vectorSearchCmdk,experimental,@grafana/search-and-storage,false,false,true
 2026-08-04,grafana.cmdkHybridSearch,experimental,@grafana/search-and-storage,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -942,6 +942,10 @@ const (
 	// Uses field-value results for dashboard search requests
 	FlagDashboardSearchFieldValueResults = "dashboard.searchFieldValueResults"
 
+	// FlagDashboardApiSearchFieldValueResults
+	// Uses field-value results for requests from the /api/search endpoint
+	FlagDashboardApiSearchFieldValueResults = "dashboard.apiSearchFieldValueResults"
+
 	// FlagDashboardVectorSearch
 	// Exposes the semantic (vector) search endpoint for dashboards under the dashboard API
 	FlagDashboardVectorSearch = "dashboard.vectorSearch"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1635,6 +1635,19 @@
     },
     {
       "metadata": {
+        "name": "dashboard.apiSearchFieldValueResults",
+        "resourceVersion": "1789021061952",
+        "creationTimestamp": "2026-09-10T06:17:41Z"
+      },
+      "spec": {
+        "description": "Uses field-value results for requests from the /api/search endpoint",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboard.generation",
         "resourceVersion": "1785840164813",
         "creationTimestamp": "2026-08-04T10:42:44Z",

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -108,6 +108,7 @@ func (s *SearchService) SearchHandler(ctx context.Context, query *Query) (model.
 		Permission:    query.Permission,
 		IsDeleted:     query.IsDeleted,
 	}
+	dashboardQuery.UseFieldValueResults = s.features != nil && s.features.IsEnabled(ctx, featuremgmt.FlagDashboardApiSearchFieldValueResults) // nolint:staticcheck
 
 	if sortOpt, exists := s.sortService.GetSortOption(query.Sort); exists {
 		dashboardQuery.Sort = sortOpt

--- a/pkg/services/search/service_test.go
+++ b/pkg/services/search/service_test.go
@@ -37,6 +37,26 @@ func reqContextOnRequest(t *testing.T, signedInUser *user.SignedInUser) *http.Re
 	return req.WithContext(ctx)
 }
 
+func TestSearch_UsesFieldValueResultsWhenEnabled(t *testing.T) {
+	dashboardService := dashboards.NewFakeDashboardService(t)
+	dashboardService.On("SearchDashboards", mock.Anything, mock.MatchedBy(func(query *dashboards.FindPersistedDashboardsQuery) bool {
+		return query.UseFieldValueResults
+	})).Return(model.HitList{}, nil)
+
+	signedInUser := &user.SignedInUser{}
+	req := reqContextOnRequest(t, signedInUser)
+	starClient := starapi.NewMockK8sClients(t)
+	starClient.On("GetStars", mock.Anything).Return([]string{}, nil)
+	svc := &SearchService{
+		starClient:       starClient,
+		dashboardService: dashboardService,
+		features:         featuremgmt.WithFeatures(featuremgmt.FlagDashboardApiSearchFieldValueResults),
+	}
+
+	_, err := svc.SearchHandler(req.Context(), &Query{SignedInUser: signedInUser})
+	require.NoError(t, err)
+}
+
 func TestSearch_SortedResults(t *testing.T) {
 	db := dbtest.NewFakeDB()
 	us := usertest.NewUserServiceFake()

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -100,11 +100,15 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 			}
 			if assert.Contains(collect, byUID, savedFolder.UID) {
 				assert.Equal(collect, model.DashHitFolder, byUID[savedFolder.UID].Type)
+				assert.NotZero(collect, byUID[savedFolder.UID].ID)
 			}
 			if assert.Contains(collect, byUID, savedDashInFolder.UID) {
 				assert.Equal(collect, savedFolder.UID, byUID[savedDashInFolder.UID].FolderUID)
+				assert.NotZero(collect, byUID[savedDashInFolder.UID].ID)
 			}
-			assert.Contains(collect, byUID, savedDashInGeneralFolder.UID)
+			if assert.Contains(collect, byUID, savedDashInGeneralFolder.UID) {
+				assert.NotZero(collect, byUID[savedDashInGeneralFolder.UID].ID)
+			}
 		}, 10*time.Second, 25*time.Millisecond)
 	})
 

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/plugindashboards"
@@ -48,6 +49,7 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableAnonymous:     true,
 		UnifiedStorageConfig: unifiedConfig,
+		EnableFeatureToggles: []string{featuremgmt.FlagDashboardApiSearchFieldValueResults},
 	})
 	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
 
@@ -75,6 +77,36 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 	savedFolder := createFolder(t, grafanaListedAddr, "Saved folder")
 	savedDashInFolder := createDashboard(t, grafanaListedAddr, "Saved dash in folder", savedFolder.ID, savedFolder.UID) // nolint:staticcheck
 	savedDashInGeneralFolder := createDashboard(t, grafanaListedAddr, "Saved dashboard in general folder", 0, "")
+
+	t.Run("searches dashboards and folders with field-value results", func(t *testing.T) {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			u := fmt.Sprintf("http://admin:admin@%s/api/search?query=Saved", grafanaListedAddr)
+			resp, err := http.Get(u) // nolint:gosec
+			if !assert.NoError(collect, err) {
+				return
+			}
+			defer resp.Body.Close() // nolint:errcheck
+			if !assert.Equal(collect, http.StatusOK, resp.StatusCode) {
+				return
+			}
+
+			var results model.HitList
+			if !assert.NoError(collect, json.NewDecoder(resp.Body).Decode(&results)) {
+				return
+			}
+			byUID := make(map[string]*model.Hit, len(results))
+			for _, hit := range results {
+				byUID[hit.UID] = hit
+			}
+			if assert.Contains(collect, byUID, savedFolder.UID) {
+				assert.Equal(collect, model.DashHitFolder, byUID[savedFolder.UID].Type)
+			}
+			if assert.Contains(collect, byUID, savedDashInFolder.UID) {
+				assert.Equal(collect, savedFolder.UID, byUID[savedDashInFolder.UID].FolderUID)
+			}
+			assert.Contains(collect, byUID, savedDashInGeneralFolder.UID)
+		}, 10*time.Second, 25*time.Millisecond)
+	})
 
 	t.Run("When saving a dashboard with non-existing id in org A", func(t *testing.T) {
 		resp, err := postDashboard(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{


### PR DESCRIPTION
## What

Adds opt-in field-value search results for `GET /api/search` behind `dashboard.apiSearchFieldValueResults`.

The toggle is applied at the `/api/search` service boundary, so other internal dashboard searches remain unchanged. The public JSON response is unchanged.

The decoder follows the response’s actual format, preserving compatibility with older search servers that return `ResourceTable`.

Includes real endpoint coverage for dashboard and folder results with unified storage enabled.

Part of https://github.com/grafana/search-and-storage-team/issues/890
