### PR TITLE
IAM: Make org filtering explicit in the resource permissions query

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/queries/resource_permission_query.sql
+++ b/pkg/registry/apis/iam/resourcepermission/queries/resource_permission_query.sql
@@ -9,19 +9,17 @@ SELECT
   COALESCE(p.datasource_type, '') as datasource_type{{ end }}
 FROM {{ .Ident .PermissionTable }} p
 INNER JOIN {{ .Ident .RoleTable }} r ON p.role_id = r.id
-LEFT JOIN {{ .Ident .UserRoleTable }} ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN {{ .Ident .UserRoleTable }} ur ON r.id = ur.role_id AND ur.org_id = {{ .Arg .Query.OrgID }}
 LEFT JOIN {{ .Ident .UserTable }} u ON ur.user_id = u.id
-LEFT JOIN {{ .Ident .TeamRoleTable }} tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN {{ .Ident .TeamRoleTable }} tr ON r.id = tr.role_id AND tr.org_id = {{ .Arg .Query.OrgID }}
 LEFT JOIN {{ .Ident .TeamTable }} t ON tr.team_id = t.id
-LEFT JOIN {{ .Ident .BuiltinRoleTable }} br ON r.id = br.role_id
+LEFT JOIN {{ .Ident .BuiltinRoleTable }} br ON r.id = br.role_id AND br.org_id = {{ .Arg .Query.OrgID }}
 WHERE r.name LIKE {{ .Arg .ManagedRolePattern }}
 {{ if .Query.ActionSets }}
 AND p.action IN ({{ .ArgList .Query.ActionSets }})
 {{ end }}
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
-{{ if .Query.OrgID }}
-AND COALESCE(ur.org_id, tr.org_id, r.org_id) = {{ .Arg .Query.OrgID }}
-{{ end }}
+AND r.org_id = {{ .Arg .Query.OrgID }}
 {{ if eq (len .Query.Scopes) 1 }}
 AND p.scope = {{ .Arg (index .Query.Scopes 0) }}
 {{ else if gt (len .Query.Scopes) 1 }}

--- a/pkg/registry/apis/iam/resourcepermission/templates.go
+++ b/pkg/registry/apis/iam/resourcepermission/templates.go
@@ -113,6 +113,9 @@ type listResourcePermissionsQueryTemplate struct {
 }
 
 func (r listResourcePermissionsQueryTemplate) Validate() error {
+	if r.Query == nil || r.Query.OrgID <= 0 {
+		return fmt.Errorf("orgID must be set")
+	}
 	return nil
 }
 

--- a/pkg/registry/apis/iam/resourcepermission/templates_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/templates_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
@@ -183,7 +185,7 @@ func TestTemplates(t *testing.T) {
 			resourcePermissionsQueryTplt: {
 				{
 					Name: "basic_query",
-					Data: getListResourcePermissionsQuery(&ListResourcePermissionsQuery{}, false),
+					Data: getListResourcePermissionsQuery(&ListResourcePermissionsQuery{OrgID: 3}, false),
 				},
 				{
 					Name: "with_all_fields",
@@ -213,4 +215,12 @@ func TestTemplates(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestListResourcePermissionsQueryTemplateRequiresOrgID(t *testing.T) {
+	err := (listResourcePermissionsQueryTemplate{
+		Query: &ListResourcePermissionsQuery{},
+	}).Validate()
+
+	require.EqualError(t, err, "orgID must be set")
 }

--- a/pkg/registry/apis/iam/resourcepermission/testdata/mysql--resource_permission_query-basic_query.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/mysql--resource_permission_query-basic_query.sql
@@ -8,11 +8,12 @@ SELECT
   COALESCE(u.is_service_account, FALSE) as is_service_account
 FROM `grafana`.`permission` p
 INNER JOIN `grafana`.`role` r ON p.role_id = r.id
-LEFT JOIN `grafana`.`user_role` ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN `grafana`.`user_role` ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN `grafana`.`user` u ON ur.user_id = u.id
-LEFT JOIN `grafana`.`team_role` tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN `grafana`.`team_role` tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN `grafana`.`team` t ON tr.team_id = t.id
-LEFT JOIN `grafana`.`builtin_role` br ON r.id = br.role_id
+LEFT JOIN `grafana`.`builtin_role` br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
+AND r.org_id = 3
 ORDER BY p.scope

--- a/pkg/registry/apis/iam/resourcepermission/testdata/mysql--resource_permission_query-with_all_fields.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/mysql--resource_permission_query-with_all_fields.sql
@@ -9,14 +9,14 @@ SELECT
   COALESCE(p.datasource_type, '') as datasource_type
 FROM `grafana`.`permission` p
 INNER JOIN `grafana`.`role` r ON p.role_id = r.id
-LEFT JOIN `grafana`.`user_role` ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN `grafana`.`user_role` ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN `grafana`.`user` u ON ur.user_id = u.id
-LEFT JOIN `grafana`.`team_role` tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN `grafana`.`team_role` tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN `grafana`.`team` t ON tr.team_id = t.id
-LEFT JOIN `grafana`.`builtin_role` br ON r.id = br.role_id
+LEFT JOIN `grafana`.`builtin_role` br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND p.action IN ('folders:admin', 'folders:edit', 'folders:view')
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
-AND COALESCE(ur.org_id, tr.org_id, r.org_id) = 3
+AND r.org_id = 3
 AND p.scope = '123'
 ORDER BY p.scope

--- a/pkg/registry/apis/iam/resourcepermission/testdata/postgres--resource_permission_query-basic_query.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/postgres--resource_permission_query-basic_query.sql
@@ -8,11 +8,12 @@ SELECT
   COALESCE(u.is_service_account, FALSE) as is_service_account
 FROM "grafana"."permission" p
 INNER JOIN "grafana"."role" r ON p.role_id = r.id
-LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN "grafana"."user" u ON ur.user_id = u.id
-LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN "grafana"."team" t ON tr.team_id = t.id
-LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id
+LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
+AND r.org_id = 3
 ORDER BY p.scope

--- a/pkg/registry/apis/iam/resourcepermission/testdata/postgres--resource_permission_query-with_all_fields.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/postgres--resource_permission_query-with_all_fields.sql
@@ -9,14 +9,14 @@ SELECT
   COALESCE(p.datasource_type, '') as datasource_type
 FROM "grafana"."permission" p
 INNER JOIN "grafana"."role" r ON p.role_id = r.id
-LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN "grafana"."user" u ON ur.user_id = u.id
-LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN "grafana"."team" t ON tr.team_id = t.id
-LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id
+LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND p.action IN ('folders:admin', 'folders:edit', 'folders:view')
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
-AND COALESCE(ur.org_id, tr.org_id, r.org_id) = 3
+AND r.org_id = 3
 AND p.scope = '123'
 ORDER BY p.scope

--- a/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--resource_permission_query-basic_query.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--resource_permission_query-basic_query.sql
@@ -8,11 +8,12 @@ SELECT
   COALESCE(u.is_service_account, FALSE) as is_service_account
 FROM "grafana"."permission" p
 INNER JOIN "grafana"."role" r ON p.role_id = r.id
-LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN "grafana"."user" u ON ur.user_id = u.id
-LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN "grafana"."team" t ON tr.team_id = t.id
-LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id
+LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
+AND r.org_id = 3
 ORDER BY p.scope

--- a/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--resource_permission_query-with_all_fields.sql
+++ b/pkg/registry/apis/iam/resourcepermission/testdata/sqlite--resource_permission_query-with_all_fields.sql
@@ -9,14 +9,14 @@ SELECT
   COALESCE(p.datasource_type, '') as datasource_type
 FROM "grafana"."permission" p
 INNER JOIN "grafana"."role" r ON p.role_id = r.id
-LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = r.org_id
+LEFT JOIN "grafana"."user_role" ur ON r.id = ur.role_id AND ur.org_id = 3
 LEFT JOIN "grafana"."user" u ON ur.user_id = u.id
-LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = r.org_id
+LEFT JOIN "grafana"."team_role" tr ON r.id = tr.role_id AND tr.org_id = 3
 LEFT JOIN "grafana"."team" t ON tr.team_id = t.id
-LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id
+LEFT JOIN "grafana"."builtin_role" br ON r.id = br.role_id AND br.org_id = 3
 WHERE r.name LIKE 'managed:%'
 AND p.action IN ('folders:admin', 'folders:edit', 'folders:view')
 AND (u.uid IS NOT NULL OR t.uid IS NOT NULL OR br.role IS NOT NULL)
-AND COALESCE(ur.org_id, tr.org_id, r.org_id) = 3
+AND r.org_id = 3
 AND p.scope = '123'
 ORDER BY p.scope


### PR DESCRIPTION
## What is this?

Makes `OrgID` mandatory for resource-permission queries and applies organization filtering directly to the role and assignment joins.

The previous query filtered by:

`COALESCE(ur.org_id, tr.org_id, r.org_id) = ?`

Because this predicate depends on nullable `LEFT JOIN` results, MySQL evaluates it after joining the assignment tables. This prevents the organization constraint from being pushed down effectively and contributes to poor join plans and cardinality estimates.

This change:

- Filters roles directly with `r.org_id = ?`.
- Joins user, team, and builtin-role assignments using the requested organization ID.
- Aligns user and team joins with the `(role_id, org_id)` indexes introduced in:
  - https://github.com/grafana/grafana/pull/132055
- Validates that every resource-permission query has a positive organization ID.

With explicit predicates, MySQL can restrict roles earlier and perform indexed assignment lookups using both `role_id` and `org_id`, instead of evaluating organization membership after the joins.

I captured a MySQL plan on a test instance, replacing the `COALESCE` predicate with a direct role predicate reduced execution time from approximately 3.6s to 1.9s before the new role-leading indexes were applied. The new indexes eliminate the remaining repeated scans of organization assignments.

## Testing

- Added coverage requiring `OrgID`.
- Updated MySQL, PostgreSQL, and SQLite query snapshots.
- Resource-permission template tests pass.