### PR TITLE
Badge: make more resilient to incorrect colors being passed

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.test.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+
+import { Badge, type BadgeColor } from './Badge';
+
+describe('Badge', () => {
+  it('renders the text', () => {
+    render(<Badge text="Alpha" color="blue" />);
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+
+  describe('with an unknown color', () => {
+    const originalEnvironment = process.env.NODE_ENV;
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+      warn = jest.spyOn(console, 'warn').mockImplementation();
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnvironment;
+      warn.mockRestore();
+    });
+
+    it('throws in development', () => {
+      process.env.NODE_ENV = 'development';
+
+      expect(() => render(<Badge text="Alpha" color={'not-a-color' as BadgeColor} />)).toThrow(
+        `Badge: unknown color 'not-a-color', falling back to 'darkgrey'`
+      );
+    });
+
+    it('warns and still renders in production', () => {
+      process.env.NODE_ENV = 'production';
+
+      render(<Badge text="Alpha" color={'not-a-color' as BadgeColor} />);
+
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+      expect(warn).toHaveBeenCalledWith(`Badge: unknown color 'not-a-color', falling back to 'darkgrey'`);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -64,7 +64,21 @@ const getSkeletonStyles = () => ({
 });
 
 const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
-  const { background, border, text } = theme.components.badge[color];
+  let badgeColor = theme.components.badge[color];
+
+  // the color prop is typed, but callers ignoring the typings would otherwise crash the whole tree
+  if (!badgeColor) {
+    const message = `Badge: unknown color '${color}', falling back to 'darkgrey'`;
+    console.warn(message);
+
+    if (process.env.NODE_ENV === 'development') {
+      throw new Error(message);
+    }
+
+    badgeColor = theme.components.badge.darkgrey;
+  }
+
+  const { background, border, text } = badgeColor;
 
   return {
     wrapper: css(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- falls back to `darkgrey` if people pass incorrect colors

**Why do we need this feature?**

- stop `Badge` crashing the whole page

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
