### PR TITLE
plugin compat: add get/update app settings

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -148,9 +148,6 @@ const config: KnipConfig = {
       ignoreDependencies: ['.*'],
     },
     'packages/grafana-plugin-compat': {
-      // index.ts isn't in package.json's `exports` map (subpaths like ./apps,
-      // ./datasources are used directly instead), so knip sees it as unreachable
-      entry: [...defaultEntries, 'src/index.ts'],
       ignoreDependencies: packageIgnoreDeps,
     },
   },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -147,6 +147,12 @@ const config: KnipConfig = {
       webpack: false,
       ignoreDependencies: ['.*'],
     },
+    'packages/grafana-plugin-compat': {
+      // index.ts isn't in package.json's `exports` map (subpaths like ./apps,
+      // ./datasources are used directly instead), so knip sees it as unreachable
+      entry: [...defaultEntries, 'src/index.ts'],
+      ignoreDependencies: packageIgnoreDeps,
+    },
   },
 };
 

--- a/packages/grafana-plugin-compat/package.json
+++ b/packages/grafana-plugin-compat/package.json
@@ -24,6 +24,11 @@
       "@grafana-app/source": "./src/datasources.ts",
       "types": "./dist/types/datasources.d.ts",
       "import": "./dist/esm/datasources.mjs"
+    },
+    "./apps": {
+      "@grafana-app/source": "./src/apps.ts",
+      "types": "./dist/types/apps.d.ts",
+      "import": "./dist/esm/apps.mjs"
     }
   },
   "publishConfig": {
@@ -42,6 +47,10 @@
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-npm-package.js",
     "postpack": "mv package.json.bak package.json"
+  },
+  "dependencies": {
+    "@grafana/data": "workspace:*",
+    "@grafana/runtime": "workspace:*"
   },
   "devDependencies": {
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/packages/grafana-plugin-compat/package.json
+++ b/packages/grafana-plugin-compat/package.json
@@ -48,9 +48,6 @@
     "prepack": "cp package.json package.json.bak && node ../../scripts/prepare-npm-package.js",
     "postpack": "mv package.json.bak package.json"
   },
-  "dependencies": {
-    "@grafana/runtime": "workspace:*"
-  },
   "devDependencies": {
     "@grafana/data": "workspace:*",
     "@typescript/native": "npm:typescript@^7.0.2",
@@ -59,5 +56,8 @@
     "rollup-plugin-esbuild": "6.2.1",
     "rollup-plugin-node-externals": "^8.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2"
+  },
+  "peerDependencies": {
+    "@grafana/runtime": "*"
   }
 }

--- a/packages/grafana-plugin-compat/package.json
+++ b/packages/grafana-plugin-compat/package.json
@@ -49,10 +49,10 @@
     "postpack": "mv package.json.bak package.json"
   },
   "dependencies": {
-    "@grafana/data": "workspace:*",
     "@grafana/runtime": "workspace:*"
   },
   "devDependencies": {
+    "@grafana/data": "workspace:*",
     "@typescript/native": "npm:typescript@^7.0.2",
     "rimraf": "^6.0.1",
     "rollup": "^4.60.1",

--- a/packages/grafana-plugin-compat/rollup.config.ts
+++ b/packages/grafana-plugin-compat/rollup.config.ts
@@ -7,7 +7,13 @@ const pkg = rq('./package.json');
 
 export default [
   {
-    input: entryPoint,
+    input: 'src/datasources.ts',
+    plugins,
+    output: [esmOutput(pkg, 'grafana-plugin-compat')],
+    treeshake: false,
+  },
+  {
+    input: 'src/apps.ts',
     plugins,
     output: [esmOutput(pkg, 'grafana-plugin-compat')],
     treeshake: false,

--- a/packages/grafana-plugin-compat/rollup.config.ts
+++ b/packages/grafana-plugin-compat/rollup.config.ts
@@ -1,13 +1,13 @@
 import { createRequire } from 'node:module';
 
-import { esmOutput, plugins } from '../rollup.config.parts';
+import { entryPoint, esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');
 
 export default [
   {
-    input: 'src/datasources.ts',
+    input: entryPoint,
     plugins,
     output: [esmOutput(pkg, 'grafana-plugin-compat')],
     treeshake: false,

--- a/packages/grafana-plugin-compat/rollup.config.ts
+++ b/packages/grafana-plugin-compat/rollup.config.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { entryPoint, esmOutput, plugins } from '../rollup.config.parts';
+import { esmOutput, plugins } from '../rollup.config.parts';
 
 const rq = createRequire(import.meta.url);
 const pkg = rq('./package.json');

--- a/packages/grafana-plugin-compat/src/apps.compat.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.compat.test.ts
@@ -1,0 +1,86 @@
+import { type PluginMeta } from '@grafana/data';
+import { type BackendSrv, setBackendSrv } from '@grafana/runtime';
+
+import { getPluginSettings, updatePluginSettings } from './apps';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  getPluginSettings: undefined,
+  updateAppPluginSettings: undefined,
+}));
+
+const mockBackendSrv: BackendSrv = {
+  chunked: jest.fn(),
+  delete: jest.fn(),
+  fetch: jest.fn(),
+  get: jest.fn(),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  datasourceRequest: jest.fn(),
+  request: jest.fn(),
+};
+
+const mockData: Partial<PluginMeta> = { enabled: true, pinned: true };
+
+describe('getPluginSettings', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setBackendSrv(mockBackendSrv);
+  });
+
+  it('should call correct function when getPluginSettings does not exists', async () => {
+    await getPluginSettings('grafana-exploretraces-app', true);
+
+    expect(mockBackendSrv.get).toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      undefined,
+      undefined,
+      {
+        showErrorAlert: true,
+        validatePath: true,
+      }
+    );
+  });
+
+  it('should default to showErrorAlert === false when getPluginSettings does not exists', async () => {
+    await getPluginSettings('grafana-exploretraces-app');
+
+    expect(mockBackendSrv.get).toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      undefined,
+      undefined,
+      {
+        showErrorAlert: false,
+        validatePath: true,
+      }
+    );
+  });
+});
+
+describe('updatePluginSettings', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setBackendSrv(mockBackendSrv);
+    mockBackendSrv.post = jest.fn().mockResolvedValue(mockData);
+    mockBackendSrv.get = jest.fn().mockResolvedValue(mockData);
+  });
+
+  it('should call correct function when updateAppPluginSettings does not exists', async () => {
+    await updatePluginSettings('grafana-exploretraces-app', mockData);
+
+    expect(mockBackendSrv.post).toHaveBeenCalled();
+    expect(mockBackendSrv.post).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      { ...mockData },
+      { validatePath: true }
+    );
+  });
+
+  it('should return correct response when updateAppPluginSettings does not exists', async () => {
+    const result = await updatePluginSettings('grafana-exploretraces-app', mockData);
+
+    expect(result).toStrictEqual(mockData);
+  });
+});

--- a/packages/grafana-plugin-compat/src/apps.compat.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.compat.test.ts
@@ -1,7 +1,7 @@
 import { type PluginMeta } from '@grafana/data';
 import { type BackendSrv, setBackendSrv } from '@grafana/runtime';
 
-import { getPluginSettings, updatePluginSettings } from './apps';
+import { getPluginSettings, updateAppPluginSettings } from './apps';
 
 jest.mock('@grafana/runtime/unstable', () => ({
   getPluginSettings: undefined,
@@ -59,7 +59,7 @@ describe('getPluginSettings', () => {
   });
 });
 
-describe('updatePluginSettings', () => {
+describe('updateAppPluginSettings', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     setBackendSrv(mockBackendSrv);
@@ -68,7 +68,7 @@ describe('updatePluginSettings', () => {
   });
 
   it('should call correct function when updateAppPluginSettings does not exists', async () => {
-    await updatePluginSettings('grafana-exploretraces-app', mockData);
+    await updateAppPluginSettings('grafana-exploretraces-app', mockData);
 
     expect(mockBackendSrv.post).toHaveBeenCalled();
     expect(mockBackendSrv.post).toHaveBeenCalledWith(
@@ -79,7 +79,7 @@ describe('updatePluginSettings', () => {
   });
 
   it('should return correct response when updateAppPluginSettings does not exists', async () => {
-    const result = await updatePluginSettings('grafana-exploretraces-app', mockData);
+    const result = await updateAppPluginSettings('grafana-exploretraces-app', mockData);
 
     expect(result).toStrictEqual(mockData);
   });

--- a/packages/grafana-plugin-compat/src/apps.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.test.ts
@@ -61,6 +61,22 @@ describe('getPluginSettings', () => {
       }
     );
   });
+
+  it('should default to showErrorAlert === false when getPluginSettings does not exists', async () => {
+    await getPluginSettings(mockId, undefined, null as unknown as typeof runtimeGetPluginSettings);
+
+    expect(mockRuntimeGetAppPluginSettings).not.toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      undefined,
+      undefined,
+      {
+        showErrorAlert: false,
+        validatePath: true,
+      }
+    );
+  });
 });
 
 describe('updatePluginSettings', () => {
@@ -69,6 +85,7 @@ describe('updatePluginSettings', () => {
     setBackendSrv(mockBackendSrv);
     mockRuntimeUpdateAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
     mockBackendSrv.post = jest.fn().mockResolvedValue(mockData);
+    mockBackendSrv.get = jest.fn().mockResolvedValue(mockData);
   });
 
   it('should call correct function when updateAppPluginSettings exists', async () => {
@@ -77,6 +94,12 @@ describe('updatePluginSettings', () => {
     expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalled();
     expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalledWith(mockId, { ...mockData });
     expect(mockBackendSrv.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should return correct response when updateAppPluginSettings exists', async () => {
+    const result = await updatePluginSettings(mockId, mockData);
+
+    expect(result).toStrictEqual(mockData);
   });
 
   it('should call correct function when updateAppPluginSettings does not exists', async () => {
@@ -89,5 +112,15 @@ describe('updatePluginSettings', () => {
       { ...mockData },
       { validatePath: true }
     );
+  });
+
+  it('should return correct response when updateAppPluginSettings does not exists', async () => {
+    const result = await updatePluginSettings(
+      mockId,
+      mockData,
+      null as unknown as typeof runtimeUpdateAppPluginSettings
+    );
+
+    expect(result).toStrictEqual(mockData);
   });
 });

--- a/packages/grafana-plugin-compat/src/apps.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.test.ts
@@ -4,7 +4,7 @@ import {
   updateAppPluginSettings as runtimeUpdateAppPluginSettings,
 } from '@grafana/runtime/unstable';
 
-import { getPluginSettings, updatePluginSettings } from './apps';
+import { getPluginSettings, updateAppPluginSettings } from './apps';
 
 jest.mock('@grafana/runtime/unstable', () => ({
   ...jest.requireActual('@grafana/runtime/unstable'),
@@ -37,21 +37,21 @@ describe('getPluginSettings', () => {
   });
 });
 
-describe('updatePluginSettings', () => {
+describe('updateAppPluginSettings', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockRuntimeUpdateAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
   });
 
   it('should call correct function when updateAppPluginSettings exists', async () => {
-    await updatePluginSettings('grafana-exploretraces-app', mockData);
+    await updateAppPluginSettings('grafana-exploretraces-app', mockData);
 
     expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalled();
     expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalledWith('grafana-exploretraces-app', { ...mockData });
   });
 
   it('should return correct response when updateAppPluginSettings exists', async () => {
-    const result = await updatePluginSettings('grafana-exploretraces-app', mockData);
+    const result = await updateAppPluginSettings('grafana-exploretraces-app', mockData);
 
     expect(result).toStrictEqual(mockData);
   });

--- a/packages/grafana-plugin-compat/src/apps.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.test.ts
@@ -1,0 +1,93 @@
+import { type PluginMeta } from '@grafana/data';
+import { type BackendSrv, setBackendSrv } from '@grafana/runtime';
+import {
+  getPluginSettings as runtimeGetPluginSettings,
+  updateAppPluginSettings as runtimeUpdateAppPluginSettings,
+} from '@grafana/runtime/unstable';
+
+import { getPluginSettings, updatePluginSettings } from './apps';
+
+jest.mock('@grafana/runtime/unstable', () => ({
+  ...jest.requireActual('@grafana/runtime/unstable'),
+  getPluginSettings: jest.fn(),
+  updateAppPluginSettings: jest.fn(),
+}));
+
+const mockBackendSrv: BackendSrv = {
+  chunked: jest.fn(),
+  delete: jest.fn(),
+  fetch: jest.fn(),
+  get: jest.fn(),
+  patch: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  datasourceRequest: jest.fn(),
+  request: jest.fn(),
+};
+
+const mockRuntimeGetAppPluginSettings = jest.mocked(runtimeGetPluginSettings);
+const mockRuntimeUpdateAppPluginSettings = jest.mocked(runtimeUpdateAppPluginSettings);
+const mockId = 'grafana-exploretraces-app';
+const mockData: Partial<PluginMeta> = { enabled: true, pinned: true };
+
+describe('getPluginSettings', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setBackendSrv(mockBackendSrv);
+    mockRuntimeGetAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
+    mockBackendSrv.get = jest.fn().mockResolvedValue(mockData);
+  });
+
+  it('should call correct function when getPluginSettings exists', async () => {
+    await getPluginSettings(mockId, true);
+
+    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalled();
+    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalledWith(mockId, true);
+    expect(mockBackendSrv.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should call correct function when getPluginSettings does not exists', async () => {
+    await getPluginSettings(mockId, true, null as unknown as typeof runtimeGetPluginSettings);
+
+    expect(mockRuntimeGetAppPluginSettings).not.toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalled();
+    expect(mockBackendSrv.get).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      undefined,
+      undefined,
+      {
+        showErrorAlert: true,
+        validatePath: true,
+      }
+    );
+  });
+});
+
+describe('updatePluginSettings', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setBackendSrv(mockBackendSrv);
+    mockRuntimeUpdateAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
+    mockBackendSrv.post = jest.fn().mockResolvedValue(mockData);
+  });
+
+  it('should call correct function when updateAppPluginSettings exists', async () => {
+    await updatePluginSettings(mockId, mockData);
+
+    expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalled();
+    expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalledWith(mockId, { ...mockData });
+    expect(mockBackendSrv.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should call correct function when updateAppPluginSettings does not exists', async () => {
+    await updatePluginSettings(mockId, mockData, null as unknown as typeof runtimeUpdateAppPluginSettings);
+
+    expect(mockRuntimeUpdateAppPluginSettings).not.toHaveBeenCalled();
+    expect(mockBackendSrv.post).toHaveBeenCalled();
+    expect(mockBackendSrv.post).toHaveBeenCalledWith(
+      `/api/plugins/grafana-exploretraces-app/settings`,
+      { ...mockData },
+      { validatePath: true }
+    );
+  });
+});

--- a/packages/grafana-plugin-compat/src/apps.test.ts
+++ b/packages/grafana-plugin-compat/src/apps.test.ts
@@ -1,5 +1,4 @@
 import { type PluginMeta } from '@grafana/data';
-import { type BackendSrv, setBackendSrv } from '@grafana/runtime';
 import {
   getPluginSettings as runtimeGetPluginSettings,
   updateAppPluginSettings as runtimeUpdateAppPluginSettings,
@@ -13,113 +12,46 @@ jest.mock('@grafana/runtime/unstable', () => ({
   updateAppPluginSettings: jest.fn(),
 }));
 
-const mockBackendSrv: BackendSrv = {
-  chunked: jest.fn(),
-  delete: jest.fn(),
-  fetch: jest.fn(),
-  get: jest.fn(),
-  patch: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-  datasourceRequest: jest.fn(),
-  request: jest.fn(),
-};
-
 const mockRuntimeGetAppPluginSettings = jest.mocked(runtimeGetPluginSettings);
 const mockRuntimeUpdateAppPluginSettings = jest.mocked(runtimeUpdateAppPluginSettings);
-const mockId = 'grafana-exploretraces-app';
 const mockData: Partial<PluginMeta> = { enabled: true, pinned: true };
 
 describe('getPluginSettings', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    setBackendSrv(mockBackendSrv);
     mockRuntimeGetAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
-    mockBackendSrv.get = jest.fn().mockResolvedValue(mockData);
   });
 
   it('should call correct function when getPluginSettings exists', async () => {
-    await getPluginSettings(mockId, true);
+    await getPluginSettings('grafana-exploretraces-app', true);
 
     expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalled();
-    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalledWith(mockId, true);
-    expect(mockBackendSrv.fetch).not.toHaveBeenCalled();
+    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalledWith('grafana-exploretraces-app', true);
   });
 
-  it('should call correct function when getPluginSettings does not exists', async () => {
-    await getPluginSettings(mockId, true, null as unknown as typeof runtimeGetPluginSettings);
+  it('should default to showErrorAlert === false when getPluginSettings exists', async () => {
+    await getPluginSettings('grafana-exploretraces-app');
 
-    expect(mockRuntimeGetAppPluginSettings).not.toHaveBeenCalled();
-    expect(mockBackendSrv.get).toHaveBeenCalled();
-    expect(mockBackendSrv.get).toHaveBeenCalledWith(
-      `/api/plugins/grafana-exploretraces-app/settings`,
-      undefined,
-      undefined,
-      {
-        showErrorAlert: true,
-        validatePath: true,
-      }
-    );
-  });
-
-  it('should default to showErrorAlert === false when getPluginSettings does not exists', async () => {
-    await getPluginSettings(mockId, undefined, null as unknown as typeof runtimeGetPluginSettings);
-
-    expect(mockRuntimeGetAppPluginSettings).not.toHaveBeenCalled();
-    expect(mockBackendSrv.get).toHaveBeenCalled();
-    expect(mockBackendSrv.get).toHaveBeenCalledWith(
-      `/api/plugins/grafana-exploretraces-app/settings`,
-      undefined,
-      undefined,
-      {
-        showErrorAlert: false,
-        validatePath: true,
-      }
-    );
+    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalled();
+    expect(mockRuntimeGetAppPluginSettings).toHaveBeenCalledWith('grafana-exploretraces-app', false);
   });
 });
 
 describe('updatePluginSettings', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    setBackendSrv(mockBackendSrv);
     mockRuntimeUpdateAppPluginSettings.mockResolvedValue(mockData as PluginMeta);
-    mockBackendSrv.post = jest.fn().mockResolvedValue(mockData);
-    mockBackendSrv.get = jest.fn().mockResolvedValue(mockData);
   });
 
   it('should call correct function when updateAppPluginSettings exists', async () => {
-    await updatePluginSettings(mockId, mockData);
+    await updatePluginSettings('grafana-exploretraces-app', mockData);
 
     expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalled();
-    expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalledWith(mockId, { ...mockData });
-    expect(mockBackendSrv.fetch).not.toHaveBeenCalled();
+    expect(mockRuntimeUpdateAppPluginSettings).toHaveBeenCalledWith('grafana-exploretraces-app', { ...mockData });
   });
 
   it('should return correct response when updateAppPluginSettings exists', async () => {
-    const result = await updatePluginSettings(mockId, mockData);
-
-    expect(result).toStrictEqual(mockData);
-  });
-
-  it('should call correct function when updateAppPluginSettings does not exists', async () => {
-    await updatePluginSettings(mockId, mockData, null as unknown as typeof runtimeUpdateAppPluginSettings);
-
-    expect(mockRuntimeUpdateAppPluginSettings).not.toHaveBeenCalled();
-    expect(mockBackendSrv.post).toHaveBeenCalled();
-    expect(mockBackendSrv.post).toHaveBeenCalledWith(
-      `/api/plugins/grafana-exploretraces-app/settings`,
-      { ...mockData },
-      { validatePath: true }
-    );
-  });
-
-  it('should return correct response when updateAppPluginSettings does not exists', async () => {
-    const result = await updatePluginSettings(
-      mockId,
-      mockData,
-      null as unknown as typeof runtimeUpdateAppPluginSettings
-    );
+    const result = await updatePluginSettings('grafana-exploretraces-app', mockData);
 
     expect(result).toStrictEqual(mockData);
   });

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -5,16 +5,12 @@ import {
   updateAppPluginSettings as runtimeUpdateAppPluginSettings,
 } from '@grafana/runtime/unstable';
 
-export function getPluginSettings(
-  pluginId: string,
-  showErrorAlert?: boolean,
-  getFn: typeof runtimeGetPluginSettings = runtimeGetPluginSettings
-): Promise<PluginMeta> {
-  if (!getFn || typeof getFn !== 'function') {
-    return backwardsCompatibleGetPluginSettings(pluginId, showErrorAlert);
+export function getPluginSettings(pluginId: string, showErrorAlert = false): Promise<PluginMeta> {
+  if (runtimeGetPluginSettings && typeof runtimeGetPluginSettings === 'function') {
+    return runtimeGetPluginSettings(pluginId, showErrorAlert);
   }
 
-  return runtimeGetPluginSettings(pluginId, showErrorAlert);
+  return backwardsCompatibleGetPluginSettings(pluginId, showErrorAlert);
 }
 
 function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert = false): Promise<PluginMeta> {
@@ -24,16 +20,12 @@ function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert =
   });
 }
 
-export function updatePluginSettings(
-  pluginId: string,
-  data: Partial<PluginMeta>,
-  updateFn: typeof runtimeUpdateAppPluginSettings = runtimeUpdateAppPluginSettings
-): Promise<PluginMeta> {
-  if (!updateFn || typeof updateFn !== 'function') {
-    return backwardsCompatibleUpdatePluginSettings(pluginId, data);
+export function updatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
+  if (runtimeUpdateAppPluginSettings || typeof runtimeUpdateAppPluginSettings === 'function') {
+    return runtimeUpdateAppPluginSettings(pluginId, data);
   }
 
-  return runtimeUpdateAppPluginSettings(pluginId, data);
+  return backwardsCompatibleUpdatePluginSettings(pluginId, data);
 }
 
 async function backwardsCompatibleUpdatePluginSettings(

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -1,0 +1,41 @@
+import { type PluginMeta } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
+import {
+  getPluginSettings as runtimeGetPluginSettings,
+  updateAppPluginSettings as runtimeUpdateAppPluginSettings,
+} from '@grafana/runtime/unstable';
+
+export function getPluginSettings(
+  pluginId: string,
+  showErrorAlert?: boolean,
+  getFn: typeof runtimeGetPluginSettings = runtimeGetPluginSettings
+): Promise<PluginMeta> {
+  if (!getFn || typeof getFn !== 'function') {
+    return backwardsCompatibleGetPluginSettings(pluginId, showErrorAlert);
+  }
+
+  return runtimeGetPluginSettings(pluginId, showErrorAlert);
+}
+
+function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert?: boolean): Promise<PluginMeta> {
+  return getBackendSrv().get(`/api/plugins/${pluginId}/settings`, undefined, undefined, {
+    showErrorAlert,
+    validatePath: true,
+  });
+}
+
+export function updatePluginSettings(
+  pluginId: string,
+  data: Partial<PluginMeta>,
+  updateFn: typeof runtimeUpdateAppPluginSettings = runtimeUpdateAppPluginSettings
+): Promise<PluginMeta> {
+  if (!updateFn || typeof updateFn !== 'function') {
+    return backwardsCompatibleUpdatePluginSettings(pluginId, data);
+  }
+
+  return runtimeUpdateAppPluginSettings(pluginId, data);
+}
+
+function backwardsCompatibleUpdatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
+  return getBackendSrv().post(`/api/plugins/${pluginId}/settings`, data, { validatePath: true });
+}

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -20,7 +20,7 @@ function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert =
   });
 }
 
-export function updatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
+export function updateAppPluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
   if (typeof runtimeUpdateAppPluginSettings === 'function') {
     return runtimeUpdateAppPluginSettings(pluginId, data);
   }

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -6,7 +6,7 @@ import {
 } from '@grafana/runtime/unstable';
 
 export function getPluginSettings(pluginId: string, showErrorAlert = false): Promise<PluginMeta> {
-  if (runtimeGetPluginSettings && typeof runtimeGetPluginSettings === 'function') {
+  if (typeof runtimeGetPluginSettings === 'function') {
     return runtimeGetPluginSettings(pluginId, showErrorAlert);
   }
 
@@ -21,7 +21,7 @@ function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert =
 }
 
 export function updatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
-  if (runtimeUpdateAppPluginSettings && typeof runtimeUpdateAppPluginSettings === 'function') {
+  if (typeof runtimeUpdateAppPluginSettings === 'function') {
     return runtimeUpdateAppPluginSettings(pluginId, data);
   }
 

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -17,7 +17,7 @@ export function getPluginSettings(
   return runtimeGetPluginSettings(pluginId, showErrorAlert);
 }
 
-function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert?: boolean): Promise<PluginMeta> {
+function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert = false): Promise<PluginMeta> {
   return getBackendSrv().get(`/api/plugins/${pluginId}/settings`, undefined, undefined, {
     showErrorAlert,
     validatePath: true,
@@ -36,6 +36,10 @@ export function updatePluginSettings(
   return runtimeUpdateAppPluginSettings(pluginId, data);
 }
 
-function backwardsCompatibleUpdatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
-  return getBackendSrv().post(`/api/plugins/${pluginId}/settings`, data, { validatePath: true });
+async function backwardsCompatibleUpdatePluginSettings(
+  pluginId: string,
+  data: Partial<PluginMeta>
+): Promise<PluginMeta> {
+  await getBackendSrv().post(`/api/plugins/${pluginId}/settings`, data, { validatePath: true });
+  return backwardsCompatibleGetPluginSettings(pluginId);
 }

--- a/packages/grafana-plugin-compat/src/apps.ts
+++ b/packages/grafana-plugin-compat/src/apps.ts
@@ -21,7 +21,7 @@ function backwardsCompatibleGetPluginSettings(pluginId: string, showErrorAlert =
 }
 
 export function updatePluginSettings(pluginId: string, data: Partial<PluginMeta>): Promise<PluginMeta> {
-  if (runtimeUpdateAppPluginSettings || typeof runtimeUpdateAppPluginSettings === 'function') {
+  if (runtimeUpdateAppPluginSettings && typeof runtimeUpdateAppPluginSettings === 'function') {
     return runtimeUpdateAppPluginSettings(pluginId, data);
   }
 

--- a/packages/grafana-plugin-compat/src/index.ts
+++ b/packages/grafana-plugin-compat/src/index.ts
@@ -1,4 +1,0 @@
-import { getPluginSettings, updatePluginSettings } from './apps';
-import { PLACEHOLDER } from './datasources';
-
-export { getPluginSettings, updatePluginSettings, PLACEHOLDER };

--- a/packages/grafana-plugin-compat/src/index.ts
+++ b/packages/grafana-plugin-compat/src/index.ts
@@ -1,0 +1,4 @@
+import { getPluginSettings, updatePluginSettings } from './apps';
+import { PLACEHOLDER } from './datasources';
+
+export { getPluginSettings, updatePluginSettings, PLACEHOLDER };

--- a/packages/grafana-plugin-compat/tsconfig.json
+++ b/packages/grafana-plugin-compat/tsconfig.json
@@ -6,8 +6,9 @@
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."],
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx"
   },
   "exclude": ["dist/**/*"],
-  "include": ["src/**/*.ts"]
+  "include": ["../../public/app/types/*.d.ts", "../grafana-ui/src/types/*.d.ts", "src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,13 +2753,14 @@ __metadata:
   resolution: "@grafana/plugin-compat@workspace:packages/grafana-plugin-compat"
   dependencies:
     "@grafana/data": "workspace:*"
-    "@grafana/runtime": "workspace:*"
     "@typescript/native": "npm:typescript@^7.0.2"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.60.1"
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
+  peerDependencies:
+    "@grafana/runtime": "*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2752,6 +2752,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/plugin-compat@workspace:packages/grafana-plugin-compat"
   dependencies:
+    "@grafana/data": "workspace:*"
+    "@grafana/runtime": "workspace:*"
     "@typescript/native": "npm:typescript@^7.0.2"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.60.1"


### PR DESCRIPTION
**What is this feature?**

This PR adds `getPluginSettings` and `updatePluginSettings` to `@grafana/plugin-compat`. Both call the new `@grafana/runtime/unstable` functions when available, and fall back to the legacy `getBackendSrv` calls otherwise.

```ts
export function getPluginSettings(
  pluginId: string,
  showErrorAlert?: boolean,
  getFn: typeof runtimeGetPluginSettings = runtimeGetPluginSettings
): Promise<PluginMeta> {
  if (!getFn || typeof getFn !== 'function') {
    return backwardsCompatibleGetPluginSettings(pluginId, showErrorAlert);
  }

  return runtimeGetPluginSettings(pluginId, showErrorAlert);
}
```

**Why do we need this feature?**

So plugins can adopt the new k8s-backed plugin settings APIs without breaking on Grafana versions that don't have them yet.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #https://github.com/grafana/traces-drilldown/issues/896

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
