### PR TITLE
IAM: Add integration tests for the AuthInfo API

### DIFF
--- a/pkg/registry/apis/iam/authinfo/store.go
+++ b/pkg/registry/apis/iam/authinfo/store.go
@@ -76,12 +76,12 @@ func (l *LegacyStore) ConvertToTable(ctx context.Context, object runtime.Object,
 	return resourceInfo.TableConverter().ConvertToTable(ctx, object, tableOptions)
 }
 
-// encodeName builds the deterministic object name for a (userUID, authModule) pair.
-func encodeName(userUID, authModule string) string {
+// EncodeName builds the deterministic object name for a (userUID, authModule) pair.
+func EncodeName(userUID, authModule string) string {
 	return userUID + "." + strings.ReplaceAll(authModule, "_", "-")
 }
 
-// decodeName reverses encodeName.
+// decodeName reverses EncodeName.
 func decodeName(name string) (userUID, authModule string, ok bool) {
 	userUID, encodedModule, ok := strings.Cut(name, ".")
 	if !ok {
@@ -217,7 +217,7 @@ func (l *LegacyStore) Create(ctx context.Context, obj runtime.Object, createVali
 	userUID := authInfoObj.Spec.UserRef.Name
 	authModule := authInfoObj.Spec.AuthModule
 
-	expectedName := encodeName(userUID, authModule)
+	expectedName := EncodeName(userUID, authModule)
 	if authInfoObj.Name != "" && authInfoObj.Name != expectedName {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("metadata.name must be %q for spec.userRef.name %q and spec.authModule %q", expectedName, userUID, authModule))
 	}
@@ -350,7 +350,7 @@ func (l *LegacyStore) DeleteCollection(ctx context.Context, deleteValidation res
 func mapToAuthInfoObject(ns claims.NamespaceInfo, userUID string, ua *login.UserAuth) iamv0alpha1.AuthInfo {
 	result := iamv0alpha1.AuthInfo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              encodeName(userUID, ua.AuthModule),
+			Name:              EncodeName(userUID, ua.AuthModule),
 			Namespace:         ns.Value,
 			ResourceVersion:   fmt.Sprintf("%d", ua.Created.UnixMilli()),
 			CreationTimestamp: metav1.NewTime(ua.Created),

--- a/pkg/registry/apis/iam/authinfo/store_test.go
+++ b/pkg/registry/apis/iam/authinfo/store_test.go
@@ -51,7 +51,7 @@ func TestEncodeName(t *testing.T) {
 		{"abc123", "auth.saml", "abc123.auth.saml"},
 	}
 	for _, tt := range tests {
-		require.Equal(t, tt.want, encodeName(tt.userUID, tt.authModule))
+		require.Equal(t, tt.want, EncodeName(tt.userUID, tt.authModule))
 
 		userUID, authModule, ok := decodeName(tt.want)
 		require.True(t, ok)

--- a/pkg/tests/apis/iam/authinfo/authinfo_integration_test.go
+++ b/pkg/tests/apis/iam/authinfo/authinfo_integration_test.go
@@ -1,0 +1,278 @@
+package authinfo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/registry/apis/iam/authinfo"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationAuthInfo(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	// Mode5 is excluded: it serves straight from unified storage, bypassing LegacyStore
+	// (and every domain rule enforced there) since nothing populates that store yet.
+	modes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode3}
+	for _, mode := range modes {
+		t.Run(fmt.Sprintf("DualWriterMode %d", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				AppModeProduction:      false,
+				DisableAnonymous:       true,
+				RBACSingleOrganization: true,
+				APIServerStorageType:   "unified",
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"authinfos.iam.grafana.app": {
+						DualWriterMode: mode,
+					},
+				},
+				EnableFeatureToggles: []string{
+					featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+					featuremgmt.FlagKubernetesUsersApi,
+					featuremgmt.FlagKubernetesAuthInfoApi,
+				},
+			})
+
+			t.Cleanup(func() {
+				helper.Shutdown()
+			})
+
+			doAuthInfoCRUDTestsUsingTheNewAPIs(t, helper)
+			doAuthInfoAuthzTests(t, helper)
+			doAuthInfoListRequiresFieldSelectorTest(t, helper)
+			doAuthInfoDeleteUnsupportedTests(t, helper)
+		})
+	}
+}
+
+func doAuthInfoCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Run("should create, get, list and update authinfo using the new APIs as a GrafanaAdmin", func(t *testing.T) {
+		ctx := context.Background()
+		userUID := createTestUser(t, helper, "authinfo-crud-user", "authinfo-crud-user@example.com")
+
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		toCreate := createAuthInfoObject(helper, userUID, "ldap", "cn=test,dc=example,dc=com")
+		created, err := authInfoClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		// The object name is deterministic: "<userUID>.<authModule>".
+		expectedName := authinfo.EncodeName(userUID, "ldap")
+		require.Equal(t, expectedName, created.GetName())
+
+		createdSpec := created.Object["spec"].(map[string]interface{})
+		require.Equal(t, userUID, createdSpec["userRef"].(map[string]interface{})["name"])
+		require.Equal(t, "ldap", createdSpec["authModule"])
+		require.Equal(t, "cn=test,dc=example,dc=com", createdSpec["authID"])
+
+		fetched, err := authInfoClient.Resource.Get(ctx, expectedName, metav1.GetOptions{})
+		require.NoError(t, err)
+		fetchedSpec := fetched.Object["spec"].(map[string]interface{})
+		require.Equal(t, "cn=test,dc=example,dc=com", fetchedSpec["authID"])
+
+		list, err := authInfoClient.Resource.List(ctx, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("spec.userRef.name=%s", userUID),
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		require.Equal(t, expectedName, list.Items[0].GetName())
+
+		toUpdate := fetched.DeepCopy()
+		toUpdate.Object["spec"].(map[string]interface{})["authID"] = "cn=updated,dc=example,dc=com"
+		updated, err := authInfoClient.Resource.Update(ctx, toUpdate, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		updatedSpec := updated.Object["spec"].(map[string]interface{})
+		require.Equal(t, "cn=updated,dc=example,dc=com", updatedSpec["authID"])
+
+		fetchedAfter, err := authInfoClient.Resource.Get(ctx, expectedName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "cn=updated,dc=example,dc=com", fetchedAfter.Object["spec"].(map[string]interface{})["authID"])
+	})
+
+	t.Run("should not create authinfo for a non-existent user", func(t *testing.T) {
+		ctx := context.Background()
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		toCreate := createAuthInfoObject(helper, "non-existent-user", "ldap", "cn=test,dc=example,dc=com")
+		_, err := authInfoClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+	})
+
+	t.Run("should not create a duplicate authinfo for the same user and auth module", func(t *testing.T) {
+		ctx := context.Background()
+		userUID := createTestUser(t, helper, "authinfo-dup-user", "authinfo-dup-user@example.com")
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		toCreate := createAuthInfoObject(helper, userUID, "ldap", "cn=test,dc=example,dc=com")
+		created, err := authInfoClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		_, err = authInfoClient.Resource.Create(ctx, createAuthInfoObject(helper, userUID, "ldap", "cn=other,dc=example,dc=com"), metav1.CreateOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(409), statusErr.ErrStatus.Code)
+	})
+
+	t.Run("should not update authinfo with a userRef or authModule change", func(t *testing.T) {
+		ctx := context.Background()
+		userUID := createTestUser(t, helper, "authinfo-immutable-user", "authinfo-immutable-user@example.com")
+		otherUserUID := createTestUser(t, helper, "authinfo-immutable-other-user", "authinfo-immutable-other-user@example.com")
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		created, err := authInfoClient.Resource.Create(ctx, createAuthInfoObject(helper, userUID, "ldap", "cn=test,dc=example,dc=com"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		toUpdate := created.DeepCopy()
+		toUpdate.Object["spec"].(map[string]interface{})["userRef"].(map[string]interface{})["name"] = otherUserUID
+		_, err = authInfoClient.Resource.Update(ctx, toUpdate, metav1.UpdateOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+		require.Contains(t, statusErr.ErrStatus.Message, "immutable")
+
+		toUpdate = created.DeepCopy()
+		toUpdate.Object["spec"].(map[string]interface{})["authModule"] = "oauth_github"
+		_, err = authInfoClient.Resource.Update(ctx, toUpdate, metav1.UpdateOptions{})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+		require.Contains(t, statusErr.ErrStatus.Message, "immutable")
+	})
+}
+
+func doAuthInfoAuthzTests(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Run("should not be able to access authinfo when using a user with insufficient permissions", func(t *testing.T) {
+		ctx := context.Background()
+		userUID := createTestUser(t, helper, "authinfo-authz-user", "authinfo-authz-user@example.com")
+
+		adminClient := authInfoResourceClient(helper, helper.Org1.Admin)
+		created, err := adminClient.Resource.Create(ctx, createAuthInfoObject(helper, userUID, "ldap", "cn=test,dc=example,dc=com"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		for _, u := range []apis.User{
+			helper.Org1.Editor,
+			helper.Org1.Viewer,
+			helper.OrgB.Admin, // Org admin, but not a Grafana admin
+		} {
+			t.Run(fmt.Sprintf("with basic role_%s", u.Identity.GetOrgRole()), func(t *testing.T) {
+				authInfoClient := authInfoResourceClient(helper, u)
+
+				_, err := authInfoClient.Resource.Get(ctx, created.GetName(), metav1.GetOptions{})
+				require.Error(t, err)
+				var statusErr *errors.StatusError
+				require.ErrorAs(t, err, &statusErr)
+				require.Equal(t, int32(403), statusErr.ErrStatus.Code)
+
+				_, err = authInfoClient.Resource.Create(ctx, createAuthInfoObject(helper, userUID, "oauth_github", "some-id"), metav1.CreateOptions{})
+				require.Error(t, err)
+				require.ErrorAs(t, err, &statusErr)
+				require.Equal(t, int32(403), statusErr.ErrStatus.Code)
+			})
+		}
+	})
+}
+
+func doAuthInfoListRequiresFieldSelectorTest(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Run("should reject list without a spec.userRef.name field selector", func(t *testing.T) {
+		ctx := context.Background()
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		_, err := authInfoClient.Resource.List(ctx, metav1.ListOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(400), statusErr.ErrStatus.Code)
+		require.Contains(t, statusErr.ErrStatus.Message, "spec.userRef.name")
+	})
+}
+
+// doAuthInfoDeleteUnsupportedTests: deleting a single auth link isn't wired
+// up yet, so Delete/DeleteCollection deliberately return 405.
+func doAuthInfoDeleteUnsupportedTests(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Run("delete and deleteCollection are not supported", func(t *testing.T) {
+		ctx := context.Background()
+		userUID := createTestUser(t, helper, "authinfo-delete-user", "authinfo-delete-user@example.com")
+		authInfoClient := authInfoResourceClient(helper, helper.Org1.Admin)
+
+		created, err := authInfoClient.Resource.Create(ctx, createAuthInfoObject(helper, userUID, "ldap", "cn=test,dc=example,dc=com"), metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = authInfoClient.Resource.Delete(ctx, created.GetName(), metav1.DeleteOptions{})
+		require.Error(t, err)
+		var statusErr *errors.StatusError
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(405), statusErr.ErrStatus.Code)
+
+		err = authInfoClient.Resource.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("spec.userRef.name=%s", userUID),
+		})
+		require.Error(t, err)
+		require.ErrorAs(t, err, &statusErr)
+		require.Equal(t, int32(405), statusErr.ErrStatus.Code)
+	})
+}
+
+func authInfoResourceClient(helper *apis.K8sTestHelper, user apis.User) *apis.K8sResourceClient {
+	return helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      user,
+		Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:       gvrAuthInfo,
+	})
+}
+
+// createTestUser creates a user via the new User API and registers its deletion as cleanup.
+func createTestUser(t *testing.T, helper *apis.K8sTestHelper, login string, email string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	userClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:       gvrUsers,
+	})
+
+	obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
+	obj.SetName(login)
+	spec := obj.Object["spec"].(map[string]interface{})
+	spec["login"] = login
+	spec["email"] = email
+	obj.Object["spec"] = spec
+
+	created, err := userClient.Resource.Create(ctx, obj, metav1.CreateOptions{})
+	require.NoError(t, err)
+	userUID := created.GetName()
+
+	t.Cleanup(func() {
+		_ = userClient.Resource.Delete(context.Background(), userUID, metav1.DeleteOptions{})
+	})
+
+	return userUID
+}
+
+// createAuthInfoObject builds an AuthInfo object with its deterministic name pre-populated.
+func createAuthInfoObject(helper *apis.K8sTestHelper, userUID, authModule, authID string) *unstructured.Unstructured {
+	obj := helper.LoadYAMLOrJSONFile("../testdata/authinfo-test-create-v0.yaml")
+	obj.SetName(authinfo.EncodeName(userUID, authModule))
+	obj.Object["spec"].(map[string]interface{})["userRef"].(map[string]interface{})["name"] = userUID
+	obj.Object["spec"].(map[string]interface{})["authModule"] = authModule
+	obj.Object["spec"].(map[string]interface{})["authID"] = authID
+	return obj
+}

--- a/pkg/tests/apis/iam/authinfo/authinfo_test.go
+++ b/pkg/tests/apis/iam/authinfo/authinfo_test.go
@@ -1,0 +1,25 @@
+package authinfo
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+var gvrUsers = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "users",
+}
+
+var gvrAuthInfo = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "authinfos",
+}
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}

--- a/pkg/tests/apis/iam/testdata/authinfo-test-create-v0.yaml
+++ b/pkg/tests/apis/iam/testdata/authinfo-test-create-v0.yaml
@@ -1,0 +1,9 @@
+apiVersion: iam.grafana.app/v0alpha1
+kind: AuthInfo
+metadata:
+  namespace: default
+spec:
+  userRef:
+    name: ""
+  authModule: "ldap"
+  authID: "cn=test,dc=example,dc=com"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds end-to-end integration tests for the new `AuthInfo` k8s API. Exercised across modes 0, 1, and 3. Mode5 is excluded because it serves straight from unified storage, bypassing LegacyStore and every domain rule enforced there, since nothing populates that store for this kind yet.

Also exports `authinfo.EncodeName` so callers can compute an `AuthInfo` object's deterministic name themselves.

**Why do we need this feature?**

The `AuthInfo` resource was registered as a k8s API in https://github.com/grafana/grafana/pull/132183 but had no test coverage beyond unit tests. This closes that gap with real HTTP level coverage through the full apiserver stack.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/identity-access-team/issues/2331.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
