### PR TITLE
Provisioning: bound decrypt calls with a timeout

### DIFF
--- a/apps/provisioning/pkg/connection/secure.go
+++ b/apps/provisioning/pkg/connection/secure.go
@@ -25,6 +25,12 @@ var (
 	ErrTokenNotFound = errors.New("token secure value not found")
 )
 
+// decryptTimeout bounds a single decrypt call so a hung or unreachable secrets
+// service can't block a reconcile indefinitely. It covers the gRPC client's
+// internal retries, which share this context. Reconcile retries on failure, so
+// this is a fail-fast bound, not a hard SLA.
+const decryptTimeout = 30 * time.Second
+
 type secretTypeLabel string
 
 const (
@@ -66,6 +72,9 @@ func (s *secureValues) get(ctx context.Context, sv common.InlineSecureValue, st 
 			s.metrics.recordSuccess(st, elapsed)
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(ctx, decryptTimeout)
+	defer cancel()
 
 	results, err := s.svc.Decrypt(ctx, provisioning.GROUP, s.namespace, sv.Name)
 	if err != nil {

--- a/apps/provisioning/pkg/connection/secure_test.go
+++ b/apps/provisioning/pkg/connection/secure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,9 +21,11 @@ import (
 type mockDecryptService struct {
 	results map[string]decrypt.DecryptResult
 	err     error
+	gotCtx  context.Context
 }
 
 func (m *mockDecryptService) Decrypt(ctx context.Context, group, namespace string, names ...string) (map[string]decrypt.DecryptResult, error) {
+	m.gotCtx = ctx
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -469,6 +472,41 @@ func TestSecureValues_NotFoundSentinel(t *testing.T) {
 		decrypter := connection.ProvideDecrypter(&mockDecryptService{results: map[string]decrypt.DecryptResult{}}, nil)
 		_, err := decrypter(pkConn).PrivateKey(context.Background())
 		require.ErrorIs(t, err, connection.ErrSecretNotFound)
+		require.NotErrorIs(t, err, connection.ErrTokenNotFound)
+	})
+}
+
+func TestSecureValues_DecryptTimeout(t *testing.T) {
+	conn := &provisioning.Connection{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-connection", Namespace: "default"},
+		Secure:     provisioning.ConnectionSecure{Token: common.InlineSecureValue{Name: "token-ref"}},
+	}
+
+	t.Run("bounds a deadline-less caller context", func(t *testing.T) {
+		mockSvc := &mockDecryptService{results: map[string]decrypt.DecryptResult{
+			"token-ref": newDecryptResult("decrypted-token"),
+		}}
+		decrypter := connection.ProvideDecrypter(mockSvc, nil)
+
+		// context.Background() carries no deadline; get must impose one.
+		_, err := decrypter(conn).Token(context.Background())
+		require.NoError(t, err)
+
+		deadline, ok := mockSvc.gotCtx.Deadline()
+		require.True(t, ok, "decrypt must receive a bounded context")
+		require.True(t, deadline.After(time.Now()), "deadline must be in the future")
+		require.True(t, deadline.Before(time.Now().Add(time.Minute)), "deadline must be bounded near the decrypt timeout")
+	})
+
+	t.Run("expired context surfaces as a transient decrypt failure", func(t *testing.T) {
+		mockSvc := &mockDecryptService{err: context.DeadlineExceeded}
+		decrypter := connection.ProvideDecrypter(mockSvc, nil)
+
+		_, err := decrypter(conn).Token(context.Background())
+		require.Error(t, err)
+		// A timeout must never look like a missing secret, which would let the
+		// controller regenerate and overwrite the token.
+		require.NotErrorIs(t, err, connection.ErrSecretNotFound)
 		require.NotErrorIs(t, err, connection.ErrTokenNotFound)
 	})
 }

--- a/apps/provisioning/pkg/repository/secure.go
+++ b/apps/provisioning/pkg/repository/secure.go
@@ -32,6 +32,12 @@ var (
 	ErrSecretDecryptFailed = errors.New("secure value could not be decrypted")
 )
 
+// decryptTimeout bounds a single decrypt call so a hung or unreachable secrets
+// service can't block a reconcile indefinitely. It covers the gRPC client's
+// internal retries, which share this context. Reconcile retries on failure, so
+// this is a fail-fast bound, not a hard SLA.
+const decryptTimeout = 30 * time.Second
+
 type secretTypeLabel string
 
 const (
@@ -72,6 +78,9 @@ func (s *secureValues) get(ctx context.Context, sv common.InlineSecureValue, st 
 			s.metrics.recordSuccess(st, elapsed)
 		}
 	}()
+
+	ctx, cancel := context.WithTimeout(ctx, decryptTimeout)
+	defer cancel()
 
 	results, err := s.svc.Decrypt(ctx, provisioning.GROUP, s.namespace, sv.Name)
 	if err != nil {

--- a/apps/provisioning/pkg/repository/secure_test.go
+++ b/apps/provisioning/pkg/repository/secure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -259,6 +260,50 @@ func TestRepositorySecureValues_NotFoundSentinel(t *testing.T) {
 		require.ErrorIs(t, err, ErrSecretNotFound)
 		require.NotErrorIs(t, err, ErrTokenNotFound)
 	})
+}
+
+func TestRepositorySecureValues_DecryptTimeout(t *testing.T) {
+	cfg := &provisioning.Repository{Secure: provisioning.SecureValues{Token: v0alpha1.InlineSecureValue{Name: "secret"}}}
+
+	t.Run("bounds a deadline-less caller context", func(t *testing.T) {
+		svc := &ctxCapturingDecryptService{}
+		decrypter := ProvideDecrypter(svc, nil)
+
+		// context.Background() carries no deadline; get must impose one.
+		_, err := decrypter(cfg).Token(context.Background())
+		require.NoError(t, err)
+
+		deadline, ok := svc.ctx.Deadline()
+		require.True(t, ok, "decrypt must receive a bounded context")
+		require.WithinDuration(t, time.Now().Add(decryptTimeout), deadline, time.Minute)
+	})
+
+	t.Run("expired context surfaces as a transient decrypt failure", func(t *testing.T) {
+		svc := &ctxCapturingDecryptService{err: context.DeadlineExceeded}
+		decrypter := ProvideDecrypter(svc, nil)
+
+		_, err := decrypter(cfg).Token(context.Background())
+		require.Error(t, err)
+		// A timeout must never look like a missing secret, which would let the
+		// controller regenerate and overwrite the token.
+		require.NotErrorIs(t, err, ErrSecretNotFound)
+		require.NotErrorIs(t, err, ErrTokenNotFound)
+		require.ErrorIs(t, err, ErrSecretDecryptFailed)
+	})
+}
+
+type ctxCapturingDecryptService struct {
+	ctx context.Context
+	err error
+}
+
+func (d *ctxCapturingDecryptService) Decrypt(ctx context.Context, _ string, _ string, names ...string) (map[string]decrypt.DecryptResult, error) {
+	d.ctx = ctx
+	if d.err != nil {
+		return nil, d.err
+	}
+	val := secretv1beta1.NewExposedSecureValue(names[0])
+	return map[string]decrypt.DecryptResult{names[0]: decrypt.NewDecryptResultValue(&val)}, nil
 }
 
 type decryptFn = func(t *testing.T, names ...string) (map[string]decrypt.DecryptResult, error)


### PR DESCRIPTION
## What

Adds a 30s timeout around every secret-decrypt call in provisioning (repository and connection secure values: tokens, webhook secrets, commit-signing keys, OAuth client secrets, private keys).

## Why

`secureValues.get` passed the caller's `context` straight through to `decrypt.DecryptService`. When a decrypt is reached from a controller/reconcile loop, the context carries no deadline, so a hung or unreachable secrets service could block a decrypt — and each of the gRPC decrypt client's 3 retries (which share that context and have no per-retry timeout) — indefinitely. Decrypts reached through the 30s-wrapped REST connectors were bounded; reconcile-driven ones were not.

Part of grafana/git-ui-sync-project#1356.

## How

Wrap the decrypt call in `secureValues.get` with `context.WithTimeout(ctx, decryptTimeout)` (30s package const) in both `apps/provisioning/pkg/repository/secure.go` and `apps/provisioning/pkg/connection/secure.go`.

Design notes:
- **Provisioning-owned seam.** Applied at the call site rather than in the shared secrets gRPC client (`pkg/registry/apis/secret/decrypt/`), so no cross-team change and it covers both the gRPC and in-process local clients.
- **Only ever tightens.** The bound derives from the caller's context, so a shorter inbound deadline (e.g. the 30s REST connector) still wins; a deadline-less reconcile context now gets one.
- **Safe classification.** The existing error handling already maps a failed decrypt to the transient `ErrSecretDecryptFailed` sentinel, so a resulting `context.DeadlineExceeded` surfaces as a retryable service failure — never as `ErrSecretNotFound`, which would let the controller regenerate and overwrite the token.

The gRPC client itself still lacks a per-retry/dial timeout; bounding it there benefits all consumers but lives in secrets-team code — a reasonable follow-up, separate from this fix.

## Testing

- `go test ./apps/provisioning/pkg/repository/ ./apps/provisioning/pkg/connection/` — pass
- Added `TestSecureValues_DecryptTimeout` in each package asserting (1) a deadline-less caller (`context.Background()`) reaches the decrypt service with a bounded context, and (2) a `context.DeadlineExceeded` surfaces as the transient decrypt failure, not as a missing-secret sentinel.

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)