### PR TITLE
TraceView: Open attribute links in the same tab in Explore and Traces Drilldown

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionCategorizedKeyValues.tsx
@@ -25,6 +25,7 @@ export type AccordionCategorizedKeyValuesProps = {
   onToggle?: null | (() => void);
   promoGetter?: AttributePluginPromoGetter;
   datasourceType?: string;
+  openLinksInSameTab?: boolean;
 };
 
 export default function AccordionCategorizedKeyValues({
@@ -36,6 +37,7 @@ export default function AccordionCategorizedKeyValues({
   onToggle = null,
   promoGetter,
   datasourceType,
+  openLinksInSameTab,
 }: AccordionCategorizedKeyValuesProps) {
   const styles = useStyles2(getStyles);
   const isEmpty = !Array.isArray(data) || !data.length;
@@ -106,6 +108,7 @@ export default function AccordionCategorizedKeyValues({
             linksGetter={linksGetter}
             promoGetter={promoGetter}
             datasourceType={datasourceType}
+            openLinksInSameTab={openLinksInSameTab}
           />
         ) : (
           <div className={styles.categories} data-testid="AccordionCategorizedKeyValues--categories">
@@ -140,6 +143,7 @@ export default function AccordionCategorizedKeyValues({
                         linksGetter={linksGetter}
                         promoGetter={promoGetter}
                         datasourceType={datasourceType}
+                        openLinksInSameTab={openLinksInSameTab}
                       />
                     </div>
                   )}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordionKeyValues.tsx
@@ -79,6 +79,7 @@ export type AccordionKeyValuesProps = {
   onToggle?: null | (() => void);
   promoGetter?: AttributePluginPromoGetter;
   datasourceType?: string;
+  openLinksInSameTab?: boolean;
 };
 
 export default function AccordionKeyValues({
@@ -96,6 +97,7 @@ export default function AccordionKeyValues({
   onToggle = null,
   promoGetter,
   datasourceType,
+  openLinksInSameTab,
 }: AccordionKeyValuesProps) {
   const isEmpty = (!Array.isArray(data) || !data.length) && !logName;
   const styles = useStyles2(getStyles);
@@ -146,6 +148,7 @@ export default function AccordionKeyValues({
           onlyValues={onlyValues}
           promoGetter={promoGetter}
           datasourceType={datasourceType}
+          openLinksInSameTab={openLinksInSameTab}
         />
       )}
     </div>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
@@ -19,9 +19,12 @@ import { locationService, reportInteraction } from '@grafana/runtime';
 
 import KeyValuesTable, { LinkValue, type KeyValuesTableProps } from './KeyValuesTable';
 
+const mockSetReturnToPrevious = jest.fn();
+
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   reportInteraction: jest.fn(),
+  useReturnToPrevious: jest.fn(() => mockSetReturnToPrevious),
   config: {
     buildInfo: {
       version: '11.0.0',
@@ -47,6 +50,7 @@ const setup = (propOverrides?: Partial<KeyValuesTableProps>) => {
 describe('LinkValue', () => {
   beforeEach(() => {
     (reportInteraction as jest.Mock).mockClear();
+    mockSetReturnToPrevious.mockClear();
   });
 
   it('renders as expected', () => {
@@ -119,6 +123,7 @@ describe('LinkValue', () => {
 
     expect(onClick).toHaveBeenCalled();
     expect(pushSpy).not.toHaveBeenCalled();
+    expect(mockSetReturnToPrevious).not.toHaveBeenCalled();
     pushSpy.mockRestore();
   });
 
@@ -134,6 +139,7 @@ describe('LinkValue', () => {
     await user.click(screen.getByRole('link', { name: 'Related traces' }));
 
     expect(pushSpy).toHaveBeenCalledWith('/explore?left=abc');
+    expect(mockSetReturnToPrevious).toHaveBeenCalledWith('Trace');
     pushSpy.mockRestore();
   });
 
@@ -147,6 +153,7 @@ describe('LinkValue', () => {
     await user.click(linkEl);
 
     expect(pushSpy).not.toHaveBeenCalled();
+    expect(mockSetReturnToPrevious).not.toHaveBeenCalled();
     pushSpy.mockRestore();
   });
 });
@@ -154,6 +161,7 @@ describe('LinkValue', () => {
 describe('KeyValuesTable tests', () => {
   beforeEach(() => {
     (reportInteraction as jest.Mock).mockClear();
+    mockSetReturnToPrevious.mockClear();
   });
 
   it('renders without exploding', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
@@ -15,7 +15,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { reportInteraction } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 
 import KeyValuesTable, { LinkValue, type KeyValuesTableProps } from './KeyValuesTable';
 
@@ -102,6 +102,52 @@ describe('LinkValue', () => {
       location: 'value',
     });
     expect(onClick).toHaveBeenCalled();
+    expect(onClick.mock.calls[0][0].defaultPrevented).toBe(true);
+  });
+
+  it('does not also push when the plugin supplies onClick', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
+    render(
+      <LinkValue link={{ title: 'Related traces', path: '/explore?left=abc', onClick }} openLinksInSameTab>
+        value
+      </LinkValue>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Related traces' }));
+
+    expect(onClick).toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+
+  it('navigates in the same tab when openLinksInSameTab is set', async () => {
+    const user = userEvent.setup();
+    const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
+    render(
+      <LinkValue link={{ title: 'Related traces', path: '/explore?left=abc' }} openLinksInSameTab>
+        value
+      </LinkValue>
+    );
+
+    await user.click(screen.getByRole('link', { name: 'Related traces' }));
+
+    expect(pushSpy).toHaveBeenCalledWith('/explore?left=abc');
+    pushSpy.mockRestore();
+  });
+
+  it('does not push when openLinksInSameTab is unset', async () => {
+    const user = userEvent.setup();
+    const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
+    render(<LinkValue link={{ title: 'Related traces', path: '/explore?left=abc' }}>value</LinkValue>);
+
+    const linkEl = screen.getByRole('link', { name: 'Related traces' });
+    expect(linkEl).toHaveAttribute('target', '_blank');
+    await user.click(linkEl);
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
   });
 });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.test.tsx
@@ -109,7 +109,7 @@ describe('LinkValue', () => {
     expect(onClick.mock.calls[0][0].defaultPrevented).toBe(true);
   });
 
-  it('does not also push when the plugin supplies onClick', async () => {
+  it('navigates in the same tab even when the plugin also supplies onClick', async () => {
     const user = userEvent.setup();
     const onClick = jest.fn();
     const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
@@ -121,9 +121,26 @@ describe('LinkValue', () => {
 
     await user.click(screen.getByRole('link', { name: 'Related traces' }));
 
-    expect(onClick).toHaveBeenCalled();
+    expect(pushSpy).toHaveBeenCalledWith('/explore?left=abc');
+    expect(mockSetReturnToPrevious).toHaveBeenCalledWith('Trace');
+    expect(onClick).not.toHaveBeenCalled();
+    pushSpy.mockRestore();
+  });
+
+  it('keeps a new tab when the plugin sets openInNewTab', async () => {
+    const user = userEvent.setup();
+    const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
+    render(
+      <LinkValue link={{ title: 'Related traces', path: '/explore?left=abc', openInNewTab: true }} openLinksInSameTab>
+        value
+      </LinkValue>
+    );
+
+    const linkEl = screen.getByRole('link', { name: 'Related traces' });
+    expect(linkEl).toHaveAttribute('target', '_blank');
+    await user.click(linkEl);
+
     expect(pushSpy).not.toHaveBeenCalled();
-    expect(mockSetReturnToPrevious).not.toHaveBeenCalled();
     pushSpy.mockRestore();
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -27,7 +27,7 @@ import {
 
 import { type GrafanaTheme2, type PluginExtensionLink, type TraceKeyValuePair } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction, useReturnToPrevious } from '@grafana/runtime';
 import { Dropdown, Icon, Menu, useStyles2 } from '@grafana/ui';
 
 import { getTraceViewLinkAttrs, openTraceViewHref } from '../../../utils/openTraceViewHref';
@@ -204,7 +204,13 @@ function onAttributeLinkClick(
     location,
     datasourceType,
     openLinksInSameTab,
-  }: { location: ResourceLinkClickLocation; datasourceType?: string; openLinksInSameTab: boolean }
+    setReturnToPrevious,
+  }: {
+    location: ResourceLinkClickLocation;
+    datasourceType?: string;
+    openLinksInSameTab: boolean;
+    setReturnToPrevious: (title: string) => void;
+  }
 ) {
   reportResourceLinkClick(link, { location, datasourceType });
   // Modifier-clicks use the anchor href (new tab). Do not also run in-app navigation.
@@ -219,6 +225,7 @@ function onAttributeLinkClick(
   }
   if (openLinksInSameTab && link.path) {
     event.preventDefault();
+    setReturnToPrevious(t('explore.key-values-table.return-to-previous-title', 'Trace'));
     openTraceViewHref(link.path);
   }
 }
@@ -231,13 +238,21 @@ export const LinkValue = ({
 }: PropsWithChildren<LinkValueProps>) => {
   const { path, title, icon = 'external-link-alt' } = link;
   const styles = useStyles2(getStyles);
+  const setReturnToPrevious = useReturnToPrevious();
   const attrs = attributeLinkAttrs(path, openLinksInSameTab);
 
   return (
     <a
       href={attrs?.href}
       title={title}
-      onClick={(event) => onAttributeLinkClick(event, link, { location: 'value', datasourceType, openLinksInSameTab })}
+      onClick={(event) =>
+        onAttributeLinkClick(event, link, {
+          location: 'value',
+          datasourceType,
+          openLinksInSameTab,
+          setReturnToPrevious,
+        })
+      }
       target={attrs?.target}
       rel={attrs?.rel}
       className={styles.linkValue}
@@ -257,6 +272,7 @@ interface LinkValuesMenuProps {
 
 const LinkValuesMenu = ({ links, datasourceType, openLinksInSameTab = false, children }: LinkValuesMenuProps) => {
   const styles = useStyles2(getStyles);
+  const setReturnToPrevious = useReturnToPrevious();
   const openValueInLabel = t('explore.key-values-table.open-value-in', 'Open value in');
   const triggerId = useId();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -295,7 +311,12 @@ const LinkValuesMenu = ({ links, datasourceType, openLinksInSameTab = false, chi
                       url={attrs?.href}
                       target={attrs?.target}
                       onClick={(event) =>
-                        onAttributeLinkClick(event, link, { location: 'menu', datasourceType, openLinksInSameTab })
+                        onAttributeLinkClick(event, link, {
+                          location: 'menu',
+                          datasourceType,
+                          openLinksInSameTab,
+                          setReturnToPrevious,
+                        })
                       }
                     />
                   </div>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -15,13 +15,22 @@
 import { css } from '@emotion/css';
 import cx from 'clsx';
 import DOMPurify from 'dompurify';
-import { type PropsWithChildren, type ReactNode, useId, useLayoutEffect, useRef, useState } from 'react';
+import {
+  type MouseEvent,
+  type PropsWithChildren,
+  type ReactNode,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
-import { type GrafanaTheme2, type PluginExtensionLink, textUtil, type TraceKeyValuePair } from '@grafana/data';
+import { type GrafanaTheme2, type PluginExtensionLink, type TraceKeyValuePair } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Dropdown, Icon, Menu, useStyles2 } from '@grafana/ui';
 
+import { getTraceViewLinkAttrs, openTraceViewHref } from '../../../utils/openTraceViewHref';
 import { autoColor } from '../../Theme';
 import CopyIcon from '../../common/CopyIcon';
 
@@ -173,22 +182,64 @@ function reportResourceLinkClick(
 interface LinkValueProps {
   link: KeyValuesTableLink;
   datasourceType?: string;
+  /** Same-tab in Explore and drilldown. Dashboard panels keep a new tab so the dashboard stays put. */
+  openLinksInSameTab?: boolean;
 }
 
-export const LinkValue = ({ link, datasourceType, children }: PropsWithChildren<LinkValueProps>) => {
-  const { path, title, onClick, icon = 'external-link-alt' } = link;
+function attributeLinkAttrs(path: string | undefined, openLinksInSameTab: boolean) {
+  const attrs = path ? getTraceViewLinkAttrs(path) : undefined;
+  if (!attrs) {
+    return undefined;
+  }
+  if (!openLinksInSameTab) {
+    return { href: attrs.href, target: '_blank' as const, rel: 'noopener noreferrer' as const };
+  }
+  return attrs;
+}
+
+function onAttributeLinkClick(
+  event: MouseEvent,
+  link: KeyValuesTableLink,
+  {
+    location,
+    datasourceType,
+    openLinksInSameTab,
+  }: { location: ResourceLinkClickLocation; datasourceType?: string; openLinksInSameTab: boolean }
+) {
+  reportResourceLinkClick(link, { location, datasourceType });
+  // Modifier-clicks use the anchor href (new tab). Do not also run in-app navigation.
+  if (event.ctrlKey || event.metaKey || event.shiftKey) {
+    return;
+  }
+  if (link.onClick) {
+    link.onClick(event);
+    // Plugin handles the click; stop the browser from also following href.
+    event.preventDefault();
+    return;
+  }
+  if (openLinksInSameTab && link.path) {
+    event.preventDefault();
+    openTraceViewHref(link.path);
+  }
+}
+
+export const LinkValue = ({
+  link,
+  datasourceType,
+  openLinksInSameTab = false,
+  children,
+}: PropsWithChildren<LinkValueProps>) => {
+  const { path, title, icon = 'external-link-alt' } = link;
   const styles = useStyles2(getStyles);
+  const attrs = attributeLinkAttrs(path, openLinksInSameTab);
 
   return (
     <a
-      href={path ? textUtil.sanitizeUrl(path) : path}
+      href={attrs?.href}
       title={title}
-      onClick={(event) => {
-        reportResourceLinkClick(link, { location: 'value', datasourceType });
-        onClick?.(event);
-      }}
-      target="_blank"
-      rel="noopener noreferrer"
+      onClick={(event) => onAttributeLinkClick(event, link, { location: 'value', datasourceType, openLinksInSameTab })}
+      target={attrs?.target}
+      rel={attrs?.rel}
       className={styles.linkValue}
     >
       <Icon name={icon} className={styles.linkIcon} />
@@ -200,10 +251,11 @@ export const LinkValue = ({ link, datasourceType, children }: PropsWithChildren<
 interface LinkValuesMenuProps {
   links: KeyValuesTableLink[];
   datasourceType?: string;
+  openLinksInSameTab?: boolean;
   children: ReactNode;
 }
 
-const LinkValuesMenu = ({ links, datasourceType, children }: LinkValuesMenuProps) => {
+const LinkValuesMenu = ({ links, datasourceType, openLinksInSameTab = false, children }: LinkValuesMenuProps) => {
   const styles = useStyles2(getStyles);
   const openValueInLabel = t('explore.key-values-table.open-value-in', 'Open value in');
   const triggerId = useId();
@@ -231,20 +283,24 @@ const LinkValuesMenu = ({ links, datasourceType, children }: LinkValuesMenuProps
         overlay={
           <Menu>
             <Menu.Group label={openValueInLabel.toLocaleUpperCase()}>
-              {links.map((link, index) => (
-                <div key={index} title={link.title}>
-                  <Menu.Item
-                    label={link.description || link.title || t('explore.key-values-table.link-fallback-label', 'Link')}
-                    icon={link.icon}
-                    url={link.path ? textUtil.sanitizeUrl(link.path) : undefined}
-                    target="_blank"
-                    onClick={(event) => {
-                      reportResourceLinkClick(link, { location: 'menu', datasourceType });
-                      link.onClick?.(event);
-                    }}
-                  />
-                </div>
-              ))}
+              {links.map((link, index) => {
+                const attrs = attributeLinkAttrs(link.path, openLinksInSameTab);
+                return (
+                  <div key={index} title={link.title}>
+                    <Menu.Item
+                      label={
+                        link.description || link.title || t('explore.key-values-table.link-fallback-label', 'Link')
+                      }
+                      icon={link.icon}
+                      url={attrs?.href}
+                      target={attrs?.target}
+                      onClick={(event) =>
+                        onAttributeLinkClick(event, link, { location: 'menu', datasourceType, openLinksInSameTab })
+                      }
+                    />
+                  </div>
+                );
+              })}
             </Menu.Group>
           </Menu>
         }
@@ -269,10 +325,11 @@ export type KeyValuesTableProps = {
   onlyValues?: boolean;
   promoGetter?: AttributePluginPromoGetter;
   datasourceType?: string;
+  openLinksInSameTab?: boolean;
 };
 
 export default function KeyValuesTable(props: KeyValuesTableProps) {
-  const { data, linksGetter, onlyValues, promoGetter, datasourceType } = props;
+  const { data, linksGetter, onlyValues, promoGetter, datasourceType, openLinksInSameTab = false } = props;
   const styles = useStyles2(getStyles);
   return (
     <div className={cx(styles.KeyValueTable)} data-testid="KeyValueTable">
@@ -294,11 +351,11 @@ export default function KeyValuesTable(props: KeyValuesTableProps) {
             const links = linksGetter?.(data, i) ?? [];
             let valueMarkup =
               links.length > 1 ? (
-                <LinkValuesMenu links={links} datasourceType={datasourceType}>
+                <LinkValuesMenu links={links} datasourceType={datasourceType} openLinksInSameTab={openLinksInSameTab}>
                   {jsonTable}
                 </LinkValuesMenu>
               ) : links.length === 1 ? (
-                <LinkValue link={links[0]} datasourceType={datasourceType}>
+                <LinkValue link={links[0]} datasourceType={datasourceType} openLinksInSameTab={openLinksInSameTab}>
                   {jsonTable}
                 </LinkValue>
               ) : (

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -160,7 +160,7 @@ function parseIfComplexJson(value: unknown) {
 }
 
 export type KeyValuesTableLink = Pick<PluginExtensionLink, 'path' | 'title' | 'onClick' | 'icon'> &
-  Partial<Pick<PluginExtensionLink, 'description' | 'pluginId' | 'category' | 'group'>>;
+  Partial<Pick<PluginExtensionLink, 'description' | 'pluginId' | 'category' | 'group' | 'openInNewTab'>>;
 
 type ResourceLinkClickLocation = 'value' | 'menu';
 
@@ -186,12 +186,16 @@ interface LinkValueProps {
   openLinksInSameTab?: boolean;
 }
 
-function attributeLinkAttrs(path: string | undefined, openLinksInSameTab: boolean) {
-  const attrs = path ? getTraceViewLinkAttrs(path) : undefined;
+function shouldOpenAttributeLinkInSameTab(openLinksInSameTab: boolean, link: KeyValuesTableLink) {
+  return openLinksInSameTab && Boolean(link.path) && !link.openInNewTab;
+}
+
+function attributeLinkAttrs(link: KeyValuesTableLink, openLinksInSameTab: boolean) {
+  const attrs = link.path ? getTraceViewLinkAttrs(link.path) : undefined;
   if (!attrs) {
     return undefined;
   }
-  if (!openLinksInSameTab) {
+  if (!shouldOpenAttributeLinkInSameTab(openLinksInSameTab, link)) {
     return { href: attrs.href, target: '_blank' as const, rel: 'noopener noreferrer' as const };
   }
   return attrs;
@@ -217,16 +221,16 @@ function onAttributeLinkClick(
   if (event.ctrlKey || event.metaKey || event.shiftKey) {
     return;
   }
-  if (link.onClick) {
-    link.onClick(event);
-    // Plugin handles the click; stop the browser from also following href.
-    event.preventDefault();
-    return;
-  }
-  if (openLinksInSameTab && link.path) {
+  // Prefer path navigation so plugins that also set onClick (e.g. Kubernetes) do not window.open.
+  if (shouldOpenAttributeLinkInSameTab(openLinksInSameTab, link) && link.path) {
     event.preventDefault();
     setReturnToPrevious(t('explore.key-values-table.return-to-previous-title', 'Trace'));
     openTraceViewHref(link.path);
+    return;
+  }
+  if (link.onClick) {
+    link.onClick(event);
+    event.preventDefault();
   }
 }
 
@@ -236,10 +240,10 @@ export const LinkValue = ({
   openLinksInSameTab = false,
   children,
 }: PropsWithChildren<LinkValueProps>) => {
-  const { path, title, icon = 'external-link-alt' } = link;
+  const { title, icon = 'external-link-alt' } = link;
   const styles = useStyles2(getStyles);
   const setReturnToPrevious = useReturnToPrevious();
-  const attrs = attributeLinkAttrs(path, openLinksInSameTab);
+  const attrs = attributeLinkAttrs(link, openLinksInSameTab);
 
   return (
     <a
@@ -300,7 +304,7 @@ const LinkValuesMenu = ({ links, datasourceType, openLinksInSameTab = false, chi
           <Menu>
             <Menu.Group label={openValueInLabel.toLocaleUpperCase()}>
               {links.map((link, index) => {
-                const attrs = attributeLinkAttrs(link.path, openLinksInSameTab);
+                const attrs = attributeLinkAttrs(link, openLinksInSameTab);
                 return (
                   <div key={index} title={link.title}>
                     <Menu.Item

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -17,7 +17,7 @@ import { SpanStatusCode } from '@opentelemetry/api';
 import React, { useCallback, useMemo } from 'react';
 
 import {
-  type CoreApp,
+  CoreApp,
   type DataFrame,
   dateTimeFormat,
   type GrafanaTheme2,
@@ -50,6 +50,7 @@ import AccordionKeyValues from './AccordionKeyValues';
 import AccordionLogs from './AccordionLogs';
 import AccordionReferences from './AccordionReferences';
 import type DetailState from './DetailState';
+import { isDrilldownContext } from './LogsLink';
 import { SpanDetailLinkButtons } from './SpanDetailLinkButtons';
 import SpanFlameGraph from './SpanFlameGraph';
 import { useAttributePluginPromoGetter } from './pluginPromo/attributePluginPromos';
@@ -469,6 +470,8 @@ export default function SpanDetail(props: SpanDetailProps) {
     [tags, process.tags]
   );
   const promoGetter = useAttributePluginPromoGetter(promoAttributeKeys);
+  // Explore, Traces Drilldown, and embedded drilldown (Unknown). Dashboard panels stay new-tab.
+  const openLinksInSameTab = app === CoreApp.Explore || isDrilldownContext(app);
 
   const listOfContentCards = [];
 
@@ -482,6 +485,7 @@ export default function SpanDetail(props: SpanDetailProps) {
         onToggle={() => summaryAttributesToggle(spanID)}
         promoGetter={promoGetter}
         datasourceType={datasourceType}
+        openLinksInSameTab={openLinksInSameTab}
       />
     );
   }
@@ -496,6 +500,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       onToggle={() => tagsToggle(spanID)}
       promoGetter={promoGetter}
       datasourceType={datasourceType}
+      openLinksInSameTab={openLinksInSameTab}
     />
   );
 
@@ -520,6 +525,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       onToggle={() => processToggle(spanID)}
       promoGetter={promoGetter}
       datasourceType={datasourceType}
+      openLinksInSameTab={openLinksInSameTab}
     />
   );
 

--- a/public/app/features/explore/TraceView/utils/openTraceViewHref.test.ts
+++ b/public/app/features/explore/TraceView/utils/openTraceViewHref.test.ts
@@ -1,0 +1,79 @@
+import { locationService } from '@grafana/runtime';
+
+import { getTraceViewLinkAttrs, openTraceViewHref } from './openTraceViewHref';
+
+describe('getTraceViewLinkAttrs', () => {
+  it('keeps Grafana paths in the same tab', () => {
+    expect(getTraceViewLinkAttrs('/explore?left=abc')).toEqual({
+      href: '/explore?left=abc',
+      target: '_self',
+    });
+  });
+
+  it('opens other origins in a new tab', () => {
+    expect(getTraceViewLinkAttrs('https://example.com/trace-details')).toEqual({
+      href: 'https://example.com/trace-details',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+  });
+
+  it('does not expose javascript URLs', () => {
+    expect(getTraceViewLinkAttrs('javascript:alert(1)')).toBeUndefined();
+  });
+});
+
+describe('openTraceViewHref', () => {
+  const pushSpy = jest.spyOn(locationService, 'push').mockImplementation(() => {});
+  const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+  afterEach(() => {
+    pushSpy.mockClear();
+    openSpy.mockClear();
+  });
+
+  afterAll(() => {
+    pushSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+
+  it('pushes Grafana paths in the same tab', () => {
+    openTraceViewHref('/explore?left=abc');
+
+    expect(pushSpy).toHaveBeenCalledWith('/explore?left=abc');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('pushes same-origin absolute URLs without the origin', () => {
+    openTraceViewHref(`${window.location.origin}/a/grafana-pyroscope-app`);
+
+    expect(pushSpy).toHaveBeenCalledWith('/a/grafana-pyroscope-app');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens other origins in a new tab', () => {
+    openTraceViewHref('https://example.com/trace-details');
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/trace-details', '_blank', 'noopener,noreferrer');
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('opens protocol-relative URLs in a new tab instead of pushing them', () => {
+    openTraceViewHref('//example.com/trace-details');
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `${window.location.protocol}//example.com/trace-details`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate javascript or mailto URLs', () => {
+    openTraceViewHref('javascript:alert(1)');
+    openTraceViewHref('mailto:ops@example.com');
+
+    expect(pushSpy).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/explore/TraceView/utils/openTraceViewHref.ts
+++ b/public/app/features/explore/TraceView/utils/openTraceViewHref.ts
@@ -1,0 +1,69 @@
+import { locationUtil, textUtil } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+
+type ResolvedTraceViewHref = {
+  href: string;
+  sameTab: boolean;
+};
+
+export type TraceViewLinkAttrs = {
+  href: string;
+  target: '_self' | '_blank';
+  rel?: 'noopener noreferrer';
+};
+
+/** Same-tab Grafana routes via the router; other http(s) origins in a new tab. */
+export function openTraceViewHref(href: string): void {
+  const resolved = resolveTraceViewHref(href);
+  if (!resolved) {
+    return;
+  }
+  if (resolved.sameTab) {
+    locationService.push(locationUtil.stripBaseFromUrl(resolved.href));
+    return;
+  }
+  window.open(resolved.href, '_blank', 'noopener,noreferrer');
+}
+
+/** Sanitized href/target for anchors (cmd-click / middle-click). */
+export function getTraceViewLinkAttrs(href: string): TraceViewLinkAttrs | undefined {
+  const resolved = resolveTraceViewHref(href);
+  if (!resolved) {
+    return undefined;
+  }
+  if (resolved.sameTab) {
+    return { href: resolved.href, target: '_self' };
+  }
+  return { href: resolved.href, target: '_blank', rel: 'noopener noreferrer' };
+}
+
+function resolveTraceViewHref(href: string): ResolvedTraceViewHref | undefined {
+  const sanitized = textUtil.sanitizeUrl(href).trim();
+  if (!sanitized || sanitized === 'about:blank') {
+    return undefined;
+  }
+
+  // Same-tab only for Grafana paths. Reject protocol-relative URLs (`//…`).
+  if (sanitized.startsWith('/') && !sanitized.startsWith('//')) {
+    return { href: sanitized, sameTab: true };
+  }
+
+  const absolute = sanitized.startsWith('//') ? `${window.location.protocol}${sanitized}` : sanitized;
+
+  try {
+    const url = new URL(absolute);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return undefined;
+    }
+    if (url.origin === window.location.origin) {
+      return { href: `${url.pathname}${url.search}${url.hash}`, sameTab: true };
+    }
+    return { href: url.href, sameTab: false };
+  } catch {
+    // Schemeless leftovers such as "explore" stay same-tab; anything with a colon is rejected.
+    if (!sanitized.includes(':')) {
+      return { href: sanitized, sameTab: true };
+    }
+    return undefined;
+  }
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8691,7 +8691,8 @@
     },
     "key-values-table": {
       "link-fallback-label": "Link",
-      "open-value-in": "Open value in"
+      "open-value-in": "Open value in",
+      "return-to-previous-title": "Trace"
     },
     "legacy-create-span-link-factory": {
       "text": {


### PR DESCRIPTION
**What is this feature?**

Part of https://github.com/grafana/grafana/issues/130743

TraceView: Open attribute links in the same tab in Explore and Traces Drilldown

**Why do we need this feature?**

- Resource/span attribute links in Explore, Traces Drilldown, and embedded drilldown navigate in the current tab so browser Back works.
- Sets Return to previous (Back to Trace) on those navigations.
- Dashboard Trace panels still open a new tab.
- If a plugin sets both `path` and `onClick` (Kubernetes), follow `path` in-app unless `openInNewTab` is set.
- External URLs and cmd/ctrl-click stay new-tab.

**Who is this feature for?**

Trace view users.