### PR TITLE
Provisioning: Label token failure metrics by user- vs system-cause

### DIFF
--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -405,7 +405,9 @@ func (c *Connection) GenerateConnectionToken(_ context.Context) (*connection.Exp
 
 	token, expiresAt, err := GenerateJWTToken(c.cfg.AppID(), c.secrets.PrivateKey)
 	if err != nil {
-		return nil, err
+		// A malformed or unparseable configured private key is a configuration
+		// problem the user must fix (re-upload the key), not a transient failure.
+		return nil, fmt.Errorf("%w: %w", connection.ErrAuthentication, err)
 	}
 
 	return &connection.ExpirableSecureValue{Token: token, ExpiresAt: expiresAt}, nil

--- a/apps/provisioning/pkg/connection/github/connection_test.go
+++ b/apps/provisioning/pkg/connection/github/connection_test.go
@@ -1481,6 +1481,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 		connection    *provisioning.Connection
 		secrets       github.ConnectionSecrets
 		expectedError string
+		wantAuthErr   bool // error must be classified as connection.ErrAuthentication (user-actionable)
 		validateToken func(t *testing.T, token common.RawSecureValue)
 	}{
 		{
@@ -1589,6 +1590,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 				PrivateKey: common.RawSecureValue("not-valid-base64!@#"),
 			},
 			expectedError: "failed to decode base64 private key",
+			wantAuthErr:   true,
 		},
 		{
 			name: "error - invalid PEM format",
@@ -1606,6 +1608,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 				PrivateKey: common.RawSecureValue(base64.StdEncoding.EncodeToString([]byte("not-a-valid-pem-format"))),
 			},
 			expectedError: "failed to parse private key",
+			wantAuthErr:   true,
 		},
 		{
 			name: "error - empty private key",
@@ -1623,6 +1626,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 				PrivateKey: common.RawSecureValue(""),
 			},
 			expectedError: "failed to parse private key",
+			wantAuthErr:   true,
 		},
 	}
 
@@ -1636,6 +1640,11 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+				if tt.wantAuthErr {
+					assert.ErrorIs(t, err, connection.ErrAuthentication, "expected a user-actionable authentication error")
+				} else {
+					assert.NotErrorIs(t, err, connection.ErrAuthentication, "expected a system-caused error")
+				}
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, token)

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -126,7 +126,7 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 		return nil, err
 	}
 	if stored.RefreshToken == "" {
-		return nil, errors.New("no refresh token available; authorize the OAuth application again")
+		return nil, fmt.Errorf("no refresh token available; authorize the OAuth application again: %w", connection.ErrAuthentication)
 	}
 
 	cfg := oauth2.Config{
@@ -137,6 +137,16 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 
 	next, err := cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: stored.RefreshToken}).Token()
 	if err != nil {
+		// A 4xx from the token endpoint (e.g. invalid_grant after the user revoked
+		// the authorization or the refresh token expired) is user-actionable: they
+		// must re-authorize. Transport and 5xx failures stay unwrapped so they
+		// classify as system-caused.
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) && retrieveErr.Response != nil &&
+			retrieveErr.Response.StatusCode >= http.StatusBadRequest &&
+			retrieveErr.Response.StatusCode < http.StatusInternalServerError {
+			return nil, fmt.Errorf("refresh access token: %w: %w", connection.ErrAuthentication, err)
+		}
 		return nil, fmt.Errorf("refresh access token: %w", err)
 	}
 

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -161,18 +161,31 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 	return &connection.ExpirableSecureValue{Token: raw, ExpiresAt: next.Expiry}, nil
 }
 
+// oauthReauthErrorCodes are token-endpoint `error` codes (RFC 6749 §5.2 and
+// provider-specific) that mean the stored authorization is no longer valid and
+// the user must re-authorize. GitHub reports a revoked/expired refresh token
+// with bad_refresh_token/refresh_token_expired — often with a 200 status rather
+// than 401/403 — while RFC 6749 and GitLab use invalid_grant.
+var oauthReauthErrorCodes = map[string]bool{
+	"invalid_grant":         true, // RFC 6749 §5.2; GitLab
+	"bad_refresh_token":     true, // GitHub: refresh token incorrect or expired
+	"refresh_token_expired": true, // GitHub: refresh token expired
+}
+
 // isOAuthReauthRequired reports whether an OAuth token-refresh error means the
 // stored authorization is invalid and the user must re-authorize, as opposed to
-// a transient failure worth retrying. It matches RFC 6749's invalid_grant (the
-// refresh token was revoked or expired) and 401/403 responses (rejected client
-// credentials), while deliberately excluding retryable statuses such as 408 and
-// 429 and all 5xx/transport errors.
+// a transient failure worth retrying. It matches the credential-rejection error
+// codes above and 401/403 responses (rejected client credentials), while
+// deliberately excluding retryable statuses such as 408 and 429 and all
+// 5xx/transport errors. oauth2 surfaces the error code even on a 200 response
+// (some providers, including GitHub, return errors that way), so the code is
+// checked independently of the HTTP status.
 func isOAuthReauthRequired(err error) bool {
 	var retrieveErr *oauth2.RetrieveError
 	if !errors.As(err, &retrieveErr) {
 		return false
 	}
-	if retrieveErr.ErrorCode == "invalid_grant" {
+	if oauthReauthErrorCodes[retrieveErr.ErrorCode] {
 		return true
 	}
 	if retrieveErr.Response != nil {

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -162,14 +162,16 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 }
 
 // oauthReauthErrorCodes are token-endpoint `error` codes (RFC 6749 §5.2 and
-// provider-specific) that mean the stored authorization is no longer valid and
-// the user must re-authorize. GitHub reports a revoked/expired refresh token
-// with bad_refresh_token/refresh_token_expired — often with a 200 status rather
-// than 401/403 — while RFC 6749 and GitLab use invalid_grant.
+// provider-specific) that mean the stored authorization or the configured client
+// credentials are no longer valid and the user must act. GitHub reports these
+// with a 200 status rather than 401/403, and oauth2 exposes the code either way,
+// so they are matched independently of the HTTP status.
 var oauthReauthErrorCodes = map[string]bool{
-	"invalid_grant":         true, // RFC 6749 §5.2; GitLab
-	"bad_refresh_token":     true, // GitHub: refresh token incorrect or expired
-	"refresh_token_expired": true, // GitHub: refresh token expired
+	"invalid_grant":                true, // RFC 6749 §5.2; GitLab: refresh token revoked/expired
+	"invalid_client":               true, // RFC 6749 §5.2: client credentials rejected
+	"bad_refresh_token":            true, // GitHub: refresh token incorrect or expired
+	"refresh_token_expired":        true, // GitHub: refresh token expired
+	"incorrect_client_credentials": true, // GitHub: client secret rotated or revoked
 }
 
 // isOAuthReauthRequired reports whether an OAuth token-refresh error means the

--- a/apps/provisioning/pkg/connection/oauth/connection.go
+++ b/apps/provisioning/pkg/connection/oauth/connection.go
@@ -137,14 +137,11 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 
 	next, err := cfg.TokenSource(ctx, &oauth2.Token{RefreshToken: stored.RefreshToken}).Token()
 	if err != nil {
-		// A 4xx from the token endpoint (e.g. invalid_grant after the user revoked
-		// the authorization or the refresh token expired) is user-actionable: they
-		// must re-authorize. Transport and 5xx failures stay unwrapped so they
-		// classify as system-caused.
-		var retrieveErr *oauth2.RetrieveError
-		if errors.As(err, &retrieveErr) && retrieveErr.Response != nil &&
-			retrieveErr.Response.StatusCode >= http.StatusBadRequest &&
-			retrieveErr.Response.StatusCode < http.StatusInternalServerError {
+		// A revoked or expired authorization is user-actionable: the user must
+		// re-authorize the OAuth application. Transient failures (timeouts, rate
+		// limiting, 5xx, transport errors) stay unwrapped so they classify as
+		// system-caused and are retried rather than surfaced as a credential fault.
+		if isOAuthReauthRequired(err) {
 			return nil, fmt.Errorf("refresh access token: %w: %w", connection.ErrAuthentication, err)
 		}
 		return nil, fmt.Errorf("refresh access token: %w", err)
@@ -162,6 +159,29 @@ func (c *oauthConnection) GenerateConnectionToken(ctx context.Context) (*connect
 	// next.Expiry is zero when the provider does not return an expiry, which maps
 	// to a non-expiring token on the status.
 	return &connection.ExpirableSecureValue{Token: raw, ExpiresAt: next.Expiry}, nil
+}
+
+// isOAuthReauthRequired reports whether an OAuth token-refresh error means the
+// stored authorization is invalid and the user must re-authorize, as opposed to
+// a transient failure worth retrying. It matches RFC 6749's invalid_grant (the
+// refresh token was revoked or expired) and 401/403 responses (rejected client
+// credentials), while deliberately excluding retryable statuses such as 408 and
+// 429 and all 5xx/transport errors.
+func isOAuthReauthRequired(err error) bool {
+	var retrieveErr *oauth2.RetrieveError
+	if !errors.As(err, &retrieveErr) {
+		return false
+	}
+	if retrieveErr.ErrorCode == "invalid_grant" {
+		return true
+	}
+	if retrieveErr.Response != nil {
+		switch retrieveErr.Response.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return true
+		}
+	}
+	return false
 }
 
 // ExchangeAuthorizationCode exchanges an OAuth authorization code for tokens.

--- a/apps/provisioning/pkg/connection/oauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/oauth/connection_test.go
@@ -252,6 +252,14 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			wantAuthErr:  true,
 		},
 		{
+			name:         "failure - GitHub bad_refresh_token (HTTP 200) is user-actionable",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusOK,
+			response:     map[string]any{"error": "bad_refresh_token"},
+			expectedErr:  "refresh access token",
+			wantAuthErr:  true,
+		},
+		{
 			name:         "failure - token endpoint 401 is user-actionable",
 			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
 			responseCode: http.StatusUnauthorized,

--- a/apps/provisioning/pkg/connection/oauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/oauth/connection_test.go
@@ -244,11 +244,26 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			wantAuthErr: true,
 		},
 		{
-			name:         "failure - token endpoint rejects refresh (4xx is user-actionable)",
+			name:         "failure - invalid_grant (revoked/expired) is user-actionable",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusBadRequest,
+			response:     map[string]any{"error": "invalid_grant"},
+			expectedErr:  "refresh access token",
+			wantAuthErr:  true,
+		},
+		{
+			name:         "failure - token endpoint 401 is user-actionable",
 			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
 			responseCode: http.StatusUnauthorized,
 			expectedErr:  "refresh access token",
 			wantAuthErr:  true,
+		},
+		{
+			name:         "failure - token endpoint 429 stays system-caused (retryable)",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusTooManyRequests,
+			expectedErr:  "refresh access token",
+			wantAuthErr:  false,
 		},
 		{
 			name:         "failure - token endpoint 5xx stays system-caused",
@@ -406,6 +421,15 @@ func newTokenServer(t *testing.T, code int, response map[string]any) *httptest.S
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if code != 0 {
+			// A non-nil response with an error status returns a JSON OAuth error
+			// body (e.g. {"error":"invalid_grant"}) so oauth2 populates
+			// RetrieveError.ErrorCode; otherwise a plain status is returned.
+			if response != nil {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(code)
+				require.NoError(t, json.NewEncoder(w).Encode(response))
+				return
+			}
 			http.Error(w, "denied", code)
 			return
 		}

--- a/apps/provisioning/pkg/connection/oauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/oauth/connection_test.go
@@ -260,6 +260,22 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			wantAuthErr:  true,
 		},
 		{
+			name:         "failure - GitHub incorrect_client_credentials (HTTP 200) is user-actionable",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusOK,
+			response:     map[string]any{"error": "incorrect_client_credentials"},
+			expectedErr:  "refresh access token",
+			wantAuthErr:  true,
+		},
+		{
+			name:         "failure - invalid_client (HTTP 400) is user-actionable",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusBadRequest,
+			response:     map[string]any{"error": "invalid_client"},
+			expectedErr:  "refresh access token",
+			wantAuthErr:  true,
+		},
+		{
 			name:         "failure - token endpoint 401 is user-actionable",
 			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
 			responseCode: http.StatusUnauthorized,

--- a/apps/provisioning/pkg/connection/oauth/connection_test.go
+++ b/apps/provisioning/pkg/connection/oauth/connection_test.go
@@ -205,6 +205,7 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 		response     map[string]any
 		responseCode int
 		expectedErr  string
+		wantAuthErr  bool // error must be classified as connection.ErrAuthentication (user-actionable)
 		validate     func(t *testing.T, token *oauth2.Token)
 	}{
 		{
@@ -240,12 +241,21 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			name:        "failure - no refresh token",
 			token:       marshalTestToken(t, &oauth2.Token{AccessToken: "access"}),
 			expectedErr: "no refresh token available; authorize the OAuth application again",
+			wantAuthErr: true,
 		},
 		{
-			name:         "failure - token endpoint rejects refresh",
+			name:         "failure - token endpoint rejects refresh (4xx is user-actionable)",
 			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
 			responseCode: http.StatusUnauthorized,
 			expectedErr:  "refresh access token",
+			wantAuthErr:  true,
+		},
+		{
+			name:         "failure - token endpoint 5xx stays system-caused",
+			token:        marshalTestToken(t, &oauth2.Token{AccessToken: "old-access", RefreshToken: "old-refresh"}),
+			responseCode: http.StatusInternalServerError,
+			expectedErr:  "refresh access token",
+			wantAuthErr:  false,
 		},
 	}
 
@@ -257,6 +267,11 @@ func TestConnection_GenerateConnectionToken(t *testing.T) {
 			raw, err := conn.GenerateConnectionToken(t.Context())
 			if tt.expectedErr != "" {
 				require.ErrorContains(t, err, tt.expectedErr)
+				if tt.wantAuthErr {
+					assert.ErrorIs(t, err, connection.ErrAuthentication, "expected a user-actionable authentication error")
+				} else {
+					assert.NotErrorIs(t, err, connection.ErrAuthentication, "expected a system-caused error")
+				}
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -529,10 +529,13 @@ func (cc *ConnectionController) generateConnectionToken(
 	logger := logging.FromContext(ctx)
 
 	start := time.Now()
-	var failed bool
+	// genErr holds the generation failure so the deferred recorder can classify
+	// its cause. The failure is swallowed below (non-blocking), so it cannot be
+	// recovered from the named err return.
+	var genErr error
 	defer func() {
-		if failed {
-			cc.tokenMetrics.recordGenerationError()
+		if genErr != nil {
+			cc.tokenMetrics.recordGenerationError(classifyTokenErrorCause(genErr))
 		} else {
 			cc.tokenMetrics.recordGeneration(time.Since(start).Seconds())
 		}
@@ -540,7 +543,7 @@ func (cc *ConnectionController) generateConnectionToken(
 
 	generated, err := conn.GenerateConnectionToken(ctx)
 	if err != nil {
-		failed = true
+		genErr = err
 		logger.Error("failed to generate connection token", "error", err)
 		return "", time.Time{}, nil, nil // Non-blocking: return empty patches
 	}

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -1429,15 +1429,12 @@ func (rc *RepositoryController) recordReconcileError(phase string, err error) {
 	rc.reconcileMetrics.RecordReconcileError(phase, cause)
 }
 
-// Returns errors that are due to user errors
+// Returns errors that are due to user errors. Token-generation failures surface
+// connection-level sentinels (app uninstalled, permissions revoked, installation
+// gone), so classification is shared with the token metric to keep the
+// reconcile-error and token-generation-error metrics consistent.
 func (rc *RepositoryController) isUserCaused(err error) bool {
-	// List of errors that are user-caused errors and are left recorded on the repository
-	if errors.Is(err, repository.ErrUnauthorized) ||
-		errors.Is(err, repository.ErrPermissionDenied) {
-		return true
-	}
-
-	return false
+	return classifyTokenErrorCause(err) == reconcileCauseUser
 }
 
 // classifyBuildFailureReason maps a repository Build failure to a Ready condition
@@ -1591,7 +1588,7 @@ func (rc *RepositoryController) generateRepositoryToken(
 	defer func() {
 		elapsed := time.Since(start).Seconds()
 		if err != nil {
-			rc.tokenMetrics.recordGenerationError()
+			rc.tokenMetrics.recordGenerationError(classifyTokenErrorCause(err))
 		} else {
 			rc.tokenMetrics.recordGeneration(elapsed)
 		}

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -2451,6 +2451,83 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 	assert.True(t, found, "expected /status/token to be refreshed even when repository is quota-blocked")
 }
 
+// TestRepositoryController_process_TokenGenerationAuthFailureIsUserCaused verifies that when
+// token generation fails because access was lost (e.g. the GitHub App was uninstalled or its
+// permissions revoked, surfaced as connection.ErrAuthentication), the failure is classified as
+// cause="user" on both the token-generation-error metric and the reconcile-error metric, so an
+// SLO/alert filtering cause!="user" does not page on-call for a condition only the customer can fix.
+func TestRepositoryController_process_TokenGenerationAuthFailureIsUserCaused(t *testing.T) {
+	namespace := "default"
+	repoName := "test-repo"
+	connName := "my-connection"
+
+	// A missing token makes shouldGenerateTokenFromConnection return true, so the token phase runs.
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: repoName, Namespace: namespace, Generation: 1},
+		Spec: provisioning.RepositorySpec{
+			Type:       provisioning.LocalRepositoryType,
+			Sync:       provisioning.SyncOptions{Enabled: false},
+			Connection: &provisioning.ConnectionInfo{Name: connName},
+		},
+		Status: provisioning.RepositoryStatus{
+			ObservedGeneration: 1,
+			Health:             provisioning.HealthStatus{Healthy: true, Checked: time.Now().UnixMilli()},
+		},
+	}
+
+	indexer := cache.NewIndexer(
+		cache.MetaNamespaceKeyFunc,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+	require.NoError(t, indexer.Add(repo))
+	repoLister := listers.NewRepositoryLister(indexer)
+
+	// Access lost: the connection can no longer mint a repository token.
+	authErr := fmt.Errorf("unable to create token for repository: %w", connection.ErrAuthentication)
+	mockConn := connection.NewMockConnection(t)
+	mockConn.EXPECT().GenerateRepositoryToken(mock.Anything, mock.Anything).Return(nil, authErr).Once()
+
+	mockConnFactory := connection.NewMockFactory(t)
+	mockConnFactory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockConn, nil).Once()
+
+	connObj := &provisioning.Connection{ObjectMeta: metav1.ObjectMeta{Name: connName, Namespace: namespace}}
+	provClient := &mockProvisioningV0alpha1Interface{
+		connectionsFunc: func(_ string) client.ConnectionInterface {
+			return mockConnectionInterface{
+				getFunc: func(_ context.Context, _ string, _ metav1.GetOptions) (*provisioning.Connection, error) {
+					return connObj, nil
+				},
+			}
+		},
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+	repoGetter := informer.NewCachedRepositoryGetter(repoLister)
+	rc := &RepositoryController{
+		repos:             repoGetter,
+		quotaGetter:       quotas.NewFixedQuotaGetter(provisioning.QuotaStatus{MaxRepositories: 100}),
+		quotaChecker:      NewRepositoryQuotaChecker(repoGetter),
+		statusPatcher:     &capturePatcher{},
+		connectionFactory: mockConnFactory,
+		client:            provClient,
+		tokenMetrics:      registerRepositoryTokenMetrics(reg),
+		reconcileMetrics:  registerReconcileErrorMetrics(reg),
+		resyncInterval:    5 * time.Minute,
+		logger:            logging.DefaultLogger.With("logger", loggerName),
+		tracer:            tracing.InitializeTracerForTest(),
+	}
+
+	_, err := rc.process(namespace + "/" + repoName)
+	require.Error(t, err, "a lost-access token failure must be returned to the workqueue")
+
+	assert.Equal(t, 1.0,
+		counterValueWithLabel(t, reg, "grafana_provisioning_repository_token_generation_errors_total", "cause", reconcileCauseUser),
+		"token generation error must be labeled cause=user")
+	assert.Equal(t, 1.0,
+		reconcileErrorCount(t, reg, reconcilePhaseToken, reconcileCauseUser),
+		"reconcile error must be counted under phase=token, cause=user")
+}
+
 // TestRepositoryController_process_RegeneratesTokenWhenSecretNotFound verifies that when the
 // repository token references a secret that can no longer be decrypted (e.g. it was deleted),
 // the controller regenerates it from the connection and rebuilds instead of failing forever.

--- a/pkg/registry/apis/provisioning/controller/token_metrics.go
+++ b/pkg/registry/apis/provisioning/controller/token_metrics.go
@@ -1,7 +1,12 @@
 package controller
 
 import (
+	"errors"
+
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
 type refreshReason string
@@ -12,20 +17,44 @@ const (
 	refreshReasonExpiring refreshReason = "expiring"
 )
 
+// classifyTokenErrorCause maps a token generation/refresh failure to a cause
+// label. "user" means the customer must act (GitHub App uninstalled or
+// suspended, permissions revoked, installation gone, repository not selected);
+// "system" covers transient/infrastructure failures that are safe to retry.
+// Alerts should page on cause="system" and route cause="user" to a
+// customer-action runbook. The token path surfaces connection-level sentinels
+// while other reconcile paths use repository-level ones, so both are matched
+// here to keep classification consistent across metrics.
+func classifyTokenErrorCause(err error) string {
+	switch {
+	case errors.Is(err, connection.ErrAuthentication),
+		errors.Is(err, connection.ErrNotFound),
+		errors.Is(err, connection.ErrRepositoryAccess),
+		errors.Is(err, repository.ErrUnauthorized),
+		errors.Is(err, repository.ErrPermissionDenied):
+		return reconcileCauseUser
+	default:
+		return reconcileCauseSystem
+	}
+}
+
 var timeToExpiryBuckets = []float64{0, 30, 60, 120, 300, 600, 1800, 3600}
 var generationDurationBuckets = []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0}
 
 // connectionTokenMetrics tracks token lifecycle events for connections.
 type connectionTokenMetrics struct {
 	generatedTotal     prometheus.Counter
-	generationErrors   prometheus.Counter
+	generationErrors   *prometheus.CounterVec
 	generatedDuration  prometheus.Histogram
 	refreshReasonTotal *prometheus.CounterVec
 	timeToExpiry       prometheus.Histogram
 	// expired is incremented every reconcile that observes an already-expired
 	// connection token, from the persisted status.token.expiration, and re-emitted
 	// each resync while the condition holds (a token whose refresh keeps failing
-	// keeps incrementing). It mirrors the repository counter.
+	// keeps incrementing). It mirrors the repository counter. It is deliberately
+	// unlabeled by cause: expiry is read from persisted status, not from a live
+	// generation attempt, so the failure cause is not known here. Correlate with
+	// generationErrors' cause label for triage.
 	expired prometheus.Counter
 }
 
@@ -36,10 +65,10 @@ func registerConnectionTokenMetrics(reg prometheus.Registerer) *connectionTokenM
 	})
 	reg.MustRegister(generatedTotal)
 
-	generationErrors := prometheus.NewCounter(prometheus.CounterOpts{
+	generationErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "grafana_provisioning_connection_token_generation_errors_total",
-		Help: "Total number of connection token generation errors",
-	})
+		Help: "Total number of connection token generation errors by cause. Filter cause!=\"user\" to exclude user-caused failures (e.g. revoked credentials, app uninstalled) from SLOs.",
+	}, []string{"cause"})
 	reg.MustRegister(generationErrors)
 
 	generatedDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -86,11 +115,11 @@ func (m *connectionTokenMetrics) recordGeneration(seconds float64) {
 	m.generatedDuration.Observe(seconds)
 }
 
-func (m *connectionTokenMetrics) recordGenerationError() {
+func (m *connectionTokenMetrics) recordGenerationError(cause string) {
 	if m == nil {
 		return
 	}
-	m.generationErrors.Inc()
+	m.generationErrors.WithLabelValues(cause).Inc()
 }
 
 func (m *connectionTokenMetrics) recordRefreshReason(reason refreshReason) {
@@ -120,7 +149,7 @@ func (m *connectionTokenMetrics) recordExpired() {
 // repositoryTokenMetrics tracks token lifecycle events for repositories.
 type repositoryTokenMetrics struct {
 	generatedTotal     prometheus.Counter
-	generationErrors   prometheus.Counter
+	generationErrors   *prometheus.CounterVec
 	generatedDuration  prometheus.Histogram
 	refreshReasonTotal *prometheus.CounterVec
 	timeToExpiry       prometheus.Histogram
@@ -128,7 +157,9 @@ type repositoryTokenMetrics struct {
 	// repository token. It is deliberately re-emitted on each resync rather than
 	// edge-triggered once: a token stuck expired (its refresh failing) keeps
 	// incrementing, so increase()/rate() alerts fire for as long as the condition
-	// holds.
+	// holds. It is intentionally unlabeled by cause: expiry is read from persisted
+	// status, not from a live generation attempt, so the failure cause is not
+	// known here. Correlate with generationErrors' cause label for triage.
 	expired prometheus.Counter
 }
 
@@ -139,10 +170,10 @@ func registerRepositoryTokenMetrics(reg prometheus.Registerer) *repositoryTokenM
 	})
 	reg.MustRegister(generatedTotal)
 
-	generationErrors := prometheus.NewCounter(prometheus.CounterOpts{
+	generationErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "grafana_provisioning_repository_token_generation_errors_total",
-		Help: "Total number of repository token generation errors",
-	})
+		Help: "Total number of repository token generation errors by cause. Filter cause!=\"user\" to exclude user-caused failures (e.g. revoked credentials, app uninstalled) from SLOs.",
+	}, []string{"cause"})
 	reg.MustRegister(generationErrors)
 
 	generatedDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
@@ -189,11 +220,11 @@ func (m *repositoryTokenMetrics) recordGeneration(seconds float64) {
 	m.generatedDuration.Observe(seconds)
 }
 
-func (m *repositoryTokenMetrics) recordGenerationError() {
+func (m *repositoryTokenMetrics) recordGenerationError(cause string) {
 	if m == nil {
 		return
 	}
-	m.generationErrors.Inc()
+	m.generationErrors.WithLabelValues(cause).Inc()
 }
 
 func (m *repositoryTokenMetrics) recordRefreshReason(reason refreshReason) {

--- a/pkg/registry/apis/provisioning/controller/token_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/token_metrics_test.go
@@ -1,19 +1,25 @@
 package controller
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
 func TestConnectionTokenMetrics_NilSafe(t *testing.T) {
 	var m *connectionTokenMetrics
 	assert.NotPanics(t, func() {
 		m.recordGeneration(0.5)
-		m.recordGenerationError()
+		m.recordGenerationError(reconcileCauseSystem)
 		m.recordRefreshReason(refreshReasonMissing)
 		m.recordTimeToExpiry(300)
 		m.recordExpired()
@@ -33,7 +39,7 @@ func TestRepositoryTokenMetrics_NilSafe(t *testing.T) {
 	var m *repositoryTokenMetrics
 	assert.NotPanics(t, func() {
 		m.recordGeneration(0.5)
-		m.recordGenerationError()
+		m.recordGenerationError(reconcileCauseSystem)
 		m.recordRefreshReason(refreshReasonExpiring)
 		m.recordTimeToExpiry(300)
 		m.recordExpired()
@@ -68,10 +74,13 @@ func TestConnectionTokenMetrics_RecordGenerationError(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	m := registerConnectionTokenMetrics(reg)
 
-	m.recordGenerationError()
+	m.recordGenerationError(reconcileCauseUser)
+	m.recordGenerationError(reconcileCauseSystem)
+	m.recordGenerationError(reconcileCauseSystem)
 
-	val := counterValue(t, reg, "grafana_provisioning_connection_token_generation_errors_total")
-	assert.Equal(t, 1.0, val)
+	const name = "grafana_provisioning_connection_token_generation_errors_total"
+	assert.Equal(t, 1.0, counterValueWithLabel(t, reg, name, "cause", reconcileCauseUser))
+	assert.Equal(t, 2.0, counterValueWithLabel(t, reg, name, "cause", reconcileCauseSystem))
 }
 
 func TestConnectionTokenMetrics_RecordRefreshReason(t *testing.T) {
@@ -128,11 +137,36 @@ func TestRepositoryTokenMetrics_RecordGenerationError(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
 	m := registerRepositoryTokenMetrics(reg)
 
-	m.recordGenerationError()
-	m.recordGenerationError()
+	m.recordGenerationError(reconcileCauseUser)
+	m.recordGenerationError(reconcileCauseUser)
+	m.recordGenerationError(reconcileCauseSystem)
 
-	val := counterValue(t, reg, "grafana_provisioning_repository_token_generation_errors_total")
-	assert.Equal(t, 2.0, val)
+	const name = "grafana_provisioning_repository_token_generation_errors_total"
+	assert.Equal(t, 2.0, counterValueWithLabel(t, reg, name, "cause", reconcileCauseUser))
+	assert.Equal(t, 1.0, counterValueWithLabel(t, reg, name, "cause", reconcileCauseSystem))
+}
+
+func TestClassifyTokenErrorCause(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil error", nil, reconcileCauseSystem},
+		{"authentication (app uninstalled / perms revoked)", connection.ErrAuthentication, reconcileCauseUser},
+		{"not found (installation gone)", connection.ErrNotFound, reconcileCauseUser},
+		{"repository access (repo not selected)", connection.ErrRepositoryAccess, reconcileCauseUser},
+		{"repository unauthorized", repository.ErrUnauthorized, reconcileCauseUser},
+		{"repository permission denied", repository.ErrPermissionDenied, reconcileCauseUser},
+		{"wrapped authentication", fmt.Errorf("unable to create token for repository: %w", connection.ErrAuthentication), reconcileCauseUser},
+		{"github service unavailable", github.ErrServiceUnavailable, reconcileCauseSystem},
+		{"transient/other", errors.New("connection reset by peer"), reconcileCauseSystem},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyTokenErrorCause(tt.err))
+		})
+	}
 }
 
 func TestRepositoryTokenMetrics_RecordRefreshReason(t *testing.T) {
@@ -188,6 +222,21 @@ func counterValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
 	require.True(t, ok, "metric %s not found", name)
 	require.NotEmpty(t, f.GetMetric())
 	return f.GetMetric()[0].GetCounter().GetValue()
+}
+
+func counterValueWithLabel(t *testing.T, reg *prometheus.Registry, name, labelName, labelValue string) float64 {
+	t.Helper()
+	families := gatherMetrics(t, reg)
+	f, ok := families[name]
+	require.True(t, ok, "metric %s not found", name)
+	for _, metric := range f.GetMetric() {
+		for _, lp := range metric.GetLabel() {
+			if lp.GetName() == labelName && lp.GetValue() == labelValue {
+				return metric.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
 }
 
 func histogramCount(t *testing.T, reg *prometheus.Registry, name string) uint64 {


### PR DESCRIPTION
## What

Adds a `cause="user"|"system"` label to the provisioning secret-rotation **token generation-error** metrics so alerts can tell apart failures on-call can fix from ones only the customer can:

- `grafana_provisioning_repository_token_generation_errors_total{cause}`
- `grafana_provisioning_connection_token_generation_errors_total{cause}`

It also makes `grafana_provisioning_repository_reconcile_errors_total{phase="token"}` classify the same failures consistently, and — so the labels are actually correct — teaches the token-generation code paths to surface the right error sentinels for OAuth/GitHub App credential failures.

- `cause="system"` → transient/infrastructure (network, 5xx, throttling): safe to retry, **page on-call**.
- `cause="user"` → the customer must act (app uninstalled/suspended, permissions revoked, installation gone, refresh token revoked/expired, client secret rotated): **route to a customer-action runbook, do not page**.

## Why

The recently introduced secret-rotation metrics fired regardless of *why* a token refresh failed. A repository whose GitHub App was uninstalled/suspended, whose permissions were revoked, or whose OAuth authorization was revoked produced the **same signal** as a transient network/5xx blip. An operator alerting on these counters would get paged for conditions on-call cannot fix.

The codebase already solved this for reconcile errors — `reconcile_errors_total` carries `cause="user"|"system"` precisely so "SLOs should alert on `cause=system` and exclude `cause=user`". This PR brings the token metrics up to the same standard and closes the gaps that made the classification wrong in practice.

## How

**1. Label the metric, reuse the existing pattern.** Both `token_generation_errors_total` counters become `CounterVec{cause}`; a shared `classifyTokenErrorCause(err)` keys on the `connection.Err*` / `repository.Err*` sentinels the token path surfaces, reusing the existing `reconcileCauseUser`/`reconcileCauseSystem` constants. Help text points operators to filter `cause!="user"`.

**2. Make reconcile classification agree.** `isUserCaused` previously only recognized `repository.ErrUnauthorized`/`ErrPermissionDenied`, so lost-permissions **token** failures (which surface `connection.Err*`) were mislabeled `cause="system"` on `reconcile_errors_total{phase="token"}`. It now delegates to the shared classifier.

**3. Surface the right sentinels at the source** (matching how `GenerateRepositoryToken` already maps GitHub HTTP codes to `connection.Err*`). Previously `GenerateConnectionToken` returned raw errors that fell through to `cause="system"`:
   - **GitHub App JWT**: a malformed/unparseable configured private key now wraps `connection.ErrAuthentication`.
   - **OAuth refresh**: user-actionable failures wrap `connection.ErrAuthentication`; transient failures stay unwrapped (system).

**4. Classify OAuth token-endpoint errors precisely.** OAuth failures are discriminated by the RFC 6749 / provider `error` code (via `oauth2.RetrieveError`), **not** a blunt 4xx range — because retryable statuses (408/429) must stay system, and because providers (notably GitHub) return credential errors with an **HTTP 200** body, which oauth2 still surfaces as an error code. `isOAuthReauthRequired` matches a documented set:

   | Error code | Source | Meaning |
   | --- | --- | --- |
   | `invalid_grant` | RFC 6749 §5.2 / GitLab | refresh token revoked or expired |
   | `invalid_client` | RFC 6749 §5.2 | client credentials rejected |
   | `bad_refresh_token` | GitHub | refresh token incorrect or expired |
   | `refresh_token_expired` | GitHub | refresh token expired |
   | `incorrect_client_credentials` | GitHub | client secret rotated or revoked |

   Plus HTTP `401`/`403`. Everything else — transient 4xx (408/429), 5xx, transport errors — stays `cause="system"`.

**5. `tokens_expired_total` is intentionally left unlabeled.** At record time the failure cause is not in scope (expiry is read from persisted status, not from a live generation attempt). It remains the unclassified "stuck" indicator; correlate it with the generation-error `cause` label for triage. Documented in code.

## Testing

`go test ./apps/provisioning/pkg/connection/... ./pkg/registry/apis/provisioning/controller/...` — all pass; `go vet` and `gofmt` clean.

- `TestClassifyTokenErrorCause` — table-driven across all sentinels, a wrapped error, `github.ErrServiceUnavailable`, a bare error, and nil.
- `TestRepositoryController_process_TokenGenerationAuthFailureIsUserCaused` — end-to-end through `process()`: a connection returning `ErrAuthentication` increments **both** `token_generation_errors_total{cause="user"}` and `reconcile_errors_total{phase="token",cause="user"}`.
- Per-`cause` assertions on the recorder unit tests.
- OAuth/GitHub source tests assert the sentinel is present for each user-actionable code (`invalid_grant`, `invalid_client`, `bad_refresh_token`, `incorrect_client_credentials`, 401) — including the **HTTP-200** error-body forms — and **absent** for 408/429/5xx and the internal routing invariant.

## Rollout / follow-up

- **No breaking change**: metric series names are unchanged; this only adds a label. Existing queries keep working (they aggregate over the new label until updated).
- **Follow-up (alerting side)**: downstream alerts/dashboards should adopt `cause!="user"` to benefit from the split. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
