### PR TITLE
Provisioning: trace the connection/repository decrypt call

### DIFF
--- a/apps/provisioning/pkg/connection/secure.go
+++ b/apps/provisioning/pkg/connection/secure.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/secret/pkg/decrypt"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
@@ -63,11 +66,28 @@ func (s *secureValues) get(ctx context.Context, sv common.InlineSecureValue, st 
 		return "", nil
 	}
 
+	// Span the decrypt call so a hung or slow secrets service shows up as a bounded
+	// span under connection.build rather than an uninstrumented gap. Started before
+	// the timeout so it covers the full bound and the gRPC client's shared-context
+	// retries. The tracer is taken from the active span already in ctx to avoid
+	// threading one through ProvideDecrypter.
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().
+		Tracer("github.com/grafana/grafana/apps/provisioning/pkg/connection").
+		Start(ctx, "provisioning.connection.decrypt",
+			trace.WithAttributes(
+				attribute.String("namespace", s.namespace),
+				attribute.String("secret.name", sv.Name),
+				attribute.String("secret.type", string(st)),
+			),
+		)
+	defer span.End()
+
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start).Seconds()
 		if err != nil {
 			s.metrics.recordError(st)
+			span.RecordError(err)
 		} else {
 			s.metrics.recordSuccess(st, elapsed)
 		}

--- a/apps/provisioning/pkg/connection/secure_test.go
+++ b/apps/provisioning/pkg/connection/secure_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -598,4 +600,82 @@ func TestSecureValues_MultipleFields(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, common.RawSecureValue("inline-token"), token)
 	})
+}
+
+func TestSecureValues_DecryptSpan(t *testing.T) {
+	conn := &provisioning.Connection{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+		Secure: provisioning.ConnectionSecure{
+			PrivateKey: common.InlineSecureValue{Name: "pk-ref"},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		mockResults map[string]decrypt.DecryptResult
+		mockErr     error
+		wantErr     bool
+	}{
+		{
+			name:        "records a span on success",
+			mockResults: map[string]decrypt.DecryptResult{"pk-ref": newDecryptResult("v")},
+		},
+		{
+			name:    "records the error on the span when decrypt fails",
+			mockErr: errors.New("boom"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			ctx, parent := tp.Tracer("test").Start(context.Background(), "parent")
+
+			mockSvc := &mockDecryptService{results: tt.mockResults, err: tt.mockErr}
+			_, err := connection.ProvideDecrypter(mockSvc, nil)(conn).PrivateKey(ctx)
+			parent.End()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			span := findSpan(t, exporter.GetSpans(), "provisioning.connection.decrypt")
+			assert.Equal(t, parent.SpanContext().TraceID(), span.SpanContext.TraceID(), "decrypt span should join the active trace")
+			assert.Equal(t, parent.SpanContext().SpanID(), span.Parent.SpanID(), "decrypt span should be a child of the active span")
+			assert.Equal(t, "ns", spanAttrString(span, "namespace"))
+			assert.Equal(t, "pk-ref", spanAttrString(span, "secret.name"))
+			assert.Equal(t, "private_key", spanAttrString(span, "secret.type"))
+
+			if tt.wantErr {
+				require.Len(t, span.Events, 1)
+				assert.Equal(t, "exception", span.Events[0].Name)
+			} else {
+				assert.Empty(t, span.Events)
+			}
+		})
+	}
+}
+
+func findSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name == name {
+			return s
+		}
+	}
+	require.FailNowf(t, "span not found", "no span named %q among %d exported spans", name, len(spans))
+	return tracetest.SpanStub{}
+}
+
+func spanAttrString(s tracetest.SpanStub, key string) string {
+	for _, kv := range s.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
 }

--- a/apps/provisioning/pkg/repository/secure.go
+++ b/apps/provisioning/pkg/repository/secure.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/secret/pkg/decrypt"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
@@ -69,11 +72,28 @@ func (s *secureValues) get(ctx context.Context, sv common.InlineSecureValue, st 
 		return "", nil
 	}
 
+	// Span the decrypt call so a hung or slow secrets service shows up as a bounded
+	// span under repository.build rather than an uninstrumented gap. Started before
+	// the timeout so it covers the full bound and the gRPC client's shared-context
+	// retries. The tracer is taken from the active span already in ctx to avoid
+	// threading one through ProvideDecrypter.
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().
+		Tracer("github.com/grafana/grafana/apps/provisioning/pkg/repository").
+		Start(ctx, "provisioning.repository.decrypt",
+			trace.WithAttributes(
+				attribute.String("namespace", s.namespace),
+				attribute.String("secret.name", sv.Name),
+				attribute.String("secret.type", string(st)),
+			),
+		)
+	defer span.End()
+
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start).Seconds()
 		if err != nil {
 			s.metrics.recordError(st)
+			span.RecordError(err)
 		} else {
 			s.metrics.recordSuccess(st, elapsed)
 		}

--- a/apps/provisioning/pkg/repository/secure_test.go
+++ b/apps/provisioning/pkg/repository/secure_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
@@ -290,6 +292,69 @@ func TestRepositorySecureValues_DecryptTimeout(t *testing.T) {
 		require.NotErrorIs(t, err, ErrTokenNotFound)
 		require.ErrorIs(t, err, ErrSecretDecryptFailed)
 	})
+}
+
+func TestRepositorySecureValues_DecryptSpan(t *testing.T) {
+	cfg := &provisioning.Repository{Secure: provisioning.SecureValues{Token: v0alpha1.InlineSecureValue{Name: "secret"}}}
+
+	tests := []struct {
+		name    string
+		svc     decrypt.DecryptService
+		wantErr bool
+	}{
+		{name: "records a span on success", svc: &ctxCapturingDecryptService{}},
+		{name: "records the error on the span when decrypt fails", svc: &ctxCapturingDecryptService{err: fmt.Errorf("boom")}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exporter := tracetest.NewInMemoryExporter()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			ctx, parent := tp.Tracer("test").Start(context.Background(), "parent")
+
+			_, err := ProvideDecrypter(tt.svc, nil)(cfg).Token(ctx)
+			parent.End()
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			span := findSpan(t, exporter.GetSpans(), "provisioning.repository.decrypt")
+			require.Equal(t, parent.SpanContext().TraceID(), span.SpanContext.TraceID(), "decrypt span should join the active trace")
+			require.Equal(t, parent.SpanContext().SpanID(), span.Parent.SpanID(), "decrypt span should be a child of the active span")
+			require.Equal(t, "secret", spanAttrString(span, "secret.name"))
+			require.Equal(t, "token", spanAttrString(span, "secret.type"))
+
+			if tt.wantErr {
+				require.Len(t, span.Events, 1)
+				require.Equal(t, "exception", span.Events[0].Name)
+			} else {
+				require.Empty(t, span.Events)
+			}
+		})
+	}
+}
+
+func findSpan(t *testing.T, spans tracetest.SpanStubs, name string) tracetest.SpanStub {
+	t.Helper()
+	for _, s := range spans {
+		if s.Name == name {
+			return s
+		}
+	}
+	require.FailNowf(t, "span not found", "no span named %q among %d exported spans", name, len(spans))
+	return tracetest.SpanStub{}
+}
+
+func spanAttrString(s tracetest.SpanStub, key string) string {
+	for _, kv := range s.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
 }
 
 type ctxCapturingDecryptService struct {


### PR DESCRIPTION
## What

Adds a `provisioning.connection.decrypt` / `provisioning.repository.decrypt` span around the decrypt call in `secureValues.get` (both `apps/provisioning/pkg/connection/secure.go` and `.../repository/secure.go`). The span carries `namespace`, `secret.name`, and `secret.type` attributes and records the error on failure.

## Why

Two prod traces of a ~2h-stuck connection reconcile (`7e41ba51…123f9e`, `…e23bd9`) showed the secrets-service **server** span parented directly under `provisioning.connection.build`, with **no client-side span** covering the decrypt RPC. The ~2h gap was completely uninstrumented — we could only tell it was a hung decrypt call (vs an internal wait) by correlating external error logs after the fact.

Analysis on the traces (durations ~equal at ~7200s, end-times ~11.5h apart) pointed to the decrypt RPC hanging on a dead socket until TCP keepalive reaped it, surfacing downstream as `Unauthenticated: expired token`. See grafana/git-ui-sync-project#1356 for the full write-up.

This closes the observability gap: the next occurrence renders as a bounded (~30s, after the recently-added decrypt timeout) span with a recorded error, directly under `connection.build` / `repository.build`.

## How

- Start the span **before** `context.WithTimeout(30s)` so it covers the full bound and the gRPC client's shared-context retries.
- The tracer is taken from the active span already in `ctx` (`trace.SpanFromContext(ctx).TracerProvider()`), since `factory.Build` already opens `connection.build`/`repository.build` into `ctx` before the decrypter runs. This keeps `ProvideDecrypter`'s signature unchanged — **no Wire regen and no grafana-enterprise breakage**.
- The error is recorded on the span from the **existing** deferred metrics block, so every error path (decrypt-call failure, not-found, per-item error) is covered and the span always ends.

## Testing

- New table tests in both packages (`secure_test.go`) using an in-memory `sdktrace` exporter: assert the decrypt span is emitted, is a child of the active span, carries the attributes, and records the error on the failure case.
- `go test ./apps/provisioning/pkg/connection/... ./apps/provisioning/pkg/repository/...` — pass.
- `gofmt` / `go vet` clean.

## Follow-up (not in this PR)

`pkg/operators/provisioning/config.go:381` wires the decrypt client with `tracing.NewNoopTracerService()`, so the client's own internal instrumentation is silently noop in the operator. Passing the real tracer there (and adding a client-side span around `client.DecryptSecureValues` in the secret package) would give a true client-RPC span for all decrypt callers.

Related: grafana/git-ui-sync-project#1356

## Checklist
- [x] Tests added/updated
- [ ] Documentation updated (n/a — internal instrumentation)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)