### PR TITLE
TableNG + Logs Table: Introduce callback to capture row order to use for keyboard navigation of Logs Table Details

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
@@ -19,6 +19,7 @@ import {
   useFilteredRows,
   useHeaderHeight,
   useManagedSort,
+  useNotifyDisplayedRowIndices,
   usePaginatedRows,
   useScrollbarWidth,
   useSortedRows,
@@ -73,6 +74,7 @@ export function TableFlat(props: TableNGProps) {
     noValue,
     onCellFilterAdded,
     onColumnResize,
+    onDisplayedRowIndicesChange,
     onSortByChange,
     showTypeIcons,
     structureRev,
@@ -131,6 +133,7 @@ export function TableFlat(props: TableNGProps) {
   } = useSortedRows(filteredRows, data.fields, [], { initialSortBy: sortBy });
 
   useManagedSort({ sortByBehavior, setSortColumns, sortBy });
+  useNotifyDisplayedRowIndices(sortedRows, onDisplayedRowIndicesChange);
 
   const [inspectCell, setInspectCell] = useState<InspectCellProps | null>(null);
   const [tooltipState, setTooltipState] = useState<DataLinksActionsTooltipState>();

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
@@ -29,6 +29,7 @@ import {
   useFilteredRows,
   useHeaderHeight,
   useManagedSort,
+  useNotifyDisplayedRowIndices,
   useNestedColWidths,
   useNestedRows,
   usePaginatedRows,
@@ -86,6 +87,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
     noValue,
     onCellFilterAdded,
     onColumnResize,
+    onDisplayedRowIndicesChange,
     onSortByChange,
     showTypeIcons,
     structureRev,
@@ -173,6 +175,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
   } = useSortedRows(filteredRows, data.fields, nestedFields, { hasNestedFrames: true, initialSortBy: sortBy });
 
   useManagedSort({ sortByBehavior, setSortColumns, sortBy });
+  useNotifyDisplayedRowIndices(sortedRows, onDisplayedRowIndicesChange);
 
   const nestedRows = useNestedRows(rows, nestedData, true, nestedFramesFieldName, filter, sortColumns);
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -175,17 +175,14 @@ describe('TableNG hooks', () => {
 
     it('does not notify again when the index order is unchanged', () => {
       const onDisplayedRowIndicesChange = jest.fn();
-      const { rerender } = renderHook(
-        ({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange),
-        {
-          initialProps: {
-            rows: [
-              { __depth: 0, __index: 0 },
-              { __depth: 0, __index: 1 },
-            ] as TableRow[],
-          },
-        }
-      );
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 0, __index: 1 },
+          ] as TableRow[],
+        },
+      });
 
       expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
 
@@ -201,17 +198,14 @@ describe('TableNG hooks', () => {
 
     it('notifies when sort order changes', () => {
       const onDisplayedRowIndicesChange = jest.fn();
-      const { rerender } = renderHook(
-        ({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange),
-        {
-          initialProps: {
-            rows: [
-              { __depth: 0, __index: 0 },
-              { __depth: 0, __index: 1 },
-            ] as TableRow[],
-          },
-        }
-      );
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 0, __index: 1 },
+          ] as TableRow[],
+        },
+      });
 
       rerender({
         rows: [
@@ -222,6 +216,179 @@ describe('TableNG hooks', () => {
 
       expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
       expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([1, 0]);
+    });
+
+    it('does not notify again when parent order is unchanged even if nested rows are present', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 2 },
+            { __depth: 1, __index: 2 },
+            { __depth: 0, __index: 0 },
+            { __depth: 1, __index: 0 },
+          ] as TableRow[],
+        },
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledWith([2, 0]);
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 2 },
+          { __depth: 1, __index: 2 },
+          { __depth: 0, __index: 0 },
+          { __depth: 1, __index: 0 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not notify when only nested rows are added, removed, or moved', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 0, __index: 1 },
+          ] as TableRow[],
+        },
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledWith([0, 1]);
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 1, __index: 0 },
+          { __depth: 0, __index: 1 },
+          { __depth: 1, __index: 1 },
+        ],
+      });
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 0, __index: 1 },
+          { __depth: 1, __index: 1 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies when a parent row is filtered out', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 1, __index: 0 },
+            { __depth: 0, __index: 1 },
+            { __depth: 0, __index: 2 },
+          ] as TableRow[],
+        },
+      });
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 1, __index: 0 },
+          { __depth: 0, __index: 2 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
+      expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([0, 2]);
+    });
+
+    it('notifies when a parent row is added', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 0, __index: 2 },
+          ] as TableRow[],
+        },
+      });
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 0, __index: 1 },
+          { __depth: 0, __index: 2 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
+      expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([0, 1, 2]);
+    });
+
+    it('notifies when displayed parent rows become empty', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 0, __index: 1 },
+          ] as TableRow[],
+        },
+      });
+
+      rerender({ rows: [] });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
+      expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([]);
+    });
+
+    it('notifies when a single parent index changes and the list length stays the same', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange), {
+        initialProps: {
+          rows: [
+            { __depth: 0, __index: 0 },
+            { __depth: 1, __index: 0 },
+            { __depth: 0, __index: 1 },
+            { __depth: 0, __index: 2 },
+          ] as TableRow[],
+        },
+      });
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 1, __index: 0 },
+          { __depth: 0, __index: 3 },
+          { __depth: 0, __index: 2 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
+      expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([0, 3, 2]);
+    });
+
+    it('does not notify when only the callback reference changes', () => {
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      const rows: TableRow[] = [
+        { __depth: 0, __index: 0 },
+        { __depth: 0, __index: 1 },
+      ];
+      const { rerender } = renderHook(
+        ({ rows, onDisplayedRowIndicesChange }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange),
+        {
+          initialProps: { rows, onDisplayedRowIndicesChange: firstCallback },
+        }
+      );
+
+      rerender({ rows, onDisplayedRowIndicesChange: secondCallback });
+
+      expect(firstCallback).toHaveBeenCalledTimes(1);
+      expect(firstCallback).toHaveBeenCalledWith([0, 1]);
+      expect(secondCallback).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -7,6 +7,7 @@ import { TABLE } from './constants';
 import {
   useFilteredRows,
   useNestedColWidths,
+  useNotifyDisplayedRowIndices,
   usePaginatedRows,
   useSortedRows,
   useHeaderHeight,
@@ -153,6 +154,74 @@ describe('TableNG hooks', () => {
       );
 
       expect(setSortColumns).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('useNotifyDisplayedRowIndices', () => {
+    it('reports parent row __index values in display order and skips nested rows', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const rows: TableRow[] = [
+        { __depth: 0, __index: 2 },
+        { __depth: 1, __index: 2 },
+        { __depth: 0, __index: 0 },
+        { __depth: 1, __index: 0 },
+      ];
+
+      renderHook(() => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange));
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledWith([2, 0]);
+    });
+
+    it('does not notify again when the index order is unchanged', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(
+        ({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange),
+        {
+          initialProps: {
+            rows: [
+              { __depth: 0, __index: 0 },
+              { __depth: 0, __index: 1 },
+            ] as TableRow[],
+          },
+        }
+      );
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 0 },
+          { __depth: 0, __index: 1 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies when sort order changes', () => {
+      const onDisplayedRowIndicesChange = jest.fn();
+      const { rerender } = renderHook(
+        ({ rows }) => useNotifyDisplayedRowIndices(rows, onDisplayedRowIndicesChange),
+        {
+          initialProps: {
+            rows: [
+              { __depth: 0, __index: 0 },
+              { __depth: 0, __index: 1 },
+            ] as TableRow[],
+          },
+        }
+      );
+
+      rerender({
+        rows: [
+          { __depth: 0, __index: 1 },
+          { __depth: 0, __index: 0 },
+        ],
+      });
+
+      expect(onDisplayedRowIndicesChange).toHaveBeenCalledTimes(2);
+      expect(onDisplayedRowIndicesChange).toHaveBeenLastCalledWith([1, 0]);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -144,10 +144,6 @@ export function useSortedRows(
   };
 }
 
-function rowIndicesEqual(a: number[], b: number[]): boolean {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
-}
-
 /**
  * Notify when the table's filtered + sorted parent-row order changes.
  */
@@ -166,13 +162,20 @@ export function useNotifyDisplayedRowIndices(
     }
 
     const indices: number[] = [];
-    for (const row of sortedRows) {
+    let hasDifferences = !prevIndicesRef.current;
+    for (let i = 0; i < sortedRows.length; i++) {
+      const row = sortedRows[i];
       if (row.__depth === 0) {
+        if (!hasDifferences && prevIndicesRef.current?.[indices.length] !== row.__index) {
+          hasDifferences = true;
+        }
         indices.push(row.__index);
       }
     }
-
-    if (prevIndicesRef.current && rowIndicesEqual(prevIndicesRef.current, indices)) {
+    if (!hasDifferences && prevIndicesRef.current?.length !== indices.length) {
+      hasDifferences = true;
+    }
+    if (!hasDifferences) {
       return;
     }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -144,6 +144,43 @@ export function useSortedRows(
   };
 }
 
+function rowIndicesEqual(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+/**
+ * Notify when the table's filtered + sorted parent-row order changes.
+ */
+export function useNotifyDisplayedRowIndices(
+  sortedRows: TableRow[],
+  onDisplayedRowIndicesChange?: (rowIndices: number[]) => void
+) {
+  const callbackRef = useRef(onDisplayedRowIndicesChange);
+  callbackRef.current = onDisplayedRowIndicesChange;
+  const prevIndicesRef = useRef<number[] | undefined>(undefined);
+
+  useEffect(() => {
+    const callback = callbackRef.current;
+    if (!callback) {
+      return;
+    }
+
+    const indices: number[] = [];
+    for (const row of sortedRows) {
+      if (row.__depth === 0) {
+        indices.push(row.__index);
+      }
+    }
+
+    if (prevIndicesRef.current && rowIndicesEqual(prevIndicesRef.current, indices)) {
+      return;
+    }
+
+    prevIndicesRef.current = indices;
+    callback(indices);
+  }, [sortedRows]);
+}
+
 export interface PaginatedRowsOptions {
   height: number;
   width: number;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -30,6 +30,7 @@ export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilte
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: MatcherScope) => void;
 type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
+export type TableDisplayedRowIndicesCallback = (rowIndices: number[]) => void;
 type FooterItem = Array<KeyValue<string>> | string | undefined;
 
 type GetActionsFunction = (frame: DataFrame, field: Field, rowIndex: number) => ActionModel[];
@@ -122,6 +123,11 @@ interface BaseTableProps {
   sortByBehavior?: SortByBehavior;
   onColumnResize?: TableColumnResizeActionCallback;
   onSortByChange?: TableSortByActionCallback;
+  /**
+   * Called when the filtered + sorted row order changes. Values are original
+   * frame indexes (`TableRow.__index`), not the current page slice.
+   */
+  onDisplayedRowIndicesChange?: TableDisplayedRowIndicesCallback;
   onCellFilterAdded?: TableFilterActionCallback;
   footerValues?: FooterItem[];
   frozenColumns?: number;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -30,7 +30,7 @@ export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilte
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: MatcherScope) => void;
 type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
-export type TableDisplayedRowIndicesCallback = (rowIndices: number[]) => void;
+type TableDisplayedRowIndicesCallback = (rowIndices: number[]) => void;
 type FooterItem = Array<KeyValue<string>> | string | undefined;
 
 type GetActionsFunction = (frame: DataFrame, field: Field, rowIndex: number) => ActionModel[];

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -7,11 +7,13 @@ export interface LogDetailsContextData {
   currentLog: LogListModel | undefined;
   closeDetails: () => void;
   detailsDisplayed: (rowIndex: number) => boolean;
+  displayedRowIndices: number[];
   enableLogDetails: boolean;
   logs: LogListModel[];
   prettifyDetailsJSON: boolean;
   replaceDetails: (log: LogListModel) => void;
   setCurrentLog: (log: LogListModel) => void;
+  setDisplayedRowIndices: (rowIndices: number[]) => void;
   setPrettifyDetailsJSON: (prettifyDetailsJSON: boolean) => void;
   showDetails: LogListModel[];
   toggleDetails: (log: number | LogListModel) => void;
@@ -21,11 +23,13 @@ export const emptyContextData: LogDetailsContextData = {
   currentLog: undefined,
   closeDetails: () => {},
   detailsDisplayed: () => false,
+  displayedRowIndices: [],
   enableLogDetails: false,
   logs: [],
   prettifyDetailsJSON: true,
   replaceDetails: () => {},
   setCurrentLog: () => {},
+  setDisplayedRowIndices: () => {},
   setPrettifyDetailsJSON: () => {},
   showDetails: [],
   toggleDetails: () => {},
@@ -58,6 +62,7 @@ export const LogDetailsContextProvider = ({
 }: Props) => {
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [currentLog, setCurrentLog] = useState<LogListModel | undefined>(undefined);
+  const [displayedRowIndices, setDisplayedRowIndicesState] = useState<number[]>([]);
   const [prettifyDetailsJSON, setPrettifyDetailsJSONState] = useState(
     prettifyDetailsJSONProp ??
       (logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.prettifyDetailsJSON`, true) : true)
@@ -156,11 +161,13 @@ export const LogDetailsContextProvider = ({
         closeDetails,
         currentLog,
         detailsDisplayed,
+        displayedRowIndices,
         enableLogDetails,
         logs,
         prettifyDetailsJSON,
         replaceDetails,
         setCurrentLog,
+        setDisplayedRowIndices: setDisplayedRowIndicesState,
         setPrettifyDetailsJSON,
         showDetails,
         toggleDetails,

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -33,6 +33,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   const {
     currentLog,
     closeDetails,
+    displayedRowIndices,
     enableLogDetails,
     logs,
     prettifyDetailsJSON,
@@ -48,6 +49,20 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
   const dragStyles = useStyles2(getDragStyles);
+
+  const navigableLogs = useMemo(() => {
+    if (!displayedRowIndices.length) {
+      return logs;
+    }
+    const next: typeof logs = [];
+    for (const index of displayedRowIndices) {
+      const log = logs[index];
+      if (log) {
+        next.push(log);
+      }
+    }
+    return next;
+  }, [displayedRowIndices, logs]);
 
   const handleCloseDetails = useCallback(() => {
     inputRef.current = '';
@@ -85,10 +100,10 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
       } else {
         return;
       }
-      if (!currentLog || logs.findIndex((log) => log.uid === currentLog.uid) < 0) {
+      if (!currentLog || navigableLogs.findIndex((log) => log.uid === currentLog.uid) < 0) {
         return;
       }
-      const nextLog = logs[logs.findIndex((log) => log.uid === currentLog.uid) + delta];
+      const nextLog = navigableLogs[navigableLogs.findIndex((log) => log.uid === currentLog.uid) + delta];
       if (!nextLog) {
         return;
       }
@@ -97,7 +112,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
     }
     document.addEventListener('keydown', handleKeydown);
     return () => document.removeEventListener('keydown', handleKeydown);
-  }, [containerElement, currentLog, logs, replaceDetails]);
+  }, [containerElement, currentLog, navigableLogs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -27,6 +27,7 @@ import {
 } from 'app/features/table/hooks';
 import { getCurrentFrameIndex, onColumnResize, onSortByChange } from 'app/features/table/utils';
 
+import { useLogDetailsContext } from './LogDetailsContext';
 import { type Options } from './options/types';
 import { defaultOptions } from './panelcfg.gen';
 
@@ -56,6 +57,7 @@ export function TableNGWrap({
 }: Props) {
   useCacheFieldDisplayNames(data.series);
 
+  const { setDisplayedRowIndices } = useLogDetailsContext();
   const panelContext = usePanelContext();
   const getActions = useCellActions(replaceVariables);
   const commonTableProps = useCommonTableProps(options, fieldConfig);
@@ -125,6 +127,7 @@ export function TableNGWrap({
         timeRange={data.timeRange}
         width={Math.max(tableWidth - fieldSelectorWidth - controlsWidth, 0)}
         height={height}
+        onDisplayedRowIndicesChange={setDisplayedRowIndices}
         onSortByChange={(sortBy) => onSortByChange(sortBy, { onOptionsChange, options })}
         onColumnResize={(displayName, resizedWidth, fieldScope) =>
           onColumnResize(displayName, resizedWidth, fieldScope, { fieldConfig, onFieldConfigChange })


### PR DESCRIPTION
TableNG: propose a onDisplayedRowIndicesChange callback to report row indices.

Logs Table: fix keyboard navigation for the Logs Table Details. It was broken because the previous/next log didn't match the current table order.

Demo:

https://github.com/user-attachments/assets/055e0d7b-b1a5-4bad-be0b-0cdab6fc7cd7

