### PR TITLE
Search API: support field-value results

### DIFF
--- a/pkg/registry/apis/appplugin/routes.go
+++ b/pkg/registry/apis/appplugin/routes.go
@@ -1,6 +1,7 @@
 package appplugin
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/apiserver/kindstore"
 	"github.com/grafana/grafana/pkg/services/apiserver/searchroutes"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/util/errhttp"
 )
 
@@ -176,13 +178,16 @@ func (b *AppPluginAPIBuilder) searchRoutes(gv schema.GroupVersion) ([]builder.AP
 	manifest := *b.manifest
 	manifest.Group = b.group
 
-	built, err := searchroutes.BuildForServedGroupVersions(
+	built, err := searchroutes.BuildForServedGroupVersionsWithOptions(
 		[]*app.ManifestData{&manifest},
 		map[schema.GroupVersion]bool{gv: true},
 		b.opts.SearchAPIEnabled,
 		b.opts.TrashAPIEnabled,
 		b.tracer,
 		b.search,
+		searchroutes.BuildOptions{FieldValueResultsEnabled: func(ctx context.Context) bool {
+			return b.features != nil && b.features.IsEnabled(ctx, featuremgmt.FlagSearchApiFieldValueResults) // nolint:staticcheck
+		}},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apis/search/handler.go
+++ b/pkg/registry/apis/search/handler.go
@@ -3,6 +3,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -45,20 +46,35 @@ func (k kindRef) gvr() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: k.group, Version: k.version, Resource: k.resource}
 }
 
+// FieldValueResultsEnabled decides whether a request uses field-value results.
+// Embedded Grafana can evaluate it per tenant; standalone servers can return a
+// process-level configuration value.
+type FieldValueResultsEnabled func(context.Context) bool
+
+type HandlerOptions struct {
+	FieldValueResultsEnabled FieldValueResultsEnabled
+}
+
 // Handler serves the search envelope endpoints for one kind.
 type Handler struct {
-	client   resourcepb.ResourceIndexClient
-	provider resource.SearchFieldsProvider
-	tracer   trace.Tracer
-	log      log.Logger
+	client                   resourcepb.ResourceIndexClient
+	provider                 resource.SearchFieldsProvider
+	tracer                   trace.Tracer
+	log                      log.Logger
+	fieldValueResultsEnabled FieldValueResultsEnabled
 }
 
 func NewHandler(client resourcepb.ResourceIndexClient, provider resource.SearchFieldsProvider, tracer trace.Tracer) *Handler {
+	return NewHandlerWithOptions(client, provider, tracer, HandlerOptions{})
+}
+
+func NewHandlerWithOptions(client resourcepb.ResourceIndexClient, provider resource.SearchFieldsProvider, tracer trace.Tracer, options HandlerOptions) *Handler {
 	return &Handler{
-		client:   client,
-		provider: provider,
-		tracer:   tracer,
-		log:      log.New("grafana-apiserver.search"),
+		client:                   client,
+		provider:                 provider,
+		tracer:                   tracer,
+		log:                      log.New("grafana-apiserver.search"),
+		fieldValueResultsEnabled: options.FieldValueResultsEnabled,
 	}
 }
 
@@ -71,6 +87,9 @@ func (h *Handler) SearchFor(kind kindRef) http.HandlerFunc {
 				return nil, nil, err
 			}
 			req, ferrs := TranslateSearchQuery(&q, kind.gvr(), namespace, h.provider)
+			if len(ferrs) == 0 && h.fieldValueResultsEnabled != nil && h.fieldValueResultsEnabled(r.Context()) {
+				req.ResultFormat = resourcepb.ResourceSearchRequest_FIELD_VALUES
+			}
 			return req, ferrs, nil
 		},
 		func(res *resourcepb.ResourceSearchResponse, limit int64) (any, error) {

--- a/pkg/registry/apis/search/handler_test.go
+++ b/pkg/registry/apis/search/handler_test.go
@@ -76,6 +76,31 @@ func TestHandler_TranslatesAndReturnsEnvelope(t *testing.T) {
 	assert.Equal(t, searchv0.TotalHitsEqual, out.Metadata.TotalHitsRelation)
 }
 
+func TestHandler_ResultFormatFollowsSelector(t *testing.T) {
+	body := `{"apiVersion":"` + searchv0.APIVERSION + `","kind":"` + searchv0.KindSearchQuery + `"}`
+
+	for name, enabled := range map[string]bool{
+		"disabled": false,
+		"enabled":  true,
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &fakeIndexClient{resp: emptyResponse()}
+			h := NewHandlerWithOptions(client, testProvider(), noop.NewTracerProvider().Tracer(""), HandlerOptions{
+				FieldValueResultsEnabled: func(context.Context) bool { return enabled },
+			})
+
+			w := doRequest(t, h, body)
+
+			require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+			want := resourcepb.ResourceSearchRequest_UNSPECIFIED
+			if enabled {
+				want = resourcepb.ResourceSearchRequest_FIELD_VALUES
+			}
+			assert.Equal(t, want, client.got.ResultFormat)
+		})
+	}
+}
+
 func TestHandler_RejectsInvalidBody(t *testing.T) {
 	h := NewHandler(&fakeIndexClient{resp: emptyResponse()}, testProvider(), noop.NewTracerProvider().Tracer(""))
 

--- a/pkg/registry/apis/search/response.go
+++ b/pkg/registry/apis/search/response.go
@@ -9,12 +9,17 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
+type decodedResults struct {
+	items          []searchv0.ResultItem
+	lastSortFields []string
+}
+
 // searchResults maps a backend search response into the public envelope.
 //
 // limit is the page size that was requested; it decides whether a continue
 // token is offered, since the backend does not say whether more results exist.
 func searchResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit int64) (*searchv0.SearchResults, error) {
-	items, err := resultItems(res.GetResults(), kind)
+	decoded, err := decodeResults(res, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -24,9 +29,9 @@ func searchResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit i
 		Metadata: searchv0.ResultsMetadata{
 			TotalHits:         res.GetTotalHits(),
 			TotalHitsRelation: totalHitsRelation(res.GetTotalHitsExact()),
-			Continue:          continueToken(res.GetResults(), limit, res.GetTotalHitsExact()),
+			Continue:          continueToken(len(decoded.items), decoded.lastSortFields, limit, res.GetTotalHitsExact()),
 		},
-		Items:  items,
+		Items:  decoded.items,
 		Facets: facets(res.GetFacet()),
 	}
 	return out, nil
@@ -35,7 +40,7 @@ func searchResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit i
 // trashResults maps a backend search response into the trash envelope. No facets:
 // trash never requests any, so the backend never returns any.
 func trashResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit int64) (*searchv0.TrashResults, error) {
-	items, err := resultItems(res.GetResults(), kind)
+	decoded, err := decodeResults(res, kind)
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +50,9 @@ func trashResults(res *resourcepb.ResourceSearchResponse, kind kindRef, limit in
 		Metadata: searchv0.ResultsMetadata{
 			TotalHits:         res.GetTotalHits(),
 			TotalHitsRelation: totalHitsRelation(res.GetTotalHitsExact()),
-			Continue:          continueToken(res.GetResults(), limit, res.GetTotalHitsExact()),
+			Continue:          continueToken(len(decoded.items), decoded.lastSortFields, limit, res.GetTotalHitsExact()),
 		},
-		Items: items,
+		Items: decoded.items,
 	}, nil
 }
 
@@ -65,54 +70,55 @@ func totalHitsRelation(exact bool) searchv0.TotalHitsRelation {
 // total as inexact. Ending the walk there would leave those results
 // unreachable, so only an exact total lets a short page finish. The cost is at
 // most one extra empty page.
-func continueToken(table *resourcepb.ResourceTable, limit int64, totalIsExact bool) string {
-	rows := table.GetRows()
+func continueToken(rowCount int, lastSortFields []string, limit int64, totalIsExact bool) string {
 	// Translation always resolves a limit, so the zero check is only here to keep
 	// the function honest if it is ever called directly.
-	if limit <= 0 || len(rows) == 0 {
+	if limit <= 0 || rowCount == 0 {
 		return ""
 	}
-	if int64(len(rows)) < limit && totalIsExact {
+	if int64(rowCount) < limit && totalIsExact {
 		return ""
 	}
 	// The cursor is the last row's sort values. The backend returns them per row
 	// and takes them back as SearchAfter, so the next page resumes at the point
 	// this one stopped, in the same order. A row without them cannot be resumed
 	// from, which happens when the query has no sort to position against.
-	last := rows[len(rows)-1]
-	if len(last.GetSortFields()) == 0 {
+	if len(lastSortFields) == 0 {
 		return ""
 	}
-	return encodeContinue(last.GetSortFields())
+	return encodeContinue(lastSortFields)
 }
 
-// resultItems converts the backend result table into envelope items. Column
-// names are already public names: the backend resolves them back from their
-// physical fields.* form when it builds the table.
-func resultItems(table *resourcepb.ResourceTable, kind kindRef) ([]searchv0.ResultItem, error) {
+func decodeResults(res *resourcepb.ResourceSearchResponse, kind kindRef) (decodedResults, error) {
+	switch res.GetResultFormat() {
+	case resourcepb.ResourceSearchRequest_UNSPECIFIED, resourcepb.ResourceSearchRequest_RESOURCE_TABLE:
+		return decodeTableResults(res.GetResults(), kind)
+	case resourcepb.ResourceSearchRequest_FIELD_VALUES:
+		return decodeFieldValueResults(res.GetFields(), res.GetRows(), kind)
+	default:
+		return decodedResults{}, fmt.Errorf("unsupported search result format %d", res.GetResultFormat())
+	}
+}
+
+// decodeTableResults converts the legacy backend result table into envelope items.
+// Column names are already public names: the backend resolves them back from
+// their physical fields.* form when it builds the table.
+func decodeTableResults(table *resourcepb.ResourceTable, kind kindRef) (decodedResults, error) {
 	rows := table.GetRows()
 	items := make([]searchv0.ResultItem, 0, len(rows))
 	cols := table.GetColumns()
 
 	for _, row := range rows {
 		if len(row.GetCells()) != len(cols) {
-			return nil, fmt.Errorf("row has %d cells but the table declares %d columns", len(row.GetCells()), len(cols))
+			return decodedResults{}, fmt.Errorf("row has %d cells but the table declares %d columns", len(row.GetCells()), len(cols))
 		}
 
-		item := searchv0.ResultItem{
-			Resource: searchv0.ResourceRef{
-				Group:    kind.group,
-				Resource: kind.resource,
-				Kind:     kind.kind,
-				Name:     row.GetKey().GetName(),
-			},
-		}
-
+		item := resultItem(kind, row.GetKey())
 		values := map[string]any{}
 		for i, col := range cols {
 			v, err := resource.DecodeCell(col, i, row.GetCells()[i])
 			if err != nil {
-				return nil, fmt.Errorf("decoding column %q: %w", col.GetName(), err)
+				return decodedResults{}, fmt.Errorf("decoding column %q: %w", col.GetName(), err)
 			}
 			if v == nil {
 				continue
@@ -132,7 +138,52 @@ func resultItems(table *resourcepb.ResourceTable, kind kindRef) ([]searchv0.Resu
 
 		items = append(items, item)
 	}
-	return items, nil
+
+	var lastSortFields []string
+	if len(rows) > 0 {
+		lastSortFields = rows[len(rows)-1].GetSortFields()
+	}
+	return decodedResults{items: items, lastSortFields: lastSortFields}, nil
+}
+
+func decodeFieldValueResults(fields []*resourcepb.ResourceSearchField, rows []*resourcepb.ResourceSearchRow, kind kindRef) (decodedResults, error) {
+	items := make([]searchv0.ResultItem, 0, len(rows))
+	for i, row := range rows {
+		if row == nil || row.GetKey() == nil {
+			return decodedResults{}, fmt.Errorf("field-value search result row %d has no resource key", i)
+		}
+		values, err := resource.DecodeSearchValues(fields, row)
+		if err != nil {
+			return decodedResults{}, fmt.Errorf("decoding field-value search result row %d: %w", i, err)
+		}
+
+		item := resultItem(kind, row.GetKey())
+		if len(values) > 0 {
+			item.Fields = &common.Unstructured{Object: values}
+		}
+		if row.Score != nil {
+			score := row.GetScore()
+			item.Score = &score
+		}
+		items = append(items, item)
+	}
+
+	var lastSortFields []string
+	if len(rows) > 0 {
+		lastSortFields = rows[len(rows)-1].GetSortFields()
+	}
+	return decodedResults{items: items, lastSortFields: lastSortFields}, nil
+}
+
+func resultItem(kind kindRef, key *resourcepb.ResourceKey) searchv0.ResultItem {
+	return searchv0.ResultItem{
+		Resource: searchv0.ResourceRef{
+			Group:    kind.group,
+			Resource: kind.resource,
+			Kind:     kind.kind,
+			Name:     key.GetName(),
+		},
+	}
 }
 
 func toFloat64(v any) (float64, bool) {

--- a/pkg/registry/apis/search/response_test.go
+++ b/pkg/registry/apis/search/response_test.go
@@ -65,6 +65,7 @@ func TestSearchResults_MapsItemsAndFields(t *testing.T) {
 	}, nil)
 
 	out, err := searchResults(&resourcepb.ResourceSearchResponse{
+		ResultFormat:   resourcepb.ResourceSearchRequest_RESOURCE_TABLE,
 		Results:        table,
 		TotalHits:      2,
 		TotalHitsExact: true,
@@ -110,6 +111,68 @@ func TestSearchResults_ScoreIsSeparateFromFields(t *testing.T) {
 
 	// _score is an envelope field, never a searchable field.
 	assert.NotContains(t, out.Items[0].Fields.Object, resource.SEARCH_FIELD_SCORE)
+}
+
+func TestSearchResults_MapsFieldValueResults(t *testing.T) {
+	score := 0.0
+	response := &resourcepb.ResourceSearchResponse{
+		ResultFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES,
+		Fields: []*resourcepb.ResourceSearchField{
+			{Name: "title", Type: resourcepb.ResourceSearchField_STRING},
+			{Name: "tags", Type: resourcepb.ResourceSearchField_STRING, IsArray: true},
+			{Name: "created", Type: resourcepb.ResourceSearchField_DATE},
+			{Name: "ratio", Type: resourcepb.ResourceSearchField_DOUBLE},
+			{Name: "published", Type: resourcepb.ResourceSearchField_BOOLEAN},
+		},
+		Rows: []*resourcepb.ResourceSearchRow{
+			{
+				Key:        &resourcepb.ResourceKey{Name: "dash-a"},
+				SortFields: []string{"dash-a"},
+				Score:      &score,
+				Values: []*resourcepb.ResourceSearchValue{
+					{FieldIndex: 0, StringValues: []string{"A dashboard"}},
+					{FieldIndex: 1, StringValues: []string{"prod", "ops"}},
+					{FieldIndex: 2, Int64Values: []int64{1234}},
+					{FieldIndex: 3, DoubleValues: []float64{1.5}},
+					{FieldIndex: 4, BooleanValues: []bool{true}},
+				},
+			},
+			{
+				Key:        &resourcepb.ResourceKey{Name: "dash-b"},
+				SortFields: []string{"dash-b"},
+				Values: []*resourcepb.ResourceSearchValue{
+					{FieldIndex: 0, StringValues: []string{"B dashboard"}},
+					{FieldIndex: 1},
+				},
+			},
+		},
+		TotalHits:      2,
+		TotalHitsExact: true,
+	}
+
+	out, err := searchResults(response, testKind, 2)
+	require.NoError(t, err)
+	require.Len(t, out.Items, 2)
+
+	assert.Equal(t, "dash-a", out.Items[0].Resource.Name)
+	require.NotNil(t, out.Items[0].Fields)
+	assert.Equal(t, "A dashboard", out.Items[0].Fields.Object["title"])
+	assert.Equal(t, []string{"prod", "ops"}, out.Items[0].Fields.Object["tags"])
+	assert.Equal(t, int64(1234), out.Items[0].Fields.Object["created"])
+	assert.Equal(t, 1.5, out.Items[0].Fields.Object["ratio"])
+	assert.Equal(t, true, out.Items[0].Fields.Object["published"])
+	require.NotNil(t, out.Items[0].Score, "a score of zero must remain present")
+	assert.InDelta(t, 0, *out.Items[0].Score, 1e-9)
+
+	require.NotNil(t, out.Items[1].Fields)
+	assert.Equal(t, []string{}, out.Items[1].Fields.Object["tags"], "present empty arrays remain arrays")
+	assert.NotContains(t, out.Items[1].Fields.Object, "ratio", "absent fields are omitted")
+	assert.Nil(t, out.Items[1].Score)
+
+	require.NotEmpty(t, out.Metadata.Continue)
+	decoded, err := decodeContinue(out.Metadata.Continue)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dash-b"}, decoded)
 }
 
 func TestSearchResults_TotalHitsRelation(t *testing.T) {
@@ -207,6 +270,26 @@ func TestSearchResults_Facets(t *testing.T) {
 		{Value: "timeseries", Count: 5},
 		{Value: "table", Count: 2},
 	}, out.Facets["panel_types"])
+}
+
+func TestSearchResults_RejectsUnsupportedResultFormat(t *testing.T) {
+	_, err := searchResults(&resourcepb.ResourceSearchResponse{
+		ResultFormat: resourcepb.ResourceSearchRequest_ResultFormat(99),
+	}, testKind, 10)
+	require.ErrorContains(t, err, "unsupported search result format 99")
+}
+
+func TestSearchResults_RejectsMalformedFieldValueResults(t *testing.T) {
+	_, err := searchResults(&resourcepb.ResourceSearchResponse{
+		ResultFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES,
+		Fields: []*resourcepb.ResourceSearchField{
+			{Name: "title", Type: resourcepb.ResourceSearchField_STRING},
+		},
+		Rows: []*resourcepb.ResourceSearchRow{
+			{Key: &resourcepb.ResourceKey{Name: "a"}, Values: []*resourcepb.ResourceSearchValue{{FieldIndex: 1, StringValues: []string{"A"}}}},
+		},
+	}, testKind, 10)
+	require.ErrorContains(t, err, "field index 1 is out of range")
 }
 
 func TestSearchResults_RejectsMalformedTable(t *testing.T) {

--- a/pkg/registry/apis/search/trash_handler_test.go
+++ b/pkg/registry/apis/search/trash_handler_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,7 +38,9 @@ func trashBody(inner string) string {
 
 func TestTrashHandler_RequestsDeletedResources(t *testing.T) {
 	client := &fakeIndexClient{resp: emptyResponse()}
-	h := NewHandler(client, testProvider(), noop.NewTracerProvider().Tracer(""))
+	h := NewHandlerWithOptions(client, testProvider(), noop.NewTracerProvider().Tracer(""), HandlerOptions{
+		FieldValueResultsEnabled: func(context.Context) bool { return true },
+	})
 
 	w := doTrashRequest(t, h, trashBody(`, "limit": 25`))
 
@@ -49,6 +52,7 @@ func TestTrashHandler_RequestsDeletedResources(t *testing.T) {
 	assert.Equal(t, testKind.group, client.got.Options.Key.Group)
 	assert.Equal(t, testKind.resource, client.got.Options.Key.Resource)
 	assert.Equal(t, int64(25), client.got.Limit)
+	assert.Equal(t, resourcepb.ResourceSearchRequest_UNSPECIFIED, client.got.ResultFormat, "the live-search setting must not change trash")
 
 	// Federating trash is refused by the backend, so the endpoint must not ask.
 	assert.Empty(t, client.got.Federated)

--- a/pkg/services/apiserver/searchroutes/searchroutes.go
+++ b/pkg/services/apiserver/searchroutes/searchroutes.go
@@ -47,6 +47,10 @@ func enrolled(group, resourceName string, kind app.ManifestVersionKind) bool {
 	return len(kind.SearchFields) > 0 || enrolledWithoutSearchFields[group+"/"+resourceName]
 }
 
+type BuildOptions struct {
+	FieldValueResultsEnabled searchapi.FieldValueResultsEnabled
+}
+
 // Build returns the search and trash routes to mount, or nil when both are off or
 // there is no client to serve them with.
 //
@@ -63,9 +67,31 @@ func Build(
 	builders []builder.APIGroupBuilder,
 	installers []appsdkapiserver.AppInstaller,
 ) []builder.GroupVersionRoutes {
+	return BuildWithOptions(searchEnabled, trashEnabled, tracer, index, builders, installers, BuildOptions{})
+}
+
+// BuildWithOptions leaves the result-format decision with the host: embedded
+// Grafana can pass a tenant setting, while a standalone server can pass a
+// process setting.
+func BuildWithOptions(
+	searchEnabled bool,
+	trashEnabled bool,
+	tracer tracing.Tracer,
+	index resourcepb.ResourceIndexClient,
+	builders []builder.APIGroupBuilder,
+	installers []appsdkapiserver.AppInstaller,
+	options BuildOptions,
+) []builder.GroupVersionRoutes {
 	// Search fields come from the compiled-in app manifests, the same
 	// declarations the index mapping is built from.
-	return BuildFromManifests(resource.AppManifests(), searchEnabled, trashEnabled, tracer, index, builders, installers)
+	routes, err := BuildForServedGroupVersionsWithOptions(
+		resource.AppManifests(), servedGroupVersions(builders, installers),
+		searchEnabled, trashEnabled, tracer, index, options,
+	)
+	if err != nil {
+		panic(err.Error())
+	}
+	return routes
 }
 
 // BuildFromManifests is Build with the kind declarations supplied by the caller.
@@ -115,6 +141,18 @@ func BuildForServedGroupVersions(
 	tracer tracing.Tracer,
 	index resourcepb.ResourceIndexClient,
 ) ([]builder.GroupVersionRoutes, error) {
+	return BuildForServedGroupVersionsWithOptions(manifests, served, searchEnabled, trashEnabled, tracer, index, BuildOptions{})
+}
+
+func BuildForServedGroupVersionsWithOptions(
+	manifests []*app.ManifestData,
+	served map[schema.GroupVersion]bool,
+	searchEnabled bool,
+	trashEnabled bool,
+	tracer tracing.Tracer,
+	index resourcepb.ResourceIndexClient,
+	options BuildOptions,
+) ([]builder.GroupVersionRoutes, error) {
 	// Whether an endpoint is on is read by the caller, because the two servers
 	// that mount them are configured differently: one from an ini file, one from
 	// flags.
@@ -126,7 +164,9 @@ func BuildForServedGroupVersions(
 	if err != nil {
 		return nil, err
 	}
-	handler := searchapi.NewHandler(index, provider, tracer)
+	handler := searchapi.NewHandlerWithOptions(index, provider, tracer, searchapi.HandlerOptions{
+		FieldValueResultsEnabled: options.FieldValueResultsEnabled,
+	})
 
 	byGroupVersion := map[schema.GroupVersion][]searchapi.Route{}
 

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -415,7 +415,12 @@ func (s *service) start(ctx context.Context) error {
 	apiserverSection := s.cfg.SectionWithEnvOverrides(searchapi.ConfigSection)
 	searchAPIEnabled := apiserverSection.Key(searchapi.ConfigKey).MustBool(true)
 	trashAPIEnabled := apiserverSection.Key(searchapi.ConfigKeyTrash).MustBool(true)
-	searchRoutes := searchroutes.Build(searchAPIEnabled, trashAPIEnabled, s.tracing, s.unified, builders, s.appInstallers)
+	searchRoutes := searchroutes.BuildWithOptions(
+		searchAPIEnabled, trashAPIEnabled, s.tracing, s.unified, builders, s.appInstallers,
+		searchroutes.BuildOptions{FieldValueResultsEnabled: func(ctx context.Context) bool {
+			return s.features != nil && s.features.IsEnabled(ctx, featuremgmt.FlagSearchApiFieldValueResults) // nolint:staticcheck
+		}},
+	)
 
 	// Add OpenAPI specs for each group+version (existing builders)
 	err = builder.SetupConfig(

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2966,6 +2966,14 @@ var (
 			Generate:    Generate{Go: true},
 		},
 		{
+			Name:        "search.apiFieldValueResults",
+			Description: "Uses field-value results for generic resource search API requests",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaSearchAndStorageSquad,
+			Expression:  "false",
+			Generate:    Generate{Go: true},
+		},
+		{
 			Name:        "dashboard.vectorSearch",
 			Description: "Exposes the semantic (vector) search endpoint for dashboards under the dashboard API",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -344,6 +344,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-06-12,grafana.visualDesignRefresh,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-09-08,dashboard.searchFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
 2026-09-10,dashboard.apiSearchFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
+2026-09-10,search.apiFieldValueResults,experimental,@grafana/search-and-storage,false,false,false
 2026-06-09,dashboard.vectorSearch,experimental,@grafana/search-and-storage,false,false,false
 2026-06-25,grafana.vectorSearchCmdk,experimental,@grafana/search-and-storage,false,false,true
 2026-08-04,grafana.cmdkHybridSearch,experimental,@grafana/search-and-storage,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -946,6 +946,10 @@ const (
 	// Uses field-value results for requests from the /api/search endpoint
 	FlagDashboardApiSearchFieldValueResults = "dashboard.apiSearchFieldValueResults"
 
+	// FlagSearchApiFieldValueResults
+	// Uses field-value results for generic resource search API requests
+	FlagSearchApiFieldValueResults = "search.apiFieldValueResults"
+
 	// FlagDashboardVectorSearch
 	// Exposes the semantic (vector) search endpoint for dashboards under the dashboard API
 	FlagDashboardVectorSearch = "dashboard.vectorSearch"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -6243,6 +6243,19 @@
     },
     {
       "metadata": {
+        "name": "search.apiFieldValueResults",
+        "resourceVersion": "1789039361718",
+        "creationTimestamp": "2026-09-10T11:22:41Z"
+      },
+      "spec": {
+        "description": "Uses field-value results for generic resource search API requests",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "secretsKeeperUI",
         "resourceVersion": "1787262357315",
         "creationTimestamp": "2026-05-22T09:03:04Z",

--- a/pkg/storage/unified/resource/search_result.go
+++ b/pkg/storage/unified/resource/search_result.go
@@ -55,6 +55,9 @@ func decodeSearchValue(field *resourcepb.ResourceSearchField, value *resourcepb.
 
 func searchScalarOrArray[T any](values []T, isArray bool) (any, error) {
 	if isArray {
+		if values == nil {
+			return []T{}, nil
+		}
 		return values, nil
 	}
 	if len(values) != 1 {

--- a/pkg/storage/unified/resource/search_result_test.go
+++ b/pkg/storage/unified/resource/search_result_test.go
@@ -16,6 +16,7 @@ func TestDecodeSearchValues(t *testing.T) {
 		{Name: "ratio", Type: resourcepb.ResourceSearchField_DOUBLE},
 		{Name: "flags", Type: resourcepb.ResourceSearchField_BOOLEAN, IsArray: true},
 		{Name: "created", Type: resourcepb.ResourceSearchField_DATE},
+		{Name: "empty", Type: resourcepb.ResourceSearchField_STRING, IsArray: true},
 	}
 	row := &resourcepb.ResourceSearchRow{Values: []*resourcepb.ResourceSearchValue{
 		{FieldIndex: 0, StringValues: []string{"Dashboard"}},
@@ -23,6 +24,9 @@ func TestDecodeSearchValues(t *testing.T) {
 		{FieldIndex: 2, DoubleValues: []float64{0.5}},
 		{FieldIndex: 3, BooleanValues: []bool{true, false}},
 		{FieldIndex: 4, Int64Values: []int64{1234}},
+		// Repeated protobuf values decode as nil after an empty array crosses the wire.
+		// The field-value entry itself preserves that the field was present.
+		{FieldIndex: 5},
 	}}
 
 	values, err := DecodeSearchValues(fields, row)
@@ -33,6 +37,7 @@ func TestDecodeSearchValues(t *testing.T) {
 		"ratio":   0.5,
 		"flags":   []bool{true, false},
 		"created": int64(1234),
+		"empty":   []string{},
 	}, values)
 }
 

--- a/pkg/tests/apis/dashboard/searchapi_test.go
+++ b/pkg/tests/apis/dashboard/searchapi_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	searchV0 "github.com/grafana/grafana/pkg/apis/search/v0alpha1"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
@@ -43,6 +44,7 @@ func TestIntegrationSearchAPI(t *testing.T) {
 		DisableAnonymous:     true,
 		APIServerStorageType: "unified",
 		EnableSearchAPI:      true,
+		EnableFeatureToggles: []string{featuremgmt.FlagSearchApiFieldValueResults},
 		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 			"dashboards.dashboard.grafana.app": {DualWriterMode: rest.Mode5},
 			"folders.folder.grafana.app":       {DualWriterMode: rest.Mode5},


### PR DESCRIPTION
Adds opt-in field-value results to the generic per-resource search API.

Embedded Grafana uses `search.apiFieldValueResults` for tenant-aware rollout. Responses are decoded using their actual format, preserving compatibility with older search servers. Standalone servers remain on resource tables until separately enabled through process configuration.

Also preserves empty arrays as `[]` instead of `null`.

The separation check is a false positive: the change under `pkg/storage/unified` updates the shared client decoder and does not change storage or search server behavior. The API continues to decode the response’s actual format, including resource tables returned by older servers.

Part of https://github.com/grafana/search-and-storage-team/issues/890