### PR TITLE
Devenv: Update opentsdb dashboards to v2

### DIFF
--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
@@ -1,216 +1,326 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "tFU1mQyWz",
+    "namespace": "stacks-81061",
+    "uid": "a15774e3-d9f8-4331-bb1e-75d65efea2e3",
+    "resourceVersion": "2095466927691751424",
+    "generation": 1,
+    "creationTimestamp": "2026-09-03T11:00:22Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "1293100798730240"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "access-policy:cd3a01aa-99d3-4e0f-b7a4-7545c1aa9458",
+      "grafana.app/managedBy": "repo",
+      "grafana.app/managerId": "gitsync-github-repository",
+      "grafana.app/sourceChecksum": "e4f1add04dc10a09f5f498b3f9fecf22616abb24",
+      "grafana.app/sourcePath": "dev-dashboards/datasource-opentsdb--opentsdb.json"
+    }
   },
-  "editable": true,
-  "gnetId": null,
-  "graphTooltip": 0,
-  "id": null,
-  "links": [],
-  "panels": [
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "gdev-opentsdb",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregator": "sum",
-          "downsampleAggregator": "avg",
-          "downsampleFillPolicy": "none",
-          "metric": "cpu",
-          "refId": "A"
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "",
+            "version": "v0",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
         }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "CPU",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "CPU",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-opentsdb"
+                      },
+                      "spec": {
+                        "aggregator": "sum",
+                        "downsampleAggregator": "avg",
+                        "downsampleFillPolicy": "none",
+                        "metric": "cpu"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "",
+            "spec": {
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "graph",
+                  "originalOptions": {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "tooltip": {
+                      "shared": true,
+                      "sort": 0,
+                      "value_type": "individual"
+                    },
+                    "xaxis": {
+                      "mode": "time",
+                      "show": true,
+                      "values": []
+                    },
+                    "yaxes": [
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      },
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      }
+                    ],
+                    "yaxis": {
+                      "align": false
+                    }
+                  }
+                },
+                "dataLinks": []
+              },
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
         }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Login Count",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-opentsdb"
+                      },
+                      "spec": {
+                        "aggregator": "sum",
+                        "downsampleAggregator": "avg",
+                        "downsampleFillPolicy": "none",
+                        "metric": "logins.count"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "",
+            "spec": {
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "graph",
+                  "originalOptions": {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "tooltip": {
+                      "shared": true,
+                      "sort": 0,
+                      "value_type": "individual"
+                    },
+                    "xaxis": {
+                      "mode": "time",
+                      "show": true,
+                      "values": []
+                    },
+                    "yaxes": [
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      },
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      }
+                    ],
+                    "yaxis": {
+                      "align": false
+                    }
+                  }
+                },
+                "dataLinks": []
+              },
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
+        }
       }
     },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "gdev-opentsdb",
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 3,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregator": "sum",
-          "downsampleAggregator": "avg",
-          "downsampleFillPolicy": "none",
-          "metric": "logins.count",
-          "refId": "A"
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 9,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 9,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": ["datasource-test", "gdev", "opentsdb"],
+    "timeSettings": {
+      "from": "now-1h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Datasource tests - OpenTSDB",
+    "variables": [],
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
         }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Login Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
       }
     }
-  ],
-  "schemaVersion": 22,
-  "tags": ["datasource-test", "gdev", "opentsdb"],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
-  },
-  "timezone": "",
-  "title": "Datasource tests - OpenTSDB",
-  "uid": "tFU1mQyWz",
-  "version": 2
+  }
 }

--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
@@ -2,22 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
-    "name": "tFU1mQyWz",
-    "namespace": "stacks-81061",
-    "uid": "a15774e3-d9f8-4331-bb1e-75d65efea2e3",
-    "resourceVersion": "2095466927691751424",
-    "generation": 1,
-    "creationTimestamp": "2026-09-03T11:00:22Z",
-    "labels": {
-      "grafana.app/deprecatedInternalID": "1293100798730240"
-    },
-    "annotations": {
-      "grafana.app/createdBy": "access-policy:cd3a01aa-99d3-4e0f-b7a4-7545c1aa9458",
-      "grafana.app/managedBy": "repo",
-      "grafana.app/managerId": "gitsync-github-repository",
-      "grafana.app/sourceChecksum": "e4f1add04dc10a09f5f498b3f9fecf22616abb24",
-      "grafana.app/sourcePath": "dev-dashboards/datasource-opentsdb--opentsdb.json"
-    }
+    "name": "tFU1mQyWz"
   },
   "spec": {
     "annotations": [

--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb.json
@@ -44,7 +44,7 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "grafana",
+                      "group": "opentsdb",
                       "version": "v0",
                       "datasource": {
                         "name": "gdev-opentsdb"
@@ -155,7 +155,7 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "grafana",
+                      "group": "opentsdb",
                       "version": "v0",
                       "datasource": {
                         "name": "gdev-opentsdb"
@@ -288,12 +288,27 @@
     "links": [],
     "liveNow": false,
     "preload": false,
-    "tags": ["datasource-test", "gdev", "opentsdb"],
+    "tags": [
+      "datasource-test",
+      "gdev",
+      "opentsdb"
+    ],
     "timeSettings": {
       "from": "now-1h",
       "to": "now",
       "autoRefresh": "",
-      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
       "hideTimepicker": false,
       "fiscalYearStartMonth": 0
     },

--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
@@ -2,22 +2,7 @@
   "apiVersion": "dashboard.grafana.app/v2",
   "kind": "Dashboard",
   "metadata": {
-    "name": "rZRUGik7k",
-    "namespace": "stacks-81061",
-    "uid": "00f3b93c-4289-4453-99ed-f8707e0f9699",
-    "resourceVersion": "2095466928255500288",
-    "generation": 1,
-    "creationTimestamp": "2026-09-03T11:00:22Z",
-    "labels": {
-      "grafana.app/deprecatedInternalID": "1293101197189120"
-    },
-    "annotations": {
-      "grafana.app/createdBy": "access-policy:cd3a01aa-99d3-4e0f-b7a4-7545c1aa9458",
-      "grafana.app/managedBy": "repo",
-      "grafana.app/managerId": "gitsync-github-repository",
-      "grafana.app/sourceChecksum": "3f6a45b744e3232258bb1fbc2d982b0ac7c3c15f",
-      "grafana.app/sourcePath": "dev-dashboards/datasource-opentsdb--opentsdb_v23.json"
-    }
+    "name": "rZRUGik7k"
   },
   "spec": {
     "annotations": [

--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
@@ -1,234 +1,355 @@
 {
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "rZRUGik7k",
+    "namespace": "stacks-81061",
+    "uid": "00f3b93c-4289-4453-99ed-f8707e0f9699",
+    "resourceVersion": "2095466928255500288",
+    "generation": 1,
+    "creationTimestamp": "2026-09-03T11:00:22Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "1293101197189120"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "access-policy:cd3a01aa-99d3-4e0f-b7a4-7545c1aa9458",
+      "grafana.app/managedBy": "repo",
+      "grafana.app/managerId": "gitsync-github-repository",
+      "grafana.app/sourceChecksum": "3f6a45b744e3232258bb1fbc2d982b0ac7c3c15f",
+      "grafana.app/sourcePath": "dev-dashboards/datasource-opentsdb--opentsdb_v23.json"
+    }
   },
-  "editable": true,
-  "graphTooltip": 0,
-  "id": 3151,
-  "links": [],
-  "panels": [
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "gdev-opentsdb-v2.3",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.1.0-pre",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregator": "sum",
-          "alias": "$tag_hostname",
-          "currentFilterGroupBy": false,
-          "currentFilterKey": "",
-          "currentFilterType": "literal_or",
-          "currentFilterValue": "",
-          "disableDownsampling": false,
-          "downsampleAggregator": "avg",
-          "downsampleFillPolicy": "none",
-          "explicitTags": false,
-          "filters": [
-            {
-              "filter": "*",
-              "groupBy": true,
-              "tagk": "hostname",
-              "type": "wildcard"
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "",
+            "version": "v0",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "CPU per host",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-opentsdb-v2.3"
+                      },
+                      "spec": {
+                        "aggregator": "sum",
+                        "alias": "$tag_hostname",
+                        "currentFilterGroupBy": false,
+                        "currentFilterKey": "",
+                        "currentFilterType": "literal_or",
+                        "currentFilterValue": "",
+                        "disableDownsampling": false,
+                        "downsampleAggregator": "avg",
+                        "downsampleFillPolicy": "none",
+                        "explicitTags": false,
+                        "filters": [
+                          {
+                            "filter": "*",
+                            "groupBy": true,
+                            "tagk": "hostname",
+                            "type": "wildcard"
+                          }
+                        ],
+                        "metric": "cpu",
+                        "shouldComputeRate": false
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
             }
-          ],
-          "metric": "cpu",
-          "refId": "A",
-          "shouldComputeRate": false
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "8.1.0-pre",
+            "spec": {
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "graph",
+                  "originalOptions": {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "tooltip": {
+                      "shared": true,
+                      "sort": 0,
+                      "value_type": "individual"
+                    },
+                    "xaxis": {
+                      "mode": "time",
+                      "show": true,
+                      "values": []
+                    },
+                    "yaxes": [
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      },
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      }
+                    ],
+                    "yaxis": {
+                      "align": false
+                    }
+                  }
+                },
+                "alertThreshold": true
+              },
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
         }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "CPU per host",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
       },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Login Count per host",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "grafana",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-opentsdb-v2.3"
+                      },
+                      "spec": {
+                        "aggregator": "sum",
+                        "alias": "$tag_hostname",
+                        "currentFilterGroupBy": false,
+                        "currentFilterKey": "",
+                        "currentFilterType": "literal_or",
+                        "currentFilterValue": "",
+                        "downsampleAggregator": "avg",
+                        "downsampleFillPolicy": "none",
+                        "filters": [
+                          {
+                            "filter": "*",
+                            "groupBy": true,
+                            "tagk": "hostname",
+                            "type": "wildcard"
+                          }
+                        ],
+                        "metric": "logins.count"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "8.1.0-pre",
+            "spec": {
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "graph",
+                  "originalOptions": {
+                    "aliasColors": {},
+                    "bars": false,
+                    "dashLength": 10,
+                    "dashes": false,
+                    "fill": 1,
+                    "fillGradient": 0,
+                    "hiddenSeries": false,
+                    "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                    },
+                    "lines": true,
+                    "linewidth": 1,
+                    "nullPointMode": "null",
+                    "percentage": false,
+                    "pointradius": 2,
+                    "points": false,
+                    "renderer": "flot",
+                    "seriesOverrides": [],
+                    "spaceLength": 10,
+                    "stack": false,
+                    "steppedLine": false,
+                    "thresholds": [],
+                    "timeRegions": [],
+                    "tooltip": {
+                      "shared": true,
+                      "sort": 0,
+                      "value_type": "individual"
+                    },
+                    "xaxis": {
+                      "mode": "time",
+                      "show": true,
+                      "values": []
+                    },
+                    "yaxes": [
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      },
+                      {
+                        "format": "short",
+                        "logBase": 1,
+                        "show": true
+                      }
+                    ],
+                    "yaxis": {
+                      "align": false
+                    }
+                  }
+                },
+                "alertThreshold": true
+              },
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
         }
-      ],
-      "yaxis": {
-        "align": false
       }
     },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "gdev-opentsdb-v2.3",
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "hiddenSeries": false,
-      "id": 4,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "8.1.0-pre",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregator": "sum",
-          "alias": "$tag_hostname",
-          "currentFilterGroupBy": false,
-          "currentFilterKey": "",
-          "currentFilterType": "literal_or",
-          "currentFilterValue": "",
-          "downsampleAggregator": "avg",
-          "downsampleFillPolicy": "none",
-          "filters": [
-            {
-              "filter": "*",
-              "groupBy": true,
-              "tagk": "hostname",
-              "type": "wildcard"
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 9,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
             }
-          ],
-          "metric": "logins.count",
-          "refId": "A"
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 9,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "from": "now-1h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Datasource tests - OpenTSDB v2.3",
+    "variables": [],
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
         }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Login Count per host",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
       }
     }
-  ],
-  "schemaVersion": 32,
-  "tags": [],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "Datasource tests - OpenTSDB v2.3",
-  "uid": "rZRUGik7k",
-  "version": 3
+  }
 }

--- a/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
+++ b/devenv/dev-dashboards/datasource-opentsdb/opentsdb_v23.json
@@ -44,7 +44,7 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "grafana",
+                      "group": "opentsdb",
                       "version": "v0",
                       "datasource": {
                         "name": "gdev-opentsdb-v2.3"
@@ -171,7 +171,7 @@
                   "spec": {
                     "query": {
                       "kind": "DataQuery",
-                      "group": "grafana",
+                      "group": "opentsdb",
                       "version": "v0",
                       "datasource": {
                         "name": "gdev-opentsdb-v2.3"
@@ -322,7 +322,18 @@
       "from": "now-1h",
       "to": "now",
       "autoRefresh": "",
-      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
       "hideTimepicker": false,
       "fiscalYearStartMonth": 0
     },


### PR DESCRIPTION
Creating a process to get devenv dashboards into grafana's community instance discovered that two devenv dashboards were never migrated to v2. This updates them.

Verified by running devenv with `sources=opentsdb` and looking at the dashboards locally.

<img width="1434" height="459" alt="Screenshot 2026-09-10 at 9 32 24 AM" src="https://github.com/user-attachments/assets/ad5e9bc6-da91-4166-8b45-6c031203caa1" />

