### PR TITLE
StateTimeline: Add row display controls

### DIFF
--- a/packages/grafana-schema/src/raw/composable/statetimeline/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/statetimeline/panelcfg/x/types.gen.ts
@@ -20,6 +20,10 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   alignValue?: ui.TimelineValueAlignment;
   /**
+   * Sets a fixed timeline row height in pixels
+   */
+  fixedRowHeight?: number;
+  /**
    * Merge equal consecutive values
    */
   mergeValues?: boolean;
@@ -28,7 +32,11 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   perPage?: number;
   /**
-   * Controls the row height
+   * Controls how timeline rows are shown when they do not fit
+   */
+  rowDisplayMode?: ('pagination' | 'scroll' | 'auto');
+  /**
+   * Controls the fraction of each row filled by the state bar
    */
   rowHeight: number;
   /**
@@ -41,6 +49,7 @@ export const defaultOptions: Partial<Options> = {
   alignValue: 'left',
   mergeValues: true,
   perPage: 20,
+  rowDisplayMode: 'scroll',
   rowHeight: 0.9,
   showValue: ui.VisibilityMode.Auto,
 };

--- a/public/app/core/constants.ts
+++ b/public/app/core/constants.ts
@@ -1,6 +1,7 @@
 export const GRID_CELL_HEIGHT = 30;
 export const GRID_CELL_VMARGIN = 8;
 export const GRID_COLUMN_COUNT = 24;
+export const STATE_TIMELINE_AUTO_HEIGHT_EVENT = 'grafana-state-timeline-height';
 export const REPEAT_DIR_VERTICAL = 'v';
 export const REPEAT_DIR_HORIZONTAL = 'h';
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx
@@ -3,6 +3,7 @@ import { waitFor } from '@testing-library/react';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import { SceneGridLayout, SceneVariableSet, TestVariable, VizPanel } from '@grafana/scenes';
+import { STATE_TIMELINE_AUTO_HEIGHT_EVENT } from 'app/core/constants';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 
 import { DashboardEditActionEvent } from '../../sidebar/events';
@@ -263,6 +264,45 @@ describe('PanelRepeaterGridItem', () => {
     const { repeater } = buildPanelRepeaterScene({ variableQueryTime: 0 });
 
     expect(repeater.getClassName()).toBe('panel-repeater-grid-item');
+  });
+
+  it('Should resize a state timeline grid item from fixed-height events', () => {
+    const gridItem = new DashboardGridItem({
+      x: 0,
+      y: 1,
+      width: 12,
+      height: 10,
+      body: new VizPanel({ key: 'panel-7', pluginId: 'state-timeline' }),
+    });
+    const grid = new SceneGridLayout({ children: [gridItem] });
+    const scene = new DashboardScene({
+      body: new DefaultGridLayoutManager({ grid }),
+    });
+    const layoutForceRender = jest.fn();
+    grid.forceRender = layoutForceRender;
+
+    const deactivate = activateFullSceneTree(scene);
+
+    window.dispatchEvent(
+      new CustomEvent(STATE_TIMELINE_AUTO_HEIGHT_EVENT, {
+        detail: { id: 7, height: 180, panelHeight: 250 },
+      })
+    );
+
+    expect(gridItem.state.height).toBe(7);
+    expect(gridItem.state.itemHeight).toBe(7);
+    expect(layoutForceRender).toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new CustomEvent(STATE_TIMELINE_AUTO_HEIGHT_EVENT, {
+        detail: { id: 7, reset: true },
+      })
+    );
+
+    expect(gridItem.state.height).toBe(10);
+    expect(gridItem.state.itemHeight).toBe(10);
+
+    deactivate();
   });
 
   it('Should not className variable is not set', () => {

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -14,7 +14,12 @@ import {
   type VariableValueSingle,
   SceneGridRow,
 } from '@grafana/scenes';
-import { GRID_COLUMN_COUNT } from 'app/core/constants';
+import {
+  GRID_CELL_HEIGHT,
+  GRID_CELL_VMARGIN,
+  GRID_COLUMN_COUNT,
+  STATE_TIMELINE_AUTO_HEIGHT_EVENT,
+} from 'app/core/constants';
 import { type OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
 import { RepeatsUpdatedEvent, DashboardStateChangedEvent } from '../../sidebar/events';
@@ -39,6 +44,15 @@ export interface DashboardGridItemState extends SceneGridItemStateLike {
 
 export type RepeatDirection = 'v' | 'h';
 
+const MIN_PANEL_CHROME_HEIGHT = 45;
+const MAX_PANEL_CHROME_HEIGHT = 70;
+
+interface StateTimelineAutoHeightBase {
+  chrome: number;
+  initialHeight: number;
+  lastHeight: number;
+}
+
 export class DashboardGridItem
   extends SceneObjectBase<DashboardGridItemState>
   implements SceneGridItemLike, DashboardLayoutItem
@@ -52,6 +66,7 @@ export class DashboardGridItem
 
   private _prevRepeatValues?: VariableValueSingle[];
   private _gridSizeSub: Unsubscribable | undefined;
+  private _stateTimelineAutoHeightBase?: StateTimelineAutoHeightBase;
 
   public constructor(state: DashboardGridItemState) {
     super(state);
@@ -60,13 +75,103 @@ export class DashboardGridItem
   }
 
   private _activationHandler() {
+    const handleStateTimelineAutoHeight = (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+
+      const { id, height, panelHeight, reset } = event.detail ?? {};
+      const eventPanelId = String(id ?? '');
+      const panelKey = String(this.state.body?.state?.key ?? '');
+
+      if (!eventPanelId) {
+        return;
+      }
+
+      if (
+        panelKey !== eventPanelId &&
+        panelKey !== `panel-${eventPanelId}` &&
+        panelKey.replace('panel-', '') !== eventPanelId
+      ) {
+        return;
+      }
+
+      if (reset) {
+        this.resetStateTimelineAutoHeight();
+        return;
+      }
+
+      if (!Number.isFinite(Number(height))) {
+        return;
+      }
+
+      if (!this._stateTimelineAutoHeightBase) {
+        const currentHeight = this.state.height ?? 0;
+        const fallbackPanelHeight = currentHeight * GRID_CELL_HEIGHT;
+        const currentPanelHeight = Number(panelHeight) || fallbackPanelHeight;
+
+        this._stateTimelineAutoHeightBase = {
+          chrome: Math.max(
+            MIN_PANEL_CHROME_HEIGHT,
+            Math.min(MAX_PANEL_CHROME_HEIGHT, fallbackPanelHeight - currentPanelHeight)
+          ),
+          initialHeight: currentHeight,
+          lastHeight: currentHeight,
+        };
+      }
+
+      const previousHeight = this.state.height ?? this._stateTimelineAutoHeightBase.lastHeight;
+      const nextHeight = Math.max(
+        2,
+        Math.ceil(
+          (Number(height) + this._stateTimelineAutoHeightBase.chrome + GRID_CELL_VMARGIN) /
+            (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN)
+        )
+      );
+
+      if (nextHeight === previousHeight) {
+        return;
+      }
+
+      this.setStateTimelineGridHeight(nextHeight, previousHeight);
+
+      this._stateTimelineAutoHeightBase.lastHeight = nextHeight;
+    };
+
+    window.addEventListener(STATE_TIMELINE_AUTO_HEIGHT_EVENT, handleStateTimelineAutoHeight);
     this.handleVariableName();
 
     this._subs.add(this.subscribeToEvent(DashboardStateChangedEvent, () => this.handleEditChange()));
 
     return () => {
+      window.removeEventListener(STATE_TIMELINE_AUTO_HEIGHT_EVENT, handleStateTimelineAutoHeight);
       this._handleGridSizeUnsubscribe();
     };
+  }
+
+  private resetStateTimelineAutoHeight() {
+    if (!this._stateTimelineAutoHeightBase) {
+      return;
+    }
+
+    const previousHeight = this.state.height ?? this._stateTimelineAutoHeightBase.lastHeight;
+    const nextHeight = this._stateTimelineAutoHeightBase.initialHeight;
+
+    this._stateTimelineAutoHeightBase = undefined;
+
+    if (nextHeight !== previousHeight) {
+      this.setStateTimelineGridHeight(nextHeight, previousHeight);
+    }
+  }
+
+  private setStateTimelineGridHeight(nextHeight: number, previousHeight: number) {
+    this.setState({ height: nextHeight, itemHeight: nextHeight });
+
+    const layout = sceneGraph.getLayout(this);
+    if (layout instanceof SceneGridLayout) {
+      layout.adjustYPositions(this.state.y!, nextHeight - previousHeight);
+      layout.forceRender();
+    }
   }
 
   private _handleGridSizeSubscribe() {

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
+import { STATE_TIMELINE_AUTO_HEIGHT_EVENT } from 'app/core/constants';
 
 import { getPanelProps } from '../test-utils';
 
@@ -55,12 +56,16 @@ const validFrame = processFrames([
   }),
 ])[0];
 
-function renderStateTimelinePanel(options?: Partial<Options>, series: DataFrame[] = [validFrame]) {
+function renderStateTimelinePanel(
+  options?: Partial<Options>,
+  series: DataFrame[] = [validFrame],
+  container?: HTMLElement
+) {
   const props = getPanelProps<Options>(
     { ...baseOptions, ...options },
     { data: { state: LoadingState.Done, series, timeRange: getDefaultTimeRange() } }
   );
-  return render(<StateTimelinePanel {...props} />);
+  return render(<StateTimelinePanel {...props} />, { container });
 }
 
 describe('StateTimelinePanel', () => {
@@ -72,6 +77,10 @@ describe('StateTimelinePanel', () => {
 
   afterEach(() => {
     consoleSpy.mockRestore();
+  });
+
+  it('defaults row display to scroll', () => {
+    expect(defaultOptions.rowDisplayMode).toBe('scroll');
   });
 
   it('renders the chart when data is valid', () => {
@@ -95,6 +104,69 @@ describe('StateTimelinePanel', () => {
     renderStateTimelinePanel({ mergeValues: false });
 
     expect(screen.getByTestId(selectors.components.VizLayout.container)).toBeInTheDocument();
+  });
+
+  it('dispatches fixed-height updates when row layout is auto height', () => {
+    const host = document.createElement('section');
+    host.className = 'panel-container';
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    renderStateTimelinePanel({ rowDisplayMode: 'auto', fixedRowHeight: 22 }, [validFrame], host);
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: STATE_TIMELINE_AUTO_HEIGHT_EVENT,
+        detail: expect.objectContaining({ height: 56 }),
+      })
+    );
+    expect(host.style.height).toBe('');
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('does not dispatch fixed-height updates when row layout is scroll', () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    renderStateTimelinePanel({ rowDisplayMode: 'scroll', fixedRowHeight: 22 }, [validFrame]);
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: STATE_TIMELINE_AUTO_HEIGHT_EVENT,
+      })
+    );
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('does not dispatch fixed-height updates when row layout is page', () => {
+    const dispatchSpy = jest.spyOn(window, 'dispatchEvent');
+
+    renderStateTimelinePanel({ rowDisplayMode: 'pagination', fixedRowHeight: 22 }, [validFrame]);
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: STATE_TIMELINE_AUTO_HEIGHT_EVENT,
+      })
+    );
+
+    dispatchSpy.mockRestore();
+  });
+
+  it('renders pagination when row layout is page with fixed row height', () => {
+    const series = processFrames([
+      createDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1000, 2000, 3000], config: {} },
+          { name: 'state1', type: FieldType.string, values: ['ok', 'warn', 'ok'], config: {} },
+          { name: 'state2', type: FieldType.string, values: ['ok', 'warn', 'ok'], config: {} },
+        ],
+      }),
+    ]);
+
+    renderStateTimelinePanel({ rowDisplayMode: 'pagination', fixedRowHeight: 80, perPage: 1 }, series);
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('renders TooltipPlugin2 when tooltip mode is not None', () => {

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo, useState } from 'react';
+import cx from 'clsx';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DashboardCursorSync, type DataFrame, type PanelProps, useDataLinksContext } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
@@ -18,6 +19,7 @@ import {
   prepareTimelineLegendItems,
   TimelineMode,
 } from 'app/core/components/TimelineChart/utils';
+import { STATE_TIMELINE_AUTO_HEIGHT_EVENT } from 'app/core/constants';
 import { getFilterByGroupedLabels } from 'app/features/panel/filters/adhoc';
 
 import { AnnotationsPlugin } from '../timeseries/plugins/AnnotationsPlugin';
@@ -27,10 +29,14 @@ import { getTimezones } from '../timeseries/utils';
 
 import { StateTimelineTooltip } from './StateTimelineTooltip';
 import { usePagination } from './hooks';
-import { type Options } from './panelcfg.gen';
-import { containerStyles } from './styles';
+import { defaultOptions, type Options } from './panelcfg.gen';
+import { containerStyles, getFixedHeightContainerStyles } from './styles';
 
 interface TimelinePanelProps extends PanelProps<Options> {}
+
+// Fixed-row modes size the uPlot canvas plus the x-axis area.
+const TIMELINE_CHART_FIXED_HEIGHT_PADDING = 34;
+const PAGINATION_FOOTER_HEIGHT_FALLBACK = 40;
 
 export const StateTimelinePanel = ({
   data,
@@ -74,10 +80,59 @@ export const StateTimelinePanel = ({
     [data.series, options.mergeValues, timeRange, theme]
   );
 
+  const rowDisplayMode = options.rowDisplayMode ?? defaultOptions.rowDisplayMode ?? 'scroll';
+  const isPaginationEnabled = rowDisplayMode === 'pagination';
   const { paginatedFrames, paginationRev, paginationElement, paginationHeight } = usePagination(
     frames,
-    options.perPage
+    isPaginationEnabled ? options.perPage : undefined
   );
+  const fixedTimelineHeight = useMemo(() => {
+    if (!options.fixedRowHeight) {
+      return undefined;
+    }
+
+    const rowCount = Math.max(
+      1,
+      paginatedFrames?.reduce((count, frame) => count + Math.max(0, frame.fields.length - 1), 0) ?? 0
+    );
+
+    return rowCount * options.fixedRowHeight + TIMELINE_CHART_FIXED_HEIGHT_PADDING;
+  }, [options.fixedRowHeight, paginatedFrames]);
+  const chartHeight = useMemo(() => {
+    if (!fixedTimelineHeight) {
+      return height - paginationHeight;
+    }
+
+    if (rowDisplayMode !== 'pagination') {
+      return fixedTimelineHeight;
+    }
+
+    return Math.min(fixedTimelineHeight, height - (paginationHeight || PAGINATION_FOOTER_HEIGHT_FALLBACK));
+  }, [fixedTimelineHeight, height, paginationHeight, rowDisplayMode]);
+
+  useEffect(() => {
+    if (!fixedTimelineHeight || rowDisplayMode !== 'auto') {
+      return;
+    }
+
+    const updateHeight = () => {
+      window.dispatchEvent(
+        new CustomEvent(STATE_TIMELINE_AUTO_HEIGHT_EVENT, {
+          detail: { id: panelId, height: fixedTimelineHeight + paginationHeight, panelHeight: height },
+        })
+      );
+    };
+
+    updateHeight();
+    const animationFrame = requestAnimationFrame(updateHeight);
+    const timeout = setTimeout(updateHeight, 250);
+
+    return () => {
+      window.dispatchEvent(new CustomEvent(STATE_TIMELINE_AUTO_HEIGHT_EVENT, { detail: { id: panelId, reset: true } }));
+      cancelAnimationFrame(animationFrame);
+      clearTimeout(timeout);
+    };
+  }, [fixedTimelineHeight, height, paginationHeight, panelId, rowDisplayMode]);
 
   const legendItems = useMemo(
     () => prepareTimelineLegendItems(paginatedFrames, options.legend, theme),
@@ -85,6 +140,21 @@ export const StateTimelinePanel = ({
   );
 
   const timezones = useMemo(() => getTimezones(options.timezone, timeZone), [options.timezone, timeZone]);
+  const fixedHeightContainerStyles = useMemo(() => {
+    if (!fixedTimelineHeight) {
+      return undefined;
+    }
+
+    if (rowDisplayMode === 'scroll') {
+      return getFixedHeightContainerStyles(height, 'auto');
+    }
+
+    if (rowDisplayMode === 'auto') {
+      return getFixedHeightContainerStyles(fixedTimelineHeight, 'hidden');
+    }
+
+    return undefined;
+  }, [fixedTimelineHeight, height, rowDisplayMode]);
 
   if (!paginatedFrames || typeof warn === 'string') {
     return <PanelDataErrorView panelId={panelId} fieldConfig={fieldConfig} data={data} message={warn} needsTimeField />;
@@ -93,7 +163,7 @@ export const StateTimelinePanel = ({
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
 
   return (
-    <div className={containerStyles}>
+    <div className={cx(containerStyles, fixedHeightContainerStyles)}>
       <TimelineChart
         theme={theme}
         frames={paginatedFrames}
@@ -102,7 +172,7 @@ export const StateTimelinePanel = ({
         timeRange={timeRange}
         timeZone={timezones}
         width={width}
-        height={height - paginationHeight}
+        height={chartHeight}
         legendItems={legendItems}
         annotations={options.annotations}
         {...options}

--- a/public/app/plugins/panel/state-timeline/module.tsx
+++ b/public/app/plugins/panel/state-timeline/module.tsx
@@ -133,9 +133,34 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(StateTimelinePanel)
         },
         defaultValue: defaultOptions.alignValue,
       })
+      .addRadio({
+        path: 'rowDisplayMode',
+        name: t('state-timeline.name-row-display-mode', 'Row display'),
+        category,
+        settings: {
+          options: [
+            { value: 'scroll', label: t('state-timeline.row-display-mode-options.label-scroll', 'Scroll') },
+            { value: 'pagination', label: t('state-timeline.row-display-mode-options.label-pagination', 'Page') },
+            { value: 'auto', label: t('state-timeline.row-display-mode-options.label-auto', 'Auto height') },
+          ],
+        },
+        defaultValue: defaultOptions.rowDisplayMode,
+      })
+      .addSliderInput({
+        path: 'fixedRowHeight',
+        name: t('state-timeline.name-fixed-row-height', 'Row height'),
+        category,
+        settings: {
+          min: 8,
+          max: 80,
+          step: 1,
+          integer: true,
+        },
+        defaultValue: defaultOptions.fixedRowHeight,
+      })
       .addSliderInput({
         path: 'rowHeight',
-        name: t('state-timeline.name-row-height', 'Row height'),
+        name: t('state-timeline.name-row-fill', 'Row fill'),
         category,
         settings: {
           min: 0,
@@ -148,6 +173,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(StateTimelinePanel)
         path: 'perPage',
         name: t('state-timeline.name-page-size', 'Page size (enable pagination)'),
         category,
+        showIf: (options) => (options.rowDisplayMode ?? defaultOptions.rowDisplayMode) === 'pagination',
         settings: {
           min: 1,
           step: 1,

--- a/public/app/plugins/panel/state-timeline/panelcfg.cue
+++ b/public/app/plugins/panel/state-timeline/panelcfg.cue
@@ -32,8 +32,12 @@ composableKinds: PanelCfg: {
 
 					//Show timeline values on chart
 					showValue: ui.VisibilityMode & (*"auto" | _)
-					//Controls the row height
+					//Controls the fraction of each row filled by the state bar
 					rowHeight: float & <=1 | *0.9
+					//Controls how timeline rows are shown when they do not fit
+					rowDisplayMode?: "pagination" | *"scroll" | "auto" @cuetsy(kind="enum", memberNames="pagination|scroll|auto")
+					//Sets a fixed timeline row height in pixels
+					fixedRowHeight?: number & >=1
 					//Merge equal consecutive values
 					mergeValues?: bool | *true
 					//Controls value alignment on the timelines

--- a/public/app/plugins/panel/state-timeline/panelcfg.gen.ts
+++ b/public/app/plugins/panel/state-timeline/panelcfg.gen.ts
@@ -18,6 +18,10 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   alignValue?: ui.TimelineValueAlignment;
   /**
+   * Sets a fixed timeline row height in pixels
+   */
+  fixedRowHeight?: number;
+  /**
    * Merge equal consecutive values
    */
   mergeValues?: boolean;
@@ -26,7 +30,11 @@ export interface Options extends ui.OptionsWithLegend, ui.OptionsWithTooltip, ui
    */
   perPage?: number;
   /**
-   * Controls the row height
+   * Controls how timeline rows are shown when they do not fit
+   */
+  rowDisplayMode?: ('pagination' | 'scroll' | 'auto');
+  /**
+   * Controls the fraction of each row filled by the state bar
    */
   rowHeight: number;
   /**
@@ -39,6 +47,7 @@ export const defaultOptions: Partial<Options> = {
   alignValue: 'left',
   mergeValues: true,
   perPage: 20,
+  rowDisplayMode: 'scroll',
   rowHeight: 0.9,
   showValue: ui.VisibilityMode.Auto,
 };

--- a/public/app/plugins/panel/state-timeline/styles.ts
+++ b/public/app/plugins/panel/state-timeline/styles.ts
@@ -4,3 +4,11 @@ export const containerStyles = css({
   display: 'flex',
   flexDirection: 'column',
 });
+
+export function getFixedHeightContainerStyles(height: number, overflowY: 'auto' | 'hidden') {
+  return css({
+    height,
+    overflowX: 'hidden',
+    overflowY,
+  });
+}


### PR DESCRIPTION
# Add row display controls to State timeline

This PR adds row display controls to the State timeline panel so dashboards with many or few timeline rows can be configured more predictably.

## Why is this needed

State timeline currently scales rows to fit the panel height. This works for some data shapes, but causes poor readability in common cases:

- Many rows are compressed until labels and state bands are difficult to read.
<img width="2179" height="704" alt="img_1" src="https://github.com/user-attachments/assets/44bc1f55-dc0c-40d4-922c-e1d2a169c594" />

- Few rows can become visually stretched and waste panel space.
<img width="2176" height="696" alt="img" src="https://github.com/user-attachments/assets/0f1c9b05-d8f8-4529-a26a-2acde124ba19" />


- Users who want consistent row sizing need to manually tune panel height or pagination.

## Who is this feature for?

Dashboard authors and viewers who use State timeline panels with many series, sparse series, or dashboards where consistent row sizing and readable timelines are important.

## Related issues

This addresses existing State timeline feature requests:

- Fixes https://github.com/grafana/grafana/issues/94728
  - Requests vertical scrolling for State timeline when many series are present.
  - Notes that the previous `Row height` option controlled bar fill as a percentage, not the actual row height. This PR renames that option to `Row fill` to better describe its behavior.

- Helps with https://github.com/grafana/grafana/issues/96500
  - Requests row-height control for State timeline rows.
  - This PR adds panel-level fixed row height. Per-series row height overrides remain out of scope.

This also relates to older dashboard sizing discussions:

- Related to https://github.com/grafana/grafana/issues/10325
  - Requests panels that can grow based on content height.
  - This PR implements that behavior narrowly for State timeline through `Auto height`.

- Related to https://github.com/grafana/grafana/issues/1141
  - Discusses auto-adjusting panel height for different display sizes.
  - This PR does not add responsive dashboard-wide resizing, but gives State timeline a content-aware height mode.

- Related to https://github.com/grafana/grafana/issues/14334
  - Requests minimum panel height support.
  - This PR does not add a generic `minHeight` grid property, but fixed row height plus scroll mode improves usability when panel height is constrained.

## What changed

This adds or updates three panel options under State timeline settings:

- **Row display**
  - **Scroll**: keeps the panel height fixed and scrolls rows internally. This is the default for new State timeline panels.
  - **Page**: keeps existing pagination behavior, with optional fixed row height.
  - **Auto height**: grows the dashboard grid item to fit visible rows.

- **Row height**
  - New optional fixed row height in pixels.
  - Available for Scroll, Page, and Auto height modes.
  - Existing dashboards keep the previous fit-to-panel behavior unless this is set.

- **Row fill**
  - Renamed from the previous `Row height` option.
  - Controls the fraction of each row filled by the state bar, allowing visual gaps between rows.
  - Available for Scroll, Page, and Auto height modes.

## Implementation notes

- The State timeline panel computes a fixed chart height from visible row count and configured fixed row height.
- Page mode caps the chart height so the pagination footer remains visible when fixed row height is set.
- Auto height dispatches a small browser event consumed by dashboard grid items.
- Dashboard grid items convert the requested pixel height into Grafana grid rows using the existing grid cell height and vertical margin constants.
- Leaving Auto height resets the grid item back to its original height.

## Screenshots

### Options

New Display mode options, including fixed `Row height` and renamed `Row fill`.

State timeline options with Scroll row display selected
<img width="318" height="515" alt="img_3" src="https://github.com/user-attachments/assets/dff914d2-9740-4437-87e9-ec2c9501627d" />


### Panel behavior

**Scroll mode** keeps many rows readable inside a fixed panel by making the panel content scrollable.

Many State timeline rows displayed with internal scrolling
<img width="2178" height="587" alt="img_2" src="https://github.com/user-attachments/assets/6330ccd7-def8-4469-b122-2604d7e03a09" />


**Page mode** remains compatible with fixed row height and keeps pagination visible.

State timeline Page mode with fixed row height and pagination
<img width="2167" height="378" alt="img_1" src="https://github.com/user-attachments/assets/f125d92f-d028-4555-8403-0d438c7445d5" />


**Auto height** shrinks the panel when only a few rows are visible, avoiding empty space below the timeline.

Auto height with a few State timeline rows
<img width="2168" height="1056" alt="img" src="https://github.com/user-attachments/assets/a1ed5702-fda7-4b69-98a4-245c1dd13bc0" />


Auto height grows the panel so all rows are visible, shifting panels below it.

Auto height with many State timeline rows
<img width="2186" height="1224" alt="img9" src="https://github.com/user-attachments/assets/8d755b8a-b435-420c-a955-2b60d6707ccd" />


## Tests

- Added State timeline panel tests for:
  - Auto height dispatching resize updates.
  - Scroll mode using internal scrolling without resizing the dashboard grid.
  - Page mode supporting fixed row height without resizing the dashboard grid.
  - Page mode keeping pagination visible when fixed row height is set.

- Added dashboard grid item test for:
  - Converting State timeline fixed height updates into grid row height changes.
  - Resetting to the original grid height when Auto height is disabled.

## Verification

- `make gen-cue`
- `git diff --check`
- `yarn eslint public/app/core/constants.ts public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx public/app/plugins/panel/state-timeline/module.tsx public/app/plugins/panel/state-timeline/styles.ts public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx`
- `yarn jest --no-watch public/app/plugins/panel/state-timeline/StateTimelinePanel.test.tsx public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.test.tsx`
