### PR TITLE
Dashboards: Support multi-selection bulk actions in the panel edit popover

### DIFF
--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActions.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/EditActions.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { useCallback, useEffect, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, type IconName } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, IconButton, Tooltip, useStyles2 } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
@@ -26,12 +26,20 @@ export function SettingsActionButton({ onClick }: { onClick: () => void }) {
 
 export const SHOW_COPIED_DURATION_MS = 2000;
 
-export function CopyActionButton({ onClick, isRepeated }: { onClick: () => void; isRepeated?: boolean }) {
+export function CopyActionButton({
+  onClick,
+  disabled,
+  disabledTooltip,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  disabledTooltip?: string;
+}) {
   const styles = useStyles2(getActionStyles);
   const [copied, setCopied] = useState(false);
-  const tooltip = isRepeated
-    ? t('dashboard-scene.control-edit-actions.copied-tooltip-disabled', "Repeated panels can't be copied individually")
-    : t('dashboard-scene.control-edit-actions.copy-clipboard-tooltip', 'Copy to clipboard');
+  const tooltip =
+    (disabled && disabledTooltip) ||
+    t('dashboard-scene.control-edit-actions.copy-clipboard-tooltip', 'Copy to clipboard');
 
   useEffect(() => {
     if (!copied) {
@@ -57,21 +65,25 @@ export function CopyActionButton({ onClick, isRepeated }: { onClick: () => void;
           onClick();
           setCopied(true);
         }}
-        disabled={isRepeated}
+        disabled={disabled}
       />
     </Tooltip>
   );
 }
 
-export function DuplicateActionButton({ onClick, isRepeated }: { onClick: () => void; isRepeated?: boolean }) {
+export function DuplicateActionButton({
+  onClick,
+  disabled,
+  disabledTooltip,
+}: {
+  onClick: () => void;
+  disabled?: boolean;
+  disabledTooltip?: string;
+}) {
   const styles = useStyles2(getActionStyles);
 
-  const tooltip = isRepeated
-    ? t(
-        'dashboard-scene.control-edit-actions.duplicate-tooltip-disabled',
-        "Repeated panels can't be duplicated individually"
-      )
-    : t('dashboard-scene.control-edit-actions.duplicate-tooltip', 'Duplicate');
+  const tooltip =
+    (disabled && disabledTooltip) || t('dashboard-scene.control-edit-actions.duplicate-tooltip', 'Duplicate');
 
   return (
     <IconButton
@@ -82,7 +94,7 @@ export function DuplicateActionButton({ onClick, isRepeated }: { onClick: () => 
       onClick={onClick}
       tooltip={tooltip}
       tooltipPlacement="top"
-      disabled={isRepeated}
+      disabled={disabled}
     />
   );
 }
@@ -92,13 +104,15 @@ export function DeleteActionButton({
   text,
   yesText,
   onConfirm,
-  isRepeated,
+  disabled,
+  disabledTooltip,
 }: {
   title: string;
   text: string;
   yesText: string;
   onConfirm: () => void;
-  isRepeated?: boolean;
+  disabled?: boolean;
+  disabledTooltip?: string;
 }) {
   const styles = useStyles2(getActionStyles);
   const { closePopover } = useEditActionsPopover();
@@ -115,9 +129,7 @@ export function DeleteActionButton({
     );
   }, [closePopover, title, text, yesText, onConfirm]);
 
-  const tooltip = isRepeated
-    ? t('dashboard-scene.control-edit-actions.delete-tooltip-disabled', "Repeated panels can't be deleted individually")
-    : t('dashboard-scene.control-edit-actions.delete-tooltip', 'Delete');
+  const tooltip = (disabled && disabledTooltip) || t('dashboard-scene.control-edit-actions.delete-tooltip', 'Delete');
 
   return (
     <IconButton
@@ -128,7 +140,37 @@ export function DeleteActionButton({
       onClick={onClickInternal}
       tooltip={tooltip}
       tooltipPlacement="top"
-      disabled={isRepeated}
+      disabled={disabled}
+    />
+  );
+}
+
+export function GroupActionButton({
+  icon,
+  label,
+  tooltip,
+  disabled,
+  onClick,
+}: {
+  icon: IconName;
+  label: string;
+  tooltip?: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  const styles = useStyles2(getActionStyles);
+
+  return (
+    <IconButton
+      name={icon}
+      variant="secondary"
+      size="md"
+      className={styles.action}
+      aria-label={label}
+      tooltip={tooltip ?? label}
+      tooltipPlacement="top"
+      disabled={disabled}
+      onClick={onClick}
     />
   );
 }

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.test.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.test.tsx
@@ -1,26 +1,30 @@
 import { act, fireEvent, render, screen, userEvent } from 'test/test-utils';
 
-import { locationService } from '@grafana/runtime';
-import { VizPanel } from '@grafana/scenes';
-import { ElementSelectionContext } from '@grafana/ui';
+import { getPanelPlugin } from '@grafana/data/test';
+import { locationService, setPluginImportUtils } from '@grafana/runtime';
+import { SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { ElementSelectionContext, type ElementSelectionContextItem } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { getCloneKey } from '../../utils/clone';
 import { DashboardInteractions } from '../../utils/interactions';
-import { getPanelIdForVizPanel } from '../../utils/utils-panels';
+import { activateFullSceneTree } from '../../utils/test-utils';
 import { DashboardScene } from '../DashboardScene';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
+import { RowItem } from '../layout-rows/RowItem';
+import { RowsLayoutManager } from '../layout-rows/RowsLayoutManager';
 
 import { SHOW_COPIED_DURATION_MS } from './EditActions';
 import { EditActionsLayoutProvider } from './EditActionsLayoutContext';
 import { WAIT_FOR_MOUSE_REST_DURATION_MS } from './EditActionsPopover';
-import { PanelEditActions, PanelEditActionsWrapper } from './PanelEditActions';
+import { PanelEditActionsBulk, PanelEditActionsSingle, PanelEditActionsWrapper } from './PanelEditActions';
 
 jest.mock('app/core/app_events', () => ({
   appEvents: {
-    subscribe: jest.fn(),
+    // Activating the dashboard subscribes to app events, and deactivating it unsubscribes.
+    subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
     publish: jest.fn(),
   },
 }));
@@ -41,6 +45,11 @@ jest.mock('./EditActionsPopover', () => ({
 }));
 const mockUseHoverPopoverSupported = jest.fn((_defaultValue?: boolean) => true);
 
+setPluginImportUtils({
+  importPanelPlugin: () => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: () => undefined,
+});
+
 async function hoverAndRest(element: HTMLElement) {
   jest.useFakeTimers();
   try {
@@ -54,97 +63,240 @@ async function hoverAndRest(element: HTMLElement) {
   }
 }
 
-function renderPanelEditActions({ isRepeated = false }: { isRepeated?: boolean } = {}) {
-  const onClickEdit = jest.fn();
-  const onClickEditVisualization = jest.fn();
-  const onClickCopy = jest.fn();
-  const onClickDuplicate = jest.fn();
-  const onClickDelete = jest.fn();
-
-  const renderResult = render(
-    <PanelEditActions
-      onClickEdit={onClickEdit}
-      onClickEditVisualization={onClickEditVisualization}
-      onClickCopy={onClickCopy}
-      onClickDuplicate={onClickDuplicate}
-      onClickDelete={onClickDelete}
-      isRepeated={isRepeated}
-    />
-  );
-
-  return {
-    ...renderResult,
-    onClickEdit,
-    onClickEditVisualization,
-    onClickCopy,
-    onClickDuplicate,
-    onClickDelete,
-  };
+function buildPanel(index: number) {
+  return new VizPanel({ title: `Panel ${index}`, pluginId: 'timeseries', key: `panel-${index}` });
 }
 
-describe('<PanelEditActions />', () => {
+function buildTestScene({ panelCount = 1, isEditing = true }: { panelCount?: number; isEditing?: boolean } = {}) {
+  const panels = Array.from({ length: panelCount }, (_, index) => buildPanel(index + 1));
+  const layoutManager = DefaultGridLayoutManager.fromVizPanels(panels);
+  const scene = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    isEditing,
+    body: layoutManager,
+  });
+  return { scene, layoutManager, panels };
+}
+
+function buildTestSceneWithRepeatedPanels({
+  cloneCountPerRepeat = 1,
+  nonRepeatedPanelCount = 0,
+}: { cloneCountPerRepeat?: number; nonRepeatedPanelCount?: number } = {}) {
+  const sourcePanel = buildPanel(1);
+  const clonedPanels = Array.from(
+    { length: cloneCountPerRepeat },
+    (_, index) =>
+      new VizPanel({
+        title: 'Panel 1',
+        pluginId: 'timeseries',
+        key: getCloneKey('panel-1', index + 1),
+        repeatSourceKey: 'panel-1',
+      })
+  );
+  const nonRepeatedPanels = Array.from({ length: nonRepeatedPanelCount }, (_, index) => buildPanel(index + 2));
+  const layoutManager = DefaultGridLayoutManager.fromGridItems([
+    new DashboardGridItem({ body: sourcePanel, repeatedPanels: clonedPanels }),
+    ...nonRepeatedPanels.map((panel) => new DashboardGridItem({ body: panel })),
+  ]);
+  const scene = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    isEditing: true,
+    body: layoutManager,
+  });
+
+  return { scene, sourcePanel, clonedPanels, nonRepeatedPanels };
+}
+
+function buildTestSceneWithPanelsInTwoRows() {
+  const panels = [buildPanel(1), buildPanel(2)];
+  const rows = panels.map(
+    (panel, index) =>
+      new RowItem({
+        key: `row-${index + 1}`,
+        title: `Row ${index + 1}`,
+        layout: DefaultGridLayoutManager.fromVizPanels([panel]),
+      })
+  );
+  const scene = new DashboardScene({
+    $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+    isEditing: true,
+    body: new RowsLayoutManager({ rows }),
+  });
+
+  return { scene, rows, panels };
+}
+
+describe('<PanelEditActionsSingle />', () => {
+  function renderPanelEditActionsSingle({ panel }: { panel: VizPanel }) {
+    const renderResult = render(<PanelEditActionsSingle panel={panel} />);
+
+    const { user } = renderResult;
+
+    const elements = {
+      settings: () => renderResult.getByRole('button', { name: 'Settings' }),
+      editVisualization: () => renderResult.getByRole('button', { name: 'Edit visualization' }),
+      copy: () => renderResult.getByRole('button', { name: 'Copy to clipboard' }),
+      duplicate: () => renderResult.getByRole('button', { name: 'Duplicate' }),
+      delete: () => renderResult.getByRole('button', { name: 'Delete' }),
+      tooltip: () => renderResult.getByRole('tooltip'),
+      // A disabled control takes its accessible name from the tooltip explaining why it is disabled.
+      disabledCopy: () => renderResult.getByRole('button', { name: "Repeated panels can't be copied individually" }),
+      disabledDuplicate: () =>
+        renderResult.getByRole('button', { name: "Repeated panels can't be duplicated individually" }),
+      disabledDelete: () => renderResult.getByRole('button', { name: "Repeated panels can't be deleted individually" }),
+    };
+
+    return {
+      ...renderResult,
+      elements,
+      actions: {
+        clickSettings: () => user.click(elements.settings()),
+        clickEditVisualization: () => user.click(elements.editVisualization()),
+        clickCopy: () => user.click(elements.copy()),
+        clickDuplicate: () => user.click(elements.duplicate()),
+        clickDelete: () => user.click(elements.delete()),
+      },
+    };
+  }
+
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     jest.useRealTimers();
   });
 
   test('renders Settings, Edit visualization, Copy, Duplicate, and Delete controls', () => {
-    renderPanelEditActions();
+    const { panels } = buildTestScene();
 
-    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Edit visualization' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Copy to clipboard' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Duplicate' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    const { elements } = renderPanelEditActionsSingle({ panel: panels[0] });
+
+    expect(elements.settings()).toBeInTheDocument();
+    expect(elements.editVisualization()).toBeInTheDocument();
+    expect(elements.copy()).toBeInTheDocument();
+    expect(elements.duplicate()).toBeInTheDocument();
+    expect(elements.delete()).toBeInTheDocument();
   });
 
-  describe('when the user clicks on Settings', () => {
-    test('calls onClickEdit', () => {
-      const { onClickEdit } = renderPanelEditActions();
+  test('when the user clicks Settings, the panel is selected via the sidebar', async () => {
+    const { scene, panels } = buildTestScene();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    await actions.clickSettings();
 
-      expect(onClickEdit).toHaveBeenCalledTimes(1);
-    });
+    expect(scene.state.sidebar.getSelectedObject()).toBe(panels[0]);
   });
 
-  describe('when the user clicks on Edit visualization', () => {
-    test('calls onClickEditVisualization', () => {
-      const { onClickEditVisualization } = renderPanelEditActions();
+  test('when the user clicks Settings, the click is reported as coming from the edit popover', async () => {
+    const { panels } = buildTestScene();
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Edit visualization' }));
+    await actions.clickSettings();
 
-      expect(onClickEditVisualization).toHaveBeenCalledTimes(1);
-    });
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('settings', 1, 'edit_popover');
+  });
+
+  test('when the panel is a repeat clone and the user clicks Settings, the source panel is selected', async () => {
+    const { scene, sourcePanel, clonedPanels } = buildTestSceneWithRepeatedPanels();
+    const { actions } = renderPanelEditActionsSingle({ panel: clonedPanels[0] });
+
+    await actions.clickSettings();
+
+    expect(scene.state.sidebar.getSelectedObject()).toBe(sourcePanel);
+  });
+
+  test('when the user clicks Edit visualization, the panel editor is opened', async () => {
+    const { panels } = buildTestScene();
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
+
+    await actions.clickEditVisualization();
+
+    expect(mockLocationServicePartial).toHaveBeenCalledWith({ editPanel: 1 });
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('configure', 1, 'edit_popover');
+  });
+
+  test('when the user clicks Duplicate, the panel is duplicated via its layout manager', async () => {
+    const { layoutManager, panels } = buildTestScene();
+    const duplicatePanel = jest.spyOn(layoutManager, 'duplicatePanel').mockImplementation();
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
+
+    await actions.clickDuplicate();
+
+    expect(duplicatePanel).toHaveBeenCalledWith(panels[0]);
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('duplicate', 1, 'edit_popover');
+  });
+
+  test('when the user clicks Delete and confirms, the panel is removed via its layout manager', async () => {
+    const { layoutManager, panels } = buildTestScene();
+    const removePanel = jest.spyOn(layoutManager, 'removePanel').mockImplementation();
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
+
+    await actions.clickDelete();
+
+    const [event] = mockPublishAppEvent.mock.calls[0];
+    expect(event).toBeInstanceOf(ShowConfirmModalEvent);
+    expect(event.payload.title).toBe('Delete panel?');
+    expect(event.payload.text).toContain('Deleting this panel will also remove all queries');
+    expect(event.payload.yesText).toBe('Delete');
+    expect(removePanel).not.toHaveBeenCalled();
+
+    event.payload.onConfirm();
+
+    expect(removePanel).toHaveBeenCalledWith(panels[0]);
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('delete', 1, 'edit_popover');
+  });
+
+  test('when the user clicks Delete and confirms, the panel removal is reported as an edit action from the popover', async () => {
+    const { layoutManager, panels } = buildTestScene();
+    jest.spyOn(layoutManager, 'removePanel').mockImplementation();
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    jest.spyOn(DashboardInteractions, 'trackDeleteDashboardElement').mockImplementation();
+    const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
+
+    await actions.clickDelete();
+    const [event] = mockPublishAppEvent.mock.calls[0];
+    event.payload.onConfirm();
+
+    expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Panel', 'edit_popover');
   });
 
   describe('Copy to clipboard', () => {
     describe('when the user hovers over the control', () => {
       test('shows a Copy to clipboard tooltip', async () => {
-        const { user } = renderPanelEditActions();
+        const { panels } = buildTestScene();
+        const { user, elements } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-        await user.hover(screen.getByRole('button', { name: 'Copy to clipboard' }));
+        await user.hover(elements.copy());
 
-        expect(screen.getByRole('tooltip')).toHaveTextContent('Copy to clipboard');
+        expect(elements.tooltip()).toHaveTextContent('Copy to clipboard');
       });
     });
 
     describe('when the user clicks on the control', () => {
-      test('calls onClickCopy', () => {
-        const { onClickCopy } = renderPanelEditActions();
+      test('the panel is copied via the dashboard', async () => {
+        const { scene, panels } = buildTestScene();
+        const copyPanel = jest.spyOn(scene, 'copyPanel').mockImplementation();
+        jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+        const { actions } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+        await actions.clickCopy();
 
-        expect(onClickCopy).toHaveBeenCalledTimes(1);
+        expect(copyPanel).toHaveBeenCalledWith(panels[0]);
+        expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('copy', 1, 'edit_popover');
       });
 
       test('shows a Copied tooltip that disappears after 2 seconds', () => {
         jest.useFakeTimers();
-        renderPanelEditActions();
+        const { panels } = buildTestScene();
+        jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+        const { elements } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+        fireEvent.click(elements.copy());
 
-        expect(screen.getByRole('tooltip')).toHaveTextContent('Copied');
+        expect(elements.tooltip()).toHaveTextContent('Copied');
 
         act(() => {
           jest.advanceTimersByTime(SHOW_COPIED_DURATION_MS);
@@ -155,210 +307,281 @@ describe('<PanelEditActions />', () => {
 
       test('if the Copied tooltip has disappeared, then hovering again over the control shows a Copy to clipboard tooltip', async () => {
         jest.useFakeTimers();
-        const { user } = renderPanelEditActions();
+        const { panels } = buildTestScene();
+        jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+        const { user, elements } = renderPanelEditActionsSingle({ panel: panels[0] });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
+        fireEvent.click(elements.copy());
 
         act(() => {
           jest.advanceTimersByTime(SHOW_COPIED_DURATION_MS);
         });
         jest.useRealTimers();
 
-        await user.hover(screen.getByRole('button', { name: 'Copy to clipboard' }));
+        await user.hover(elements.copy());
 
-        expect(screen.getByRole('tooltip')).toHaveTextContent('Copy to clipboard');
+        expect(elements.tooltip()).toHaveTextContent('Copy to clipboard');
       });
     });
   });
 
-  describe('when the user clicks on Duplicate', () => {
-    test('calls onClickDuplicate', () => {
-      const { onClickDuplicate } = renderPanelEditActions();
+  test('when the panel is a repeat clone, Copy, Duplicate and Delete are disabled and Settings and Edit visualization stay enabled', () => {
+    const { clonedPanels } = buildTestSceneWithRepeatedPanels();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    const { elements } = renderPanelEditActionsSingle({ panel: clonedPanels[0] });
 
-      expect(onClickDuplicate).toHaveBeenCalledTimes(1);
-    });
+    expect(elements.settings()).toBeEnabled();
+    expect(elements.editVisualization()).toBeEnabled();
+    expect(elements.disabledCopy()).toBeDisabled();
+    expect(elements.disabledDuplicate()).toBeDisabled();
+    expect(elements.disabledDelete()).toBeDisabled();
+  });
+});
+
+describe('<PanelEditActionsBulk />', () => {
+  let deactivate: (() => void) | undefined;
+
+  function renderPanelEditActionsBulk({
+    panel,
+    selected,
+  }: {
+    panel: VizPanel;
+    selected: ElementSelectionContextItem[];
+  }) {
+    const renderResult = render(
+      <ElementSelectionContext.Provider value={{ enabled: true, selected, onSelect: jest.fn(), onClear: jest.fn() }}>
+        <PanelEditActionsBulk panel={panel} />
+      </ElementSelectionContext.Provider>
+    );
+
+    const { user } = renderResult;
+
+    const elements = {
+      groupIntoRow: () => renderResult.getByRole('button', { name: 'Group into row' }),
+      groupIntoTab: () => renderResult.getByRole('button', { name: 'Group into tab' }),
+      delete: () => renderResult.getByRole('button', { name: 'Delete' }),
+      // Both group controls take their accessible name from the tooltip explaining why they are
+      // disabled, and that reason is the same for either target.
+      groupControlsDisabledFor: (reason: string) => renderResult.getAllByRole('button', { name: reason }),
+    };
+
+    return {
+      ...renderResult,
+      elements,
+      actions: {
+        clickGroupIntoRow: () => user.click(elements.groupIntoRow()),
+        clickGroupIntoTab: () => user.click(elements.groupIntoTab()),
+        clickDelete: () => user.click(elements.delete()),
+      },
+    };
+  }
+
+  afterEach(() => {
+    deactivate?.();
+    deactivate = undefined;
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
-  describe('when the user clicks on the delete action', () => {
-    test('publishes a ShowConfirmModalEvent', () => {
-      const { onClickDelete } = renderPanelEditActions();
+  test('when two panels are selected, the label reads 2 panels selected', () => {
+    const { panels } = buildTestScene({ panelCount: 2 });
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
 
-      fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    renderPanelEditActionsBulk({ panel: panels[0], selected });
 
-      expect(mockPublishAppEvent).toHaveBeenCalledTimes(1);
-
-      const [arg] = mockPublishAppEvent.mock.calls[0];
-      expect(arg).toBeInstanceOf(ShowConfirmModalEvent);
-      expect(arg).toEqual(
-        expect.objectContaining({
-          payload: {
-            title: 'Delete panel?',
-            text: expect.stringContaining('Deleting this panel will also remove all queries'),
-            yesText: 'Delete',
-            onConfirm: onClickDelete,
-          },
-        })
-      );
-    });
+    expect(screen.getByText('2 panels selected')).toBeInTheDocument();
   });
 
-  describe('when isRepeated is true', () => {
-    test('disables Copy, Duplicate, and Delete controls ; keeps Settings and Edit visualization enabled', () => {
-      renderPanelEditActions({ isRepeated: true });
-
-      expect(screen.getByRole('button', { name: 'Settings' })).toBeEnabled();
-      expect(screen.getByRole('button', { name: 'Edit visualization' })).toBeEnabled();
-      expect(screen.getByRole('button', { name: "Repeated panels can't be copied individually" })).toBeDisabled();
-      expect(screen.getByRole('button', { name: "Repeated panels can't be duplicated individually" })).toBeDisabled();
-      expect(screen.getByRole('button', { name: "Repeated panels can't be deleted individually" })).toBeDisabled();
+  test('when a selected panel is repeated, its rendered clones are counted too', () => {
+    const { sourcePanel, nonRepeatedPanels } = buildTestSceneWithRepeatedPanels({
+      cloneCountPerRepeat: 1,
+      nonRepeatedPanelCount: 1,
     });
+    const selected = [{ id: sourcePanel.state.key! }, { id: nonRepeatedPanels[0].state.key! }];
+
+    renderPanelEditActionsBulk({ panel: sourcePanel, selected });
+
+    expect(screen.getByText('3 panels selected')).toBeInTheDocument();
+  });
+
+  test('when the selection also holds a row, only the selected panels are counted', () => {
+    const { rows, panels } = buildTestSceneWithPanelsInTwoRows();
+    const selected = [{ id: rows[0].state.key! }, { id: 'panel-1' }, { id: 'panel-2' }];
+
+    renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    expect(screen.getByText('2 panels selected')).toBeInTheDocument();
+  });
+
+  test('when the user clicks Group into row, the selected panels are grouped into a new row', async () => {
+    const { scene, panels } = buildTestScene({ panelCount: 2 });
+    // Grouping goes through an edit action, which only the activated sidebar handles.
+    deactivate = activateFullSceneTree(scene);
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { actions } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    await actions.clickGroupIntoRow();
+
+    const body = scene.state.body;
+    if (!(body instanceof RowsLayoutManager)) {
+      throw new Error('expected rows layout');
+    }
+    expect(body.state.rows).toHaveLength(1);
+    // Comparing keys rather than the panels themselves: a failing toEqual on scene objects
+    // serializes a circular graph and takes the jest worker down with it.
+    expect(
+      body.state.rows[0]
+        .getLayout()
+        .getVizPanels()
+        .map((panel) => panel.state.key)
+    ).toEqual(['panel-1', 'panel-2']);
+  });
+
+  test('when the user clicks Group into row, the click is reported as coming from the edit popover', async () => {
+    const { scene, panels } = buildTestScene({ panelCount: 2 });
+    deactivate = activateFullSceneTree(scene);
+    jest.spyOn(DashboardInteractions, 'trackGroupRowClick').mockImplementation();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { actions } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    await actions.clickGroupIntoRow();
+
+    expect(DashboardInteractions.trackGroupRowClick).toHaveBeenCalledWith('edit_popover');
+  });
+
+  test('when the user clicks Group into tab, the click is reported as coming from the edit popover', async () => {
+    const { scene, panels } = buildTestScene({ panelCount: 2 });
+    deactivate = activateFullSceneTree(scene);
+    jest.spyOn(DashboardInteractions, 'trackGroupTabClick').mockImplementation();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { actions } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    await actions.clickGroupIntoTab();
+
+    expect(DashboardInteractions.trackGroupTabClick).toHaveBeenCalledWith('edit_popover');
+  });
+
+  test('when the selection spans two different rows, Group into row and Group into tab are disabled', () => {
+    const { panels } = buildTestSceneWithPanelsInTwoRows();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+
+    const { elements } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    const [groupIntoRow, groupIntoTab] = elements.groupControlsDisabledFor(
+      'Select items within the same row, tab, or grid to group them'
+    );
+    expect(groupIntoRow).toBeDisabled();
+    expect(groupIntoTab).toBeDisabled();
+  });
+
+  test('when the user clicks Delete and confirms, every selected panel is removed', async () => {
+    const { layoutManager, panels } = buildTestScene({ panelCount: 2 });
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { actions } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    await actions.clickDelete();
+
+    const [event] = mockPublishAppEvent.mock.calls[0];
+    expect(event).toBeInstanceOf(ShowConfirmModalEvent);
+    expect(event.payload.title).toBe('Multiple panels');
+    expect(layoutManager.getVizPanels().map((panel) => panel.state.key)).toEqual(['panel-1', 'panel-2']);
+
+    event.payload.onConfirm();
+
+    expect(layoutManager.getVizPanels().map((panel) => panel.state.key)).toEqual([]);
+  });
+
+  test('when the user clicks Delete and confirms, each removal is reported as coming from the edit popover', async () => {
+    const { panels } = buildTestScene({ panelCount: 2 });
+    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { actions } = renderPanelEditActionsBulk({ panel: panels[0], selected });
+
+    await actions.clickDelete();
+    const [event] = mockPublishAppEvent.mock.calls[0];
+    event.payload.onConfirm();
+
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('delete', 1, 'edit_popover');
+    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('delete', 2, 'edit_popover');
   });
 });
 
 describe('<PanelEditActionsWrapper />', () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  function renderPanelEditActionsWrapper(panel: VizPanel) {
-    return render(
-      <ElementSelectionContext.Provider
-        value={{ enabled: true, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
-      >
+  function renderPanelEditActionsWrapper({
+    panel,
+    selected = [],
+  }: {
+    panel: VizPanel;
+    selected?: ElementSelectionContextItem[];
+  }) {
+    const renderResult = render(
+      <ElementSelectionContext.Provider value={{ enabled: true, selected, onSelect: jest.fn(), onClear: jest.fn() }}>
         <PanelEditActionsWrapper panel={panel}>
           <div data-testid="reference-child">panel</div>
         </PanelEditActionsWrapper>
       </ElementSelectionContext.Provider>
     );
+
+    return {
+      ...renderResult,
+      elements: {
+        referenceChild: () => renderResult.getByTestId('reference-child'),
+        // One control unique to each content, to tell the two apart.
+        editVisualization: () => renderResult.queryByRole('button', { name: 'Edit visualization' }),
+        selectionLabel: (count: number) => renderResult.queryByText(`${count} panels selected`),
+      },
+    };
   }
 
-  describe('when the user clicks Settings ', () => {
-    test('the panel is selected via the sidebar', async () => {
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'test-panel' });
-      const scene = new DashboardScene({
-        isEditing: true,
-        body: DefaultGridLayoutManager.fromVizPanels([panel]),
-      });
-
-      renderPanelEditActionsWrapper(panel);
-
-      await hoverAndRest(screen.getByTestId('reference-child'));
-      fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
-
-      expect(scene.state.sidebar.getSelectedObject()).toBe(panel);
-    });
-
-    test('the source panel is always selected in case of repeated panels', async () => {
-      const sourcePanel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'test-panel' });
-      const clonedPanel = new VizPanel({
-        title: 'Test panel',
-        pluginId: 'timeseries',
-        key: getCloneKey('test-panel', 1),
-        repeatSourceKey: 'test-panel',
-      });
-      const scene = new DashboardScene({
-        isEditing: true,
-        body: DefaultGridLayoutManager.fromGridItems([
-          new DashboardGridItem({ body: sourcePanel, repeatedPanels: [clonedPanel] }),
-        ]),
-      });
-
-      renderPanelEditActionsWrapper(clonedPanel);
-
-      await hoverAndRest(screen.getByTestId('reference-child'));
-      fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
-
-      expect(scene.state.sidebar.getSelectedObject()).toBe(sourcePanel);
-    });
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
-  test('if the user clicks Edit visualization, the panel editor is opened', async () => {
-    const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
-    new DashboardScene({
-      isEditing: true,
-      body: DefaultGridLayoutManager.fromVizPanels([panel]),
-    });
-    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+  test('when two panels are selected and the pointer rests on one of them, the bulk actions are shown', async () => {
+    const { panels } = buildTestScene({ panelCount: 2 });
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { elements } = renderPanelEditActionsWrapper({ panel: panels[0], selected });
 
-    renderPanelEditActionsWrapper(panel);
+    await hoverAndRest(elements.referenceChild());
 
-    await hoverAndRest(screen.getByTestId('reference-child'));
-    fireEvent.click(screen.getByRole('button', { name: 'Edit visualization' }));
-
-    expect(mockLocationServicePartial).toHaveBeenCalledWith({ editPanel: getPanelIdForVizPanel(panel) });
-    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith(
-      'configure',
-      getPanelIdForVizPanel(panel),
-      'edit_popover'
-    );
+    expect(elements.selectionLabel(2)).toBeInTheDocument();
+    expect(elements.editVisualization()).not.toBeInTheDocument();
   });
 
-  test('if the user clicks Copy, the panel is copied via the dashboard', async () => {
-    const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
-    const scene = new DashboardScene({
-      isEditing: true,
-      body: DefaultGridLayoutManager.fromVizPanels([panel]),
-    });
+  test('when two panels are selected and the pointer rests on an unselected panel, the single panel actions are shown', async () => {
+    const { panels } = buildTestScene({ panelCount: 3 });
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { elements } = renderPanelEditActionsWrapper({ panel: panels[2], selected });
 
-    const copyPanel = jest.spyOn(scene, 'copyPanel').mockImplementation();
-    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    await hoverAndRest(elements.referenceChild());
 
-    renderPanelEditActionsWrapper(panel);
-
-    await hoverAndRest(screen.getByTestId('reference-child'));
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to clipboard' }));
-
-    expect(copyPanel).toHaveBeenCalledWith(panel);
-    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith(
-      'copy',
-      getPanelIdForVizPanel(panel),
-      'edit_popover'
-    );
+    expect(elements.editVisualization()).toBeInTheDocument();
+    expect(elements.selectionLabel(2)).not.toBeInTheDocument();
   });
 
-  test('if the user clicks Duplicate, the panel is duplicated via its layout manager', async () => {
-    const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
-    const layoutManager = DefaultGridLayoutManager.fromVizPanels([panel]);
-    new DashboardScene({
-      isEditing: true,
-      body: layoutManager,
+  test('when the pointer rests on a repeat clone whose source panel is selected, the bulk actions are shown', async () => {
+    const { clonedPanels } = buildTestSceneWithRepeatedPanels({
+      cloneCountPerRepeat: 1,
+      nonRepeatedPanelCount: 1,
     });
-    const duplicatePanel = jest.spyOn(layoutManager, 'duplicatePanel').mockImplementation();
-    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+    const { elements } = renderPanelEditActionsWrapper({ panel: clonedPanels[0], selected });
 
-    renderPanelEditActionsWrapper(panel);
+    await hoverAndRest(elements.referenceChild());
 
-    await hoverAndRest(screen.getByTestId('reference-child'));
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
-
-    expect(duplicatePanel).toHaveBeenCalledWith(panel);
-    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('duplicate', 1, 'edit_popover');
+    // The clone is selected through its source, which renders as two panels.
+    expect(elements.selectionLabel(3)).toBeInTheDocument();
   });
 
-  test('if the user clicks & confirms Delete, the panel is removed via its layout manager', async () => {
-    const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
-    const layoutManager = DefaultGridLayoutManager.fromVizPanels([panel]);
-    new DashboardScene({
-      isEditing: true,
-      body: layoutManager,
-    });
-    const removePanel = jest.spyOn(layoutManager, 'removePanel').mockImplementation();
-    jest.spyOn(DashboardInteractions, 'panelActionClicked').mockImplementation();
+  test('when a single panel is selected and the pointer rests on it, the single panel actions are shown', async () => {
+    const { panels } = buildTestScene();
+    const selected = [{ id: 'panel-1' }];
+    const { elements } = renderPanelEditActionsWrapper({ panel: panels[0], selected });
 
-    renderPanelEditActionsWrapper(panel);
+    await hoverAndRest(elements.referenceChild());
 
-    await hoverAndRest(screen.getByTestId('reference-child'));
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
-
-    expect(removePanel).not.toHaveBeenCalled();
-
-    const [event] = mockPublishAppEvent.mock.calls[0];
-    event.payload.onConfirm();
-
-    expect(removePanel).toHaveBeenCalledWith(panel);
-    expect(DashboardInteractions.panelActionClicked).toHaveBeenCalledWith('delete', 1, 'edit_popover');
+    expect(elements.editVisualization()).toBeInTheDocument();
   });
 
   describe('when a layout provider supplies a portal root', () => {
@@ -366,18 +589,14 @@ describe('<PanelEditActionsWrapper />', () => {
       const portalRoot = document.createElement('div');
       document.body.appendChild(portalRoot);
 
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
-      new DashboardScene({
-        isEditing: true,
-        body: DefaultGridLayoutManager.fromVizPanels([panel]),
-      });
+      const { panels } = buildTestScene();
 
       render(
         <EditActionsLayoutProvider containerRef={{ current: portalRoot }} isDocked={false} isHidden={false}>
           <ElementSelectionContext.Provider
             value={{ enabled: true, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
           >
-            <PanelEditActionsWrapper panel={panel}>
+            <PanelEditActionsWrapper panel={panels[0]}>
               <div data-testid="reference-child">panel</div>
             </PanelEditActionsWrapper>
           </ElementSelectionContext.Provider>
@@ -394,13 +613,13 @@ describe('<PanelEditActionsWrapper />', () => {
 
   describe('when the dashboard is not in edit mode', () => {
     test('resting the pointer does not show the edit actions', async () => {
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
+      const { panels } = buildTestScene({ isEditing: false });
 
       render(
         <ElementSelectionContext.Provider
           value={{ enabled: false, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
         >
-          <PanelEditActionsWrapper panel={panel}>
+          <PanelEditActionsWrapper panel={panels[0]}>
             <div data-testid="reference-child">panel</div>
           </PanelEditActionsWrapper>
         </ElementSelectionContext.Provider>
@@ -414,12 +633,12 @@ describe('<PanelEditActionsWrapper />', () => {
 
   describe('when edit mode is toggled off and on again', () => {
     test('the child is not remounted, so its transient state is preserved', async () => {
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
+      const { panels } = buildTestScene();
       const tree = (selectionEnabled: boolean) => (
         <ElementSelectionContext.Provider
           value={{ enabled: selectionEnabled, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
         >
-          <PanelEditActionsWrapper panel={panel}>
+          <PanelEditActionsWrapper panel={panels[0]}>
             <input data-testid="reference-child" />
           </PanelEditActionsWrapper>
         </ElementSelectionContext.Provider>
@@ -435,12 +654,12 @@ describe('<PanelEditActionsWrapper />', () => {
     });
 
     test('resting the pointer shows the edit actions again', async () => {
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
+      const { panels } = buildTestScene();
       const tree = (selectionEnabled: boolean) => (
         <ElementSelectionContext.Provider
           value={{ enabled: selectionEnabled, selected: [], onSelect: jest.fn(), onClear: jest.fn() }}
         >
-          <PanelEditActionsWrapper panel={panel}>
+          <PanelEditActionsWrapper panel={panels[0]}>
             <div data-testid="reference-child">panel</div>
           </PanelEditActionsWrapper>
         </ElementSelectionContext.Provider>
@@ -464,9 +683,9 @@ describe('<PanelEditActionsWrapper />', () => {
     });
 
     test('when hover popover is not supported and the pointer rests, the floating content is not shown', async () => {
-      const panel = new VizPanel({ title: 'Test panel', pluginId: 'timeseries', key: 'panel-1' });
+      const { panels } = buildTestScene();
 
-      renderPanelEditActionsWrapper(panel);
+      renderPanelEditActionsWrapper({ panel: panels[0] });
 
       await hoverAndRest(screen.getByTestId('reference-child'));
 

--- a/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.tsx
+++ b/public/app/features/dashboard-scene/scene/edit-actions-popover/PanelEditActions.tsx
@@ -1,15 +1,19 @@
 import { cx } from '@emotion/css';
-import { useCallback, useMemo, type JSX } from 'react';
+import { useMemo, type JSX } from 'react';
 
-import { t } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { type VizPanel } from '@grafana/scenes';
-import { Button, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, Text, useStyles2, useTheme2 } from '@grafana/ui';
 
-import { isRepeatCloneOrChildOf } from '../../utils/clone';
+import { getEditableElementFor } from '../../actions/utils/getEditableElementFor';
+import { getRenderedInstanceCount, isRepeatCloneOrChildOf } from '../../utils/clone';
 import { getLayoutManagerFor } from '../../utils/getLayoutManagerFor';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getPanelIdForVizPanel } from '../../utils/utils-panels';
+import { useGroupSelection } from '../layouts-shared/GroupSelectedActions';
+import { useSelectedPanelsFor, useSelectionCountFor } from '../layouts-shared/useIsMultiSelection';
+import { isBulkActionElement } from '../types/BulkActionElement';
 import { getDashboardSceneLike } from '../types/dashboard';
 
 import {
@@ -17,27 +21,74 @@ import {
   DeleteActionButton,
   DuplicateActionButton,
   getActionStyles,
+  GroupActionButton,
   SettingsActionButton,
 } from './EditActions';
 import { useEditActionsLayout } from './EditActionsLayoutContext';
 import { EditActionsPopover, useHoverPopoverSupported } from './EditActionsPopover';
 
-export function PanelEditActions({
-  onClickEdit,
-  onClickEditVisualization,
-  onClickCopy,
-  onClickDuplicate,
-  onClickDelete,
-  isRepeated,
-}: {
-  onClickEdit: () => void;
-  onClickEditVisualization: () => void;
-  onClickCopy: () => void;
-  onClickDuplicate: () => void;
-  onClickDelete: () => void;
-  isRepeated: boolean;
-}) {
+export function PanelEditActionsWrapper({ panel, children }: { panel: VizPanel; children: JSX.Element }) {
+  const theme = useTheme2();
+  // Repeat clones are selected through their source panel, so the selection never holds a clone key.
+  const selectionCount = useSelectionCountFor(panel.state.repeatSourceKey ?? panel.state.key);
+  const isPopoverSupported = useHoverPopoverSupported();
+  const { getPortalRoot, getSidebarShiftPadding } = useEditActionsLayout();
+
+  // Branching stays on the selected element count so a lone repeat keeps the single panel actions.
+  const editActions = useMemo(
+    () => (selectionCount > 1 ? <PanelEditActionsBulk panel={panel} /> : <PanelEditActionsSingle panel={panel} />),
+    [panel, selectionCount]
+  );
+
+  return (
+    <EditActionsPopover
+      content={editActions}
+      disabled={!isPopoverSupported}
+      placement="top-end"
+      portalRoot={getPortalRoot}
+      zIndex={theme.zIndex.dropdown}
+      shiftPadding={getSidebarShiftPadding}
+    >
+      {children}
+    </EditActionsPopover>
+  );
+}
+
+export function PanelEditActionsSingle({ panel }: { panel: VizPanel }) {
   const styles = useStyles2(getActionStyles);
+  const isRepeated = isRepeatCloneOrChildOf(panel);
+
+  const onClickEdit = () => {
+    DashboardInteractions.panelActionClicked('settings', getPanelIdForVizPanel(panel), 'edit_popover');
+    const { selectionContext } = getDashboardSceneLike(panel).state.sidebar.state;
+    selectionContext.onSelect({ id: panel.state.key! }, { force: true });
+  };
+
+  const onClickEditVisualization = () => {
+    const panelId = getPanelIdForVizPanel(panel);
+    DashboardInteractions.panelActionClicked('configure', panelId, 'edit_popover');
+    locationService.partial({ editPanel: panelId });
+  };
+
+  const onClickCopy = () => {
+    const panelId = getPanelIdForVizPanel(panel);
+    DashboardInteractions.panelActionClicked('copy', panelId, 'edit_popover');
+    getDashboardSceneLike(panel).copyPanel(panel);
+  };
+
+  const onClickDuplicate = () => {
+    const panelId = getPanelIdForVizPanel(panel);
+    DashboardInteractions.panelActionClicked('duplicate', panelId, 'edit_popover');
+    getLayoutManagerFor(panel).duplicatePanel?.(panel);
+  };
+
+  const onClickDelete = () => {
+    const panelId = getPanelIdForVizPanel(panel);
+    DashboardInteractions.panelActionClicked('delete', panelId, 'edit_popover');
+    // Same element type name the sidebar reports, so removals stay comparable across both surfaces.
+    DashboardInteractions.trackDeleteDashboardElement(t('dashboard.sidebar.elements.panel', 'Panel'), 'edit_popover');
+    getLayoutManagerFor(panel).removePanel?.(panel);
+  };
 
   return (
     <>
@@ -53,8 +104,22 @@ export function PanelEditActions({
         {t('dashboard-scene.panel-edit-actions.edit-visualization', 'Edit visualization')}
       </Button>
       <div className={styles.actionsDivider} />
-      <CopyActionButton onClick={onClickCopy} isRepeated={isRepeated} />
-      <DuplicateActionButton onClick={onClickDuplicate} isRepeated={isRepeated} />
+      <CopyActionButton
+        onClick={onClickCopy}
+        disabled={isRepeated}
+        disabledTooltip={t(
+          'dashboard-scene.control-edit-actions.copied-tooltip-disabled',
+          "Repeated panels can't be copied individually"
+        )}
+      />
+      <DuplicateActionButton
+        onClick={onClickDuplicate}
+        disabled={isRepeated}
+        disabledTooltip={t(
+          'dashboard-scene.control-edit-actions.duplicate-tooltip-disabled',
+          "Repeated panels can't be duplicated individually"
+        )}
+      />
       <DeleteActionButton
         title={t('dashboard.sidebar.viz-panel.delete-panel-title', 'Delete panel?')}
         text={t(
@@ -63,70 +128,71 @@ export function PanelEditActions({
         )}
         yesText={t('dashboard.sidebar.viz-panel.delete-panel-yes', 'Delete')}
         onConfirm={onClickDelete}
-        isRepeated={isRepeated}
+        disabled={isRepeated}
+        disabledTooltip={t(
+          'dashboard-scene.control-edit-actions.delete-tooltip-disabled',
+          "Repeated panels can't be deleted individually"
+        )}
       />
     </>
   );
 }
 
-export function PanelEditActionsWrapper({ panel, children }: { panel: VizPanel; children: JSX.Element }) {
-  const theme = useTheme2();
-  const isPopoverSupported = useHoverPopoverSupported();
-  const { getPortalRoot, getSidebarShiftPadding } = useEditActionsLayout();
+export function PanelEditActionsBulk({ panel }: { panel: VizPanel }) {
+  const styles = useStyles2(getActionStyles);
 
-  const onClickEdit = useCallback(() => {
-    const { selectionContext } = getDashboardSceneLike(panel).state.sidebar.state;
-    selectionContext.onSelect({ id: panel.state.key! }, { force: true });
-  }, [panel]);
+  const panels = useSelectedPanelsFor(panel);
+  const panelCount = panels.reduce((total, panel) => total + getRenderedInstanceCount(panel), 0);
+  const { rowGrouping, tabGrouping, group } = useGroupSelection(panels, 'edit_popover');
 
-  const onClickEditVisualization = useCallback(() => {
-    const panelId = getPanelIdForVizPanel(panel);
-    DashboardInteractions.panelActionClicked('configure', panelId, 'edit_popover');
-    locationService.partial({ editPanel: panelId });
-  }, [panel]);
-
-  const onClickCopy = useCallback(() => {
-    const panelId = getPanelIdForVizPanel(panel);
-    DashboardInteractions.panelActionClicked('copy', panelId, 'edit_popover');
-    getDashboardSceneLike(panel).copyPanel(panel);
-  }, [panel]);
-
-  const onClickDuplicate = useCallback(() => {
-    const panelId = getPanelIdForVizPanel(panel);
-    DashboardInteractions.panelActionClicked('duplicate', panelId, 'edit_popover');
-    getLayoutManagerFor(panel).duplicatePanel?.(panel);
-  }, [panel]);
-
-  const onClickDelete = useCallback(() => {
-    const panelId = getPanelIdForVizPanel(panel);
-    DashboardInteractions.panelActionClicked('delete', panelId, 'edit_popover');
-    getLayoutManagerFor(panel).removePanel?.(panel);
-  }, [panel]);
-
-  const editActions = useMemo(
-    () => (
-      <PanelEditActions
-        onClickEdit={onClickEdit}
-        onClickEditVisualization={onClickEditVisualization}
-        onClickCopy={onClickCopy}
-        onClickDuplicate={onClickDuplicate}
-        onClickDelete={onClickDelete}
-        isRepeated={isRepeatCloneOrChildOf(panel)}
-      />
-    ),
-    [onClickEdit, onClickEditVisualization, onClickCopy, onClickDuplicate, onClickDelete, panel]
-  );
+  const onClickDelete = () => {
+    panels.forEach((panel) => {
+      const element = getEditableElementFor(panel);
+      if (element && isBulkActionElement(element)) {
+        element.onDelete('edit_popover');
+      }
+    });
+  };
 
   return (
-    <EditActionsPopover
-      content={editActions}
-      disabled={!isPopoverSupported}
-      placement="top-end"
-      portalRoot={getPortalRoot}
-      zIndex={theme.zIndex.dropdown}
-      shiftPadding={getSidebarShiftPadding}
-    >
-      {children}
-    </EditActionsPopover>
+    <>
+      <Text element="p" variant="bodySmall" color="secondary">
+        <Trans
+          i18nKey="dashboard-scene.panel-edit-actions.panels-selected"
+          count={panelCount}
+          tOptions={{
+            defaultValue_one: '{{count}} panel selected',
+            defaultValue_other: '{{count}} panels selected',
+          }}
+        >
+          {'{{count}}'} panels selected
+        </Trans>
+      </Text>
+      <div className={styles.actionsDivider} />
+      <GroupActionButton
+        icon="list-ul"
+        label={t('dashboard.sidebar.group.into-row', 'Group into row')}
+        disabled={!rowGrouping.enabled}
+        tooltip={!rowGrouping.enabled ? rowGrouping.reason : undefined}
+        onClick={() => group('row')}
+      />
+      <GroupActionButton
+        icon="layers"
+        label={t('dashboard.sidebar.group.into-tab', 'Group into tab')}
+        disabled={!tabGrouping.enabled}
+        tooltip={!tabGrouping.enabled ? tabGrouping.reason : undefined}
+        onClick={() => group('tab')}
+      />
+      <div className={styles.actionsDivider} />
+      <DeleteActionButton
+        title={t('dashboard.sidebar.elements.multiple-panels', 'Multiple panels')}
+        text={t(
+          'dashboard.sidebar.elements.multiple-panels-delete-text',
+          'Are you sure you want to delete these panels? All queries will be removed.'
+        )}
+        yesText={t('dashboard.sidebar.viz-panel.delete-panel-yes', 'Delete')}
+        onConfirm={onClickDelete}
+      />
+    </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -63,7 +63,7 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
               testId={selectors.components.CanvasGridAddActions.addRow}
               onClick={() => {
                 addNewRowTo(layoutManager);
-                DashboardInteractions.trackGroupRowClick();
+                DashboardInteractions.trackGroupRowClick('canvas');
               }}
             ></Menu.Item>
             <Menu.Item
@@ -75,7 +75,7 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
               description={getDisableTabsMessage(disableTabsReason)}
               onClick={() => {
                 addNewTabTo(layoutManager);
-                DashboardInteractions.trackGroupTabClick();
+                DashboardInteractions.trackGroupTabClick('canvas');
               }}
             ></Menu.Item>
           </Menu>

--- a/public/app/features/dashboard-scene/scene/layouts-shared/GroupSelectedActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/GroupSelectedActions.tsx
@@ -9,6 +9,7 @@ import { AddButton } from '../../sidebar/add-new/AddButton';
 import { getLayoutManagerFor } from '../../utils/getLayoutManagerFor';
 import { DashboardInteractions } from '../../utils/interactions';
 import { type GroupTarget, type GroupingResult, isGroupableLayoutManager } from '../types/DashboardLayoutManager';
+import { type EditActionSource } from '../types/EditableDashboardElement';
 
 const DISABLED: GroupingResult = { enabled: false };
 
@@ -37,7 +38,7 @@ interface Props {
   items: SceneObject[];
 }
 
-export function GroupSelectedActions({ items }: Props) {
+export function useGroupSelection(items: SceneObject[], trackingSource: EditActionSource) {
   const manager = resolveGroupableManager(items);
   const rowGrouping = manager?.canGroupSelectionInto(items, 'row') ?? DISABLED;
   const tabGrouping = manager?.canGroupSelectionInto(items, 'tab') ?? DISABLED;
@@ -50,11 +51,18 @@ export function GroupSelectedActions({ items }: Props) {
     groupSelectionInto({ source: manager.getRoot(), items, target });
 
     if (target === 'row') {
-      DashboardInteractions.trackGroupRowClick();
+      DashboardInteractions.trackGroupRowClick(trackingSource);
     } else {
-      DashboardInteractions.trackGroupTabClick();
+      DashboardInteractions.trackGroupTabClick(trackingSource);
     }
   };
+
+  return { rowGrouping, tabGrouping, group };
+}
+
+export function GroupSelectedActions({ items }: Props) {
+  // This view is only rendered by the sidebar; the popover builds its own controls.
+  const { rowGrouping, tabGrouping, group } = useGroupSelection(items, 'edit_pane');
 
   return (
     <Stack direction="column" gap={1}>

--- a/public/app/features/dashboard-scene/scene/layouts-shared/useIsMultiSelection.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/useIsMultiSelection.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+
+import { VizPanel } from '@grafana/scenes';
+import { ElementSelectionContext, type ElementSelectionContextItem } from '@grafana/ui';
+
+import { DashboardScene } from '../DashboardScene';
+import { DefaultGridLayoutManager } from '../layout-default/DefaultGridLayoutManager';
+
+import { useIsMultiSelection, useSelectedObjectsFor, useSelectionCountFor } from './useIsMultiSelection';
+
+function buildTestScene() {
+  const panel1 = new VizPanel({ key: 'panel-1', title: 'Panel 1', pluginId: 'timeseries' });
+  const panel2 = new VizPanel({ key: 'panel-2', title: 'Panel 2', pluginId: 'timeseries' });
+  const scene = new DashboardScene({
+    isEditing: true,
+    body: DefaultGridLayoutManager.fromVizPanels([panel1, panel2]),
+  });
+
+  return { scene, panel1, panel2 };
+}
+
+function renderSelectionHook<T>(hook: () => T, selected: ElementSelectionContextItem[]) {
+  return renderHook(hook, {
+    wrapper: ({ children }: PropsWithChildren) => (
+      <ElementSelectionContext.Provider value={{ enabled: true, selected, onSelect: jest.fn(), onClear: jest.fn() }}>
+        {children}
+      </ElementSelectionContext.Provider>
+    ),
+  });
+}
+
+describe('useIsMultiSelection()', () => {
+  test('when more than one element is selected, true is returned', () => {
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+
+    const { result } = renderSelectionHook(() => useIsMultiSelection(), selected);
+
+    expect(result.current).toBe(true);
+  });
+
+  test('when a single element is selected, false is returned', () => {
+    const selected = [{ id: 'panel-1' }];
+
+    const { result } = renderSelectionHook(() => useIsMultiSelection(), selected);
+
+    expect(result.current).toBe(false);
+  });
+
+  test('when nothing is selected, false is returned', () => {
+    const selected: ElementSelectionContextItem[] = [];
+
+    const { result } = renderSelectionHook(() => useIsMultiSelection(), selected);
+
+    expect(result.current).toBe(false);
+  });
+
+  test('when there is no selection context, false is returned', () => {
+    const { result } = renderHook(() => useIsMultiSelection());
+
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useSelectionCountFor()', () => {
+  test('when the given element is part of the selection, the number of selected elements is returned', () => {
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+
+    const { result } = renderSelectionHook(() => useSelectionCountFor('panel-1'), selected);
+
+    expect(result.current).toBe(2);
+  });
+
+  test('when the given element is not part of the selection, 0 is returned', () => {
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+
+    const { result } = renderSelectionHook(() => useSelectionCountFor('panel-3'), selected);
+
+    expect(result.current).toBe(0);
+  });
+
+  test('when no element key is given, 0 is returned', () => {
+    const selected = [{ id: 'panel-1' }, { id: 'panel-2' }];
+
+    const { result } = renderSelectionHook(() => useSelectionCountFor(undefined), selected);
+
+    expect(result.current).toBe(0);
+  });
+});
+
+describe('useSelectedObjectsFor()', () => {
+  test('when several elements are selected, their scene objects are returned in selection order', () => {
+    const { panel1, panel2 } = buildTestScene();
+    const selected = [{ id: 'panel-2' }, { id: 'panel-1' }];
+
+    const { result } = renderSelectionHook(() => useSelectedObjectsFor(panel1), selected);
+
+    expect(result.current.map((obj) => obj.state.key)).toEqual(['panel-2', 'panel-1']);
+    expect(result.current[0]).toBe(panel2);
+    expect(result.current[1]).toBe(panel1);
+  });
+
+  test('when a selected element cannot be found in the scene, it is left out', () => {
+    const { panel1 } = buildTestScene();
+    const selected = [{ id: 'panel-1' }, { id: 'removed-panel' }];
+
+    const { result } = renderSelectionHook(() => useSelectedObjectsFor(panel1), selected);
+
+    expect(result.current.map((obj) => obj.state.key)).toEqual(['panel-1']);
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layouts-shared/useIsMultiSelection.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/useIsMultiSelection.ts
@@ -1,6 +1,9 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
+import { type SceneObject, VizPanel } from '@grafana/scenes';
 import { ElementSelectionContext } from '@grafana/ui';
+
+import { getDashboardSceneLike } from '../types/dashboard';
 
 /**
  * Whether more than one element is currently selected on the dashboard canvas.
@@ -10,4 +13,40 @@ import { ElementSelectionContext } from '@grafana/ui';
 export function useIsMultiSelection(): boolean {
   const context = useContext(ElementSelectionContext);
   return (context?.selected.length ?? 0) > 1;
+}
+
+/**
+ * Number of selected elements when the given element is part of the selection, 0 otherwise.
+ */
+export function useSelectionCountFor(id: string | undefined): number {
+  const context = useContext(ElementSelectionContext);
+  const selected = context?.selected ?? [];
+
+  if (!id || !selected.some((item) => item.id === id)) {
+    return 0;
+  }
+
+  return selected.length;
+}
+
+/**
+ * The currently selected elements resolved to their scene objects, in selection order.
+ */
+export function useSelectedObjectsFor(sceneObject: SceneObject): SceneObject[] {
+  const context = useContext(ElementSelectionContext);
+  const selected = context?.selected;
+  const sidebar = getDashboardSceneLike(sceneObject).state.sidebar;
+
+  return useMemo(
+    () =>
+      (selected ?? [])
+        .map((item) => sidebar.getSelectedObject(item.id))
+        .filter((obj): obj is SceneObject => obj !== undefined),
+    [selected, sidebar]
+  );
+}
+
+export function useSelectedPanelsFor(sceneObject: SceneObject): VizPanel[] {
+  const selected = useSelectedObjectsFor(sceneObject);
+  return useMemo(() => selected.filter((obj) => obj instanceof VizPanel), [selected]);
 }

--- a/public/app/features/dashboard-scene/scene/types/BulkActionElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/BulkActionElement.ts
@@ -1,10 +1,10 @@
-import { type EditableDashboardElement } from './EditableDashboardElement';
+import { type EditActionSource, type EditableDashboardElement } from './EditableDashboardElement';
 
 export interface BulkActionElement extends EditableDashboardElement {
   /**
    * Called when the element should be deleted
    */
-  onDelete(): void;
+  onDelete(source?: EditActionSource): void;
 
   /**
    * Called when the element should be copied

--- a/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
@@ -5,6 +5,12 @@ import { type SceneObject } from '@grafana/scenes';
 import { type OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 
 /**
+ * Where an edit action was triggered from, so tracking can tell the sidebar apart from the
+ * hover popover shown on the canvas.
+ */
+export type EditActionSource = 'edit_pane' | 'edit_popover';
+
+/**
  * Interface for elements that have options
  */
 export interface EditableDashboardElement {

--- a/public/app/features/dashboard-scene/sidebar/ElementEditPaneHeader.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/ElementEditPaneHeader.test.tsx
@@ -49,7 +49,7 @@ describe('ElementEditPaneHeader', () => {
       const user = userEvent.setup();
       await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
 
-      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Row');
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Row', 'edit_pane');
     });
 
     it('should call DashboardInteractions.trackDeleteDashboardElement when deleting a tab', async () => {
@@ -60,7 +60,7 @@ describe('ElementEditPaneHeader', () => {
       const user = userEvent.setup();
       await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
 
-      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Tab');
+      expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Tab', 'edit_pane');
     });
   });
 
@@ -72,7 +72,7 @@ describe('ElementEditPaneHeader', () => {
     const user = userEvent.setup();
     await user.click(screen.getByTestId(selectors.components.EditPaneHeader.deleteButton));
 
-    expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Panel');
+    expect(DashboardInteractions.trackDeleteDashboardElement).toHaveBeenCalledWith('Panel', 'edit_pane');
   });
 
   describe('tracking panel actions', () => {

--- a/public/app/features/dashboard-scene/sidebar/ElementEditPaneHeader.tsx
+++ b/public/app/features/dashboard-scene/sidebar/ElementEditPaneHeader.tsx
@@ -34,7 +34,7 @@ export function ElementEditPaneHeader({ element, sidebar }: EditPaneHeaderProps)
     } else if (onDelete) {
       onDelete();
     }
-    DashboardInteractions.trackDeleteDashboardElement(elementInfo.typeName);
+    DashboardInteractions.trackDeleteDashboardElement(elementInfo.typeName, 'edit_pane');
   };
 
   return (

--- a/public/app/features/dashboard-scene/sidebar/VizPanelEditableElement.tsx
+++ b/public/app/features/dashboard-scene/sidebar/VizPanelEditableElement.tsx
@@ -21,6 +21,7 @@ import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { type BulkActionElement } from '../scene/types/BulkActionElement';
 import { isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
 import {
+  type EditActionSource,
   type EditableDashboardElement,
   type EditableDashboardElementInfo,
 } from '../scene/types/EditableDashboardElement';
@@ -115,7 +116,7 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
 
   public useSidebarOptions = useSidebarOptions.bind(this);
 
-  public onDelete(source: PanelActionSource = 'edit_pane') {
+  public onDelete(source: EditActionSource = 'edit_pane') {
     DashboardInteractions.panelActionClicked('delete', getPanelIdForVizPanel(this.panel), source);
     const layout = dashboardSceneGraph.getLayoutManagerFor(this.panel);
     layout.removePanel?.(this.panel);
@@ -137,13 +138,13 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     );
   }
 
-  public onDuplicate(source: PanelActionSource = 'edit_pane') {
+  public onDuplicate(source: EditActionSource = 'edit_pane') {
     DashboardInteractions.panelActionClicked('duplicate', getPanelIdForVizPanel(this.panel), source);
     const layout = dashboardSceneGraph.getLayoutManagerFor(this.panel);
     layout.duplicatePanel?.(this.panel);
   }
 
-  public onCopy(source: PanelActionSource = 'edit_pane') {
+  public onCopy(source: EditActionSource = 'edit_pane') {
     DashboardInteractions.panelActionClicked('copy', getPanelIdForVizPanel(this.panel), source);
     const dashboard = getDashboardSceneFor(this.panel);
     dashboard.copyPanel(this.panel);
@@ -163,8 +164,6 @@ export class VizPanelEditableElement implements EditableDashboardElement, BulkAc
     }
   }
 }
-
-type PanelActionSource = 'edit_pane' | 'edit_popover';
 
 type OpenPanelEditVizProps = { panel: VizPanel };
 

--- a/public/app/features/dashboard-scene/utils/clone.test.ts
+++ b/public/app/features/dashboard-scene/utils/clone.test.ts
@@ -1,6 +1,10 @@
-import { ConstantVariable, SceneVariableSet } from '@grafana/scenes';
+import { ConstantVariable, SceneVariableSet, VizPanel } from '@grafana/scenes';
 
-import { cloneSectionVariableSet, getCloneKey } from './clone';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { TabItem } from '../scene/layout-tabs/TabItem';
+
+import { cloneSectionVariableSet, getCloneKey, getRenderedInstanceCount } from './clone';
 
 describe('clone', () => {
   describe('getCloneKey', () => {
@@ -22,6 +26,48 @@ describe('clone', () => {
       expect(cloned!.state.variables[0]).not.toBe(constant);
       expect(cloned!.state.variables[0].state.key).not.toBe(constant.state.key);
       expect(cloned!.state.variables[0].state.name).toBe('env');
+    });
+  });
+
+  describe('getRenderedInstanceCount', () => {
+    it('counts a panel that is not repeated once', () => {
+      const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries' });
+      new DashboardGridItem({ body: panel });
+
+      expect(getRenderedInstanceCount(panel)).toBe(1);
+    });
+
+    it('counts the source panel plus the clones held by its grid item', () => {
+      const panel = new VizPanel({ key: 'panel-1', pluginId: 'timeseries' });
+      new DashboardGridItem({
+        body: panel,
+        repeatedPanels: [
+          new VizPanel({ key: getCloneKey('panel-1', 1), pluginId: 'timeseries' }),
+          new VizPanel({ key: getCloneKey('panel-1', 2), pluginId: 'timeseries' }),
+        ],
+      });
+
+      expect(getRenderedInstanceCount(panel)).toBe(3);
+    });
+
+    it('counts the source row plus its repeated rows', () => {
+      const row = new RowItem({
+        key: 'row-1',
+        title: 'Row',
+        repeatedRows: [new RowItem({ key: getCloneKey('row-1', 1), title: 'Row' })],
+      });
+
+      expect(getRenderedInstanceCount(row)).toBe(2);
+    });
+
+    it('counts the source tab plus its repeated tabs', () => {
+      const tab = new TabItem({
+        key: 'tab-1',
+        title: 'Tab',
+        repeatedTabs: [new TabItem({ key: getCloneKey('tab-1', 1), title: 'Tab' })],
+      });
+
+      expect(getRenderedInstanceCount(tab)).toBe(2);
     });
   });
 });

--- a/public/app/features/dashboard-scene/utils/clone.ts
+++ b/public/app/features/dashboard-scene/utils/clone.ts
@@ -50,6 +50,36 @@ export function getRepeatCloneSourceKey(scene: SceneObject): string | undefined 
   return undefined;
 }
 
+/**
+ * How many panels an element renders as. A repeat renders its source plus one clone per variable
+ * value; everything else renders once. Panels keep their clones on the parent layout item, rows
+ * and tabs on themselves.
+ */
+export function getRenderedInstanceCount(scene: SceneObject): number {
+  const repeats = getRepeats(scene) ?? getRepeats(scene.parent);
+  return 1 + (repeats?.length ?? 0);
+}
+
+function getRepeats(scene: SceneObject | undefined): unknown[] | undefined {
+  const state = scene?.state;
+
+  if (!state) {
+    return undefined;
+  }
+
+  if ('repeatedPanels' in state && Array.isArray(state.repeatedPanels)) {
+    return state.repeatedPanels;
+  }
+  if ('repeatedRows' in state && Array.isArray(state.repeatedRows)) {
+    return state.repeatedRows;
+  }
+  if ('repeatedTabs' in state && Array.isArray(state.repeatedTabs)) {
+    return state.repeatedTabs;
+  }
+
+  return undefined;
+}
+
 export function getLocalVariableValueSet(
   variable: SceneVariable<MultiValueVariableState>,
   value: VariableValueSingle,

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -184,7 +184,16 @@ export const DashboardInteractions = {
   },
 
   panelActionClicked(
-    item: 'configure' | 'configure_dropdown' | 'edit' | 'copy' | 'duplicate' | 'delete' | 'view' | 'use_library_panel',
+    item:
+      | 'configure'
+      | 'configure_dropdown'
+      | 'edit'
+      | 'settings'
+      | 'copy'
+      | 'duplicate'
+      | 'delete'
+      | 'view'
+      | 'use_library_panel',
     id: number,
     source: 'panel' | 'edit_pane' | 'edit_popover' | 'keyboard',
     panelType?: string
@@ -207,11 +216,11 @@ export const DashboardInteractions = {
   ) {
     reportDashboardInteraction('edit_action_clicked', { item: 'add_panel', source, target, action });
   },
-  trackGroupRowClick() {
-    reportDashboardInteraction('edit_action_clicked', { item: 'group_row' });
+  trackGroupRowClick(source: 'canvas' | 'edit_pane' | 'edit_popover') {
+    reportDashboardInteraction('edit_action_clicked', { item: 'group_row', source });
   },
-  trackGroupTabClick() {
-    reportDashboardInteraction('edit_action_clicked', { item: 'group_tab' });
+  trackGroupTabClick(source: 'canvas' | 'edit_pane' | 'edit_popover') {
+    reportDashboardInteraction('edit_action_clicked', { item: 'group_tab', source });
   },
   trackUngroupClick() {
     reportDashboardInteraction('edit_action_clicked', { item: 'ungroup' });
@@ -223,8 +232,8 @@ export const DashboardInteractions = {
   ) {
     reportDashboardInteraction('edit_action_clicked', { item: 'paste_panel', source, target, action });
   },
-  trackDeleteDashboardElement(elementType: string) {
-    reportDashboardInteraction('edit_action_clicked', { item: `remove_${elementType.toLowerCase()}` });
+  trackDeleteDashboardElement(elementType: string, source: 'edit_pane' | 'edit_popover') {
+    reportDashboardInteraction('edit_action_clicked', { item: `remove_${elementType.toLowerCase()}`, source });
   },
   panelLinkClicked: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('panelheader_datalink_clicked', properties);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7478,7 +7478,9 @@
       "title-delete-all-transformations": "Delete all transformations?"
     },
     "panel-edit-actions": {
-      "edit-visualization": "Edit visualization"
+      "edit-visualization": "Edit visualization",
+      "panels-selected_one": "{{count}} panel selected",
+      "panels-selected_other": "{{count}} panels selected"
     },
     "panel-edit-controls": {
       "table-view-aria-label-toggletableview": "Toggle table view",


### PR DESCRIPTION
This PR resolves https://github.com/grafana/grafana/issues/132286 by making the panel hover popover work with multi-selection, so bulk actions are available directly on the canvas instead of only in the sidebar:

<img width="2010" height="1678" alt="image" src="https://github.com/user-attachments/assets/ff9b5849-7b12-46ff-a2d0-9eb9d7ace5ab" />

## Approach

`PanelEditActionsWrapper` now picks its content based on how many elements are selected: 
- `PanelEditActionsSingle` (the previous behavior) or
- the new `PanelEditActionsBulk` (selection count, group into row/tab, delete).

The grouping logic was extracted from `GroupSelectedActions` into a `useGroupSelection` hook so both the sidebar and the popover share it, each passing its own tracking source.

## Key changes

1. `PanelEditActions.tsx`: split into `PanelEditActionsSingle` / `PanelEditActionsBulk`; the wrapper branches on selection count.
2. `useIsMultiSelection.ts`: new `useSelectionCountFor`, `useSelectedObjectsFor` and `useSelectedPanelsFor` hooks to read the selection and resolve it to Scene objects.
3. `clone.ts`: new `getRenderedInstanceCount`, which reads `repeatedPanels` / `repeatedRows` / `repeatedTabs` from the element or its parent layout item.
4. Tracking: `trackGroupRowClick`, `trackGroupTabClick` and `trackDeleteDashboardElement` now take a source (`canvas` / `edit_pane` / `edit_popover`); `panelActionClicked` gains a `settings` item. 
5. `EditActions.tsx`: new generic `GroupActionButton`.

## How to test

- Edit mode, select 2+ panels, hover one of them: the popover shows "N panels selected", group into row, group into tab and delete.
- Group into row / tab from the popover, then verify the same via the edit pane.
- Delete a multi-selection from the popover: all selected panels are removed.
- Select a single panel: the popover is unchanged (edit, edit visualization, copy, duplicate, delete).
- Repeated panels: hover a clone with a multi-selection active (count includes clones); select only the repeat and confirm the single-panel actions still show, with copy/duplicate/delete disabled.
- Grouping disabled cases (e.g. panels already inside a row/tab) show the reason as tooltip.