### PR TITLE
DateTime: Increase parity in luxon-moment-compat wrapper (part 2)

### DIFF
--- a/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/format.parity.test.ts
@@ -1,6 +1,44 @@
 import { convertMomentToLuxonForParsing, convertMomentToLuxonWithOrdinal, formatWithOrdinal } from './format';
 import { DateTime } from './luxon';
 
+describe('weekday tokens', () => {
+  it.each([
+    { locale: 'en-US', date: '2024-05-05', expected: '0 Su' },
+    { locale: 'de', date: '2024-05-08', expected: '3 Mi' },
+    { locale: 'fr', date: '2024-05-07', expected: '2 ma' },
+    { locale: 'ja', date: '2024-05-06', expected: '1 月' },
+  ])('formats numeric and minimal weekdays in $locale', ({ locale, date, expected }) => {
+    expect(formatWithOrdinal(DateTime.fromISO(date, { locale, zone: 'UTC' }), 'd dd')).toBe(expected);
+  });
+
+  it('keeps escaped weekday tokens and day-of-month tokens distinct', () => {
+    const date = DateTime.utc(2024, 5, 5).setLocale('en-US');
+    expect(formatWithOrdinal(date, '[d dd] \\d d dd DD [ddd]')).toBe('d dd d 0 Su 05 ddd');
+  });
+});
+
+describe('localized llll', () => {
+  it.each([
+    { locale: 'en-US', expected: 'Tue, Mar 5, 2024, 8:05 AM' },
+    { locale: 'fr', expected: 'mar. 5 mars 2024, 08:05' },
+    { locale: 'de', expected: 'Di, 5. Mär 2024, 08:05' },
+    { locale: 'ja', expected: '2024/3/5(火) 8:05' },
+  ])('formats and parses locale-specific field order and time in $locale', ({ locale, expected }) => {
+    const date = DateTime.utc(2024, 3, 5, 8, 5).setLocale(locale);
+    const formatted = formatWithOrdinal(date, 'llll');
+
+    expect(formatted).toBe(expected);
+    expect(
+      DateTime.fromFormat(formatted, convertMomentToLuxonForParsing('llll', locale), { locale, zone: 'UTC' }).toISO()
+    ).toBe('2024-03-05T08:05:00.000Z');
+  });
+
+  it('preserves bracket literals alongside the localized macro', () => {
+    const date = DateTime.utc(2024, 3, 5, 8, 5).setLocale('fr');
+    expect(formatWithOrdinal(date, '[llll] llll [L]')).toBe('llll mar. 5 mars 2024, 08:05 L');
+  });
+});
+
 describe('localized padded L', () => {
   it.each([
     { locale: 'en-US', expected: '03/05/2024' },

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/format.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/format.ts
@@ -6,15 +6,15 @@ const PADDED_ONE_TO_TWENTY_FOUR_HOUR_FORMAT = "'__khs__'HH'__khe__'";
 
 const TOKEN_MAP: Record<string, string> = {
   // moment's L* tokens are locale-aware (word order changes per locale), so map them to luxon's
-  // localized macro tokens rather than fixed patterns. `L` is expanded separately to pad the date.
-  // No macro uses an abbreviated weekday, so `llll` keeps an en-US shaped pattern.
+  // localized macro tokens rather than fixed patterns. `L` and `llll` use generated Intl patterns
+  // for padded dates and abbreviated weekdays, respectively.
   LLLL: 'DDDD t',
   LLL: 'DDD t',
   LL: 'DDD',
   LTS: 'tt',
   LT: 't',
   L: 'MM/dd/yyyy',
-  llll: 'ccc, LLL d, yyyy h:mm a',
+  llll: 'ccc, DD t',
   lll: 'DD t',
   ll: 'DD',
   l: 'D',
@@ -29,6 +29,8 @@ const TOKEN_MAP: Record<string, string> = {
   D: 'd',
   dddd: 'cccc',
   ddd: 'ccc',
+  dd: "'__weekdayMin__'",
+  d: "'__weekdayNumber__'",
   // HH/H, hh/h, mm/m, ss/s are identical in moment and luxon and pass through unmapped.
   // Moment's k/kk clock runs from 1-24, while Luxon's H/HH clock runs from 0-23.
   kk: PADDED_ONE_TO_TWENTY_FOUR_HOUR_FORMAT,
@@ -57,6 +59,8 @@ const TOKEN_MAP: Record<string, string> = {
 
 const PARSING_TOKEN_MAP: Record<string, string> = {
   ...TOKEN_MAP,
+  dd: 'ccc',
+  d: 'c',
   kk: 'HH',
   k: 'H',
   SSSSSSSSS: 'u',
@@ -81,12 +85,14 @@ const LOWER_MERIDIEM_MARKER_PATTERN = /__mls__(.*?)__mle__/g;
 const ONE_TO_TWENTY_FOUR_HOUR_MARKER = '__khs__';
 const ONE_TO_TWENTY_FOUR_HOUR_MARKER_PATTERN = /__khs__(\d{1,2})__khe__/g;
 const ORDINAL_SUFFIXES = ['th', 'st', 'nd', 'rd'] as const;
+const WEEKDAY_MARKER_PATTERN = /__weekday(Number|Min)__/g;
 
 interface ConvertedFormat {
   luxonFormat: string;
   hasOrdinal: boolean;
   hasMeridiem: boolean;
   hasOneToTwentyFourHour: boolean;
+  hasWeekday: boolean;
 }
 
 // format conversion runs on every format() call in hot paths (table cells, axis ticks) and format
@@ -111,6 +117,7 @@ function convertFormat(format: string, omitZoneName = false, forParsing = false,
       hasOrdinal: luxonFormat.includes(ORDINAL_MARKER),
       hasMeridiem: luxonFormat.includes(MERIDIEM_START_MARKER),
       hasOneToTwentyFourHour: luxonFormat.includes(ONE_TO_TWENTY_FOUR_HOUR_MARKER),
+      hasWeekday: luxonFormat.includes('__weekday'),
     };
     convertedFormatCache.set(cacheKey, converted);
   }
@@ -141,14 +148,22 @@ function replaceMomentToken(
     return `d'${ORDINAL_MARKER}'`;
   }
 
-  if (match === 'L') {
-    const localizedFormat = DateTime.parseFormatForOpts(
-      { year: 'numeric', month: '2-digit', day: '2-digit' },
-      { locale }
-    );
+  if (match === 'L' || match === 'llll') {
+    // Resolve llll fields first to preserve Intl's effective time padding and numeric month choices.
+    const options =
+      match === 'L'
+        ? { year: 'numeric', month: '2-digit', day: '2-digit' }
+        : new Intl.DateTimeFormat(locale, DateTime.DATETIME_MED_WITH_WEEKDAY).resolvedOptions();
+    // Intl resolves valid format options, but its declarations widen field values to strings.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const localizedFormat = DateTime.parseFormatForOpts(options as Intl.DateTimeFormatOptions, { locale });
     // Luxon generates a parser-only numeric-year token; adapt only this generated pattern,
     // not the user's tokens or escaped literals, so the same pattern also formats correctly.
-    return (localizedFormat ?? TOKEN_MAP.L).replace('yyyyy', 'yyyy');
+    // Keep generated name tokens consistent with the shim's mappings so formatted names also parse.
+    return (localizedFormat ?? TOKEN_MAP[match])
+      .replace('yyyyy', 'yyyy')
+      .replace('EEE', TOKEN_MAP.ddd)
+      .replace('MMM', TOKEN_MAP.MMM);
   }
 
   return (forParsing ? PARSING_TOKEN_MAP : TOKEN_MAP)[match] ?? match;
@@ -176,7 +191,7 @@ function getOrdinal(day: number): string {
 }
 
 export function formatWithOrdinal(luxonDateTime: DateTime, momentFormat: string): string {
-  const { luxonFormat, hasOrdinal, hasMeridiem, hasOneToTwentyFourHour } = convertFormat(
+  const { luxonFormat, hasOrdinal, hasMeridiem, hasOneToTwentyFourHour, hasWeekday } = convertFormat(
     momentFormat,
     luxonDateTime.zone.type === 'system',
     false,
@@ -206,6 +221,12 @@ export function formatWithOrdinal(luxonDateTime: DateTime, momentFormat: string)
   if (hasOneToTwentyFourHour) {
     formatted = formatted.replace(ONE_TO_TWENTY_FOUR_HOUR_MARKER_PATTERN, (_: string, rawHour: string) =>
       Number(rawHour) === 0 ? '24' : rawHour
+    );
+  }
+
+  if (hasWeekday) {
+    formatted = formatted.replace(WEEKDAY_MARKER_PATTERN, (_: string, kind: string) =>
+      kind === 'Number' ? String(luxonDateTime.weekday % 7) : (luxonDateTime.weekdayShort?.slice(0, 2) ?? '')
     );
   }
 

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.parity.test.ts
@@ -206,6 +206,27 @@ describe('moment compatibility parity', () => {
   });
 
   describe('locale and week semantics', () => {
+    it.each(['de', 'en-AU'])('uses Intl Monday-first week rules for %s', (locale) => {
+      const value = moment.utc('2024-05-05').locale(locale);
+      expect(value.week()).toBe(18);
+      expect(value.clone().startOf('week').format('YYYY-MM-DD')).toBe('2024-04-29');
+    });
+
+    it('keeps locale and ISO week accessors, aliases, and setters separate', () => {
+      const value = moment.utc('2024-05-05').locale('en-US');
+      expect(value.weeks()).toBe(19);
+      expect(value.isoWeeks()).toBe(18);
+      expect(value.clone().set('weeks', 20).format('YYYY-MM-DD')).toBe('2024-05-12');
+      expect(value.clone().set('isoWeeks', 20).format('YYYY-MM-DD')).toBe('2024-05-19');
+    });
+
+    it('applies the week-start override to numbering as well as boundaries', () => {
+      moment.updateLocale('parity-intl-week', { parentLocale: 'en-US', week: { dow: 1 } });
+      const value = moment.utc('2024-05-05');
+      expect(value.week()).toBe(18);
+      expect(value.startOf('week').format('YYYY-MM-DD')).toBe('2024-04-29');
+    });
+
     it('gets the instance locale without changing it or adopting a later global locale', () => {
       const value = moment.utc('2024-05-06').locale('de');
       moment.locale('fr');
@@ -255,7 +276,81 @@ describe('moment compatibility parity', () => {
     });
   });
 
+  describe('DST wall-time parsing', () => {
+    it.each([Date.UTC(2024, 0, 15), Date.UTC(2024, 6, 15)])(
+      'chooses the earlier fold occurrence with the clock at %s',
+      (now) => {
+        Settings.now = () => now;
+        Settings.resetCaches();
+
+        expect(moment.tz('2024-11-03T01:30:00', 'America/New_York').toISOString()).toBe('2024-11-03T05:30:00.000Z');
+        expect(moment.tz('2024-11-03 01:30', 'YYYY-MM-DD HH:mm', 'America/New_York').toISOString()).toBe(
+          '2024-11-03T05:30:00.000Z'
+        );
+        expect(moment.tz([2024, 10, 3, 1, 30], 'America/New_York').toISOString()).toBe('2024-11-03T05:30:00.000Z');
+        expect(
+          moment.tz({ year: 2024, month: 10, day: 3, hour: 1, minute: 30 }, 'America/New_York').toISOString()
+        ).toBe('2024-11-03T05:30:00.000Z');
+      }
+    );
+
+    it('retains explicitly selected later occurrences', () => {
+      const later = moment.tz('2024-11-03T01:30:00-05:00', 'America/New_York');
+      expect(later.toISOString()).toBe('2024-11-03T06:30:00.000Z');
+      expect(moment.tz('2024-11-03 01:30 -0500', 'YYYY-MM-DD HH:mm ZZ', 'America/New_York').toISOString()).toBe(
+        '2024-11-03T06:30:00.000Z'
+      );
+      expect(moment.tz(1730615400000, 'America/New_York').toISOString()).toBe('2024-11-03T06:30:00.000Z');
+      expect(moment.tz('1730615400', 'X', 'America/New_York').toISOString()).toBe('2024-11-03T06:30:00.000Z');
+      expect(moment(later).add(0).toISOString()).toBe('2024-11-03T06:30:00.000Z');
+    });
+
+    it('keeps spring-gap adjustment forward', () => {
+      expect(moment.tz('2024-03-10T02:30:00', 'America/New_York').toISOString()).toBe('2024-03-10T07:30:00.000Z');
+    });
+  });
+
+  describe('UTC offset setters', () => {
+    it.each([
+      { input: 5.5, minutes: 330, formatted: '17:30 +05:30' },
+      { input: 16, minutes: 16, formatted: '12:16 +00:16' },
+      { input: '-0530', minutes: -330, formatted: '06:30 -05:30' },
+      { input: '+05', minutes: 300, formatted: '17:00 +05:00' },
+    ])('sets offset $input without changing the instant', ({ input, minutes, formatted }) => {
+      const value = moment.utc('2024-05-08T12:00:00Z').utcOffset(input);
+      expect(value.utcOffset()).toBe(minutes);
+      expect(value.format('HH:mm Z')).toBe(formatted);
+      expect(value.toISOString()).toBe('2024-05-08T12:00:00.000Z');
+    });
+
+    it('can preserve wall time and then convert the instant back to Z', () => {
+      const value = moment.utc('2024-05-08T12:00:00Z').locale('de');
+      expect(value.utcOffset('-05:00', true)).toBe(value);
+      expect(value.toISOString()).toBe('2024-05-08T17:00:00.000Z');
+      expect(value.locale()).toBe('de');
+      expect(value.utcOffset('Z').format('HH:mm Z')).toBe('17:00 +00:00');
+      expect(value.utcOffset('garbage')).toBe(value);
+      expect(value.utcOffset()).toBe(0);
+    });
+
+    it('replaces a named zone with a fixed offset for subsequent arithmetic', () => {
+      const value = moment.tz('2024-03-09T12:00:00', 'America/New_York').utcOffset(-300);
+      expect(value.add(1, 'day').format('YYYY-MM-DD HH:mm Z')).toBe('2024-03-10 12:00 -05:00');
+    });
+  });
+
   describe('construction and zone conversion', () => {
+    it('uses the requested zone and locale for empty-array input at the current instant', () => {
+      Settings.now = () => 1714996800000;
+      moment.locale('de');
+      const named = moment.tz([], 'America/New_York');
+
+      expect(moment.utc([]).format('HH:mm Z')).toBe('12:00 +00:00');
+      expect(named.format('HH:mm Z')).toBe('08:00 -04:00');
+      expect(named.format('MMMM')).toBe('Mai');
+      expect(named.valueOf()).toBe(1714996800000);
+    });
+
     it('preserves the locale and system-zone identity when copying a local instance', () => {
       const source = moment('2024-05-06T12:00:00').locale('de');
       moment.locale('fr');

--- a/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
+++ b/packages/grafana-data/src/datetime/luxon_moment_compat/moment.ts
@@ -12,6 +12,7 @@ import {
   IANAZone,
   Info,
   Settings,
+  type WeekdayNumbers,
   type Zone,
 } from './luxon';
 
@@ -78,6 +79,11 @@ type MomentDurationInput =
   | Pick<MomentDurationLike, 'asMilliseconds'>
   | undefined
   | null;
+
+interface MomentLocaleConfig {
+  parentLocale?: string;
+  week?: { dow?: number };
+}
 
 interface MomentOptions {
   locale?: string;
@@ -163,6 +169,7 @@ export interface MomentLike {
   unix(): number;
   toLocaleString(): string;
   utcOffset(): number;
+  utcOffset(value: number | string, keepLocalTime?: boolean): MomentLike;
   format(template?: FormatArg): string;
   fromNow(withoutSuffix?: boolean): string;
   toNow(withoutSuffix?: boolean): string;
@@ -328,10 +335,6 @@ function isInputObject(value: unknown): value is InputObject {
 const ARRAY_INPUT_UNITS = ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond'] as const;
 
 function normalizeArrayInput(input: InputArray, options?: MomentOptions): DateTime {
-  if (input.length === 0) {
-    return DateTime.now();
-  }
-
   const values = input.slice(0, ARRAY_INPUT_UNITS.length).map(Number);
 
   if (values.some((v) => Number.isNaN(v))) {
@@ -473,12 +476,23 @@ function parseFromCachedFormat(value: string, fmt: string, options?: MomentOptio
     formatParserCache.set(key, parser);
   }
 
-  return DateTime.fromFormatParser(value, parser, options);
+  return resolveParsedZone(DateTime.fromFormatParser(value, parser, { ...options, setZone: true }), options);
+}
+
+function preferEarlierOffset(dt: DateTime): DateTime {
+  return dt
+    .getPossibleOffsets()
+    .reduce((earlier, candidate) => (candidate.toMillis() < earlier.toMillis() ? candidate : earlier), dt);
+}
+
+function resolveParsedZone(dt: DateTime, options?: MomentOptions): DateTime {
+  // Parse with setZone first: explicit offsets stay fixed and must not be reinterpreted as ambiguous wall times.
+  return preferEarlierOffset(dt).setZone(options?.zone ?? Settings.defaultZone);
 }
 
 function parseWithFormat(value: string, format: MomentFormat, options?: MomentOptions): DateTime {
   if (format === ISO_8601) {
-    return DateTime.fromISO(value, options);
+    return resolveParsedZone(DateTime.fromISO(value, { ...options, setZone: true }), options);
   }
 
   // moment's unix timestamp tokens (X = seconds, x = millis) are output-only in luxon;
@@ -546,10 +560,10 @@ function parseWithFormat(value: string, format: MomentFormat, options?: MomentOp
 
 function parseWithFallbacks(value: string, options?: MomentOptions): DateTime {
   const parsers = [
-    () => DateTime.fromISO(value, options),
+    () => parseWithFormat(value, ISO_8601, options),
     () => DateTime.fromRFC2822(value, options),
     () => DateTime.fromHTTP(value, options),
-    () => DateTime.fromSQL(value, options),
+    () => resolveParsedZone(DateTime.fromSQL(value, { ...options, setZone: true }), options),
     // like moment, fall back to js Date() parsing as a last resort. it accepts looser inputs than
     // the luxon parsers above, e.g. RFC 2822 strings missing their mandatory timezone (seen in
     // RSS pubDates), which it interprets in the environment's local zone.
@@ -694,6 +708,28 @@ function getLocaleFirstDayOfWeek(locale = currentLocale): number {
   return localeOverrides.get(locale)?.dow ?? Info.getStartOfWeek({ locale: normalizeLocale(locale) }) % 7;
 }
 
+function isWeekdayNumber(value: number): value is WeekdayNumbers {
+  return Number.isInteger(value) && value >= 1 && value <= 7;
+}
+
+function getLocaleWeekNumber(dt: DateTime, locale: string): number {
+  const dow = localeOverrides.get(locale)?.dow;
+  if (dow == null) {
+    return dt.localWeekNumber;
+  }
+  const firstDay = dow || 7;
+  if (!isWeekdayNumber(firstDay)) {
+    return NaN;
+  }
+  return dt.reconfigure({
+    weekSettings: {
+      firstDay,
+      minimalDays: Info.getMinimumDaysInFirstWeek({ locale: dt.locale ?? undefined }),
+      weekend: [6, 7],
+    },
+  }).localWeekNumber;
+}
+
 function normalizeZoneName(name: string): string {
   return name.toLowerCase() === 'utc' ? 'UTC' : canonicalZoneName(name);
 }
@@ -769,14 +805,14 @@ function createTimeZoneInfo(name: string): MomentTimeZoneInfo | null {
 function parseInput(input: MomentInput, options?: MomentOptions, parseOptions?: ParseOptions): DateTime {
   const locale = normalizeLocale(options?.locale);
 
-  if (typeof input === 'undefined') {
+  if (typeof input === 'undefined' || (Array.isArray(input) && input.length === 0)) {
     return DateTime.now()
       .reconfigure({ locale })
       .setZone(options?.zone ?? 'local');
   }
 
   if (Array.isArray(input)) {
-    return normalizeArrayInput(input, options);
+    return preferEarlierOffset(normalizeArrayInput(input, { ...options, locale }));
   }
 
   if (isMomentLike(input)) {
@@ -835,10 +871,7 @@ function parseInput(input: MomentInput, options?: MomentOptions, parseOptions?: 
     if (normalized.millisecond != null) {
       normalized.millisecond = Math.trunc(normalized.millisecond);
     }
-    return DateTime.fromObject(normalized, {
-      ...options,
-      locale,
-    });
+    return preferEarlierOffset(DateTime.fromObject(normalized, { ...options, locale }));
   }
 
   return DateTime.invalid('unsupported moment input');
@@ -910,7 +943,6 @@ class MomentCompat implements MomentLike {
   declare dates: UnitAccessor;
   declare days: UnitAccessor;
   declare weeks: UnitAccessor;
-  declare isoWeek: UnitAccessor;
   declare isoWeeks: UnitAccessor;
   declare hours: UnitAccessor;
   declare minutes: UnitAccessor;
@@ -1051,6 +1083,13 @@ class MomentCompat implements MomentLike {
   week(): number;
   week(value: number): MomentLike;
   week(value?: number): number | MomentLike {
+    const week = getLocaleWeekNumber(this._dt, this._locale);
+    return value == null ? week : this._setDt(this._dt.plus({ weeks: value - week }));
+  }
+
+  isoWeek(): number;
+  isoWeek(value: number): MomentLike;
+  isoWeek(value?: number): number | MomentLike {
     return value == null ? this._dt.weekNumber : this._setDt(this._dt.plus({ weeks: value - this._dt.weekNumber }));
   }
 
@@ -1150,8 +1189,27 @@ class MomentCompat implements MomentLike {
     return this._dt.toLocaleString(DateTime.DATETIME_MED);
   }
 
-  utcOffset(): number {
-    return this._dt.offset;
+  utcOffset(): number;
+  utcOffset(value: number | string, keepLocalTime?: boolean): MomentLike;
+  utcOffset(value?: number | string, keepLocalTime = false): number | MomentLike {
+    if (value == null) {
+      return this._dt.offset;
+    }
+
+    let zone: FixedOffsetZone | null;
+    if (typeof value === 'string') {
+      const offset = value.match(/Z|[+-]\d\d(?::?\d\d)?/gi)?.at(-1);
+      if (!offset) {
+        return this;
+      }
+      zone = FixedOffsetZone.parseSpecifier(
+        offset.toUpperCase() === 'Z' ? 'UTC' : `UTC${offset.replace(/([+-]\d{2})(\d{2})$/, '$1:$2')}`
+      );
+    } else {
+      zone = FixedOffsetZone.instance(Math.abs(value) < 16 ? value * 60 : value);
+    }
+
+    return zone ? this._setDt(this._dt.setZone(zone, { keepLocalTime })) : this;
   }
 
   format(template?: FormatArg): string {
@@ -1187,8 +1245,7 @@ proto.dates = proto.date;
 proto.days = proto.day;
 
 proto.weeks = proto.week;
-proto.isoWeek = proto.week;
-proto.isoWeeks = proto.week;
+proto.isoWeeks = proto.isoWeek;
 proto.hours = proto.hour;
 proto.minutes = proto.minute;
 proto.seconds = proto.second;
@@ -1256,7 +1313,7 @@ export interface MomentFactory {
   isMoment(input: unknown): input is MomentLike;
   locale(locale?: string): string;
   localeData(locale?: string): { firstDayOfWeek: () => number };
-  updateLocale(locale: string, config: { parentLocale?: string; week?: { dow?: number } }): string;
+  updateLocale(locale: string, config: MomentLocaleConfig): string;
   tz: MomentTzFactory;
   weekdays(locale?: string): string[];
 }
@@ -1314,7 +1371,7 @@ const moment: MomentFactory = Object.assign(
       firstDayOfWeek: () => getLocaleFirstDayOfWeek(locale),
     }),
 
-    updateLocale: (locale: string, config: { parentLocale?: string; week?: { dow?: number } }): string => {
+    updateLocale: (locale: string, config: MomentLocaleConfig): string => {
       const parentLocale = config.parentLocale ?? locale;
       localeOverrides.set(locale, {
         locale: normalizeLocale(parentLocale) ?? DEFAULT_LOCALE,

--- a/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.parity.test.ts
@@ -49,6 +49,13 @@ describe('Luxon-backed DateTime wrapper', () => {
     expect(wrapper.toDuration(source, 'days').asMilliseconds()).toBe(5400000);
   });
 
+  it('exposes chainable UTC offset setters through the public DateTime API', () => {
+    const value = wrapper.toUtc('2024-05-08T12:00:00Z');
+    expect(value.utcOffset('+05:30', true)).toBe(value);
+    expect(value.utcOffset()).toBe(330);
+    expect(value.toISOString()).toBe('2024-05-08T06:30:00.000Z');
+  });
+
   it('accepts toDuration results in public arithmetic', () => {
     const duration = wrapper.toDuration(5, 'minutes');
     const value = wrapper.toUtc('2024-05-08T12:00:00Z');

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -55,7 +55,8 @@ export interface DateTime extends Object {
   valueOf: () => number;
   unix: () => number;
   utc: () => DateTime;
-  utcOffset: () => number;
+  utcOffset(): number;
+  utcOffset(value: number | string, keepLocalTime?: boolean): DateTime;
   hour?: () => number;
   minute?: () => number;
 }


### PR DESCRIPTION
(follow-up to https://github.com/grafana/grafana/pull/132233)

some additional parity / simplifications caught in the audit.