### PR TITLE
Provisioning: deduplicate connection controller work queue

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,15 +38,6 @@ const (
 	tokenWriteRetryDelay = 2 * time.Second
 )
 
-type connectionQueueItem struct {
-	key      string
-	attempts int
-	// trigger records what enqueued this item, for the processing-level metrics.
-	// It rides the item so retries (which re-add the same item) keep the
-	// attribution.
-	trigger usinformer.ProcessTrigger
-}
-
 // ConnectionStatusPatcher defines the interface for updating connection status.
 //
 //go:generate mockery --name=ConnectionStatusPatcher --structname=MockConnectionStatusPatcher --inpackage --filename=connection_status_patcher_mock.go --with-expecter
@@ -66,12 +58,14 @@ type ConnectionController struct {
 
 	// processed classifies each delivery (encapsulating the NATS/apiserver
 	// backend) and counts the start of each reconcile by what enqueued it.
-	processed *usinformer.ProcessedMetrics
+	processed  *usinformer.ProcessedMetrics
+	triggersMu sync.Mutex
+	triggers   map[string]usinformer.ProcessTrigger
 
 	// To allow injection for testing.
-	processFn func(ctx context.Context, item *connectionQueueItem) error
+	processFn func(ctx context.Context, key string) error
 
-	queue          workqueue.TypedRateLimitingInterface[*connectionQueueItem]
+	queue          workqueue.TypedRateLimitingInterface[string]
 	resyncInterval time.Duration
 	drainTimeout   time.Duration
 }
@@ -92,9 +86,10 @@ func NewConnectionController(
 		conns:     conns,
 		tracer:    tracer,
 		processed: usinformer.NewProcessedMetrics(registry, "connections", natsBacked),
+		triggers:  make(map[string]usinformer.ProcessTrigger),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name:            "provisioningConnectionController",
 				MetricsProvider: newWorkerQueueWaitProvider(registry, "connection"),
 			},
@@ -144,7 +139,34 @@ func (cc *ConnectionController) enqueue(obj interface{}, trigger usinformer.Proc
 		cc.logger.Error("failed to get key for object", "error", err)
 		return
 	}
-	cc.queue.Add(&connectionQueueItem{key: key, trigger: trigger})
+	// Store the attribution before a worker can pick up the key.
+	cc.setTrigger(key, trigger)
+	cc.queue.Add(key)
+}
+
+// The first enqueue owns the attribution when subsequent events coalesce onto
+// the same key. Lazy initialization also supports controllers built as literals.
+func (cc *ConnectionController) setTrigger(key string, trigger usinformer.ProcessTrigger) {
+	cc.triggersMu.Lock()
+	defer cc.triggersMu.Unlock()
+	if cc.triggers == nil {
+		cc.triggers = make(map[string]usinformer.ProcessTrigger)
+	}
+	if _, ok := cc.triggers[key]; !ok {
+		cc.triggers[key] = trigger
+	}
+}
+
+// Pop attribution at pickup so terminal outcomes cannot erase a newer event
+// received during reconciliation. Retries restore the popped attribution.
+func (cc *ConnectionController) popTrigger(key string) (usinformer.ProcessTrigger, bool) {
+	cc.triggersMu.Lock()
+	defer cc.triggersMu.Unlock()
+	trigger, ok := cc.triggers[key]
+	if ok {
+		delete(cc.triggers, key)
+	}
+	return trigger, ok
 }
 
 // connectionResourceVersion returns the resource version of a delivered
@@ -212,57 +234,63 @@ func (cc *ConnectionController) runWorker(ctx context.Context) {
 }
 
 func (cc *ConnectionController) processNextWorkItem(ctx context.Context) bool {
-	item, quit := cc.queue.Get()
+	key, quit := cc.queue.Get()
 	if quit {
 		return false
 	}
-	defer cc.queue.Done(item)
+	defer cc.queue.Done(key)
 
-	namespace, name, _ := cache.SplitMetaNamespaceKey(item.key)
-	logger := logging.FromContext(ctx).With("work_key", item.key, "namespace", namespace, "connection", name)
+	namespace, name, _ := cache.SplitMetaNamespaceKey(key)
+	logger := logging.FromContext(ctx).With("work_key", key, "namespace", namespace, "connection", name)
 	logger.Info("ConnectionController processing key")
 
-	// Count the start of processing once per pickup, attributed to what enqueued
-	// the item. Retries re-add the same item (attempts already bumped) and are not
-	// recounted.
-	if item.attempts == 0 {
-		cc.processed.RecordProcessed(item.trigger)
+	trigger, ok := cc.popTrigger(key)
+	// NumRequeues counts prior AddRateLimited calls, excluding this attempt.
+	attempts := cc.queue.NumRequeues(key) + 1
+	// Only informer-driven first attempts count. Internal AddAfter reschedules
+	// have no attribution, and rate-limited retries must not be counted again.
+	if ok && attempts == 1 {
+		cc.processed.RecordProcessed(trigger)
 	}
 
-	err := cc.processFn(ctx, item)
+	err := cc.processFn(ctx, key)
 	if err == nil {
-		cc.queue.Forget(item)
+		cc.queue.Forget(key)
 		return true
 	}
 
-	item.attempts++
-	logger = logger.With("error", err, "attempts", item.attempts)
+	logger = logger.With("error", err, "attempts", attempts)
 	logger.Error("ConnectionController failed to process key")
 
-	if item.attempts >= connectionMaxAttempts {
+	if attempts >= connectionMaxAttempts {
 		logger.Error("ConnectionController failed too many times")
-		cc.queue.Forget(item)
+		cc.queue.Forget(key)
 		return true
 	}
 
 	if !apierrors.IsServiceUnavailable(err) {
 		logger.Info("ConnectionController will not retry")
-		cc.queue.Forget(item)
+		cc.queue.Forget(key)
 		return true
 	}
 
 	logger.Info("ConnectionController will retry as service is unavailable")
-	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", item, err))
-	cc.queue.AddRateLimited(item)
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+	// Keep retry attribution without overwriting an event received in flight or
+	// inventing attribution for an internal reschedule.
+	if ok {
+		cc.setTrigger(key, trigger)
+	}
+	cc.queue.AddRateLimited(key)
 
 	return true
 }
 
-func (cc *ConnectionController) process(ctx context.Context, item *connectionQueueItem) (err error) {
-	logger := cc.logger.With("key", item.key)
+func (cc *ConnectionController) process(ctx context.Context, key string) (err error) {
+	logger := cc.logger.With("key", key)
 	ctx = logging.Context(ctx, logger)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(item.key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		logger.Error("retrieving namespace and name from key", "error", err)
 		return err
@@ -332,7 +360,7 @@ func (cc *ConnectionController) process(ctx context.Context, item *connectionQue
 			// would delete it and can loop under secret-store read-after-write lag.
 			if tokenRecentlyCreated(time.UnixMilli(conn.Status.Token.LastUpdated)) {
 				logger.Info("connection token secret not yet readable after recent write; will retry", "error", err)
-				cc.queue.AddAfter(&connectionQueueItem{key: item.key}, tokenWriteRetryDelay)
+				cc.queue.AddAfter(key, tokenWriteRetryDelay)
 				return nil
 			}
 			logger.Warn("connection token secret could not be decrypted, regenerating", "error", err)

--- a/pkg/registry/apis/provisioning/controller/connection_queue_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_queue_test.go
@@ -1,0 +1,293 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+	testingclock "k8s.io/utils/clock/testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/informer"
+)
+
+func newConnectionControllerForQueueTest(t *testing.T) (*ConnectionController, *prometheus.Registry) {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	cc := NewConnectionController(nil, nil, nil, nil, time.Minute, 5*time.Second, reg, nil, false)
+	t.Cleanup(cc.queue.ShutDown)
+	return cc, reg
+}
+
+// Advance only the queue clock: Kubernetes' global error backoff keeps a wall
+// clock timestamp that cannot be used inside a synctest bubble.
+func useFakeConnectionQueueClock(t *testing.T, cc *ConnectionController) *testingclock.FakeClock {
+	t.Helper()
+	cc.queue.ShutDown()
+	clock := testingclock.NewFakeClock(time.Now())
+	cc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Clock: clock},
+	)
+	t.Cleanup(cc.queue.ShutDown)
+	return clock
+}
+
+func TestConnectionController_DeduplicatesEnqueueBeforeProcessing(t *testing.T) {
+	cc, _ := newConnectionControllerForQueueTest(t)
+	var processedKeys []string
+	cc.processFn = func(_ context.Context, key string) error {
+		processedKeys = append(processedKeys, key)
+		return nil
+	}
+
+	conns := []*provisioning.Connection{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "conn-a"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "conn-b"}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-b", Name: "conn-a"}},
+	}
+	handler := cc.EventHandler()
+	for _, conn := range conns {
+		handler.AddFunc(conn, true)
+		for range 5 {
+			handler.UpdateFunc(conn, conn.DeepCopy())
+		}
+	}
+
+	require.Equal(t, len(conns), cc.queue.Len())
+	for range conns {
+		require.Positive(t, cc.queue.Len())
+		require.True(t, cc.processNextWorkItem(t.Context()))
+	}
+	assert.ElementsMatch(t, []string{"ns-a/conn-a", "ns-a/conn-b", "ns-b/conn-a"}, processedKeys)
+	assert.Zero(t, cc.queue.Len())
+	assert.Empty(t, cc.triggers)
+}
+
+func TestConnectionController_DeduplicatesEnqueueWhileProcessing(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cc, _ := newConnectionControllerForQueueTest(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		release := make(chan struct{})
+		releaseFirst := sync.OnceFunc(func() { close(release) })
+		t.Cleanup(releaseFirst)
+		var processCount, otherProcessCount atomic.Int32
+		cc.processFn = func(_ context.Context, key string) error {
+			switch key {
+			case "ns-a/conn":
+				if processCount.Add(1) == 1 {
+					<-release
+				}
+			case "ns-b/conn":
+				otherProcessCount.Add(1)
+			default:
+				t.Errorf("unexpected connection key %q", key)
+			}
+			return nil
+		}
+
+		conn := &provisioning.Connection{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "conn"}}
+		handler := cc.EventHandler()
+		handler.AddFunc(conn, true)
+		runDone := make(chan struct{})
+		go func() {
+			cc.Run(ctx, 2, func() {}, func() {})
+			close(runDone)
+		}()
+		synctest.Wait()
+		require.Equal(t, int32(1), processCount.Load())
+
+		for range 5 {
+			handler.UpdateFunc(conn, conn.DeepCopy())
+		}
+		handler.AddFunc(&provisioning.Connection{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-b", Name: "conn"}}, false)
+		synctest.Wait()
+		assert.Equal(t, int32(1), processCount.Load(), "the in-flight key must not be processed by another worker")
+		assert.Equal(t, int32(1), otherProcessCount.Load(), "another connection can be processed concurrently")
+
+		releaseFirst()
+		synctest.Wait()
+		cancel()
+		<-runDone
+		assert.Equal(t, int32(2), processCount.Load(), "updates must coalesce into one additional reconciliation")
+		assert.Equal(t, int32(1), otherProcessCount.Load())
+		assert.Zero(t, cc.queue.Len())
+		assert.Empty(t, cc.triggers)
+	})
+}
+
+func TestConnectionController_RetriesAndClearsState(t *testing.T) {
+	unavailable := apierrors.NewServiceUnavailable("temporarily unavailable")
+	terminal := errors.New("invalid connection")
+	for _, tt := range []struct {
+		name     string
+		results  []error
+		internal bool
+	}{
+		{name: "service unavailable exhausts attempts", results: []error{unavailable, unavailable, unavailable}},
+		{name: "non-retryable error", results: []error{terminal}},
+		{name: "retry succeeds", results: []error{unavailable, nil}},
+		{name: "retry fails permanently", results: []error{unavailable, terminal}},
+		{name: "internal retry has no attribution", results: []error{unavailable, nil}, internal: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cc, reg := newConnectionControllerForQueueTest(t)
+			clock := useFakeConnectionQueueClock(t, cc)
+			const key = "ns/conn"
+			conn := &provisioning.Connection{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "conn", ResourceVersion: "5"}}
+			processCount := 0
+			cc.processFn = func(_ context.Context, gotKey string) error {
+				require.Equal(t, key, gotKey)
+				require.Less(t, processCount, len(tt.results), "unexpected retry")
+				assert.Equal(t, processCount, cc.queue.NumRequeues(key))
+				err := tt.results[processCount]
+				processCount++
+				return err
+			}
+			wantTrigger := "initial"
+			if tt.internal {
+				cc.queue.Add(key)
+				wantTrigger = ""
+			} else {
+				cc.EventHandler().AddFunc(conn, true)
+			}
+
+			for i := range tt.results {
+				require.True(t, cc.processNextWorkItem(t.Context()))
+				if i < len(tt.results)-1 {
+					assert.Equal(t, i+1, cc.queue.NumRequeues(key))
+					if tt.internal {
+						assert.Empty(t, cc.triggers)
+					} else {
+						assert.Equal(t, wantTrigger, string(cc.triggers[key]))
+					}
+					clock.Step(time.Second)
+				}
+			}
+			assert.Equal(t, len(tt.results), processCount)
+			assert.Zero(t, cc.queue.NumRequeues(key))
+			assert.Empty(t, cc.triggers)
+			assertOnlyProcessedTrigger(t, reg, "connections", wantTrigger)
+			assert.Zero(t, cc.queue.Len())
+
+			cc.processFn = func(_ context.Context, gotKey string) error {
+				assert.Equal(t, key, gotKey)
+				assert.Zero(t, cc.queue.NumRequeues(key), "a new event starts with a fresh retry budget")
+				return nil
+			}
+			cc.EventHandler().AddFunc(conn, false)
+			require.True(t, cc.processNextWorkItem(t.Context()))
+			assert.Equal(t, 1.0, processedCounterValue(t, reg, "connections", "live"))
+			assert.Zero(t, cc.queue.NumRequeues(key))
+			assert.Zero(t, cc.queue.Len())
+			assert.Empty(t, cc.triggers)
+		})
+	}
+}
+
+func TestConnectionController_DirtyRedeliveryKeepsTrigger(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		firstError error
+	}{
+		{name: "success"},
+		{name: "terminal error", firstError: errors.New("invalid connection")},
+		{name: "retryable error", firstError: apierrors.NewServiceUnavailable("temporarily unavailable")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cc, reg := newConnectionControllerForQueueTest(t)
+			clock := useFakeConnectionQueueClock(t, cc)
+			conn := &provisioning.Connection{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "conn", ResourceVersion: "5"}}
+			updated := conn.DeepCopy()
+			updated.ResourceVersion = "6"
+			processCount := 0
+			cc.processFn = func(context.Context, string) error {
+				processCount++
+				if processCount == 1 {
+					cc.EventHandler().UpdateFunc(conn, updated)
+					return tt.firstError
+				}
+				return nil
+			}
+
+			cc.EventHandler().AddFunc(conn, true)
+			require.True(t, cc.processNextWorkItem(t.Context()))
+			require.Equal(t, 1, cc.queue.Len())
+			assert.Equal(t, "live", string(cc.triggers["ns/conn"]), "completion and retry must preserve the newer event")
+			require.True(t, cc.processNextWorkItem(t.Context()))
+
+			if apierrors.IsServiceUnavailable(tt.firstError) {
+				clock.Step(time.Second)
+				// The dirty delivery consumes the retry budget. The delayed retry
+				// still arrives, but has no informer event to count after success.
+				require.True(t, cc.processNextWorkItem(t.Context()))
+				assert.Equal(t, 3, processCount)
+				assertOnlyProcessedTrigger(t, reg, "connections", "initial")
+			} else {
+				assert.Equal(t, 2, processCount)
+				assert.Equal(t, 1.0, processedCounterValue(t, reg, "connections", "initial"))
+				assert.Equal(t, 1.0, processedCounterValue(t, reg, "connections", "live"))
+				assert.Zero(t, processedCounterValue(t, reg, "connections", "relist"))
+			}
+			assert.Zero(t, cc.queue.NumRequeues("ns/conn"))
+			assert.Zero(t, cc.queue.Len())
+			assert.Empty(t, cc.triggers)
+		})
+	}
+}
+
+func TestConnectionController_RecentlyWrittenTokenReschedulesKey(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cc, reg := newConnectionControllerForQueueTest(t)
+		conn := &provisioning.Connection{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "conn", ResourceVersion: "5"},
+			Secure:     provisioning.ConnectionSecure{Token: common.InlineSecureValue{Name: "recent-token"}},
+			Status:     provisioning.ConnectionStatus{Token: provisioning.TokenStatus{LastUpdated: time.Now().UnixMilli()}},
+		}
+		original := conn.DeepCopy()
+		cc.conns = informer.NewCachedConnectionGetter(&mockConnectionLister{conn: conn})
+		cc.tracer = tracing.NewNoopTracerService()
+		healthChecker := NewMockConnectionHealthChecker(t)
+		healthChecker.EXPECT().ShouldCheckHealth(conn).Return(false).Twice()
+		cc.healthChecker = healthChecker
+		factory := connection.NewMockFactory(t)
+		factory.EXPECT().Build(mock.Anything, conn).
+			Return(nil, fmt.Errorf("unable to decrypt token: %w", connection.ErrTokenNotFound)).Once()
+		factory.EXPECT().Build(mock.Anything, conn).Return(connection.NewMockConnection(t), nil).Once()
+		cc.connectionFactory = factory
+
+		cc.EventHandler().AddFunc(conn, true)
+		require.True(t, cc.processNextWorkItem(t.Context()))
+		synctest.Wait()
+		require.Zero(t, cc.queue.Len())
+
+		time.Sleep(tokenWriteRetryDelay - time.Nanosecond)
+		synctest.Wait()
+		require.Zero(t, cc.queue.Len(), "token retry must wait for the configured delay")
+		time.Sleep(time.Nanosecond)
+		synctest.Wait()
+		require.Equal(t, 1, cc.queue.Len())
+		require.True(t, cc.processNextWorkItem(t.Context()))
+		assert.Zero(t, cc.queue.Len())
+		assert.Zero(t, cc.queue.NumRequeues("ns/conn"))
+		assert.Empty(t, cc.triggers)
+		assertOnlyProcessedTrigger(t, reg, "connections", "initial")
+		assert.Equal(t, original, conn, "the recent token must not be cleared or regenerated")
+	})
+}

--- a/pkg/registry/apis/provisioning/controller/connection_test.go
+++ b/pkg/registry/apis/provisioning/controller/connection_test.go
@@ -1227,8 +1227,8 @@ func TestConnectionController_process(t *testing.T) {
 				tracer:            tracing.InitializeTracerForTest(),
 			}
 
-			item := &connectionQueueItem{key: tt.conn.Namespace + "/" + tt.conn.Name}
-			err := cc.process(t.Context(), item)
+			key := tt.conn.Namespace + "/" + tt.conn.Name
+			err := cc.process(t.Context(), key)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -1393,10 +1393,8 @@ func TestConnectionController_process_FieldErrors(t *testing.T) {
 			}
 
 			// Process the connection
-			item := &connectionQueueItem{
-				key: "default/test-conn",
-			}
-			err := cc.process(ctx, item)
+			key := "default/test-conn"
+			err := cc.process(ctx, key)
 			require.NoError(t, err, "process should succeed")
 		})
 	}

--- a/pkg/registry/apis/provisioning/controller/processed_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/processed_metrics_test.go
@@ -250,6 +250,40 @@ func TestConnectionController_RecordsProcessingByTrigger(t *testing.T) {
 			feed:        func(h cache.ResourceEventHandlerDetailedFuncs) { h.UpdateFunc(conn("5"), conn("5")) },
 			wantTrigger: "relist",
 		},
+		{
+			name:        "apiserver live update",
+			feed:        func(h cache.ResourceEventHandlerDetailedFuncs) { h.UpdateFunc(conn("5"), conn("6")) },
+			wantTrigger: "live",
+		},
+		{
+			name:        "nats relist add",
+			natsBacked:  true,
+			feed:        func(h cache.ResourceEventHandlerDetailedFuncs) { h.AddFunc(conn("5"), false) },
+			wantTrigger: "relist",
+		},
+		{
+			name:        "nats live add",
+			natsBacked:  true,
+			feed:        func(h cache.ResourceEventHandlerDetailedFuncs) { h.AddFunc(conn(""), false) },
+			wantTrigger: "live",
+		},
+		{
+			name: "coalesced updates keep initial trigger",
+			feed: func(h cache.ResourceEventHandlerDetailedFuncs) {
+				h.AddFunc(conn("5"), true)
+				h.UpdateFunc(conn("5"), conn("6"))
+				h.UpdateFunc(conn("6"), conn("6"))
+			},
+			wantTrigger: "initial",
+		},
+		{
+			name: "coalesced relist keeps live trigger",
+			feed: func(h cache.ResourceEventHandlerDetailedFuncs) {
+				h.AddFunc(conn("5"), false)
+				h.UpdateFunc(conn("5"), conn("5"))
+			},
+			wantTrigger: "live",
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,13 +293,13 @@ func TestConnectionController_RecordsProcessingByTrigger(t *testing.T) {
 
 			cc := &ConnectionController{
 				queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-					workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
-					workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{Name: "test-processed"},
+					workqueue.DefaultTypedControllerRateLimiter[string](),
+					workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-processed"},
 				),
 				logger:       logging.DefaultLogger.With("logger", "test"),
 				drainTimeout: 5 * time.Second,
 				processed:    usinformer.NewProcessedMetrics(reg, "connections", tt.natsBacked),
-				processFn: func(context.Context, *connectionQueueItem) error {
+				processFn: func(context.Context, string) error {
 					close(processedDone)
 					return nil
 				},

--- a/pkg/registry/apis/provisioning/controller/shutdown_test.go
+++ b/pkg/registry/apis/provisioning/controller/shutdown_test.go
@@ -174,8 +174,8 @@ func TestConnectionController_Run_DrainWaitsForInFlight(t *testing.T) {
 
 	cc := &ConnectionController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-connection-drain",
 			},
 		),
@@ -183,14 +183,14 @@ func TestConnectionController_Run_DrainWaitsForInFlight(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	cc.processFn = func(ctx context.Context, item *connectionQueueItem) error {
+	cc.processFn = func(ctx context.Context, key string) error {
 		close(processingStarted)
 		<-processCh
 		processed.Store(true)
 		return nil
 	}
 
-	cc.queue.Add(&connectionQueueItem{key: "test/conn"})
+	cc.queue.Add("test/conn")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
@@ -230,8 +230,8 @@ func TestConnectionController_Run_DrainTimeoutForcesShutdown(t *testing.T) {
 
 	cc := &ConnectionController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-connection-drain-timeout",
 			},
 		),
@@ -240,12 +240,12 @@ func TestConnectionController_Run_DrainTimeoutForcesShutdown(t *testing.T) {
 	}
 
 	// processFn blocks forever to simulate a stuck reconciliation
-	cc.processFn = func(ctx context.Context, item *connectionQueueItem) error {
+	cc.processFn = func(ctx context.Context, key string) error {
 		close(processingStarted)
 		select {}
 	}
 
-	cc.queue.Add(&connectionQueueItem{key: "test/stuck"})
+	cc.queue.Add("test/stuck")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
@@ -276,8 +276,8 @@ func TestConnectionController_Run_OnShutdownCalledBeforeDrain(t *testing.T) {
 
 	cc := &ConnectionController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*connectionQueueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*connectionQueueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-connection-shutdown-ordering",
 			},
 		),
@@ -285,13 +285,13 @@ func TestConnectionController_Run_OnShutdownCalledBeforeDrain(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	cc.processFn = func(ctx context.Context, item *connectionQueueItem) error {
+	cc.processFn = func(ctx context.Context, key string) error {
 		close(processingStarted)
 		<-processCh
 		return nil
 	}
 
-	cc.queue.Add(&connectionQueueItem{key: "test/ordering"})
+	cc.queue.Add("test/ordering")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})

--- a/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
+++ b/pkg/registry/apis/provisioning/controller/worker_queue_metrics_test.go
@@ -77,7 +77,7 @@ func TestRepositoryController_WorkerQueueWaitHistogram(t *testing.T) {
 }
 
 // TestConnectionController_WorkerQueueWaitHistogram verifies the queue-wait histogram
-// records one observation each time a worker picks an item up off the queue.
+// records one observation each time a worker picks a key up off the queue.
 func TestConnectionController_WorkerQueueWaitHistogram(t *testing.T) {
 	const metricName = "grafana_provisioning_connection_worker_queue_wait_seconds"
 
@@ -92,15 +92,16 @@ func TestConnectionController_WorkerQueueWaitHistogram(t *testing.T) {
 
 	require.Equal(t, uint64(0), histogramSampleCountByName(t, reg, metricName))
 
-	cc.queue.Add(&connectionQueueItem{key: "ns/conn-a"})
-	cc.queue.Add(&connectionQueueItem{key: "ns/conn-b"})
+	cc.queue.Add("ns/conn-a")
+	cc.queue.Add("ns/conn-a")
+	cc.queue.Add("ns/conn-b")
 
-	item, _ := cc.queue.Get()
-	cc.queue.Done(item)
+	key, _ := cc.queue.Get()
+	cc.queue.Done(key)
 	require.Equal(t, uint64(1), histogramSampleCountByName(t, reg, metricName))
 
-	item, _ = cc.queue.Get()
-	cc.queue.Done(item)
+	key, _ = cc.queue.Get()
+	cc.queue.Done(key)
 	require.Equal(t, uint64(2), histogramSampleCountByName(t, reg, metricName))
 }
 
@@ -150,12 +151,13 @@ func TestConnectionController_WorkerQueueSizeGauge(t *testing.T) {
 
 	require.Equal(t, 0.0, gaugeValueByName(t, reg, metricName))
 
-	cc.queue.Add(&connectionQueueItem{key: "ns/conn-a"})
-	cc.queue.Add(&connectionQueueItem{key: "ns/conn-b"})
+	cc.queue.Add("ns/conn-a")
+	cc.queue.Add("ns/conn-a")
+	cc.queue.Add("ns/conn-b")
 	require.Equal(t, 2.0, gaugeValueByName(t, reg, metricName))
 
-	// Get removes the item from the queue (Len drops); Done clears it from processing.
-	item, _ := cc.queue.Get()
-	cc.queue.Done(item)
+	// Get removes the key from the queue (Len drops); Done clears it from processing.
+	key, _ := cc.queue.Get()
+	cc.queue.Done(key)
 	require.Equal(t, 1.0, gaugeValueByName(t, reg, metricName))
 }


### PR DESCRIPTION
**What is this feature?**

The connection controller now queues `namespace/name` strings, following the repository controller's pattern. Repeated events coalesce, and each connection is processed by at most one worker per controller instance.

Retry counts come from the workqueue. Trigger bookkeeping also follows the [repository controller's existing approach](https://github.com/grafana/grafana/blob/ef81cebecfd060a720728fa78419c77f50d16f27/pkg/registry/apis/provisioning/controller/repository.go#L274-L316): a mutex-protected map carries event-source attribution from enqueue to pickup and across retries. The connection controller already classified these events; this change moves their attribution from the queued struct into the map. Delayed token-read retries also use the string key.

**Why do we need this feature?**

Each informer event previously allocated a distinct `*connectionQueueItem`, so events for the same connection bypassed workqueue deduplication. Frequent status updates or errors could grow the queue and cause concurrent reconciliations of the same connection.

**Who is this feature for?**

Grafana Git Sync users and operators.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/1116

**Special notes for your reviewer:**

The status-update reconciliation policy remains unchanged.

Validation passed:

```sh
go test -mod=readonly -short -race ./pkg/registry/apis/provisioning/controller
```

Regression tests cover duplicate events before and during processing, multiple workers and namespaces, the three-attempt retry limit and cleanup, metric attribution, and delayed token reads. Existing shutdown and queue-metrics tests also pass.
