### PR TITLE
Search: Preserve embedding updates during provider throttling

### DIFF
--- a/pkg/storage/unified/search/embed/embedder/azure/client.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client.go
@@ -2,10 +2,24 @@ package azure
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/azure"
+
+	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
+)
+
+const (
+	retryAfterMsHeader = "Retry-After-Ms"
+	retryAfterHeader   = "Retry-After"
 )
 
 // restClient wraps the OpenAI SDK configured for an Azure OpenAI deployment.
@@ -56,7 +70,7 @@ func (c *restClient) EmbedTexts(ctx context.Context, texts []string, dimensions 
 
 	resp, err := c.client.Embeddings.New(ctx, params)
 	if err != nil {
-		return EmbedResult{}, fmt.Errorf("azure: embeddings: %w", err)
+		return EmbedResult{}, fmt.Errorf("azure: embeddings: %w", retryableError(err, time.Now()))
 	}
 	if len(resp.Data) != len(texts) {
 		return EmbedResult{}, fmt.Errorf("azure: got %d vectors for %d inputs", len(resp.Data), len(texts))
@@ -73,4 +87,46 @@ func (c *restClient) EmbedTexts(ctx context.Context, texts []string, dimensions 
 		vectors[d.Index] = v
 	}
 	return EmbedResult{Vectors: vectors, InputTokens: int(resp.Usage.PromptTokens)}, nil
+}
+
+func retryableError(err error, now time.Time) error {
+	var netErr net.Error
+	retryable := errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
+	var apiErr *openai.Error
+	var delay time.Duration
+	if errors.As(err, &apiErr) {
+		retryable = apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= http.StatusInternalServerError
+		if retryable && apiErr.Response != nil {
+			delay = retryAfter(apiErr.Response.Header, now)
+		}
+	}
+	if !retryable {
+		return err
+	}
+	return &embedder.RetryableError{Err: err, RetryAfter: delay}
+}
+
+func retryAfter(headers http.Header, now time.Time) time.Duration {
+	// Azure's millisecond hint is more precise than Retry-After.
+	for _, hint := range []struct {
+		name string
+		unit time.Duration
+	}{
+		{retryAfterMsHeader, time.Millisecond},
+		{retryAfterHeader, time.Second},
+	} {
+		value := strings.TrimSpace(headers.Get(hint.name))
+		if value == "" {
+			continue
+		}
+		if n, err := strconv.ParseFloat(value, 64); err == nil && n > 0 && n < float64(math.MaxInt64)/float64(hint.unit) {
+			return time.Duration(n * float64(hint.unit))
+		}
+		if hint.name == retryAfterHeader {
+			if deadline, err := http.ParseTime(value); err == nil {
+				return max(0, deadline.Sub(now))
+			}
+		}
+	}
+	return 0
 }

--- a/pkg/storage/unified/search/embed/embedder/azure/client.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client.go
@@ -95,7 +95,7 @@ func retryableError(err error, now time.Time) error {
 	var apiErr *openai.Error
 	var delay time.Duration
 	if errors.As(err, &apiErr) {
-		retryable = apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= http.StatusInternalServerError
+		retryable = apiErr.StatusCode == http.StatusRequestTimeout || apiErr.StatusCode == http.StatusConflict || apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= http.StatusInternalServerError
 		if retryable && apiErr.Response != nil {
 			delay = retryAfter(apiErr.Response.Header, now)
 		}

--- a/pkg/storage/unified/search/embed/embedder/azure/client.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client.go
@@ -95,7 +95,13 @@ func retryableError(err error, now time.Time) error {
 	var apiErr *openai.Error
 	var delay time.Duration
 	if errors.As(err, &apiErr) {
-		retryable = apiErr.StatusCode == http.StatusRequestTimeout || apiErr.StatusCode == http.StatusConflict || apiErr.StatusCode == http.StatusTooManyRequests || apiErr.StatusCode >= http.StatusInternalServerError
+		switch apiErr.StatusCode {
+		case http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests,
+			http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			retryable = true
+		default:
+			retryable = false
+		}
 		if retryable && apiErr.Response != nil {
 			delay = retryAfter(apiErr.Response.Header, now)
 		}

--- a/pkg/storage/unified/search/embed/embedder/azure/client_test.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client_test.go
@@ -91,12 +91,27 @@ func TestNewClient_Validation(t *testing.T) {
 
 func TestRetryableError(t *testing.T) {
 	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
-	for _, code := range []int{http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests, http.StatusServiceUnavailable, http.StatusBadRequest, http.StatusUnauthorized} {
-		t.Run(fmt.Sprint(code), func(t *testing.T) {
-			original := &openai.Error{StatusCode: code, Response: &http.Response{Header: http.Header{retryAfterMsHeader: []string{"90000"}}}}
+	for _, tt := range []struct {
+		code      int
+		retryable bool
+	}{
+		{http.StatusRequestTimeout, true},
+		{http.StatusConflict, true},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusNotImplemented, false},
+		{http.StatusHTTPVersionNotSupported, false},
+	} {
+		t.Run(fmt.Sprint(tt.code), func(t *testing.T) {
+			original := &openai.Error{StatusCode: tt.code, Response: &http.Response{Header: http.Header{retryAfterMsHeader: []string{"90000"}}}}
 			err := retryableError(original, now)
 			var retryErr *embedder.RetryableError
-			require.Equal(t, code == http.StatusRequestTimeout || code == http.StatusConflict || code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable, errors.As(err, &retryErr))
+			require.Equal(t, tt.retryable, errors.As(err, &retryErr))
 			assert.ErrorIs(t, err, original)
 			if retryErr != nil {
 				assert.Equal(t, 90*time.Second, retryErr.RetryAfter)

--- a/pkg/storage/unified/search/embed/embedder/azure/client_test.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client_test.go
@@ -91,12 +91,12 @@ func TestNewClient_Validation(t *testing.T) {
 
 func TestRetryableError(t *testing.T) {
 	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
-	for _, code := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable, http.StatusBadRequest, http.StatusUnauthorized} {
+	for _, code := range []int{http.StatusRequestTimeout, http.StatusConflict, http.StatusTooManyRequests, http.StatusServiceUnavailable, http.StatusBadRequest, http.StatusUnauthorized} {
 		t.Run(fmt.Sprint(code), func(t *testing.T) {
 			original := &openai.Error{StatusCode: code, Response: &http.Response{Header: http.Header{retryAfterMsHeader: []string{"90000"}}}}
 			err := retryableError(original, now)
 			var retryErr *embedder.RetryableError
-			require.Equal(t, code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable, errors.As(err, &retryErr))
+			require.Equal(t, code == http.StatusRequestTimeout || code == http.StatusConflict || code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable, errors.As(err, &retryErr))
 			assert.ErrorIs(t, err, original)
 			if retryErr != nil {
 				assert.Equal(t, 90*time.Second, retryErr.RetryAfter)

--- a/pkg/storage/unified/search/embed/embedder/azure/client_test.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/client_test.go
@@ -2,13 +2,20 @@ package azure
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 )
 
 // TestRestClient_EmbedTexts drives the SDK-backed client against a stub Azure
@@ -80,4 +87,76 @@ func TestNewClient_Validation(t *testing.T) {
 	require.Error(t, err)
 	_, err = NewClient("https://x", "dep", "v", "")
 	require.Error(t, err)
+}
+
+func TestRetryableError(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	for _, code := range []int{http.StatusTooManyRequests, http.StatusServiceUnavailable, http.StatusBadRequest, http.StatusUnauthorized} {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			original := &openai.Error{StatusCode: code, Response: &http.Response{Header: http.Header{retryAfterMsHeader: []string{"90000"}}}}
+			err := retryableError(original, now)
+			var retryErr *embedder.RetryableError
+			require.Equal(t, code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable, errors.As(err, &retryErr))
+			assert.ErrorIs(t, err, original)
+			if retryErr != nil {
+				assert.Equal(t, 90*time.Second, retryErr.RetryAfter)
+			}
+		})
+	}
+	for _, cause := range []error{context.DeadlineExceeded, context.Canceled, errors.New("unknown")} {
+		var retryErr *embedder.RetryableError
+		err := retryableError(fmt.Errorf("client: %w", cause), now)
+		assert.Equal(t, errors.Is(cause, context.DeadlineExceeded), errors.As(err, &retryErr))
+		assert.ErrorIs(t, err, cause)
+	}
+}
+
+func TestRetryAfter(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name    string
+		ms      string
+		seconds string
+		want    time.Duration
+	}{
+		{"milliseconds", "90000", "", 90 * time.Second},
+		{"seconds", "", "120", 2 * time.Minute},
+		{"fractional seconds", "", "1.5", 1500 * time.Millisecond},
+		{"prefer milliseconds", "1500", "2", 1500 * time.Millisecond},
+		{"invalid milliseconds falls back", "invalid", "2", 2 * time.Second},
+		{"HTTP date", "", now.Add(3 * time.Minute).Format(http.TimeFormat), 3 * time.Minute},
+		{"past date", "", now.Add(-time.Minute).Format(http.TimeFormat), 0},
+		{"negative", "-60", "-60", 0},
+		{"invalid", "", "tomorrow", 0},
+		{"overflow", "1e100", "1e100", 0},
+		{"NaN", "NaN", "NaN", 0},
+		{"infinity", "+Inf", "+Inf", 0},
+		{"missing", "", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(retryAfterMsHeader, tt.ms)
+			h.Set(retryAfterHeader, tt.seconds)
+			assert.Equal(t, tt.want, retryAfter(h, now))
+		})
+	}
+}
+
+func TestRestClient_EmbedTexts_ReturnsRetryHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(retryAfterMsHeader, "90000")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"quota exhausted","type":"rate_limit_error","code":"429"}}`))
+	}))
+	defer srv.Close()
+	c := &restClient{client: openai.NewClient(option.WithBaseURL(srv.URL), option.WithAPIKey("test"), option.WithMaxRetries(0)), deployment: "dep"}
+	_, err := c.EmbedTexts(t.Context(), []string{"CPU usage"}, 4)
+	var retryErr *embedder.RetryableError
+	require.ErrorAs(t, err, &retryErr)
+	assert.Equal(t, 90*time.Second, retryErr.RetryAfter)
+	var apiErr *openai.Error
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusTooManyRequests, apiErr.StatusCode)
 }

--- a/pkg/storage/unified/search/embed/embedder/azure/embed_dense.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/embed_dense.go
@@ -51,7 +51,7 @@ func (e *DenseEmbedder) EmbedText(ctx context.Context, input embedder.EmbedTextI
 		res, err := e.client.EmbedTexts(callCtx, texts, e.dim)
 		if err != nil {
 			if errors.Is(context.Cause(callCtx), ErrCallTimeout) {
-				return nil, ErrCallTimeout
+				return nil, &embedder.RetryableError{Err: ErrCallTimeout}
 			}
 			return nil, err
 		}

--- a/pkg/storage/unified/search/embed/embedder/azure/embed_dense_test.go
+++ b/pkg/storage/unified/search/embed/embedder/azure/embed_dense_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 type fakeClient struct {
+	wantErr   error
 	mu        sync.Mutex
 	calls     [][]string
 	dim       int
@@ -24,6 +25,9 @@ type fakeClient struct {
 }
 
 func (f *fakeClient) EmbedTexts(_ context.Context, texts []string, dimensions int) (EmbedResult, error) {
+	if f.wantErr != nil {
+		return EmbedResult{}, f.wantErr
+	}
 	n := atomic.AddInt32(&f.callNum, 1)
 	f.mu.Lock()
 	f.calls = append(f.calls, texts)
@@ -118,4 +122,16 @@ func TestDenseEmbedder_EmbedText_SumsTokensAcrossChunks(t *testing.T) {
 	out, err := e.EmbedText(context.Background(), embedder.EmbedTextInput{Texts: texts})
 	require.NoError(t, err)
 	assert.Equal(t, 21, out.InputTokens)
+}
+
+func TestDenseEmbedder_EmbedText_RetryableCallTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(ErrCallTimeout)
+	fc := &fakeClient{wantErr: context.Canceled}
+	e := NewDenseEmbedder(fc, 4, 1)
+	_, err := e.EmbedText(ctx, embedder.EmbedTextInput{Texts: []string{"CPU usage"}})
+	var retryErr *embedder.RetryableError
+	require.ErrorAs(t, err, &retryErr)
+	assert.ErrorIs(t, err, ErrCallTimeout)
+	assert.Zero(t, retryErr.RetryAfter)
 }

--- a/pkg/storage/unified/search/embed/embedder/batch_embedder.go
+++ b/pkg/storage/unified/search/embed/embedder/batch_embedder.go
@@ -3,6 +3,7 @@ package embedder
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
@@ -91,3 +92,17 @@ func (b *BatchEmbedder) Embed(
 func (b *BatchEmbedder) Model() string {
 	return b.embedder.Model
 }
+
+// RetryableError identifies a transient embedding failure. Callers can use
+// errors.As to schedule a retry while errors.Is/As still reach the cause.
+type RetryableError struct {
+	Err error
+	// RetryAfter is the provider's suggested minimum delay; zero means no hint.
+	RetryAfter time.Duration
+}
+
+func (e *RetryableError) Error() string {
+	return fmt.Sprintf("embedding provider temporarily unavailable: %v", e.Err)
+}
+
+func (e *RetryableError) Unwrap() error { return e.Err }

--- a/pkg/storage/unified/search/embed/embedder/batch_embedder_test.go
+++ b/pkg/storage/unified/search/embed/embedder/batch_embedder_test.go
@@ -3,7 +3,9 @@ package embedder
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -168,4 +170,22 @@ func (l *lengthMismatchingEmbedder) EmbedText(_ context.Context, _ EmbedTextInpu
 		out[i] = Embedding{Dense: []float32{0, 0, 0}}
 	}
 	return EmbedTextOutput{Embeddings: out}, nil
+}
+
+func TestBatchEmbedder_Embed_PreservesRetryableError(t *testing.T) {
+	cause := errors.New("provider failure")
+	for _, hint := range []time.Duration{0, time.Minute} {
+		t.Run(hint.String(), func(t *testing.T) {
+			retryErr := &RetryableError{Err: cause, RetryAfter: hint}
+			fake := &fakeTextEmbedder{wantErr: fmt.Errorf("provider client: %w", retryErr)}
+			be := NewBatchEmbedder(newTestEmbedder(fake))
+			vectors, err := be.Embed(t.Context(), "ns", "dashboards", 42, 1, []embed.Item{{UID: "dash", Content: "CPU usage"}})
+			require.Error(t, err)
+			assert.Nil(t, vectors)
+			assert.ErrorIs(t, err, cause)
+			var got *RetryableError
+			require.ErrorAs(t, err, &got)
+			assert.Same(t, retryErr, got)
+		})
+	}
 }

--- a/pkg/storage/unified/search/embed/embedder/bedrock/client.go
+++ b/pkg/storage/unified/search/embed/embedder/bedrock/client.go
@@ -3,15 +3,26 @@ package bedrock
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
+	"net"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/aws/smithy-go"
 	smithymiddleware "github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+
+	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 )
+
+const retryAfterHeader = "X-Amz-Retry-After"
 
 // runtimeAPI is the subset of the Bedrock runtime SDK we use; declaring it
 // as an interface keeps the client testable without a live AWS client.
@@ -69,7 +80,7 @@ func (c *awsClient) EmbedTexts(ctx context.Context, model string, texts []string
 		Body:        body,
 	})
 	if err != nil {
-		return EmbedResult{}, fmt.Errorf("bedrock: invoke: %w", err)
+		return EmbedResult{}, fmt.Errorf("bedrock: invoke: %w", retryableError(err))
 	}
 
 	var resp cohereEmbedResponse
@@ -109,4 +120,28 @@ func inputTokensFromMetadata(md smithymiddleware.Metadata) int {
 	}
 	n, _ := strconv.Atoi(resp.Header.Get("X-Amzn-Bedrock-Input-Token-Count"))
 	return n
+}
+
+func retryableError(err error) error {
+	var netErr net.Error
+	retryable := errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.(type) {
+		case *types.ThrottlingException, *types.ServiceQuotaExceededException, *types.ServiceUnavailableException, *types.InternalServerException, *types.ModelTimeoutException, *types.ModelNotReadyException:
+			retryable = true
+		}
+	}
+	if !retryable {
+		return err
+	}
+	var delay time.Duration
+	var responseErr *smithyhttp.ResponseError
+	if errors.As(err, &responseErr) && responseErr.Response != nil && responseErr.Response.Response != nil {
+		value := strings.TrimSpace(responseErr.Response.Header.Get(retryAfterHeader))
+		if ms, parseErr := strconv.ParseInt(value, 10, 64); parseErr == nil && ms > 0 && ms <= math.MaxInt64/int64(time.Millisecond) {
+			delay = time.Duration(ms) * time.Millisecond
+		}
+	}
+	return &embedder.RetryableError{Err: err, RetryAfter: delay}
 }

--- a/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense.go
+++ b/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense.go
@@ -53,7 +53,7 @@ func (e *DenseEmbedder) EmbedText(ctx context.Context, input embedder.EmbedTextI
 		res, err := e.client.EmbedTexts(callCtx, e.model, texts, inputType, e.dim)
 		if err != nil {
 			if errors.Is(context.Cause(callCtx), ErrCallTimeout) {
-				return nil, ErrCallTimeout
+				return nil, &embedder.RetryableError{Err: ErrCallTimeout}
 			}
 			return nil, err
 		}

--- a/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense_test.go
+++ b/pkg/storage/unified/search/embed/embedder/bedrock/embed_dense_test.go
@@ -3,10 +3,17 @@ package bedrock
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,6 +21,7 @@ import (
 )
 
 type fakeClient struct {
+	wantErr   error
 	mu        sync.Mutex
 	calls     [][]string
 	dim       int
@@ -24,6 +32,9 @@ type fakeClient struct {
 }
 
 func (f *fakeClient) EmbedTexts(_ context.Context, _ string, texts []string, inputType string, _ int) (EmbedResult, error) {
+	if f.wantErr != nil {
+		return EmbedResult{}, f.wantErr
+	}
 	n := atomic.AddInt32(&f.callNum, 1)
 	f.mu.Lock()
 	f.calls = append(f.calls, texts)
@@ -151,4 +162,59 @@ func TestDenseEmbedder_EmbedText_SumsTokensAcrossChunks(t *testing.T) {
 	out, err := e.EmbedText(context.Background(), embedder.EmbedTextInput{Texts: texts})
 	require.NoError(t, err)
 	assert.Equal(t, 21, out.InputTokens)
+}
+
+func TestDenseEmbedder_EmbedText_RetryableCallTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(ErrCallTimeout)
+	fc := &fakeClient{wantErr: context.Canceled}
+	e := NewDenseEmbedder(fc, "model", 4, 1)
+	_, err := e.EmbedText(ctx, embedder.EmbedTextInput{Texts: []string{"CPU usage"}})
+	var retryErr *embedder.RetryableError
+	require.ErrorAs(t, err, &retryErr)
+	assert.ErrorIs(t, err, ErrCallTimeout)
+	assert.Zero(t, retryErr.RetryAfter)
+}
+
+type failingRuntime struct{ err error }
+
+func (f failingRuntime) InvokeModel(context.Context, *bedrockruntime.InvokeModelInput, ...func(*bedrockruntime.Options)) (*bedrockruntime.InvokeModelOutput, error) {
+	return nil, f.err
+}
+
+func TestClientRetryableError(t *testing.T) {
+	for _, original := range []smithy.APIError{
+		&types.ThrottlingException{}, &types.ServiceQuotaExceededException{}, &types.ServiceUnavailableException{},
+		&types.InternalServerException{}, &types.ModelTimeoutException{}, &types.ModelNotReadyException{},
+		&types.ValidationException{}, &types.AccessDeniedException{},
+	} {
+		t.Run(original.ErrorCode(), func(t *testing.T) {
+			h := http.Header{}
+			h.Set(retryAfterHeader, "120000")
+			err := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusTooManyRequests, Header: h}}, Err: original}
+			c := &awsClient{runtime: failingRuntime{err: fmt.Errorf("SDK: %w", err)}}
+			_, got := c.EmbedTexts(t.Context(), "model", []string{"CPU usage"}, "search_document", 4)
+			wantRetry := true
+			switch original.(type) {
+			case *types.ValidationException, *types.AccessDeniedException:
+				wantRetry = false
+			}
+			var retryErr *embedder.RetryableError
+			require.Equal(t, wantRetry, errors.As(got, &retryErr))
+			assert.ErrorIs(t, got, original)
+			if retryErr != nil {
+				assert.Equal(t, 2*time.Minute, retryErr.RetryAfter)
+			}
+		})
+	}
+	for _, hint := range []string{"", "invalid", "-1", "9223372036854775807"} {
+		t.Run("invalid hint "+hint, func(t *testing.T) {
+			h := http.Header{}
+			h.Set(retryAfterHeader, hint)
+			err := &smithyhttp.ResponseError{Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusTooManyRequests, Header: h}}, Err: &types.ThrottlingException{}}
+			var retryErr *embedder.RetryableError
+			require.ErrorAs(t, retryableError(err), &retryErr)
+			assert.Zero(t, retryErr.RetryAfter)
+		})
+	}
 }

--- a/pkg/storage/unified/search/embed/embedder/vertex/client.go
+++ b/pkg/storage/unified/search/embed/embedder/vertex/client.go
@@ -2,13 +2,21 @@ package vertex
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"time"
 
 	aiplatform "cloud.google.com/go/aiplatform/apiv1"
 	"cloud.google.com/go/aiplatform/apiv1/aiplatformpb"
 	"google.golang.org/api/option"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 )
 
 // httpClient is the production Client backed by Google's aiplatform SDK
@@ -82,7 +90,7 @@ func (c *httpClient) PredictEmbeddings(ctx context.Context, model string, texts 
 
 	resp, err := c.pred.Predict(ctx, req)
 	if err != nil {
-		return EmbeddingResult{}, fmt.Errorf("vertex: predict: %w", err)
+		return EmbeddingResult{}, fmt.Errorf("vertex: predict: %w", retryableError(err))
 	}
 	if len(resp.GetPredictions()) != len(texts) {
 		return EmbeddingResult{}, fmt.Errorf("vertex: got %d predictions for %d inputs", len(resp.GetPredictions()), len(texts))
@@ -114,4 +122,26 @@ func (c *httpClient) Close() error {
 		return nil
 	}
 	return c.pred.Close()
+}
+
+func retryableError(err error) error {
+	var netErr net.Error
+	retryable := errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout())
+	switch status.Code(err) {
+	case codes.ResourceExhausted, codes.Unavailable, codes.DeadlineExceeded:
+		retryable = true
+	default:
+	}
+	if !retryable {
+		return err
+	}
+	var delay time.Duration
+	for _, detail := range status.Convert(err).Details() {
+		if info, ok := detail.(*errdetails.RetryInfo); ok {
+			if d := info.GetRetryDelay(); d != nil && d.CheckValid() == nil {
+				delay = max(delay, d.AsDuration())
+			}
+		}
+	}
+	return &embedder.RetryableError{Err: err, RetryAfter: delay}
 }

--- a/pkg/storage/unified/search/embed/embedder/vertex/embed_dense.go
+++ b/pkg/storage/unified/search/embed/embedder/vertex/embed_dense.go
@@ -50,7 +50,7 @@ func (e *DenseEmbedder) EmbedText(ctx context.Context, input embedder.EmbedTextI
 		res, err := e.client.PredictEmbeddings(callCtx, e.model, texts, e.dim, taskType)
 		if err != nil {
 			if errors.Is(context.Cause(callCtx), ErrCallTimeout) {
-				return nil, ErrCallTimeout
+				return nil, &embedder.RetryableError{Err: ErrCallTimeout}
 			}
 			return nil, err
 		}

--- a/pkg/storage/unified/search/embed/embedder/vertex/embed_dense_test.go
+++ b/pkg/storage/unified/search/embed/embedder/vertex/embed_dense_test.go
@@ -3,18 +3,25 @@ package vertex
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/grafana/grafana/pkg/storage/unified/search/embed/embedder"
 )
 
 // fakeClient records calls and returns synthetic vectors.
 type fakeClient struct {
+	wantErr   error
 	mu        sync.Mutex
 	calls     [][]string // texts per call, in arrival order
 	dim       int
@@ -25,6 +32,9 @@ type fakeClient struct {
 }
 
 func (f *fakeClient) PredictEmbeddings(_ context.Context, _ string, texts []string, _ int, taskType string) (EmbeddingResult, error) {
+	if f.wantErr != nil {
+		return EmbeddingResult{}, f.wantErr
+	}
 	n := atomic.AddInt32(&f.callNum, 1)
 	f.mu.Lock()
 	f.calls = append(f.calls, texts)
@@ -173,4 +183,49 @@ func TestDenseEmbedder_EmbedText_SumsTokensAcrossChunks(t *testing.T) {
 	out, err := e.EmbedText(context.Background(), embedder.EmbedTextInput{Texts: texts})
 	require.NoError(t, err)
 	assert.Equal(t, 21, out.InputTokens)
+}
+
+func TestDenseEmbedder_EmbedText_RetryableCallTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(t.Context())
+	cancel(ErrCallTimeout)
+	fc := &fakeClient{wantErr: context.Canceled}
+	e := NewDenseEmbedder(fc, "model", 4, 1)
+	_, err := e.EmbedText(ctx, embedder.EmbedTextInput{Texts: []string{"CPU usage"}})
+	var retryErr *embedder.RetryableError
+	require.ErrorAs(t, err, &retryErr)
+	assert.ErrorIs(t, err, ErrCallTimeout)
+	assert.Zero(t, retryErr.RetryAfter)
+}
+
+func TestRetryableError(t *testing.T) {
+	for _, code := range []codes.Code{codes.ResourceExhausted, codes.Unavailable, codes.DeadlineExceeded, codes.InvalidArgument, codes.Canceled} {
+		t.Run(code.String(), func(t *testing.T) {
+			original := status.Error(code, "provider failure")
+			err := retryableError(fmt.Errorf("client: %w", original))
+			var retryErr *embedder.RetryableError
+			require.Equal(t, code == codes.ResourceExhausted || code == codes.Unavailable || code == codes.DeadlineExceeded, errors.As(err, &retryErr))
+			assert.ErrorIs(t, err, original)
+			if retryErr != nil {
+				assert.Zero(t, retryErr.RetryAfter)
+			}
+		})
+	}
+	for _, tt := range []struct {
+		name string
+		hint *durationpb.Duration
+		want time.Duration
+	}{
+		{"hint", durationpb.New(2 * time.Minute), 2 * time.Minute},
+		{"negative", durationpb.New(-time.Second), 0},
+		{"missing", nil, 0},
+		{"invalid", &durationpb.Duration{Nanos: 2000000000}, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := status.New(codes.ResourceExhausted, "quota").WithDetails(&errdetails.RetryInfo{RetryDelay: tt.hint})
+			require.NoError(t, err)
+			var retryErr *embedder.RetryableError
+			require.ErrorAs(t, retryableError(fmt.Errorf("predict: %w", s.Err())), &retryErr)
+			assert.Equal(t, tt.want, retryErr.RetryAfter)
+		})
+	}
 }

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/dskit/backoff"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -77,6 +78,7 @@ type pendingEvent struct {
 	value     []byte
 	rv        int64
 	attempts  int
+	retry     bool
 }
 
 func pendingKey(group, resource, namespace, name string) string {
@@ -136,6 +138,11 @@ type Reconciler struct {
 	// Only ever touched from the sweep, which runs on Run's goroutine.
 	lastSweepSinceRv int64
 	lastSweepAt      time.Time
+
+	// Shared provider failures pause both watch processing and sweeps so
+	// a backlog cannot turn a quota rejection into a burst of retries.
+	embedRetryAt time.Time
+	embedBackoff *backoff.Backoff
 
 	// exhausted records the highest RV per resource whose retry budget
 	// ran out, so a sweep re-listing it from storage doesn't hand it a
@@ -440,6 +447,9 @@ func (s *Reconciler) checkpointRV(ctx context.Context) (int64, error) {
 // writer of the checkpoint: a completed walk from the cursor is the only
 // thing that shows nothing below the new value was missed.
 func (s *Reconciler) sweep(ctx context.Context) {
+	if time.Now().Before(s.embedRetryAt) {
+		return
+	}
 	sinceRv, err := s.checkpointRV(ctx)
 	if err != nil {
 		s.log.Error("reconciler: sweep read checkpoint", "err", err)
@@ -489,6 +499,7 @@ func (s *Reconciler) sweep(ctx context.Context) {
 		s.forgetExhaustedBelow(target)
 	}
 	s.log.Debug("reconciler: sweep complete", "from", sinceRv, "to", target)
+	s.embedBackoff = nil
 }
 
 // reconcileSince walks ListModifiedSince in batches and returns the RV
@@ -522,16 +533,23 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 		succeeded      int
 		lowestFailedRv = int64(math.MaxInt64)
 	)
+	// An interrupted iterator must retain earlier failures too, including
+	// lookback writes that a later listing may no longer return.
+	defer func() {
+		for _, ev := range failed {
+			s.enqueue(ev)
+		}
+	}()
 
 	flush := func(batch []*pendingEvent) bool {
 		batchLowestFailed, batchFailed, batchSuccess, abort := s.processEvents(ctx, batch)
+		failed = append(failed, batchFailed...)
 		if abort {
 			return false
 		}
 		if batchLowestFailed < lowestFailedRv {
 			lowestFailedRv = batchLowestFailed
 		}
-		failed = append(failed, batchFailed...)
 		succeeded += len(batchSuccess)
 		return true
 	}
@@ -582,9 +600,6 @@ func (s *Reconciler) reconcileSince(ctx context.Context, builder embed.Builder, 
 	}
 
 	target := pickLatestRV(sinceRv, resource.ToSnowflakeRV(latestRv), lowestFailedRv)
-	for _, ev := range failed {
-		s.enqueue(ev)
-	}
 	logger.Info("reconciler: reconcileSince builder complete",
 		"group", builder.Group(), "resource", builder.Resource(),
 		"events", succeeded, "failed", len(failed),
@@ -626,6 +641,9 @@ func (s *Reconciler) dropPendingUpTo(ev *pendingEvent) {
 // processPending drains the in-memory pending map (watch-sourced events,
 // plus failed retries) and runs the batch through processBatch.
 func (s *Reconciler) processPending(ctx context.Context) {
+	if time.Now().Before(s.embedRetryAt) {
+		return
+	}
 	s.processBatch(ctx, s.drainPending())
 }
 
@@ -653,27 +671,25 @@ func (s *Reconciler) processBatch(ctx context.Context, batch []*pendingEvent) {
 	// back writes the cursor has already passed.
 	live := make([]*pendingEvent, 0, len(batch))
 	for _, ev := range batch {
-		if ev.rv > sinceRv || ev.attempts > 0 {
+		if ev.rv > sinceRv || ev.attempts > 0 || ev.retry {
 			live = append(live, ev)
 		}
 	}
 	batch = live
 
-	_, failed, successes, abort := s.processEvents(ctx, batch)
-	if abort {
-		s.requeue(batch)
-		return
-	}
-
-	// A cursor of 0 keeps the sweep switched off entirely, so hold the
-	// batch until the seed lands instead of waiting for another write.
+	// Persist a sweep starting point before calling the provider, so an
+	// outage on the first event remains recoverable after a restart.
 	if sinceRv == 0 && !s.seedCheckpoint(ctx, batch) {
 		s.requeue(batch)
 		return
 	}
 
+	_, failed, successes, abort := s.processEvents(ctx, batch)
 	for _, ev := range failed {
 		s.enqueue(ev)
+	}
+	if abort {
+		return
 	}
 
 	switch {
@@ -711,15 +727,24 @@ func (s *Reconciler) seedCheckpoint(ctx context.Context, batch []*pendingEvent) 
 
 // processEvents runs the embed/upsert loop without advancing the
 // cursor — the caller decides when to commit progress. abort is true if
-// ctx was cancelled mid-loop; the caller should treat all events as
-// un-processed.
+// ctx was cancelled or the embedding provider needs a cooldown; the
+// failed then includes the unprocessed remainder, and the caller must
+// enqueue it and leave the checkpoint unchanged.
 // For new resources, it ensures a partition and backfill job is created
 func (s *Reconciler) processEvents(ctx context.Context, batch []*pendingEvent) (lowestFailedRv int64, failed, successes []*pendingEvent, abort bool) {
 	logger := s.log.FromContext(ctx)
 	lowestFailedRv = math.MaxInt64
-	for _, ev := range batch {
+	unfinished := func(start int) []*pendingEvent {
+		for _, ev := range batch[start:] {
+			// Unattempted lookback events also need to survive the live
+			// path's cursor filter when this batch is interrupted.
+			ev.retry = true
+		}
+		return append(failed, batch[start:]...)
+	}
+	for i, ev := range batch {
 		if ctx.Err() != nil {
-			return lowestFailedRv, nil, nil, true
+			return lowestFailedRv, unfinished(i), successes, true
 		}
 		builder, ok := s.builders[builderKey(ev.group, ev.resource)]
 		if !ok {
@@ -739,6 +764,16 @@ func (s *Reconciler) processEvents(ctx context.Context, batch []*pendingEvent) (
 		}
 
 		if err := s.processEvent(ctx, builder, ev); err != nil {
+			if ctx.Err() != nil {
+				ev.attempts--
+				return lowestFailedRv, unfinished(i), successes, true
+			}
+			var retryErr *embedder.RetryableError
+			if errors.As(err, &retryErr) {
+				ev.attempts--
+				s.backoffEmbedding(ctx, ev, retryErr)
+				return lowestFailedRv, unfinished(i), successes, true
+			}
 			logger.Warn("reconciler: process event",
 				"namespace", ev.namespace, "name", ev.name,
 				"rv", ev.rv, "attempts", ev.attempts,
@@ -1016,4 +1051,29 @@ func pickLatestRV(sinceRv, latestRv, lowestFailedRv int64) int64 {
 		return sinceRv
 	}
 	return candidate
+}
+
+const (
+	minEmbedRetryDelay = time.Minute
+	maxEmbedRetryDelay = 5 * time.Minute
+)
+
+func (s *Reconciler) backoffEmbedding(ctx context.Context, ev *pendingEvent, err *embedder.RetryableError) {
+	if ctx.Err() != nil {
+		return
+	}
+	if s.embedBackoff == nil {
+		s.embedBackoff = backoff.New(ctx, backoff.Config{
+			MinBackoff: minEmbedRetryDelay,
+			MaxBackoff: maxEmbedRetryDelay,
+			MaxRetries: 0,
+		})
+	}
+	now := time.Now()
+	providerDelay := err.RetryAfter
+	delay := min(maxEmbedRetryDelay, max(s.embedBackoff.NextDelay(), providerDelay))
+	s.embedRetryAt = now.Add(delay)
+	s.log.FromContext(ctx).Warn("reconciler: embedding provider backoff; checkpoint retained",
+		"namespace", ev.namespace, "name", ev.name, "rv", ev.rv,
+		"retryAt", s.embedRetryAt, "delay", delay, "providerDelay", providerDelay, "err", err)
 }

--- a/pkg/storage/unified/search/embed/reconciler/reconciler.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler.go
@@ -44,8 +44,8 @@ type Backfiller interface {
 const DefaultInterval = time.Minute
 
 // maxEventAttempts caps retries so a permanently broken dashboard
-// can't wedge cursor advancement forever. ~5 minutes at the default
-// poll interval — long enough to ride out transient Vertex hiccups.
+// can't wedge cursor advancement forever. This includes provider errors:
+// providers can misclassify an invalid request as temporarily unavailable.
 const maxEventAttempts = 5
 
 // defaultLockRetryInterval is how long Run waits between attempts to
@@ -770,9 +770,9 @@ func (s *Reconciler) processEvents(ctx context.Context, batch []*pendingEvent) (
 			}
 			var retryErr *embedder.RetryableError
 			if errors.As(err, &retryErr) {
-				ev.attempts--
 				s.backoffEmbedding(ctx, ev, retryErr)
-				return lowestFailedRv, unfinished(i), successes, true
+				lowestFailedRv = s.recordFailure(ev, &failed, lowestFailedRv, logger)
+				return lowestFailedRv, unfinished(i + 1), successes, true
 			}
 			logger.Warn("reconciler: process event",
 				"namespace", ev.namespace, "name", ev.name,

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -1847,7 +1847,7 @@ func TestReconciler_EmbeddingBackoff(t *testing.T) {
 		t.Run(hint.String(), func(t *testing.T) {
 			s, st, vec, text := setupEmbeddingRetry(t, snowflakeRV(50))
 			s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), st.changes[0].Value))
-			for attempt := range maxEventAttempts + 3 {
+			for attempt := range maxEventAttempts - 1 {
 				s.embedRetryAt = time.Time{}
 				text.failNext = &embedder.RetryableError{Err: errBoom, RetryAfter: hint}
 				before := time.Now()
@@ -1968,4 +1968,57 @@ func TestReconciler_EmbeddingLiveRecovery(t *testing.T) {
 			assert.Zero(t, s.pendingLen())
 		})
 	}
+}
+
+func TestReconciler_EmbeddingRetryCap(t *testing.T) {
+	for _, source := range []string{"watch", "sweep", "lookback"} {
+		t.Run(source, func(t *testing.T) {
+			cursor := snowflakeRV(50)
+			if source == "lookback" {
+				cursor = snowflakeRV(105)
+			}
+			s, st, vec, text := setupEmbeddingRetry(t, cursor)
+			if source == "watch" {
+				s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), st.changes[0].Value))
+			}
+			st.lookback, st.latestRvOverride = 10, snowflakeRV(110)
+			s.metrics = resource.ProvideVectorMetrics(prometheus.NewPedanticRegistry())
+			for attempt := range maxEventAttempts {
+				s.embedRetryAt = time.Time{}
+				text.failNext = &embedder.RetryableError{Err: errBoom}
+				s.reconcileCycle(t.Context())
+				require.Equal(t, attempt+1, text.calls)
+				require.Equal(t, cursor, vec.latestRV, "a provider failure still aborts the sweep")
+				if attempt+1 < maxEventAttempts {
+					require.Equal(t, 1, s.pendingLen())
+					require.Equal(t, attempt+1, s.pending[pendingKey(dashGroup, dashRes, "ns", "dash")].attempts)
+				}
+			}
+			require.Zero(t, s.pendingLen(), "the exhausted event must not be requeued as unfinished")
+			require.True(t, s.isExhausted(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), nil)))
+			assert.Equal(t, 1.0, testutil.ToFloat64(s.metrics.ReconcilerEventsDroppedTotal.WithLabelValues(dashGroup, dashRes, "retries_exhausted")))
+			s.reconcileCycle(t.Context())
+			require.Equal(t, maxEventAttempts, text.calls, "cooldown still applies after the final failure")
+			s.embedRetryAt = time.Time{}
+			s.reconcileCycle(t.Context())
+			assert.Equal(t, maxEventAttempts, text.calls, "re-listing must not reset the exhausted allowance")
+			assert.Equal(t, snowflakeRV(110), vec.latestRV, "cursor can pass the broken dashboard")
+		})
+	}
+}
+
+func TestReconciler_EmbeddingRetryCap_PreservesUnfinishedEvents(t *testing.T) {
+	s, _, vec, text := setupEmbeddingRetry(t, snowflakeRV(50))
+	broken := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "broken", snowflakeRV(100), minimalDashboard("broken", "Broken"))
+	broken.attempts = maxEventAttempts - 1
+	next := dashEvent(resourcepb.WatchEvent_ADDED, "ns", "next", snowflakeRV(110), minimalDashboard("next", "Next"))
+	text.failNext = &embedder.RetryableError{Err: errBoom}
+	_, failed, successes, abort := s.processEvents(t.Context(), []*pendingEvent{broken, next})
+	require.True(t, abort)
+	require.Empty(t, successes)
+	require.Equal(t, []*pendingEvent{next}, failed)
+	require.Zero(t, next.attempts, "unattempted events do not consume their allowance")
+	s.processBatch(t.Context(), failed)
+	require.Len(t, vec.upserts, 1)
+	assert.Equal(t, "next", vec.upserts[0][0].UID)
 }

--- a/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
+++ b/pkg/storage/unified/search/embed/reconciler/reconciler_test.go
@@ -1830,3 +1830,142 @@ func TestReconciler_ExhaustedRecord_SurvivesLookbackRelist(t *testing.T) {
 	s.forgetExhaustedBelow(past)
 	assert.Empty(t, s.exhausted, "dropped once a sweep no longer lists it")
 }
+
+func setupEmbeddingRetry(t *testing.T, cursor int64) (*Reconciler, *fakeStorage, *fakeVector, *fakeText) {
+	t.Helper()
+	st := &fakeStorage{changes: []*resource.ModifiedResource{
+		dashChange(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), minimalDashboard("dash", "Dash")),
+	}}
+	vec := newFakeVector()
+	vec.latestRV = cursor
+	s, text := newReconciler(t, st, vec)
+	return s, st, vec, text
+}
+
+func TestReconciler_EmbeddingBackoff(t *testing.T) {
+	for _, hint := range []time.Duration{0, time.Second, 10 * time.Minute} {
+		t.Run(hint.String(), func(t *testing.T) {
+			s, st, vec, text := setupEmbeddingRetry(t, snowflakeRV(50))
+			s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), st.changes[0].Value))
+			for attempt := range maxEventAttempts + 3 {
+				s.embedRetryAt = time.Time{}
+				text.failNext = &embedder.RetryableError{Err: errBoom, RetryAfter: hint}
+				before := time.Now()
+				s.reconcileCycle(t.Context())
+				require.Equal(t, attempt+1, text.calls)
+				require.Equal(t, snowflakeRV(50), vec.latestRV)
+				require.Equal(t, 1, s.pendingLen())
+				require.Empty(t, s.exhausted)
+				require.Equal(t, attempt+1, s.embedBackoff.NumRetries())
+				assert.False(t, s.embedRetryAt.Before(before.Add(min(5*time.Minute, max(hint, time.Minute)))))
+				assert.True(t, s.embedRetryAt.Before(time.Now().Add(5*time.Minute)), "provider hints cannot exceed the hard cap")
+				s.reconcileCycle(t.Context())
+				require.Equal(t, attempt+1, text.calls, "cooldown suppresses calls")
+				require.Empty(t, st.lastCalledWith, "cooldown suppresses scans")
+			}
+			s.embedRetryAt = time.Time{}
+			s.reconcileCycle(t.Context())
+			assert.Equal(t, snowflakeRV(100), vec.latestRV)
+			assert.Zero(t, s.pendingLen())
+			assert.Nil(t, s.embedBackoff, "recovery resets backoff")
+			assert.Len(t, vec.upserts, 1)
+		})
+	}
+}
+
+func TestReconciler_EmbeddingSweepRecovery(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		batchSize          int
+		upsertErr          error
+		failFirst, restart bool
+		pending            []string
+	}{
+		{"unprocessed remainder", 1000, nil, false, false, []string{"b", "c"}},
+		{"earlier batch failure", 1, errBoom, false, false, []string{"a", "b"}},
+		{"same batch failure", 1000, errBoom, false, false, []string{"a", "b", "c"}},
+		{"failed lookback write", 1000, nil, true, false, []string{"a", "b", "c"}},
+		{"restart after partial sweep", 1, nil, false, true, []string{"b"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oldBatchSize := startupBatchSize
+			startupBatchSize = tt.batchSize
+			t.Cleanup(func() { startupBatchSize = oldBatchSize })
+			s, st, vec, text := setupEmbeddingRetry(t, snowflakeRV(100))
+			st.changes = nil
+			for i, name := range []string{"a", "b", "c"} {
+				rv := []int64{95, 110, 120}[i]
+				st.changes = append(st.changes, dashChange(resourcepb.WatchEvent_ADDED, "ns", name, snowflakeRV(rv), minimalDashboard(name, name)))
+			}
+			st.lookback, st.latestRvOverride = 10, snowflakeRV(120)
+			yielded := 0
+			st.onYield = func() { yielded++ }
+			throttled := &embedder.RetryableError{Err: errBoom}
+			vec.upsertErrFn = func([]vector.Vector) error { text.failNext = throttled; return tt.upsertErr }
+			if tt.failFirst {
+				text.failNext = throttled
+			}
+			s.reconcileCycle(t.Context())
+			require.Equal(t, snowflakeRV(100), vec.latestRV, "interrupted sweep retains cursor")
+			require.Equal(t, len(tt.pending), s.pendingLen())
+			for _, name := range tt.pending {
+				assert.Contains(t, s.pending, pendingKey(dashGroup, dashRes, "ns", name))
+			}
+			indexed := len(vec.upserts)
+			if indexed > 0 {
+				assert.NotContains(t, s.pending, pendingKey(dashGroup, dashRes, "ns", "a"), "known success is not queued")
+			}
+			vec.upsertErrFn, st.onYield = nil, nil
+			if tt.restart {
+				s, text = newReconciler(t, st, vec)
+			} else {
+				// Only unlisted rows remain: queued lookback writes must survive independently.
+				st.changes = st.changes[yielded:]
+			}
+			callsBefore := text.calls
+			s.embedRetryAt = time.Time{}
+			s.reconcileCycle(t.Context())
+			assert.Equal(t, 3-indexed, text.calls-callsBefore, "successful content is not re-embedded")
+			assert.Len(t, vec.upserts, 3)
+			assert.Zero(t, s.pendingLen())
+			assert.Equal(t, snowflakeRV(120), vec.latestRV)
+		})
+	}
+}
+
+func TestReconciler_EmbeddingLiveRecovery(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cursor  int64
+		restart bool
+	}{
+		{"initial seed survives restart", 0, true},
+		{"newer delete supersedes retry", snowflakeRV(50), false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, st, vec, text := setupEmbeddingRetry(t, tt.cursor)
+			text.failNext = &embedder.RetryableError{Err: errBoom}
+			s.enqueue(dashEvent(resourcepb.WatchEvent_ADDED, "ns", "dash", snowflakeRV(100), st.changes[0].Value))
+			s.reconcileCycle(t.Context())
+			require.Equal(t, 1, s.pendingLen())
+			if tt.restart {
+				require.Equal(t, snowflakeRV(100)-1, vec.latestRV)
+				s, _ = newReconciler(t, st, vec)
+				s.reconcileCycle(t.Context())
+				assert.Equal(t, snowflakeRV(100), vec.latestRV)
+				assert.Len(t, vec.upserts, 1)
+			} else {
+				st.changes = nil
+				s.enqueue(dashEvent(resourcepb.WatchEvent_DELETED, "ns", "dash", snowflakeRV(200), nil))
+				s.reconcileCycle(t.Context())
+				assert.Empty(t, vec.deletes, "new events do not bypass cooldown")
+				s.embedRetryAt = time.Time{}
+				s.reconcileCycle(t.Context())
+				assert.Equal(t, 1, text.calls)
+				assert.Empty(t, vec.upserts)
+				assert.Len(t, vec.deletes, 1)
+			}
+			assert.Zero(t, s.pendingLen())
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Pause embedding reconciliation after provider throttling or other retryable failures. Use dskit's exponential backoff with jitter, a one-minute minimum, and a hard five-minute maximum including provider retry hints.

Each provider client returns `embedder.RetryableError` with its optional retry hint and original cause. The reconciler handles that shared type without provider-specific dependencies. Interrupted batches retain only failed and unprocessed events, and the initial checkpoint is seeded before the first provider call for restart recovery.

All failures, including retryable provider errors, consume the existing five-attempt allowance. Providers can misclassify invalid requests as transient errors, so an exhausted revision is dropped and marked to prevent a sweep from granting it a fresh allowance. The shared cooldown still applies after the final provider failure.

**Why do we need this feature?**

Shared embedding quotas can be exhausted by dashboard changes. Without a cooldown, reconciling the backlog repeatedly calls an unavailable provider and quickly consumes the event retry allowance. Backoff spaces those attempts and pauses backlog scans; successful dashboard content is skipped when the sweep resumes.

**Who is this feature for?**

Tenants using unified-storage vector search and operators maintaining embedding freshness.

**Which issue(s) does this PR fix?**

Part of grafana/search-and-storage-team#961.

**Special notes for your reviewer:**

- The cooldown pauses the whole reconciler. Backfills are unchanged, and pending work can grow during an outage.
- Long outages can still exhaust five attempts and drop updates. The finite limit prevents a dashboard that consistently receives a misleading transient error from blocking reconciliation indefinitely.
- Azure retry classification explicitly includes HTTP 408, 409, 429, 500, 502, 503, and 504; it does not retry every 5xx response at the reconciler level.
- The five-minute delay cap also limits longer provider hints.
- Backend-only change; no client/server protocol changes.

Validation: embedding package tests passed, including provider classification and hints, capped retry exhaustion from watch/sweep/lookback paths, unfinished-event preservation, partial-sweep and restart recovery, and newer deletes. Scoped `make lint-go` and `git diff --check` passed.
