### PR TITLE
FeatureToggles: Restrict legacy config.featureToggles usage via lint rule

### DIFF
--- a/.github/workflows/scripts/test-endpoint-migration-check.sh
+++ b/.github/workflows/scripts/test-endpoint-migration-check.sh
@@ -76,10 +76,12 @@ if [[ -z "$REMOVED_API" ]]; then
 fi
 
 # === Migration detected — check for feature toggle ===
+# Accepts either an OpenFeature read (preferred) or a legacy config.featureToggles
+# read, since flags that have not been migrated yet are still valid.
 TOGGLE_PRESENT=$(echo "$FILTERED_DIFF" | \
   grep -E '^\+' | \
   grep -vE '^\+\+\+' | \
-  grep -E 'config\.featureToggles\.\w+' || true)
+  grep -E "(useFlag[A-Z][a-zA-Z]*\(|getBooleanValue\(|FlagKeys\.\w+|config\.featureToggles\.\w+)" || true)
 
 if [[ -n "$TOGGLE_PRESENT" ]]; then
   echo "Endpoint migration detected AND feature toggle found. Check passed."
@@ -105,13 +107,20 @@ echo ""
 echo "How to fix:"
 echo "  Gate the migration behind a feature toggle with a fallback:"
 echo ""
-echo "    import { config } from '@grafana/runtime';"
+echo "    import { useFlagYourFeatureFlag } from '@grafana/runtime/internal';"
 echo ""
-echo "    if (config.featureToggles.yourFeatureFlag) {"
+echo "    const useNewApi = useFlagYourFeatureFlag();"
+echo "    if (useNewApi) {"
 echo "      // Use new K8s API endpoint"
 echo "    } else {"
 echo "      // Keep existing API call as fallback"
 echo "    }"
+echo ""
+echo "  Outside React, use:"
+echo "    getFeatureFlagClient().getBooleanValue(FlagKeys.YourFeatureFlag, false)"
+echo ""
+echo "  The flag needs 'React: true' in its Generate field in"
+echo "  pkg/services/featuremgmt/registry.go. See contribute/feature-toggles.md."
 echo ""
 echo "  If a toggle is not needed (e.g., the backend endpoint is already"
 echo "  fully rolled out on all channels), add the label:"

--- a/.github/workflows/scripts/test-endpoint-migration-check.sh
+++ b/.github/workflows/scripts/test-endpoint-migration-check.sh
@@ -81,7 +81,7 @@ fi
 TOGGLE_PRESENT=$(echo "$FILTERED_DIFF" | \
   grep -E '^\+' | \
   grep -vE '^\+\+\+' | \
-  grep -E "(useFlag[A-Z][a-zA-Z]*\(|getBooleanValue\(|FlagKeys\.\w+|config\.featureToggles\.\w+)" || true)
+  grep -E "(useFlag[A-Z][A-Za-z0-9]*\(|getBooleanValue\(|FlagKeys\.\w+|config\.featureToggles\.\w+)" || true)
 
 if [[ -n "$TOGGLE_PRESENT" ]]; then
   echo "Endpoint migration detected AND feature toggle found. Check passed."

--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -18,12 +18,12 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 
 The `Generate` field on a `FeatureFlag` controls which clients are generated. The available targets are:
 
-| Target                   | Description                                                                                                             |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `GenerateLegacyGo`       | Generates a Go constant in `toggles_gen.go`, skipping new name requirements (legacy, prefer `GenerateGo` for new flags) |
-| `GenerateLegacyFrontend` | Generates a TypeScript constant in `featureToggles.gen.ts` (legacy, prefer `GenerateReact` for new flags)               |
-| `GenerateGo`             | Generates a Go constant in `toggles_gen.go`                                                                             |
-| `GenerateReact`          | Generates a typed React hook in `openfeature.gen.ts` via the OpenFeature CLI                                            |
+| Target           | Description                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `LegacyGo`       | Generates a Go constant in `toggles_gen.go`, skipping new name requirements (legacy, prefer `Go` for new flags) |
+| `LegacyFrontend` | Generates a TypeScript constant in `featureToggles.gen.ts` (legacy, prefer `React` for new flags)               |
+| `Go`             | Generates a Go constant in `toggles_gen.go`                                                                     |
+| `React`          | Generates a typed React hook in `openfeature.gen.ts` via the OpenFeature CLI                                    |
 
 e.g.
 
@@ -32,11 +32,44 @@ e.g.
     Name:        "grafana.newPreferencesPage",
     Description: "Whether to use the new SharedPreferences functional component",
     Stage:       FeatureStageExperimental,
-    Generate:    []GenerateTarget{GenerateGo, GenerateReact},
+    Generate:    Generate{Go: true, React: true},
     Owner:       grafanaFrontendPlatformSquad,
     Expression:  "false",
 },
 ```
+
+## Migrating an existing legacy flag to OpenFeature
+
+Reading a flag from `config.featureToggles` is blocked by the `@grafana/no-config-feature-toggles`
+lint rule. That map is a static bootData snapshot, and the multi-tenant frontend service serves it
+empty — so every flag read through it resolves to `false` there, including flags that are GA and
+enabled by default.
+
+If you hit that rule on a flag that already exists as a legacy toggle, add `React: true` **alongside**
+its existing `LegacyFrontend`:
+
+```go
+Generate: Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
+```
+
+Do **not** rename the flag to the `component.flagName` convention as part of this. The name is the
+OFREP key, and it is also the key used in `custom.ini` under `[feature_toggles]` and in any Cloud
+per-stack override, so renaming it silently drops those. Keeping either legacy target set also keeps
+the naming check satisfied. Then run `make gen-feature-toggles` and move the frontend reads over to
+the generated hook or the client.
+
+Existing reads can be migrated incrementally — a flag can have both targets while some call sites are
+still legacy.
+
+Two things to watch when you migrate the reads:
+
+- **The evaluation default changes for default-on flags.** The generated `useFlagXxx` hook bakes the
+  registry `Expression` in as its default, so a flag with `Expression: "true"` starts resolving to
+  `true` where the legacy read gave `false` (jest starts with an empty `config.featureToggles`).
+  That is the correct behaviour, but it can flip unrelated test suites onto the new code path.
+- **Tests need `setTestFlags`.** `testWithFeatureToggles` only writes `config.featureToggles`, so it
+  no longer gates a migrated read. Use `setTestFlags` from `@grafana/test-utils/unstable` instead,
+  and reset it in `afterEach` wrapped in `act` — it fires OpenFeature events into mounted components.
 
 ## How to use the flag in your code
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -355,6 +355,9 @@
     }
   },
   "packages/grafana-runtime/src/utils/DataSourceWithBackend.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
@@ -362,6 +365,11 @@
   "packages/grafana-runtime/src/utils/queryResponse.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    }
+  },
+  "packages/grafana-runtime/src/utils/useFavoriteDatasources.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
     }
   },
   "packages/grafana-schema/src/veneer/common.types.ts": {
@@ -379,6 +387,11 @@
   },
   "packages/grafana-sql/src/components/DatasetSelector.tsx": {
     "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "packages/grafana-sql/src/components/QueryHeader.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -748,6 +761,21 @@
       "count": 1
     }
   },
+  "public/app/AppWrapper.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/api/clients/folder/v1beta1/hooks.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 9
+    }
+  },
+  "public/app/app.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
+    }
+  },
   "public/app/core/TableModel.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2
@@ -756,6 +784,16 @@
   "public/app/core/components/AccessControl/PermissionList.tsx": {
     "@grafana/no-gf-form": {
       "count": 1
+    }
+  },
+  "public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
     }
   },
   "public/app/core/components/DynamicImports/SafeDynamicImport.tsx": {
@@ -784,12 +822,25 @@
       "count": 1
     }
   },
+  "public/app/core/components/Login/LoginCtrl.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/core/components/Login/LoginForm.tsx": {
     "@grafana/require-no-margin": {
       "count": 2
     }
   },
+  "public/app/core/components/NestedFolderPicker/useFoldersQuery.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/core/components/OptionsUI/fieldColor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    },
     "@grafana/require-no-margin": {
       "count": 1
     }
@@ -847,6 +898,11 @@
       "count": 1
     }
   },
+  "public/app/core/navtree/sections/admin.navEntry.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/core/services/ResponseQueue.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -861,6 +917,9 @@
     }
   },
   "public/app/core/services/context_srv.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
@@ -909,8 +968,18 @@
       "count": 2
     }
   },
+  "public/app/features/actions/ConnectionPicker.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/actions/ParamsEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/actions/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -934,6 +1003,11 @@
       "count": 2
     }
   },
+  "public/app/features/admin/Users/OrgUsersTable.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/admin/ldap/LdapDrawer.tsx": {
     "@grafana/require-no-margin": {
       "count": 23
@@ -946,6 +1020,16 @@
   },
   "public/app/features/admin/ldap/LdapSettingsPage.tsx": {
     "@grafana/require-no-margin": {
+      "count": 5
+    }
+  },
+  "public/app/features/admin/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/routes.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 5
     }
   },
@@ -972,6 +1056,26 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/NotificationPoliciesPage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/api/configApi.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/api/integrationSchemasApi.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/AlertingPageWrapper.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/components/AnnotationDetailsField.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -992,8 +1096,53 @@
       "count": 1
     }
   },
+  "public/app/features/alerting/unified/components/assistant/AnalizeRuleButton.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/contact-points/DuplicateMessageTemplate.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/contact-points/EditMessageTemplate.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/contact-points/NewMessageTemplate.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/folder-actions/FolderActionsButton.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx": {
     "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1002,9 +1151,34 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/import-to-gma/useShowImportToGMARulesBanner.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/mute-timings/EditMuteTiming.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/mute-timings/MuteTimingForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/components/mute-timings/MuteTimingTimeInterval.tsx": {
     "@grafana/require-no-margin": {
       "count": 5
+    }
+  },
+  "public/app/features/alerting/unified/components/mute-timings/NewMuteTiming.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/components/notification-policies/EditNotificationPolicyForm.tsx": {
@@ -1013,7 +1187,15 @@
     }
   },
   "public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/receivers/TemplateForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1071,6 +1253,11 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -1097,6 +1284,16 @@
       "count": 1
     }
   },
+  "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/ActiveTimingFields.tsx": {
     "@grafana/require-no-margin": {
       "count": 1
@@ -1105,6 +1302,11 @@
   "public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/route-settings/RouteTimings.tsx": {
     "@grafana/require-no-margin": {
       "count": 3
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts": {
@@ -1118,12 +1320,40 @@
     }
   },
   "public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    },
     "@grafana/no-get-data-source-srv": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-viewer/AlertRuleMenu.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-viewer/Details.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rule-viewer/tabs/AlertVersionHistory.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
   "public/app/features/alerting/unified/components/rule-viewer/tabs/QueryAndCondition.test.tsx": {
     "@grafana/no-get-data-source-srv": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/rules/CloudRules.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1147,8 +1377,18 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryPage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/components/rules/state-history/StateHistory.tsx": {
     "@grafana/require-no-margin": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/components/settings/SettingsContext.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1170,13 +1410,33 @@
       "count": 1
     }
   },
+  "public/app/features/alerting/unified/featureToggles.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 8
+    }
+  },
   "public/app/features/alerting/unified/group-details/GroupEditPage.tsx": {
     "@grafana/require-no-margin": {
       "count": 5
     }
   },
+  "public/app/features/alerting/unified/home/GettingStarted.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/home/Insights.tsx": {
     "@grafana/no-get-data-source-srv": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/hooks/abilities/otherAbilities.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/hooks/useAbilities.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1223,6 +1483,31 @@
       "count": 2
     }
   },
+  "public/app/features/alerting/unified/navigation/useAlertActivityNav.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/alerting/unified/navigation/useAlertRulesNav.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/alerting/unified/navigation/useDeletedRulesNav.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/navigation/useNotificationConfigNav.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/alerting/unified/notifications/NotificationsListSceneObject.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/alerting/unified/rule-editor/formDefaults.test.ts": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -1230,6 +1515,26 @@
   },
   "public/app/features/alerting/unified/rule-editor/formDefaults.ts": {
     "@grafana/no-get-data-source-srv": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/rule-list/RuleList.v2.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/alerting/unified/rule-list/RuleListPageTitle.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/settings/navigation.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1241,6 +1546,21 @@
   "public/app/features/alerting/unified/testSetup/datasources.ts": {
     "@grafana/no-config-datasources": {
       "count": 2
+    }
+  },
+  "public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/alerting/unified/triage/instance-details/InstanceTimeline.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/alerting/unified/triage/instance-details/startInvestigationFromAlert.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts": {
@@ -1268,6 +1588,11 @@
       "count": 1
     }
   },
+  "public/app/features/alerting/unified/utils/cloud-alertmanager-notifier-types.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/alerting/unified/utils/datasource.ts": {
     "@grafana/no-config-datasources": {
       "count": 1
@@ -1279,6 +1604,11 @@
   "public/app/features/alerting/unified/utils/misc.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    }
+  },
+  "public/app/features/alerting/unified/utils/pageAccess.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
     }
   },
   "public/app/features/alerting/unified/utils/receiver-form.ts": {
@@ -1298,6 +1628,9 @@
     }
   },
   "public/app/features/alerting/unified/utils/rule-form.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    },
     "@grafana/no-get-data-source-srv": {
       "count": 1
     }
@@ -1348,8 +1681,63 @@
       "count": 1
     }
   },
+  "public/app/features/browse-dashboards/api/services.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/browse-dashboards/components/DeletedDashboardsLimitBanner.tsx": {
     "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "public/app/features/browse-dashboards/components/RestoreModal.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/browse-dashboards/utils/dashboards.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/canvas/runtime/element.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
+    }
+  },
+  "public/app/features/canvas/runtime/scene.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 6
+    }
+  },
+  "public/app/features/canvas/runtime/sceneAbleManagement.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 5
+    }
+  },
+  "public/app/features/commandPalette/scopes/recentScopesActions.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/commandPalette/scopes/scopeActions.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/connections/tabs/ConnectData/ConnectData.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/correlations/CorrelationsPageWrapper.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/correlations/Forms/AddCorrelationForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1364,6 +1752,11 @@
     },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
+    }
+  },
+  "public/app/features/correlations/Forms/EditCorrelationForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/correlations/Forms/QueryEditorField.tsx": {
@@ -1381,6 +1774,11 @@
       "count": 2
     }
   },
+  "public/app/features/correlations/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/dashboard-prompt/datasources.ts": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -1389,6 +1787,11 @@
   "public/app/features/dashboard-scene/addToDashboard/AddToDashboardForm.tsx": {
     "@grafana/require-no-margin": {
       "count": 2
+    }
+  },
+  "public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/dashboard-scene/inspect/HelpWizard/HelpWizard.tsx": {
@@ -1401,6 +1804,11 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/mutation-api/commands/types.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/dashboard-scene/pages/DashboardScenePage.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -1409,13 +1817,81 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 9
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelDataPane/NewAlertRuleButton.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Body/TransformationTypePicker.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/saving/getDashboardChanges.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
+    }
+  },
+  "public/app/features/dashboard-scene/scene/DashboardControls.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 7
+    }
+  },
   "public/app/features/dashboard-scene/scene/DashboardScene.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    },
     "@grafana/no-get-data-source-srv": {
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/dashboard-scene/scene/NavToolbarActions.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/VariableControls.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/dashboard-controls-menu/DashboardControlsMenu.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/dashboard-filters-overview/useFiltersOverviewState.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1437,9 +1913,22 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "react-hooks/rules-of-hooks": {
       "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 7
     }
   },
   "public/app/features/dashboard-scene/scene/layout-default/row-actions/RowOptionsForm.tsx": {
@@ -1447,15 +1936,31 @@
       "count": 2
     }
   },
+  "public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@grafana/require-no-margin": {
       "count": 1
     },
     "react-hooks/rules-of-hooks": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
   "public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@grafana/require-no-margin": {
       "count": 1
     },
@@ -1463,19 +1968,58 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/scene/layouts-shared/addNew.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRangeDrawer.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/serialization/groupByMigration.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
     }
   },
   "public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts": {
     "@grafana/no-config-datasources": {
       "count": 1
+    },
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
     }
   },
   "public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 11
+    },
     "@grafana/no-get-data-source-srv": {
       "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
     }
   },
   "public/app/features/dashboard-scene/serialization/transformSceneToSaveModel.test.ts": {
@@ -1504,8 +2048,18 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/settings/AnnotationsEditView.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/AutoRefreshIntervals.tsx": {
     "@grafana/require-no-margin": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/JsonModelEditView.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1514,9 +2068,24 @@
       "count": 5
     }
   },
+  "public/app/features/dashboard-scene/settings/VariablesEditView.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx": {
     "react-hooks/rules-of-hooks": {
       "count": 4
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx": {
@@ -1537,9 +2106,19 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/settings/variables/editors/AdHocFiltersVariableEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
   "public/app/features/dashboard-scene/settings/variables/editors/GroupByVariableEditor.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/settings/variables/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
     }
   },
   "public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx": {
@@ -1558,6 +2137,9 @@
     }
   },
   "public/app/features/dashboard-scene/sharing/ShareExportTab.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    },
     "react-hooks/exhaustive-deps": {
       "count": 1
     }
@@ -1585,6 +2167,36 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/sidebar/SectionVariablesList.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/dashboard-scene/sidebar/add-new/AddNewPane.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/sidebar/dashboard/DashboardEditableElement.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/dashboard-scene/sidebar/dashboard/DashboardVariablesList.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard-scene/utils/DashboardModelCompatibilityWrapper.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -1595,11 +2207,41 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard-scene/utils/dashboardSessionState.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/interactions.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard-scene/utils/tracking.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 4
+    }
+  },
+  "public/app/features/dashboard-scene/utils/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/features/dashboard-scene/utils/variables.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 10
+    }
+  },
   "public/app/features/dashboard/api/ResponseTransformers.ts": {
     "@grafana/no-config-datasources": {
       "count": 1
     },
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/api/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1677,6 +2319,11 @@
       "count": 3
     }
   },
+  "public/app/features/dashboard/components/ShareModal/SharePublicDashboard/SharePublicDashboardUtils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard/components/ShareModal/ShareSnapshot.tsx": {
     "@grafana/require-no-margin": {
       "count": 4
@@ -1693,6 +2340,11 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/dashboard/components/TransformationsEditor/TransformationsEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
@@ -1706,8 +2358,43 @@
       "count": 1
     }
   },
+  "public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyExtensionPoint.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardLibrary/DashboardCard.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardLibrary/SuggestedDashboardsList/SuggestedDashboardsList.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/dashgrid/DashboardLibrary/hooks/useTemplateDashboardsAvailability.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/services/DashboardLoaderSrv.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/dashboard/services/ReportRenderReadinessObserver.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -1773,6 +2460,11 @@
       "count": 1
     }
   },
+  "public/app/features/datasources/components/BuildDashboardButton.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/datasources/components/ButtonRow.tsx": {
     "@grafana/no-gf-form": {
       "count": 1
@@ -1781,6 +2473,11 @@
   "public/app/features/datasources/components/DataSourcePluginState.tsx": {
     "@grafana/no-gf-form": {
       "count": 3
+    }
+  },
+  "public/app/features/datasources/components/DataSourceTestingStatus.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
     }
   },
   "public/app/features/datasources/hooks.ts": {
@@ -1794,6 +2491,9 @@
     }
   },
   "public/app/features/datasources/state/actions.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
@@ -1802,6 +2502,9 @@
     }
   },
   "public/app/features/datasources/state/navModel.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     },
@@ -1882,6 +2585,11 @@
       "count": 1
     }
   },
+  "public/app/features/explore/QueryLibrary/utils/identity.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1
@@ -1948,6 +2656,11 @@
       "count": 1
     }
   },
+  "public/app/features/explore/state/correlations.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/explore/state/time.test.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
@@ -1971,8 +2684,18 @@
       "count": 2
     }
   },
+  "public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/features/expressions/guards.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/expressions/types.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -2038,6 +2761,11 @@
       "count": 1
     }
   },
+  "public/app/features/manage-dashboards/import/components/DashboardImportK8s.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/migrate-to-cloud/cloud/MigrationTokenPane/CreateTokenModal.tsx": {
     "@grafana/require-no-margin": {
       "count": 1
@@ -2060,6 +2788,11 @@
   },
   "public/app/features/migrate-to-cloud/onprem/useNotifyOnSuccess.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/notebook/scene/NotebookScene.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -2098,14 +2831,34 @@
       "count": 3
     }
   },
+  "public/app/features/playlist/StartModal.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/plugins/admin/components/GetStartedWithPlugin/GetStartedWithDataSource.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/plugins/admin/components/PluginDetailsBody.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/plugins/admin/components/PluginDetailsPanel.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
   "public/app/features/plugins/admin/hooks/usePluginConfig.tsx": {
     "react-hooks/exhaustive-deps": {
       "count": 1
+    }
+  },
+  "public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
     }
   },
   "public/app/features/plugins/admin/pages/Browse.tsx": {
@@ -2126,6 +2879,11 @@
       "count": 1
     }
   },
+  "public/app/features/plugins/components/restrictedGrafanaApis/RestrictedGrafanaApisProvider.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/plugins/datasource_srv.ts": {
     "@grafana/no-get-data-source-srv": {
       "count": 1
@@ -2134,6 +2892,21 @@
       "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
+      "count": 1
+    }
+  },
+  "public/app/features/plugins/importer/importPluginModule.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/plugins/importer/pluginImporter.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/plugins/sandbox/codeLoader.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -2160,6 +2933,11 @@
   "public/app/features/profile/UserProfileEditForm.tsx": {
     "@grafana/require-no-margin": {
       "count": 3
+    }
+  },
+  "public/app/features/provisioning/GettingStarted/features.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/query/components/QueryEditorRow.tsx": {
@@ -2235,6 +3013,21 @@
       "count": 3
     }
   },
+  "public/app/features/scopes/ScopesContextProvider.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/scopes/dashboards/ScopesDashboardsService.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/features/search/page/components/ActionRow.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/features/search/page/components/columns.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -2246,8 +3039,16 @@
     }
   },
   "public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    },
     "@grafana/require-no-margin": {
       "count": 4
+    }
+  },
+  "public/app/features/serviceaccounts/ServiceAccountsListPage.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/serviceaccounts/components/CreateTokenModal.tsx": {
@@ -2257,6 +3058,21 @@
   },
   "public/app/features/serviceaccounts/state/reducers.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/features/table/hooks.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/teams/TeamPages.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/features/teams/state/navModel.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -2368,6 +3184,11 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
+    }
+  },
+  "public/app/features/transformers/standardTransformers.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/features/transformers/suggestionsInput/SuggestionsInput.tsx": {
@@ -2555,14 +3376,34 @@
       "count": 1
     }
   },
+  "public/app/plugins/datasource/azuremonitor/components/ConfigEditor/MonitorConfig.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/AzureCheatSheet.tsx": {
     "@grafana/require-no-margin": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryEditor.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
+    }
+  },
+  "public/app/plugins/datasource/azuremonitor/components/QueryEditor/QueryHeader.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
     }
   },
   "public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filters.tsx": {
@@ -2573,6 +3414,11 @@
   "public/app/plugins/datasource/azuremonitor/components/VariableEditor/VariableEditor.tsx": {
     "@grafana/require-no-margin": {
       "count": 7
+    }
+  },
+  "public/app/plugins/datasource/azuremonitor/featureFlags.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/plugins/datasource/azuremonitor/module.ts": {
@@ -2608,13 +3454,68 @@
       "count": 1
     }
   },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/VariableQueryEditor/VariableQueryEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LegacyLogGroupNamesSelection.tsx": {
     "@grafana/no-gf-form": {
       "count": 1
     }
   },
+  "public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/plugins/datasource/cloudwatch/guards.ts": {
     "@typescript-eslint/consistent-type-assertions": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/hooks.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/language/dynamic-labels/language.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/cloudwatch/tracking.ts": {
+    "@grafana/no-config-feature-toggles": {
       "count": 1
     }
   },
@@ -2624,6 +3525,9 @@
     }
   },
   "public/app/plugins/datasource/cloudwatch/utils/datalinks.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
     }
@@ -2684,6 +3588,9 @@
     }
   },
   "public/app/plugins/datasource/grafana/components/QueryEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    },
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }
@@ -2710,6 +3617,9 @@
     }
   },
   "public/app/plugins/datasource/graphite/datasource.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 11
+    },
     "@typescript-eslint/no-explicit-any": {
       "count": 8
     }
@@ -2775,6 +3685,16 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/alertlist/UnifiedAlertList.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/panel/alertlist/module.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/annolist/AnnoListPanel.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
@@ -2803,6 +3723,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/canvas/components/CanvasContextMenu.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 2
+    }
+  },
   "public/app/plugins/panel/canvas/editor/LineStyleEditor.tsx": {
     "@grafana/require-no-margin": {
       "count": 1
@@ -2811,6 +3736,21 @@
   "public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx": {
     "@grafana/require-no-margin": {
       "count": 2
+    }
+  },
+  "public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/panel/canvas/module.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 3
+    }
+  },
+  "public/app/plugins/panel/canvas/utils.ts": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
     }
   },
   "public/app/plugins/panel/debug/CursorView.tsx": {
@@ -2968,6 +3908,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/timeseries/LineStyleEditor.tsx": {
+    "@grafana/no-config-feature-toggles": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/timeseries/migrations.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 4
@@ -2994,6 +3939,11 @@
       "count": 14
     },
     "@typescript-eslint/no-explicit-any": {
+      "count": 4
+    }
+  },
+  "public/app/routes/routes.tsx": {
+    "@grafana/no-config-feature-toggles": {
       "count": 4
     }
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -644,6 +644,7 @@ module.exports = [
       '@grafana/no-config-apps': 'error',
       '@grafana/no-config-panels': 'error',
       '@grafana/no-config-datasources': 'error',
+      '@grafana/no-config-feature-toggles': 'error',
     },
   },
   {

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -365,3 +365,30 @@ const logger = createMonitoringLogger('features.my-area');
 import { getLogger } from '@grafana/runtime/unstable';
 const logger = getLogger('features.my-area');
 ```
+
+### `no-config-feature-toggles`
+
+Disallow reads of the legacy `config.featureToggles` map. Feature flags should be read through OpenFeature instead — `useFlagXxx()` from `@grafana/runtime/internal` in React, or `getFeatureFlagClient().getBooleanValue(FlagKeys.Xxx, default)` outside it.
+
+`config.featureToggles` is a static snapshot taken from bootData at page load. The multi-tenant frontend service serves an empty map, so every flag read through it resolves to `false` there — including flags that are GA and enabled by default, which silently sends code down retired paths. OpenFeature resolves flags over OFREP per tenant instead, and picks up changes without a reload.
+
+The rule matches on the `featureToggles` property rather than a `config` receiver, because the receiver is not always named `config` — aliased imports (`config as grafanaConfig`), renamed locals (`cfg`) and namespace imports (`runtime.config`) all reach the same map.
+
+#### Examples
+
+```ts
+// Bad ❌
+import { config } from '@grafana/runtime';
+if (config.featureToggles.myFeatureFlag) {
+}
+
+// Good ✅ — in React
+import { useFlagMyFeatureFlag } from '@grafana/runtime/internal';
+const enabled = useFlagMyFeatureFlag();
+
+// Good ✅ — outside React
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.MyFeatureFlag, false);
+```
+
+If the flag has no OpenFeature target yet, add `React: true` alongside its existing `LegacyFrontend` in `pkg/services/featuremgmt/registry.go` — do not rename it, since the name is the OFREP key — then run `make gen-feature-toggles`. New flags should use `Generate{React: true}` with a `component.flagName` name and no legacy target. See [the feature flags guide](../../contribute/feature-toggles.md).

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -370,10 +370,6 @@ const logger = getLogger('features.my-area');
 
 Disallow reads of the legacy `config.featureToggles` map. Feature flags should be read through OpenFeature instead — `useFlagXxx()` from `@grafana/runtime/internal` in React, or `getFeatureFlagClient().getBooleanValue(FlagKeys.Xxx, default)` outside it.
 
-`config.featureToggles` is a static snapshot taken from bootData at page load. The multi-tenant frontend service serves an empty map, so every flag read through it resolves to `false` there — including flags that are GA and enabled by default, which silently sends code down retired paths. OpenFeature resolves flags over OFREP per tenant instead, and picks up changes without a reload.
-
-The rule matches on the `featureToggles` property rather than a `config` receiver, because the receiver is not always named `config` — aliased imports (`config as grafanaConfig`), renamed locals (`cfg`) and namespace imports (`runtime.config`) all reach the same map.
-
 #### Examples
 
 ```ts

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -58,6 +58,22 @@ module.exports = createNoRestrictedSyntax(
       'Usage of config.datasources is not allowed. Use getDataSourceInstanceSettings, getDataSourceInstanceList or the matching hooks from @grafana/runtime/unstable instead',
   },
   {
+    name: 'no-config-feature-toggles',
+    // Matches on the property rather than `object.name="config"` because the receiver is not always
+    // called config - aliased imports and namespace imports reach the same map.
+    selector: 'MemberExpression[property.name="featureToggles"]',
+    message: [
+      'Usage of config.featureToggles is not allowed.',
+      'It is a static bootData snapshot and is empty in the multi-tenant frontend service, so every flag reads false there.',
+      'Read the flag via OpenFeature instead: useFlagXxx() from @grafana/runtime/internal in React,',
+      'or getFeatureFlagClient().getBooleanValue(FlagKeys.Xxx, default) outside React.',
+      'If the flag has no OpenFeature target yet, add `React: true` alongside its existing `LegacyFrontend`',
+      'in pkg/services/featuremgmt/registry.go - do not rename it - then run make gen-feature-toggles.',
+      'New flags should use `Generate{React: true}` with a component.flagName name and no legacy target.',
+      'See contribute/feature-toggles.md.',
+    ].join(' '),
+  },
+  {
     name: 'no-direct-date-fns',
     selector: 'ImportDeclaration[source.value="date-fns"][importKind!="type"]',
     message: 'Use deep imports instead (e.g. date-fns/format) to avoid pulling in the entire library.',

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -62,16 +62,7 @@ module.exports = createNoRestrictedSyntax(
     // Matches on the property rather than `object.name="config"` because the receiver is not always
     // called config - aliased imports and namespace imports reach the same map.
     selector: 'MemberExpression[property.name="featureToggles"]',
-    message: [
-      'Usage of config.featureToggles is not allowed.',
-      'It is a static bootData snapshot and is empty in the multi-tenant frontend service, so every flag reads false there.',
-      'Read the flag via OpenFeature instead: useFlagXxx() from @grafana/runtime/internal in React,',
-      'or getFeatureFlagClient().getBooleanValue(FlagKeys.Xxx, default) outside React.',
-      'If the flag has no OpenFeature target yet, add `React: true` alongside its existing `LegacyFrontend`',
-      'in pkg/services/featuremgmt/registry.go - do not rename it - then run make gen-feature-toggles.',
-      'New flags should use `Generate{React: true}` with a component.flagName name and no legacy target.',
-      'See contribute/feature-toggles.md.',
-    ].join(' '),
+    message: 'Usage of legacy config.featureToggles is no longer allowed. Use OpenFeature feature flags instead.',
   },
   {
     name: 'no-direct-date-fns',

--- a/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
+++ b/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
@@ -127,3 +127,76 @@ ruleTester.run('zod-import-namespace', zodImportNamespaceRule, {
     },
   ],
 });
+
+const featureTogglesRule = noRestrictedSyntax.rules['no-config-feature-toggles'];
+ruleTester.run('no-config-feature-toggles', featureTogglesRule, {
+  valid: [
+    {
+      name: 'OpenFeature hook',
+      code: `const enabled = useFlagFoldersAppPlatformAPI();`,
+    },
+    {
+      name: 'OpenFeature client outside React',
+      code: `const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.FoldersAppPlatformAPI, false);`,
+    },
+    {
+      name: 'keyof FeatureToggles type reference',
+      code: `function f(flags: Array<keyof FeatureToggles>) {}`,
+    },
+    {
+      name: 'featureToggles as an object literal key',
+      code: `const cfg = { featureToggles: { someFlag: true } };`,
+    },
+    {
+      name: 'unrelated config property',
+      code: `const url = config.appSubUrl;`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'direct dot access',
+      code: `if (config.featureToggles.someFlag) {}`,
+      errors: 1,
+    },
+    {
+      name: 'bracket access with a string literal (dotted flag name)',
+      code: `const on = config.featureToggles['alerting.rulesAPIV2'];`,
+      errors: 1,
+    },
+    {
+      name: 'bracket access with a variable key',
+      code: `const on = config.featureToggles[BATCH_API_FLAG];`,
+      errors: 1,
+    },
+    {
+      name: 'aliased receiver from an aliased import',
+      code: `const on = grafanaConfig.featureToggles.vizActionsAuth;`,
+      errors: 1,
+    },
+    {
+      name: 'renamed local binding',
+      code: `if (cfg.featureToggles.alertingNavigationV2) {}`,
+      errors: 1,
+    },
+    {
+      name: 'namespace import receiver',
+      code: `if (runtime.config.featureToggles.someFlag) {}`,
+      errors: 1,
+    },
+    {
+      name: 'optional chaining',
+      code: `const on = config.featureToggles?.alertingJiraIntegration;`,
+      errors: 1,
+    },
+    {
+      name: 'optional chaining on both links',
+      code: `const on = config?.featureToggles?.sqlExpressions;`,
+      errors: 1,
+    },
+    {
+      name: 'aliasing the whole map',
+      code: `const featureToggles = config.featureToggles || {};`,
+      errors: 1,
+    },
+  ],
+});

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -292,6 +292,7 @@ export class GrafanaBootConfig {
     overrideFeatureTogglesFromUrl(this);
     overrideFeatureTogglesFromLocalStorage(this);
 
+    // eslint-disable-next-line @grafana/no-config-feature-toggles -- owns the legacy toggle map
     this.bootData.settings.featureToggles = this.featureToggles;
 
     // Creating theme after applying feature toggle overrides in case we need to toggle anything
@@ -304,6 +305,7 @@ export class GrafanaBootConfig {
 // localstorage key: grafana.featureToggles
 // example value: panelEditor=1,panelInspector=1
 function overrideFeatureTogglesFromLocalStorage(config: GrafanaBootConfig) {
+  // eslint-disable-next-line @grafana/no-config-feature-toggles -- implements the localStorage toggle override
   const featureToggles = config.featureToggles;
   const localStorageKey = 'grafana.featureToggles';
   const localStorageValue = store.get(localStorageKey);
@@ -333,6 +335,7 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
   const params = new URLSearchParams(window.location.search);
   params.forEach((value, key) => {
     if (key.startsWith('__feature.')) {
+      // eslint-disable-next-line @grafana/no-config-feature-toggles -- implements the URL toggle override
       const featureToggles = config.featureToggles as Record<string, boolean>;
       const featureName = key.substring(10);
 

--- a/public/app/features/alerting/unified/AGENTS.md
+++ b/public/app/features/alerting/unified/AGENTS.md
@@ -316,13 +316,31 @@ mockFolder();
 
 A full list of features can be found in `pkg/services/featuremgmt/toggles_gen.csv` – focus on feature toggles owned by `@grafana/alerting-squad`.
 
-```typescript
-import { config } from '@grafana/runtime';
+Read flags through OpenFeature. Reading `config.featureToggles` is blocked by the
+`@grafana/no-config-feature-toggles` lint rule — that map is empty in the multi-tenant frontend
+service, so flags read from it are always `false` there.
 
-if (config.featureToggles.alertingTriage) {
+```typescript
+import { useFlagAlertingTriage } from '@grafana/runtime/internal';
+
+const isTriageEnabled = useFlagAlertingTriage();
+if (isTriageEnabled) {
   // Render triage view
 }
 ```
+
+Outside React — including the page-access predicates in `utils/pageAccess.ts`, which run during
+redux store creation — use the client instead:
+
+```typescript
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+
+getFeatureFlagClient().getBooleanValue(FlagKeys.AlertingTriage, false);
+```
+
+If a flag has no OpenFeature target yet, see the migration steps in
+`contribute/feature-toggles.md`. In tests, gate migrated flags with `setTestFlags` from
+`@grafana/test-utils/unstable` rather than `testWithFeatureToggles`.
 
 A common configuration setting would be `unifiedAlertingEnabled` which allows a user to configure Grafana without any alerting UI or backend enabled at all.
 


### PR DESCRIPTION
**What is this feature?**

Adds `@grafana/no-config-feature-toggles` to block reads of the legacy `config.featureToggles` map, and grandfathers the existing 367 reads via `eslint-suppressions.json` — same pattern as `config.datasources` and `getDataSourceSrv`.

Production code only: tests keep using `testWithFeatureToggles` for flags that are still legacy, and enterprise is left out since there's no suppressions mechanism for it yet.

**Why do we need this feature?**

`config.featureToggles` is a static bootData snapshot and the multi-tenant frontend service serves it empty, so every flag read through it resolves to `false` there — including GA, default-on flags, which silently sends code down retired paths. OpenFeature resolves per tenant over OFREP instead, and nothing was stopping more legacy reads landing.

**Who is this feature for?**

UI devs, and anyone working on multi-tenant Grafana.