### PR TITLE
provisioning: support GitHub App connections on Enterprise

### DIFF
--- a/apps/provisioning/kinds/connection.cue
+++ b/apps/provisioning/kinds/connection.cue
@@ -25,6 +25,9 @@ connection: {
 					// Installation-level information
 					// GitHub App installation ID
 					installationID: int
+
+					// The GitHub Enterprise Server URL. Empty uses github.com.
+					serverUrl?: string
 				}
 				#GitHubEnterpriseOAuthConnectionConfig: {
 					// The GitHub Enterprise Server URL (e.g. `https://ghes.example.com`).

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -53,6 +53,9 @@ type GitHubConnectionConfig struct {
 
 	// GitHub App installation ID
 	InstallationID string `json:"installationID"`
+
+	// The GitHub Enterprise Server URL. Empty uses github.com.
+	ServerURL string `json:"serverUrl,omitempty"`
 }
 
 func (GitHubConnectionConfig) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1151,6 +1151,13 @@ func schema_pkg_apis_provisioning_v0alpha1_GitHubConnectionConfig(ref common.Ref
 							Format:      "",
 						},
 					},
+					"serverUrl": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The GitHub Enterprise Server URL. Empty uses github.com.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"appID", "installationID"},
 			},

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -30,6 +30,7 @@ API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,GitHubEnterprise
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,GitHubEnterpriseOAuth
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,OAuth
+API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseOAuthConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseRepositoryConfig,ServerURL

--- a/apps/provisioning/pkg/connection/github/config_test.go
+++ b/apps/provisioning/pkg/connection/github/config_test.go
@@ -1,0 +1,20 @@
+package github
+
+import (
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigCustomServerURL(t *testing.T) {
+	conn := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			GitHub: &provisioning.GitHubConnectionConfig{
+				ServerURL: "https://ghes.example.com",
+			},
+		},
+	}
+
+	require.Equal(t, "https://ghes.example.com", (config{obj: conn}).CustomServerURL())
+}

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -95,7 +95,10 @@ func (c config) InstallationID() string {
 }
 
 func (c config) CustomServerURL() string {
-	return ""
+	if c.obj.Spec.GitHub == nil {
+		return ""
+	}
+	return c.obj.Spec.GitHub.ServerURL
 }
 
 var _ ConnectionConfig = config{}

--- a/apps/provisioning/pkg/connection/github/mutator.go
+++ b/apps/provisioning/pkg/connection/github/mutator.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -21,8 +22,12 @@ func Mutate(_ context.Context, obj runtime.Object) error {
 		return nil
 	}
 
-	// Set URL from GitHub installation
-	conn.Spec.URL = fmt.Sprintf("https://github.com/settings/installations/%s", conn.Spec.GitHub.InstallationID)
+	// Set URL from the configured GitHub installation host.
+	serverURL := strings.TrimRight(conn.Spec.GitHub.ServerURL, "/")
+	if serverURL == "" {
+		serverURL = "https://github.com"
+	}
+	conn.Spec.URL = fmt.Sprintf("%s/settings/installations/%s", serverURL, conn.Spec.GitHub.InstallationID)
 
 	return nil
 }

--- a/apps/provisioning/pkg/connection/github/mutator_test.go
+++ b/apps/provisioning/pkg/connection/github/mutator_test.go
@@ -217,6 +217,21 @@ func TestMutate(t *testing.T) {
 	}
 }
 
+func TestMutate_UsesConfiguredEnterpriseServerURL(t *testing.T) {
+	conn := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			Type: provisioning.GithubConnectionType,
+			GitHub: &provisioning.GitHubConnectionConfig{
+				InstallationID: "789012",
+				ServerURL:      "https://ghes.example.com/",
+			},
+		},
+	}
+
+	require.NoError(t, github.Mutate(t.Context(), conn))
+	assert.Equal(t, "https://ghes.example.com/settings/installations/789012", conn.Spec.URL)
+}
+
 func TestMutate_MultipleCallsIdempotent(t *testing.T) {
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 	ctx := t.Context()

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubconnectionconfig.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubconnectionconfig.go
@@ -11,6 +11,8 @@ type GitHubConnectionConfigApplyConfiguration struct {
 	AppID *string `json:"appID,omitempty"`
 	// GitHub App installation ID
 	InstallationID *string `json:"installationID,omitempty"`
+	// The GitHub Enterprise Server URL. Empty uses github.com.
+	ServerURL *string `json:"serverUrl,omitempty"`
 }
 
 // GitHubConnectionConfigApplyConfiguration constructs a declarative configuration of the GitHubConnectionConfig type for use with
@@ -32,5 +34,13 @@ func (b *GitHubConnectionConfigApplyConfiguration) WithAppID(value string) *GitH
 // If called multiple times, the InstallationID field is set to the value of the last call.
 func (b *GitHubConnectionConfigApplyConfiguration) WithInstallationID(value string) *GitHubConnectionConfigApplyConfiguration {
 	b.InstallationID = &value
+	return b
+}
+
+// WithServerURL sets the ServerURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServerURL field is set to the value of the last call.
+func (b *GitHubConnectionConfigApplyConfiguration) WithServerURL(value string) *GitHubConnectionConfigApplyConfiguration {
+	b.ServerURL = &value
 	return b
 }


### PR DESCRIPTION
Fixes #132149.

GitHub App connections configured for GitHub Enterprise Server were incorrectly validated against github.com and generated github.com installation links. This change carries the configured GitHub Enterprise server URL through the connection/client configuration and uses it when building the installation URL, while preserving github.com as the default.

Includes regression coverage and generated code updates.