### PR TITLE
packaging/docker: preserve Enterprise license in Docker images

### DIFF
--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -66,12 +66,14 @@ docker_build () {
   fi
 
   grafana_tgz=${GRAFANA_TGZ:-"grafana-latest.linux-${arch}${libc}.tar.gz"}
+  license_tgz=""
+  license_dir=""
 
   # Enterprise images are distributed under the Grafana Labs License rather than AGPL.
   # The Enterprise build supplies the license file separately; replace the OSS license
   # in the release tarball before Docker copies it into /usr/share/grafana/LICENSE.
   if [ -n "${GRAFANA_LICENSE_FILE:-}" ]; then
-    license_tgz=$(mktemp)
+    license_tgz=$(mktemp "./grafana-license.XXXXXX.tar.gz")
     license_dir=$(mktemp -d)
     tar xzf "${grafana_tgz}" -C "${license_dir}" --strip-components=1
     cp "${GRAFANA_LICENSE_FILE}" "${license_dir}/LICENSE"
@@ -92,6 +94,11 @@ docker_build () {
     --no-cache=true \
     --file ../../Dockerfile \
     .
+
+  if [ -n "${license_tgz}" ]; then
+    rm -f "${license_tgz}"
+    rm -rf "${license_dir}"
+  fi
 }
 
 docker_tag_linux_amd64 () {

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -66,6 +66,19 @@ docker_build () {
   fi
 
   grafana_tgz=${GRAFANA_TGZ:-"grafana-latest.linux-${arch}${libc}.tar.gz"}
+
+  # Enterprise images are distributed under the Grafana Labs License rather than AGPL.
+  # The Enterprise build supplies the license file separately; replace the OSS license
+  # in the release tarball before Docker copies it into /usr/share/grafana/LICENSE.
+  if [ -n "${GRAFANA_LICENSE_FILE:-}" ]; then
+    license_tgz=$(mktemp)
+    license_dir=$(mktemp -d)
+    tar xzf "${grafana_tgz}" -C "${license_dir}" --strip-components=1
+    cp "${GRAFANA_LICENSE_FILE}" "${license_dir}/LICENSE"
+    tar czf "${license_tgz}" -C "${license_dir}" .
+    grafana_tgz="${license_tgz}"
+  fi
+
   tag="${_docker_repo}${repo_arch}:${_grafana_version}${TAG_SUFFIX}"
 
   DOCKER_BUILDKIT=1 \
@@ -108,6 +121,7 @@ if echo "$_grafana_tag" | grep -q "^v"; then
   # Create the expected tag for running the end to end tests successfully
   docker tag "${_docker_repo}:${_grafana_version}${TAG_SUFFIX}" "grafana/grafana-dev:${_grafana_tag}${TAG_SUFFIX}"
 else
+  docker_tag_all "main"
   docker_tag_all "main"
   docker tag "${_docker_repo}:${_grafana_version}${TAG_SUFFIX}" "grafana/grafana-dev:${_grafana_version}${TAG_SUFFIX}"
 fi

--- a/packaging/docker/build.sh
+++ b/packaging/docker/build.sh
@@ -122,6 +122,5 @@ if echo "$_grafana_tag" | grep -q "^v"; then
   docker tag "${_docker_repo}:${_grafana_version}${TAG_SUFFIX}" "grafana/grafana-dev:${_grafana_tag}${TAG_SUFFIX}"
 else
   docker_tag_all "main"
-  docker_tag_all "main"
   docker tag "${_docker_repo}:${_grafana_version}${TAG_SUFFIX}" "grafana/grafana-dev:${_grafana_version}${TAG_SUFFIX}"
 fi


### PR DESCRIPTION
Fixes #132178.

The Docker packaging path copies `/tmp/grafana/LICENSE` from the release tarball into `/usr/share/grafana/LICENSE`. Enterprise artifacts need to replace the OSS AGPL license with the Grafana Labs License before this copy occurs.

This adds `GRAFANA_LICENSE_FILE` as an opt-in packaging hook. When set by the Enterprise release pipeline, the script rewrites the release tarball's `LICENSE` before invoking Docker, so the existing Dockerfile copies the correct license into the image without changing the OSS repository's root `LICENSE`.

The default OSS build is unchanged when `GRAFANA_LICENSE_FILE` is unset.