### PR TITLE
Alerting: Keep the sub path when alerting buttons are opened in a new tab

### DIFF
--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -2,6 +2,8 @@ import { screen, waitFor, within } from '@testing-library/react';
 import { render } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
+import { config } from '@grafana/runtime';
+
 import SettingsPage from './Settings';
 import DataSourcesResponse from './components/settings/mocks/api/datasources.json';
 import { setupGrafanaManagedServer, withExternalOnlySetting } from './components/settings/mocks/server';
@@ -79,6 +81,22 @@ describe('Alerting settings', () => {
       // expect link to data source, provisioned badge, type, and status
       expect(within(card).getByRole('link', { name: ds.name })).toBeInTheDocument();
     });
+  });
+
+  it('includes the app sub path in the add Alertmanager link', async () => {
+    const originalAppSubUrl = config.appSubUrl;
+    config.appSubUrl = '/sub';
+
+    try {
+      render(<SettingsPage />);
+
+      expect(await screen.findByRole('link', { name: /add new alertmanager/i })).toHaveAttribute(
+        'href',
+        '/sub/connections/datasources/alertmanager'
+      );
+    } finally {
+      config.appSubUrl = originalAppSubUrl;
+    }
   });
 
   it('should render the page with external only', async () => {

--- a/public/app/features/alerting/unified/Settings.tsx
+++ b/public/app/features/alerting/unified/Settings.tsx
@@ -8,6 +8,7 @@ import { ExternalAlertmanagers } from './components/settings/ExternalAlertmanage
 import InternalAlertmanager from './components/settings/InternalAlertmanager';
 import { SettingsProvider, useSettings } from './components/settings/SettingsContext';
 import { useSettingsPageNav } from './settings/navigation';
+import { createRelativeUrl } from './utils/url';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
 
 function AlertmanagerSettingsPage() {
@@ -34,7 +35,7 @@ function AlertmanagerSettingsContent() {
           key="add-alertmanager"
           title={t('alerting.settings-content.title-alerting-settings', 'Alerting settings')}
           component={
-            <LinkButton href="/connections/datasources/alertmanager" icon="plus" variant="primary">
+            <LinkButton href={createRelativeUrl('/connections/datasources/alertmanager')} icon="plus" variant="primary">
               <Trans i18nKey="alerting.settings-content.add-new-alertmanager">Add new Alertmanager</Trans>
             </LinkButton>
           }

--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from 'test/test-utils';
 
+import { config } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../../mockApi';
@@ -56,5 +57,26 @@ describe('ContactPointHeader', () => {
     renderWithProvider(<ContactPointHeader contactPoint={contactPointWithConvertedPrometheus} onDelete={jest.fn()} />);
 
     expect(screen.getByText('Imported')).toBeInTheDocument();
+  });
+
+  describe('when Grafana is served from a sub path', () => {
+    const originalAppSubUrl = config.appSubUrl;
+
+    beforeEach(() => {
+      config.appSubUrl = '/sub';
+    });
+
+    afterEach(() => {
+      config.appSubUrl = originalAppSubUrl;
+    });
+
+    it('includes the sub path in the edit link', () => {
+      renderWithProvider(<ContactPointHeader contactPoint={mockContactPoint} onDelete={jest.fn()} />);
+
+      expect(screen.getByTestId(/^(edit|view)-action$/)).toHaveAttribute(
+        'href',
+        '/sub/alerting/notifications/receivers/test-contact-point/edit'
+      );
+    });
   });
 });

--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -260,7 +260,7 @@ export const ContactPointHeader = ({ contactPoint, onDelete }: ContactPointHeade
           icon={canEdit ? 'pen' : 'eye'}
           type="button"
           data-testid={`${canEdit ? 'edit' : 'view'}-action`}
-          href={`/alerting/notifications/receivers/${encodeURIComponent(urlId)}/edit`}
+          href={createRelativeUrl(`/alerting/notifications/receivers/${encodeURIComponent(urlId)}/edit`)}
         >
           {canEdit
             ? t('alerting.contact-point-header.button-edit', 'Edit')

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.test.tsx
@@ -3,6 +3,7 @@ import { type ComponentProps, type ReactNode } from 'react';
 import { render, screen, userEvent, waitFor, waitForElementToBeRemoved, within } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { MIMIR_DATASOURCE_UID } from 'app/features/alerting/unified/mocks/server/constants';
 import { flushMicrotasks } from 'app/features/alerting/unified/test/test-utils';
 import { K8sAnnotations } from 'app/features/alerting/unified/utils/k8s/constants';
@@ -183,6 +184,36 @@ describe('contact points', () => {
         );
         await screen.findByText(/create notification templates/i);
         expect(screen.queryByText(/^misconfigured$/i)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('when Grafana is served from a sub path', () => {
+      const originalAppSubUrl = config.appSubUrl;
+
+      beforeEach(() => {
+        config.appSubUrl = '/sub';
+      });
+
+      afterEach(() => {
+        config.appSubUrl = originalAppSubUrl;
+      });
+
+      it('includes the sub path in the new contact point link', async () => {
+        renderWithProvider(<ContactPointsPageContents />);
+
+        expect(await screen.findByRole('link', { name: 'add contact point' })).toHaveAttribute(
+          'href',
+          '/sub/alerting/notifications/receivers/new'
+        );
+      });
+
+      it('includes the sub path in the new notification template link', async () => {
+        renderWithProvider(<ContactPointsPageContents />, { initialEntries: ['/?tab=templates'] });
+
+        expect(await screen.findByRole('link', { name: /new notification template/i })).toHaveAttribute(
+          'href',
+          '/sub/alerting/notifications/templates/new'
+        );
       });
     });
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPoints.tsx
@@ -18,7 +18,7 @@ import {
   Text,
 } from '@grafana/ui';
 import { shouldUseK8sApi } from 'app/features/alerting/unified/utils/k8s/utils';
-import { makeAMLink, stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
+import { stringifyErrorLike } from 'app/features/alerting/unified/utils/misc';
 
 import { isGranted, isSupported } from '../../hooks/abilities/abilityUtils';
 import {
@@ -32,6 +32,7 @@ import { useURLSearchParams } from '../../hooks/useURLSearchParams';
 import { useContactPointsNav } from '../../navigation/useNotificationConfigNav';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from '../GrafanaAlertmanagerWarning';
@@ -90,7 +91,9 @@ const ContactPointsTab = () => {
         button={
           addContactPointAbility.granted && (
             <LinkButton
-              href={makeAMLink('/alerting/notifications/receivers/new', selectedAlertmanager)}
+              href={createRelativeUrl('/alerting/notifications/receivers/new', {
+                alertmanager: selectedAlertmanager!,
+              })}
               icon="plus"
               size="lg"
             >
@@ -115,7 +118,7 @@ const ContactPointsTab = () => {
               icon="plus"
               aria-label={t('alerting.contact-points-tab.aria-label-add-contact-point', 'add contact point')}
               variant="primary"
-              href="/alerting/notifications/receivers/new"
+              href={createRelativeUrl('/alerting/notifications/receivers/new')}
               disabled={!addContactPointAbility.granted}
               data-testid={selectors.pages.Alerting.ContactPoints.addContactPointLink}
             >
@@ -170,7 +173,7 @@ const NotificationTemplatesTab = () => {
           <LinkButton
             icon="plus"
             variant="primary"
-            href="/alerting/notifications/templates/new"
+            href={createRelativeUrl('/alerting/notifications/templates/new')}
             disabled={!createTemplateAbility.granted}
           >
             <Trans i18nKey="alerting.notification-templates-tab.add-notification-template-group">

--- a/public/app/features/alerting/unified/components/contact-points/TemplatesPage.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/TemplatesPage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../../mockApi';
+import { grantUserPermissions } from '../../mocks';
+
+import TemplatesPage from './TemplatesPage';
+
+setupMswServer();
+
+describe('TemplatesPage', () => {
+  const originalAppSubUrl = config.appSubUrl;
+
+  beforeEach(() => {
+    grantUserPermissions([
+      AccessControlAction.AlertingNotificationsRead,
+      AccessControlAction.AlertingNotificationsWrite,
+    ]);
+  });
+
+  afterEach(() => {
+    config.appSubUrl = originalAppSubUrl;
+  });
+
+  it('includes the sub path in the new template link', async () => {
+    config.appSubUrl = '/sub';
+
+    render(<TemplatesPage />);
+
+    expect(await screen.findByRole('link', { name: /new notification template/i })).toHaveAttribute(
+      'href',
+      '/sub/alerting/notifications/templates/new'
+    );
+  });
+});

--- a/public/app/features/alerting/unified/components/contact-points/TemplatesPage.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/TemplatesPage.tsx
@@ -5,6 +5,7 @@ import { isSupported } from '../../hooks/abilities/abilityUtils';
 import { useNotificationTemplateAbility } from '../../hooks/abilities/alertmanager/useNotificationTemplateAbility';
 import { NotificationTemplateAction } from '../../hooks/abilities/types';
 import { useTemplatesNav } from '../../navigation/useNotificationConfigNav';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
 import { GrafanaAlertmanagerWarning } from '../GrafanaAlertmanagerWarning';
@@ -26,7 +27,7 @@ function TemplatesPageContent() {
           <LinkButton
             icon="plus"
             variant="primary"
-            href="/alerting/notifications/templates/new"
+            href={createRelativeUrl('/alerting/notifications/templates/new')}
             disabled={!createTemplateAbility.granted}
           >
             <Trans i18nKey="alerting.templates-page.add-template">New notification template</Trans>

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.test.tsx
@@ -1,7 +1,7 @@
 import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byLabelText, byRole } from 'testing-library-selector';
 
-import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { config, setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -60,6 +60,19 @@ describe('ImportToGMARules', () => {
 
     expect(ui.importSource.existingDatasource.get()).toBeInTheDocument();
     expect(ui.importSource.yaml.get()).toBeInTheDocument();
+  });
+
+  it('includes the app sub path in the cancel link', () => {
+    const originalAppSubUrl = config.appSubUrl;
+    config.appSubUrl = '/sub';
+
+    try {
+      render(<ImportToGMARules />);
+
+      expect(byRole('link', { name: /cancel/i }).get()).toHaveAttribute('href', '/sub/alerting/list');
+    } finally {
+      config.appSubUrl = originalAppSubUrl;
+    }
   });
 
   describe('existing datasource', () => {

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMARules.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../utils/datasource';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
 import { CreateNewFolder } from '../create-folder/CreateNewFolder';
@@ -224,7 +225,7 @@ const ImportToGMARules = () => {
                   </Stack>
                 </Button>
 
-                <LinkButton variant="secondary" href="/alerting/list">
+                <LinkButton variant="secondary" href={createRelativeUrl('/alerting/list')}>
                   <Trans i18nKey="common.cancel">Cancel</Trans>
                 </LinkButton>
               </Stack>

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byLabelText, byRole, byText } from 'testing-library-selector';
 
+import { config } from '@grafana/runtime';
 import {
   type AlertManagerDataSourceJsonData,
   AlertManagerImplementation,
@@ -230,6 +231,25 @@ describe('AutoSyncConfiguration — edge-case states', () => {
     expect(await edgeUi.noDatasourcesMessage.find()).toBeInTheDocument();
     expect(edgeUi.addMimirDatasourceLink.get()).toBeInTheDocument();
     expect(edgeUi.addMimirDatasourceLink.get()).toHaveAttribute('href', '/connections/datasources/alertmanager');
+  });
+
+  it('case 7b: the "Add Mimir datasource" link keeps the app sub path', async () => {
+    const originalAppSubUrl = config.appSubUrl;
+    config.appSubUrl = '/sub';
+    setupAutoSyncConfig(server);
+    setupDatasourcesEndpoint(server, []);
+    setupDataSources();
+
+    try {
+      render(<AutoSyncConfiguration />);
+
+      expect(await edgeUi.addMimirDatasourceLink.find()).toHaveAttribute(
+        'href',
+        '/sub/connections/datasources/alertmanager'
+      );
+    } finally {
+      config.appSubUrl = originalAppSubUrl;
+    }
   });
 
   it('case 8: orphan UID — warning callout + Disable sync action visible, Save remains available for recovery', async () => {

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
@@ -6,6 +6,7 @@ import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, Card, ConfirmModal, Field, LinkButton, Select, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { hasConfiguredUid, isOperatorManaged } from '../../utils/autoSync';
+import { createRelativeUrl } from '../../utils/url';
 
 import { AutoSyncStatusBadge } from './AutoSyncStatusBadge';
 import { useAutoSyncConfiguration } from './useAutoSyncConfiguration';
@@ -121,7 +122,7 @@ export function AutoSyncConfiguration({ stagedConfigIdentifier }: AutoSyncConfig
                     </Trans>
                   </span>
                   <LinkButton
-                    href="/connections/datasources/alertmanager"
+                    href={createRelativeUrl('/connections/datasources/alertmanager')}
                     icon="plus"
                     variant="secondary"
                     fill="outline"

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -4,7 +4,7 @@ import { byRole, byTestId } from 'testing-library-selector';
 
 import { OrgRole } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { config, setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { setupMswServer } from '../mockApi';
@@ -227,6 +227,20 @@ describe('RuleListActions', () => {
 
     expect(ui.newRuleButton.query()).not.toBeInTheDocument();
     expect(ui.moreButton.get()).toBeInTheDocument();
+  });
+
+  it('should include the app sub path in the "New alert rule" link', () => {
+    const originalAppSubUrl = config.appSubUrl;
+    config.appSubUrl = '/sub';
+    grantUserPermissions([AccessControlAction.AlertingRuleCreate]);
+
+    try {
+      render(<RuleListActions />);
+
+      expect(ui.newRuleButton.get()).toHaveAttribute('href', '/sub/alerting/new/alerting');
+    } finally {
+      config.appSubUrl = originalAppSubUrl;
+    }
   });
 
   it('should only show New alert rule for export when the user has view Grafana rules permission', async () => {

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -20,6 +20,7 @@ import { useImportEntrypointState } from '../hooks/useImportEntrypointState';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
 import { ALERTING_PATHS } from '../utils/navigation';
+import { createRelativeUrl } from '../utils/url';
 
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
@@ -151,7 +152,7 @@ export function RuleListActions() {
         <LinkButton
           variant="primary"
           icon="plus"
-          href="/alerting/new/alerting"
+          href={createRelativeUrl('/alerting/new/alerting')}
           data-testid={selectors.pages.Alerting.RuleList.newAlertRuleLink}
         >
           <Trans i18nKey="alerting.rule-list.new-alert-rule">New alert rule</Trans>

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byRole, byText } from 'testing-library-selector';
 
+import { config } from '@grafana/runtime';
 import { type AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { configureStore } from 'app/store/configureStore';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -88,6 +89,24 @@ describe('Import settings tab', () => {
     expect(await ui.emptyState.find()).toBeInTheDocument();
     expect(ui.importCta.get()).toBeInTheDocument();
     expect(ui.learnMoreLink.get()).toBeInTheDocument();
+  });
+
+  it('includes the app sub path in the import and add Alertmanager links', async () => {
+    const originalAppSubUrl = config.appSubUrl;
+    config.appSubUrl = '/sub';
+
+    try {
+      render(<ImportSettingsPage />);
+
+      expect(await ui.emptyState.find()).toBeInTheDocument();
+      expect(ui.importCta.get()).toHaveAttribute('href', '/sub/alerting/import-to-gma');
+      expect(byRole('link', { name: /add new alertmanager/i }).get()).toHaveAttribute(
+        'href',
+        '/sub/connections/datasources/alertmanager'
+      );
+    } finally {
+      config.appSubUrl = originalAppSubUrl;
+    }
   });
 
   it('shows a configuration staged after it was already rendered as empty', async () => {

--- a/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
+++ b/public/app/features/alerting/unified/settings/import/ImportSettingsPage.tsx
@@ -12,6 +12,7 @@ import { AlertmanagerProvider } from '../../state/AlertmanagerContext';
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { DOCS_URL_ALERTING_MIGRATION } from '../../utils/docs';
 import { stringifyErrorLike } from '../../utils/misc';
+import { createRelativeUrl } from '../../utils/url';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { useSettingsPageNav } from '../navigation';
 
@@ -33,7 +34,7 @@ function ImportSettingsPage() {
           key="add-alertmanager"
           title={t('alerting.settings-content.title-alerting-settings', 'Alerting settings')}
           component={
-            <LinkButton href="/connections/datasources/alertmanager" icon="plus" variant="primary">
+            <LinkButton href={createRelativeUrl('/connections/datasources/alertmanager')} icon="plus" variant="primary">
               <Trans i18nKey="alerting.settings-content.add-new-alertmanager">Add new Alertmanager</Trans>
             </LinkButton>
           }
@@ -108,7 +109,7 @@ function StagedConfigurationSection() {
           variant="call-to-action"
           message={t('alerting.settings.import.empty-title', 'No configuration imported yet')}
           button={
-            <LinkButton icon="cloud-upload" size="lg" href={IMPORT_WIZARD_URL}>
+            <LinkButton icon="cloud-upload" size="lg" href={createRelativeUrl(IMPORT_WIZARD_URL)}>
               <Trans i18nKey="alerting.settings.import.empty-cta">Import Alertmanager configuration</Trans>
             </LinkButton>
           }


### PR DESCRIPTION
**What is this feature?**

When Grafana is served from a sub path, several buttons in alerting render `<a href="/alerting/...">` without it. A plain left click still works, because `interceptLinkClicks` catches it and hands the path to `locationService.push`, which adds the base back. Ctrl/cmd+click, middle click, "Open link in new tab" and "Copy link address" don't go through that interceptor, so the browser resolves `/alerting/...` against the origin and the user ends up on `https://host/alerting/...` instead of `https://host/grafana/alerting/...`.

I was reading the contact points page and saw that its LinkButtons got raw paths, then grepped alerting for `LinkButton` hrefs that start with `/` and don't go through `createRelativeUrl`. This PR fixes these:

- Contact points: "New contact point" (list header and empty state), "New notification template" on the templates tab, and the Edit/View button of each contact point
- Notification templates page: "New notification template"
- Settings and Import settings pages: "Add new Alertmanager", plus "Import Alertmanager configuration" in the import empty state
- Auto-sync card: "Add Mimir datasource"
- Import to GMA form: "Cancel"
- Rule list v2: "New alert rule"

Each href now goes through `createRelativeUrl`, which is what `public/app/features/alerting/unified/AGENTS.md` asks for with LinkButton ("LinkButton renders a native HTML anchor element, so it doesn't use React Router. You must manually add the subpath prefix using `createRelativeUrl`") and what `ImportToGMABanner` already does. The empty-state contact point button was built with `makeAMLink`, which doesn't add the sub path either. It keeps its `alertmanager` query param; that page sits behind `AlertManagerPagePermissionsCheck`, so an Alertmanager is always selected there.

**Why do we need this feature?**

Opening any of these buttons in a new tab, or sharing the copied link, is broken on every instance behind a sub path. #131494 fixed the same kind of bug on the data sources pages.

**Who is this feature for?**

People running Grafana under a sub path who use alerting.

**Which issue(s) does this PR fix?**:

I couldn't find an existing issue for these buttons.

**Special notes for your reviewer:**

I added tests that set `config.appSubUrl = '/sub'`, the same way `RuleActionsButtons.test.tsx` does, and check the href of each button. On the 8 touched test suites, with this change: 128 tests, all passing. With the component sources put back to main and the same tests: all 8 suites fail, 9 tests red and 119 green. For example, TemplatesPage "includes the sub path in the new template link" expects `/sub/alerting/notifications/templates/new` and gets `/alerting/notifications/templates/new`.

The empty-state "New contact point" button is the only one without its own test, since the existing mocks always return contact points; it uses the same helper. I checked all this with the tests, not in a running instance behind a proxy.

`SilencesTable` and `ReceiverForm` have the same problem through `makeAMLink('/alerting/...')`. I left them out: `makeAMLink` drops the `alertmanager` param when the name is empty, and I'd rather handle that in a separate PR than in passing here.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

AI tools used
