### PR TITLE
Dashboards/UI: make existing tests tolerate asynchronous rendering

### DIFF
--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.test.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.test.tsx
@@ -21,43 +21,43 @@ describe('The FileDropzone component', () => {
     jest.resetAllMocks();
   });
 
-  it('should show the default text of the dropzone component when no props passed', () => {
+  it('should show the default text of the dropzone component when no props passed', async () => {
     render(<FileDropzone />);
 
-    expect(screen.getByText('Upload file')).toBeInTheDocument();
+    expect(await screen.findByText('Upload file')).toBeInTheDocument();
   });
 
-  it('should show the accepted file type(s) when passed in as a string', () => {
+  it('should show the accepted file type(s) when passed in as a string', async () => {
     render(<FileDropzone options={{ accept: '.json' }} />);
 
-    expect(screen.getByText('Accepted file type: .json')).toBeInTheDocument();
+    expect(await screen.findByText('Accepted file type: .json')).toBeInTheDocument();
   });
 
   it('should show an error message when the file size exceeds the max file size', async () => {
     render(<FileDropzone options={{ maxSize: 1 }} />);
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData(files));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData(files));
 
     expect(await screen.findByText('File is larger than 1 B')).toBeInTheDocument();
   });
 
-  it('should show the accepted file type(s) when passed in as a array of strings', () => {
+  it('should show the accepted file type(s) when passed in as a array of strings', async () => {
     render(<FileDropzone options={{ accept: ['.json', '.txt'] }} />);
 
-    expect(screen.getByText('Accepted file types: .json, .txt')).toBeInTheDocument();
+    expect(await screen.findByText('Accepted file types: .json, .txt')).toBeInTheDocument();
   });
 
-  it('should show the accepted file type(s) when passed in as an `Accept` object', () => {
+  it('should show the accepted file type(s) when passed in as an `Accept` object', async () => {
     render(<FileDropzone options={{ accept: { 'text/*': ['.json', '.txt'] } }} />);
 
-    expect(screen.getByText('Accepted file types: .json, .txt')).toBeInTheDocument();
+    expect(await screen.findByText('Accepted file types: .json, .txt')).toBeInTheDocument();
   });
 
   it('should handle file removal from the list', async () => {
     const user = userEvent.setup();
     render(<FileDropzone />);
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData(files));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData(files));
 
     expect(await screen.findAllByLabelText(REMOVE_FILE)).toHaveLength(3);
 
@@ -69,7 +69,7 @@ describe('The FileDropzone component', () => {
   it('should overwrite selected file when multiple false', async () => {
     render(<FileDropzone options={{ multiple: false }} />);
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData([file({})]));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData([file({})]));
 
     expect(await screen.findAllByLabelText(REMOVE_FILE)).toHaveLength(1);
     expect(screen.getByText('ping.json')).toBeInTheDocument();
@@ -84,7 +84,7 @@ describe('The FileDropzone component', () => {
     render(<FileDropzone readAs="readAsDataURL" />);
     const fileReaderSpy = jest.spyOn(FileReader.prototype, 'readAsDataURL');
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData([file({})]));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData([file({})]));
 
     expect(await screen.findByText('ping.json')).toBeInTheDocument();
     expect(fileReaderSpy).toBeCalled();
@@ -94,7 +94,7 @@ describe('The FileDropzone component', () => {
     render(<FileDropzone />);
     const fileReaderSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData([file({})]));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData([file({})]));
 
     expect(await screen.findByText('ping.json')).toBeInTheDocument();
     expect(fileReaderSpy).toBeCalled();
@@ -106,14 +106,14 @@ describe('The FileDropzone component', () => {
     render(<FileDropzone options={{ onDrop }} />);
     const fileReaderSpy = jest.spyOn(FileReader.prototype, 'readAsText');
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData([fileToUpload]));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData([fileToUpload]));
 
     expect(await screen.findByText('ping.json')).toBeInTheDocument();
     expect(fileReaderSpy).not.toBeCalled();
     expect(onDrop).toHaveBeenCalledWith([fileToUpload], [], expect.anything());
   });
 
-  it('should show children inside the dropzone', () => {
+  it('should show children inside the dropzone', async () => {
     const component = (
       <FileDropzone>
         <p>Custom dropzone text</p>
@@ -121,13 +121,13 @@ describe('The FileDropzone component', () => {
     );
     render(component);
 
-    expect(screen.getByText('Custom dropzone text')).toBeInTheDocument();
+    expect(await screen.findByText('Custom dropzone text')).toBeInTheDocument();
   });
 
   it('should handle file list overwrite when fileListRenderer is passed', async () => {
     render(<FileDropzone fileListRenderer={() => null} />);
 
-    dispatchEvt(screen.getByTestId('dropzone'), 'drop', mockData([file({})]));
+    dispatchEvt(await screen.findByTestId('dropzone'), 'drop', mockData([file({})]));
 
     // need to await this in order to have the drop finished
     await screen.findByTestId('dropzone');

--- a/packages/grafana-ui/src/components/Forms/Field.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/Field.test.tsx
@@ -394,14 +394,14 @@ describe('Field', () => {
   });
 
   describe('FileDropzone', () => {
-    it('associates with the field label correctly when no id is set', () => {
+    it('associates with the field label correctly when no id is set', async () => {
       render(
         <Field label="My label">
           <FileDropzone />
         </Field>
       );
 
-      expect(screen.getByLabelText('My label')).toBeInTheDocument();
+      expect(await screen.findByLabelText('My label')).toBeInTheDocument();
     });
   });
 

--- a/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineField.test.tsx
@@ -416,14 +416,14 @@ describe('InlineField', () => {
   });
 
   describe('FileDropzone', () => {
-    it('associates with the field label correctly when no id is set', () => {
+    it('associates with the field label correctly when no id is set', async () => {
       render(
         <InlineField label="My label">
           <FileDropzone />
         </InlineField>
       );
 
-      expect(screen.getByLabelText('My label')).toBeInTheDocument();
+      expect(await screen.findByLabelText('My label')).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/dashboard-scene/components/SuggestedDashboardsBanner.test.tsx
+++ b/public/app/features/dashboard-scene/components/SuggestedDashboardsBanner.test.tsx
@@ -29,13 +29,13 @@ function renderBanner(route: string, initialEntry: string) {
 }
 
 describe('SuggestedDashboardsBanner', () => {
-  it('should render the banner when route is Template and URL params are present', () => {
+  it('should render the banner when route is Template and URL params are present', async () => {
     renderBanner(
       DashboardRoutes.Template,
       '/dashboard/templates/my-dash-uid?suggestedDashboardBanner=true&datasource=ds1'
     );
 
-    expect(screen.getByText(/You are viewing/)).toBeInTheDocument();
+    expect(await screen.findByText(/You are viewing/)).toBeInTheDocument();
     expect(screen.getByText(/other suggested dashboards/)).toBeInTheDocument();
     expect(screen.getByText(/create one from scratch/)).toBeInTheDocument();
   });

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList/DraggableList.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList/DraggableList.test.tsx
@@ -1,5 +1,5 @@
 import { type DropResult } from '@hello-pangea/dnd';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { DraggableList } from './DraggableList';
 
@@ -40,21 +40,24 @@ describe('DraggableList', () => {
     expect(screen.getByText('Item B')).toBeInTheDocument();
   });
 
-  it('enables dragging by default when isDragDisabled is omitted', () => {
+  it('enables dragging by default when isDragDisabled is omitted', async () => {
     renderList();
 
-    expect(getDragHandle('Item A')).toBeInTheDocument();
+    await waitFor(() => expect(getDragHandle('Item A')).toBeInTheDocument());
   });
 
-  it('enables dragging when isDragDisabled is false', () => {
+  it('enables dragging when isDragDisabled is false', async () => {
     renderList(false);
 
-    expect(getDragHandle('Item A')).toBeInTheDocument();
+    await waitFor(() => expect(getDragHandle('Item A')).toBeInTheDocument());
   });
 
-  it('disables dragging when isDragDisabled is true', () => {
-    renderList(true);
+  it('disables dragging when isDragDisabled is true', async () => {
+    const { container } = renderList(true);
 
+    await waitFor(() =>
+      expect(container.querySelector('[data-rfd-droppable-id="test-droppable"]')).toBeInTheDocument()
+    );
     expect(getDragHandle('Item A')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -171,7 +171,7 @@ describe('SaveDashboardDrawer', () => {
 
       sceneGraph.getTimeRange(dashboard).setState({ from: 'now-1h', to: 'now' });
 
-      openAndRender();
+      await openAndRender();
 
       await userEvent.click(screen.getByTestId(selectors.pages.SaveDashboardModal.saveTimerange));
       const message = await screen.findByLabelText('message');
@@ -447,7 +447,7 @@ describe('SaveDashboardDrawer', () => {
       jest.mocked(useDashboardRepositoryView).mockImplementation(() => repoState);
 
       const { dashboard, openAndRender } = setup();
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
 
       // Mounting a form here would swap it out once the repository resolves, dropping typed input
       expect(await screen.findByTestId('Spinner')).toBeInTheDocument();
@@ -471,7 +471,7 @@ describe('SaveDashboardDrawer', () => {
       jest.mocked(useDashboardRepositoryView).mockImplementation(() => repoState);
 
       const { dashboard, openAndRender } = setup();
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
       expect(
         await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput)
       ).toBeInTheDocument();
@@ -489,7 +489,7 @@ describe('SaveDashboardDrawer', () => {
       jest.mocked(useDashboardRepositoryView).mockImplementation(() => repoState);
 
       const { dashboard, openAndRender } = setup();
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
       expect(await screen.findByTestId('provisioned-form')).toHaveAttribute('data-held', 'false');
 
       repoState = view({
@@ -513,7 +513,7 @@ describe('SaveDashboardDrawer', () => {
 
       const { dashboard, openAndRender } = setup();
       dashboard.setState({ uid: '', version: 0 });
-      openAndRender();
+      await openAndRender();
 
       expect(await screen.findByTestId('provisioned-form')).toBeInTheDocument();
       await userEvent.click(screen.getByRole('button', { name: 'Save to Grafana database instead' }));
@@ -543,7 +543,7 @@ describe('SaveDashboardDrawer', () => {
 
       const { dashboard, openAndRender } = setup();
       dashboard.setState({ uid: '', version: 0 });
-      openAndRender();
+      await openAndRender();
 
       expect(await screen.findByTestId('provisioned-form')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /instead$/ })).not.toBeInTheDocument();
@@ -555,7 +555,7 @@ describe('SaveDashboardDrawer', () => {
 
       const { dashboard, openAndRender } = setup();
       dashboard.setState({ uid: '', version: 0 });
-      openAndRender();
+      await openAndRender();
       expect(await screen.findByTestId('provisioned-form')).toBeInTheDocument();
 
       // The picked folder is annotated with a repository that no longer exists
@@ -594,7 +594,7 @@ describe('SaveDashboardDrawer', () => {
 
       const { dashboard, openAndRender } = setup();
       dashboard.setState({ uid: '', version: 0 });
-      openAndRender();
+      await openAndRender();
 
       expect(await screen.findByTestId('provisioned-form')).toBeInTheDocument();
       await userEvent.click(screen.getByRole('button', { name: 'Save to Grafana database instead' }));
@@ -645,7 +645,7 @@ describe('SaveDashboardDrawer', () => {
 
       const { dashboard, openAndRender } = setup();
       dashboard.setState({ uid: '', version: 0 });
-      openAndRender();
+      await openAndRender();
 
       expect(
         await screen.findByTestId(selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput)
@@ -660,7 +660,7 @@ describe('SaveDashboardDrawer', () => {
         .mockReturnValue(view({ isNewSave: false, isProvisioned: true, repository: folderlessRepo }));
 
       const stored = setup();
-      stored.openAndRender();
+      await stored.openAndRender();
       expect(await screen.findByRole('heading', { name: 'Provisioned dashboard' })).toBeInTheDocument();
       cleanup();
 
@@ -670,7 +670,7 @@ describe('SaveDashboardDrawer', () => {
 
       const fresh = setup();
       fresh.dashboard.setState({ uid: '', version: 0 });
-      fresh.openAndRender();
+      await fresh.openAndRender();
       expect(await screen.findByRole('heading', { name: 'Save dashboard' })).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', { name: 'Save to Grafana database instead' }));
@@ -686,7 +686,7 @@ describe('SaveDashboardDrawer', () => {
         dashboard.setState({ uid: '', version: 0, tags: ['my-tag'] });
       });
 
-      openAndRender();
+      await openAndRender();
       expect(await screen.findByText('Save dashboard')).toBeInTheDocument();
       expect(screen.queryByLabelText('Copy tags')).not.toBeInTheDocument();
 
@@ -704,7 +704,7 @@ describe('SaveDashboardDrawer', () => {
         dashboard.setState({ tags: ['my-tag'] });
       });
 
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
       expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
 
       mockSaveDashboard();
@@ -721,7 +721,7 @@ describe('SaveDashboardDrawer', () => {
         dashboard.setState({ tags: ['my-tag'] });
       });
 
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
       expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
 
       await userEvent.click(screen.getByLabelText('Copy tags'));

--- a/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardDrawer.test.tsx
@@ -79,7 +79,7 @@ const ui = {
 describe('SaveDashboardDrawer', () => {
   describe('Given an already saved dashboard', () => {
     it('should render save drawer with only message textarea', async () => {
-      setup().openAndRender();
+      await setup().openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByTestId(selectors.pages.SaveDashboardModal.saveTimerange)).not.toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('SaveDashboardDrawer', () => {
     });
 
     it('When there are no changes', async () => {
-      setup().openAndRender();
+      await setup().openAndRender();
       expect(screen.getByText('No changes to save')).toBeInTheDocument();
     });
 
@@ -97,7 +97,7 @@ describe('SaveDashboardDrawer', () => {
 
       sceneGraph.getTimeRange(dashboard).setState({ from: 'now-1h', to: 'now' });
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByTestId(selectors.pages.SaveDashboardModal.saveTimerange)).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe('SaveDashboardDrawer', () => {
         .getVariables(dashboard)
         .setState({ variables: [new ConstantVariable({ name: 'constant', type: 'constant', value: 'new value' })] });
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(ui.saveVariablesCheckbox.get()).toBeInTheDocument();
@@ -135,7 +135,7 @@ describe('SaveDashboardDrawer', () => {
         ],
       });
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(ui.saveVariablesCheckbox.get()).toBeInTheDocument();
@@ -155,7 +155,7 @@ describe('SaveDashboardDrawer', () => {
 
       sceneGraph.getTimeRange(dashboard).setState({ from: 'now-1h', to: 'now' });
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByTestId(selectors.pages.SaveDashboardModal.saveTimerange)).toBeInTheDocument();
@@ -193,7 +193,7 @@ describe('SaveDashboardDrawer', () => {
         refreshPicker.setState({ refresh: '5s' });
       }
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByTestId(selectors.pages.SaveDashboardModal.saveRefresh)).toBeInTheDocument();
@@ -207,7 +207,7 @@ describe('SaveDashboardDrawer', () => {
         refreshPicker.setState({ refresh: '5s' });
       }
 
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.getByTestId(selectors.pages.SaveDashboardModal.saveRefresh)).toBeInTheDocument();
@@ -223,7 +223,7 @@ describe('SaveDashboardDrawer', () => {
 
       dashboard.setState({ title: 'New title' });
 
-      openAndRender();
+      await openAndRender();
 
       await userEvent.click(await screen.findByRole('tab', { name: /Changes/ }));
 
@@ -235,7 +235,7 @@ describe('SaveDashboardDrawer', () => {
 
       dashboard.setState({ title: 'New title' });
 
-      openAndRender();
+      await openAndRender();
 
       mockSaveDashboard();
 
@@ -253,7 +253,7 @@ describe('SaveDashboardDrawer', () => {
 
       dashboard.setState({ title: 'New title' });
 
-      openAndRender();
+      await openAndRender();
 
       mockSaveDashboard({ saveError: 'version-mismatch' });
 
@@ -293,7 +293,7 @@ describe('SaveDashboardDrawer', () => {
       // just changing the title here, in real case scenario changes are reflected through migrations
       // eg. panel version - same for other manager tests below
       dashboard.setState({ title: 'updated title' });
-      openAndRender();
+      await openAndRender();
 
       expect(screen.queryByRole('tab', { name: /Changes/ })).toBeInTheDocument();
     });
@@ -304,7 +304,7 @@ describe('SaveDashboardDrawer', () => {
       });
 
       dashboard.setState({ title: 'updated title' });
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
@@ -316,7 +316,7 @@ describe('SaveDashboardDrawer', () => {
       });
 
       dashboard.setState({ title: 'updated title' });
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
@@ -330,7 +330,7 @@ describe('SaveDashboardDrawer', () => {
       });
 
       dashboard.setState({ title: 'updated title' });
-      openAndRender();
+      await openAndRender();
 
       expect(await ui.saveDashbordText.find()).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: /Changes/ })).not.toBeInTheDocument();
@@ -340,7 +340,7 @@ describe('SaveDashboardDrawer', () => {
   describe('Save as copy', () => {
     it('Should show save as form', async () => {
       const { openAndRender } = setup();
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
 
       expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
 
@@ -359,7 +359,7 @@ describe('SaveDashboardDrawer', () => {
       });
       const initialFolderUid = dashboard.getInitialState()?.meta.folderUid;
 
-      const drawer = openAndRender({ saveAsCopy: true });
+      const drawer = await openAndRender({ saveAsCopy: true });
       expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
 
       act(() => {
@@ -397,7 +397,7 @@ describe('SaveDashboardDrawer', () => {
         },
       });
 
-      openAndRender({ saveAsCopy: true });
+      await openAndRender({ saveAsCopy: true });
       expect(await screen.findByText('Save dashboard copy')).toBeInTheDocument();
 
       mockSaveDashboard();
@@ -747,7 +747,7 @@ describe('SaveDashboardDrawer', () => {
       registerSaveAsTemplateForm(StubForm);
 
       const { openAndRender } = setup();
-      openAndRender({ saveAsDashboardTemplate: true });
+      await openAndRender({ saveAsDashboardTemplate: true });
 
       expect(await screen.findByTestId('stub-save-as-template-form')).toBeInTheDocument();
       expect(await screen.findByText('Save as template')).toBeInTheDocument();
@@ -761,7 +761,7 @@ describe('SaveDashboardDrawer', () => {
       registerSaveDashboardTemplateForm(StubForm);
 
       const { openAndRender } = setup();
-      openAndRender({ saveDashboardTemplate: true });
+      await openAndRender({ saveDashboardTemplate: true });
 
       expect(await screen.findByTestId('stub-update-template-form')).toBeInTheDocument();
       expect(await screen.findByText('Save template')).toBeInTheDocument();
@@ -770,7 +770,7 @@ describe('SaveDashboardDrawer', () => {
 
     it('falls back to the standard save form when saveAsDashboardTemplate is true but no form is registered', async () => {
       const { openAndRender } = setup();
-      openAndRender({ saveAsDashboardTemplate: true });
+      await openAndRender({ saveAsDashboardTemplate: true });
 
       // No crash, drawer still mounts with the save-as-template title even without the extension form
       expect(await screen.findByText('Save as template')).toBeInTheDocument();
@@ -843,10 +843,10 @@ function setup(overrides?: Partial<DashboardSceneState>) {
 
   dashboard.onEnterEditMode();
 
-  const openAndRender = (
+  const openAndRender = async (
     opts: { saveAsCopy?: boolean; saveAsDashboardTemplate?: boolean; saveDashboardTemplate?: boolean } = {}
   ) => {
-    dashboard.openSaveDrawer(opts);
+    await dashboard.openSaveDrawer(opts);
     const drawer = dashboard.state.overlay as SaveDashboardDrawer;
     render(
       <TestProvider>

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -1981,11 +1981,11 @@ describe('DashboardScene', () => {
   });
 
   describe('openSaveDrawer with template flags', () => {
-    it('opens the drawer in saveAsDashboardTemplate mode', () => {
+    it('opens the drawer in saveAsDashboardTemplate mode', async () => {
       const scene = buildTestScene();
       scene.onEnterEditMode();
 
-      scene.openSaveDrawer({ saveAsDashboardTemplate: true });
+      await scene.openSaveDrawer({ saveAsDashboardTemplate: true });
 
       const overlay = scene.state.overlay;
       expect(overlay).toBeInstanceOf(SaveDashboardDrawer);
@@ -1993,11 +1993,11 @@ describe('DashboardScene', () => {
       expect((overlay as SaveDashboardDrawer).state.saveDashboardTemplate).toBeUndefined();
     });
 
-    it('opens the drawer in saveDashboardTemplate mode', () => {
+    it('opens the drawer in saveDashboardTemplate mode', async () => {
       const scene = buildTestScene();
       scene.onEnterEditMode();
 
-      scene.openSaveDrawer({ saveDashboardTemplate: true });
+      await scene.openSaveDrawer({ saveDashboardTemplate: true });
 
       const overlay = scene.state.overlay;
       expect(overlay).toBeInstanceOf(SaveDashboardDrawer);
@@ -2005,10 +2005,10 @@ describe('DashboardScene', () => {
       expect((overlay as SaveDashboardDrawer).state.saveAsDashboardTemplate).toBeUndefined();
     });
 
-    it('does nothing when the scene is not in edit mode', () => {
+    it('does nothing when the scene is not in edit mode', async () => {
       const scene = buildTestScene();
       // Not entering edit mode
-      scene.openSaveDrawer({ saveAsDashboardTemplate: true });
+      await scene.openSaveDrawer({ saveAsDashboardTemplate: true });
       expect(scene.state.overlay).toBeUndefined();
     });
   });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.test.ts
@@ -261,6 +261,23 @@ describe('DashboardSceneUrlSync', () => {
   });
 
   describe('entering edit mode', () => {
+    it('keeps the URL and selected edit view in sync after successive updates', async () => {
+      const scene = buildTestScene();
+      scene.setState({
+        editable: true,
+        isEditing: true,
+        meta: { ...scene.state.meta, canEdit: true },
+      });
+
+      scene.urlSync?.updateFromUrl({ editview: 'settings' });
+      expect(scene.urlSync?.getUrlState().editview).toBe('settings');
+
+      scene.urlSync?.updateFromUrl({ editview: 'variables' });
+      expect(scene.urlSync?.getUrlState().editview).toBe('variables');
+
+      await waitFor(() => expect(scene.state.editview?.getUrlKey()).toBe('variables'));
+    });
+
     it('it should be possible to go from the view panel view to the edit view when the dashboard is not in edit mdoe', async () => {
       const scene = buildTestScene();
       scene.setState({ isEditing: false });

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableMultiPropStaticOptionsForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableMultiPropStaticOptionsForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from '@testing-library/react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -169,6 +169,9 @@ describe('<VariableMultiPropStaticOptionsForm />', () => {
       ];
       const { elements, findByText } = renderForm({ properties: ['text', 'value'], options, onChange });
 
+      await waitFor(() => {
+        expect(within(elements.rows()[0]).getByTestId('icon-draggabledots').closest('[role="button"]')).not.toBeNull();
+      });
       const dragIcon = within(elements.rows()[0]).getByTestId('icon-draggabledots');
       const handle = dragIcon.closest('[role="button"]')!;
 

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { act, screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
@@ -97,6 +97,18 @@ describe('DashboardSidebarRenderer', () => {
     render(<DashboardSidebarSplitter dashboard={scene} />);
 
     expect(await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outlineButton)).toBeInTheDocument();
+  });
+
+  it('opens the add pane when the Add button is clicked', async () => {
+    const user = userEvent.setup();
+    const scene = buildTestScene();
+
+    act(() => activateFullSceneTree(scene));
+    render(<DashboardSidebarSplitter dashboard={scene} isEditing />);
+
+    await user.click(await screen.findByTestId(selectors.pages.Dashboard.Sidebar.addButton));
+
+    await waitFor(() => expect(scene.state.sidebar.state.openPane?.getId()).toBe('add'));
   });
 
   it('Should sync sidebar docked state with sidebar state', async () => {

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarSplitter.test.tsx
@@ -43,7 +43,7 @@ describe('DashboardSidebarSplitter', () => {
     await user.click(screen.getByTestId(selectors.pages.Dashboard.Sidebar.optionsButton));
 
     // switch to auto and confirm change
-    await user.click(screen.getByLabelText('layout-selection-option-Auto'));
+    await user.click(await screen.findByLabelText('layout-selection-option-Auto'));
     let confirmButton = screen.getByTestId(selectors.pages.ConfirmModal.delete);
     await user.click(confirmButton);
 

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardAnnotationsList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardAnnotationsList.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, within } from '@testing-library/react';
+import { act, fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -231,6 +231,9 @@ describe('User interactions', () => {
       direction: 'up' | 'down',
       positions = 1
     ) {
+      await waitFor(() => {
+        expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]').length).toBeGreaterThan(itemIndex);
+      });
       const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
       const handle = dragHandles[itemIndex] as HTMLElement;
       handle.focus();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from '@testing-library/react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { VariableHide } from '@grafana/data';
@@ -151,6 +151,9 @@ describe('<DashboardFiltersList />', () => {
         direction: 'up' | 'down',
         positions = 1
       ) {
+        await waitFor(() => {
+          expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]').length).toBeGreaterThan(itemIndex);
+        });
         const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
         const handle = dragHandles[itemIndex] as HTMLElement;
         handle.focus();
@@ -194,6 +197,9 @@ describe('<DashboardFiltersList />', () => {
 
         const { container, findByText } = render(<DashboardFiltersList variableSet={variableSet} />);
 
+        await waitFor(() => {
+          expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]').length).toBeGreaterThan(0);
+        });
         const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
         const handle = dragHandles[0] as HTMLElement;
         handle.focus();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardLinksList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardLinksList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from '@testing-library/react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -150,6 +150,9 @@ describe('<DashboardLinksList />', () => {
         direction: 'up' | 'down',
         positions = 1
       ) {
+        await waitFor(() => {
+          expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]').length).toBeGreaterThan(itemIndex);
+        });
         const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
         const handle = dragHandles[itemIndex] as HTMLElement;
         handle.focus();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardVariablesList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardVariablesList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, within } from '@testing-library/react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { VariableHide } from '@grafana/data';
@@ -182,6 +182,9 @@ describe('<DashboardVariablesList />', () => {
         direction: 'up' | 'down',
         positions = 1
       ) {
+        await waitFor(() => {
+          expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]').length).toBeGreaterThan(itemIndex);
+        });
         const dragHandles = container.querySelectorAll('[data-rfd-drag-handle-draggable-id]');
         const handle = dragHandles[itemIndex] as HTMLElement;
         handle.focus();

--- a/public/app/features/dashboard-scene/sidebar/outline/DashboardOutline.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/outline/DashboardOutline.test.tsx
@@ -122,7 +122,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
+      await user.click(await screen.findByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
       expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
 
       unmount();
@@ -135,7 +135,9 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+      expect(
+        await screen.findByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))
+      ).toBeInTheDocument();
     });
 
     it('should share collapsed state across clones', () => {
@@ -170,7 +172,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
+      await user.click(await screen.findByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
       expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
 
       unmount();
@@ -190,7 +192,9 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+      expect(
+        await screen.findByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))
+      ).toBeInTheDocument();
     });
   });
 
@@ -213,7 +217,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
       // select Row lvl 1 (index 3 because Variables is at 0, Annotations at 1, Links at 2)
-      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 1')));
+      await user.click(await screen.findByTestId(selectors.components.PanelEditor.Outline.item('Row level 1')));
       expect(DashboardInteractions.outlineItemClicked).toHaveBeenNthCalledWith(1, {
         index: 3,
         depth: 1,
@@ -259,7 +263,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
       // select Row lvl 1 (index 0 because variables and annotations aren't shown in view mode)
-      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 1')));
+      await user.click(await screen.findByTestId(selectors.components.PanelEditor.Outline.item('Row level 1')));
       expect(DashboardInteractions.outlineItemClicked).toHaveBeenNthCalledWith(1, {
         index: 0,
         depth: 1,
@@ -286,11 +290,13 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
+      const searchInput = await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
+
       expect(
         screen.queryByTestId(selectors.components.PanelEditor.Outline.item('Tab level 3 - B'))
       ).not.toBeInTheDocument();
 
-      await user.type(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput), 'Tab level 3 - B');
+      await user.type(searchInput, 'Tab level 3 - B');
 
       // Wait for debounced search to complete
       await waitFor(() => {
@@ -326,7 +332,7 @@ describe('DashboardOutline', () => {
       );
 
       await user.type(
-        screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput),
+        await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput),
         'important system metrics'
       );
 
@@ -354,7 +360,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      const searchInput = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
+      const searchInput = await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
 
       await user.type(searchInput, 'does-not-exist');
       await waitFor(() => {
@@ -389,7 +395,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      const searchInput = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
+      const searchInput = await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
       await user.type(searchInput, 'Row level 1');
       expect(searchInput).toHaveValue('Row level 1');
 
@@ -403,7 +409,9 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      expect(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput)).toHaveValue('Row level 1');
+      expect(await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput)).toHaveValue(
+        'Row level 1'
+      );
     });
 
     it('preserves search query after entering and exiting edit mode', async () => {
@@ -423,7 +431,7 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      const searchInput = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
+      const searchInput = await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput);
       await user.type(searchInput, 'Row level 1');
       expect(searchInput).toHaveValue('Row level 1');
 
@@ -444,7 +452,9 @@ describe('DashboardOutline', () => {
         </ElementSelectionContext.Provider>
       );
 
-      expect(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput)).toHaveValue('Row level 1');
+      expect(await screen.findByTestId(selectors.pages.Dashboard.Sidebar.outline.searchInput)).toHaveValue(
+        'Row level 1'
+      );
     });
   });
 });


### PR DESCRIPTION
extracts some test-only changes from https://github.com/grafana/grafana/pull/131737