### PR TITLE
Router: use metav1.APIGroup as key

### DIFF
--- a/pkg/router/AGENTS.md
+++ b/pkg/router/AGENTS.md
@@ -83,7 +83,7 @@ latency blip across all traffic when only one route changed.
 Implementation: `GrafanaRouter.served` is a persistent `map[group]*handlerEntry`, keyed by group.
 Each entry holds the live `Backend` (kept so discovery synthesis reflects what's actually served,
 not the raw `Load()` result — see Discovery endpoints below), its resolved `http.Handler`, and
-`lastRV`, the fingerprint last applied. On reconcile, groups whose `lastRV` is unchanged are left
+`lastKey`, the fingerprint last applied. On reconcile, groups whose `lastKey` is unchanged are left
 untouched, changed/new groups are rebuilt, and removed groups are dropped; then a fresh immutable
 `map[group]Backend` snapshot is published via one atomic store. **Connection-pool survival comes
 from the shared transport cache, not the Backend identity** (`transportFor`, keyed by
@@ -94,7 +94,7 @@ Because reconcile only rebuilds the *changed* group, unrelated backends are neve
 
 The router serves by **group**, the natural key of the loaded config — not by flattened path
 prefixes. `GrafanaRouter.snapshot` is an `atomic.Pointer[map[group]servingEntry]` (handler plus the
-group's current RV, needed by the `/openapi/v3/apis/<group>/<version>` cache — see Discovery
+group's current key, needed by the `/openapi/v3/apis/<group>/<version>` cache — see Discovery
 endpoints below); reconcile rebuilds and stores it, serving loads it lock-free per request.
 
 **Why not a general path mux (e.g. a `PathRecorderMux` port).** A kube-aggregator-style mux flattens
@@ -153,7 +153,7 @@ TBD. Possibly inspect a manifest. Use a gRPC client to translate http calls via 
 | `/apis/{group}`                                | single backend | proxy to the owning backend (see decision)    |
 | `/apis`                                        | router         | **synthesized** `metav1.APIGroupList`         |
 | `/openapi/v3`                                  | router         | **synthesized** `handler3.OpenAPIV3Discovery` |
-| `/openapi/v3/apis/{group}/{version}`           | single backend | proxy, cached and RV-busted (see below)       |
+| `/openapi/v3/apis/{group}/{version}`           | single backend | proxy, cached and key-busted (see below)      |
 
 **Decision: one backend owns ALL versions of a given group.** A group is never split across
 backends (reconcile keys `served` by group; a duplicate group is last-wins, and discovery is
@@ -163,10 +163,10 @@ synthesized from `served`, so it never advertises both). Consequences:
   directly to the single owning backend**. No cross-backend merge is needed at group level.
 - `/apis` (root, `APIGroupList` — the union across every group) and `/openapi/v3` (root, a small
   path→hash discovery index, **never** a merged OpenAPI schema) both require router-side synthesis
-  from each backend's `Manifest()`, done once per `reconcile()` cycle and stored via `atomic.Pointer`
+  from each backend's `Group()`, done once per `reconcile()` cycle and stored via `atomic.Pointer`
   alongside `snapshot` (`buildAPIGroupList`/`buildOpenAPIV3Index` in `discovery.go`).
 - `/openapi/v3/apis/{group}/{version}` (the actual heavy per-group document) is a pure proxy to the
-  owning backend, same as `/apis/{group}/{version}` — fronted by an RV-keyed `sync.Map` cache
+  owning backend, same as `/apis/{group}/{version}` — fronted by a key-validated `sync.Map` cache
   (`openapiDocs` in `router.go`) so repeat requests between manifest changes skip the backend
   round-trip. Cache-miss proxy requests strip `If-None-Match`/`If-Modified-Since` before forwarding,
   so an unrelated backend ETag scheme can't produce a bodyless 304 the router would otherwise have
@@ -208,7 +208,7 @@ The signal and the state are split; do not conflate them.
   with **no payload**. The router treats it as a level trigger, not a stream of deltas. How the
   loader produces or coalesces that edge is the loader's concern, not the router's.
 - **`reconcile` is level-triggered.** On each wake it calls `RoutesLoader.Load` to re-read the full
-  desired set, then converges: upsert changed groups (`lastRV` compare), skip unchanged ones, drop
+  desired set, then converges: upsert changed groups (`lastKey` compare), skip unchanged ones, drop
   groups that disappeared. Safe to run on any wake — dropped signals cost nothing because Load reads
   current truth.
 - **Ordering:** receive from the channel *before* calling Load (drain-then-load), so an event during
@@ -228,7 +228,7 @@ The signal and the state are split; do not conflate them.
 - **`Ready` must not fail on a partial reconcile error — but must fail if nothing has ever been
   served.** A non-nil reconcile error (one group's `Backend.Load` failed) does not stop the router
   serving every other group on last-known-good — that is the whole point of the "keep serving, don't
-  advance `lastRV`" design above. Gating `/readyz` (the enterprise command wires `Ready` there) on any
+  advance `lastKey`" design above. Gating `/readyz` (the enterprise command wires `Ready` there) on any
   error would drain the whole router from its LB rotation over one misconfigured group, while it's
   still able to proxy everything else. The first fix for this went too far, though — making `Ready`
   ignore `err` entirely whenever `phase == serving` — and regressed the case where the *very first*

--- a/pkg/router/breaker_test.go
+++ b/pkg/router/breaker_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sony/gobreaker/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsBackendFailure(t *testing.T) {
@@ -74,7 +75,7 @@ func withGroupHandler(group string, h http.Handler) *GrafanaRouter {
 	s := NewGrafanaRouter(stubLoader{})
 	s.served[group] = &handlerEntry{
 		handler: h,
-		lastRV:  "1",
+		lastKey: "1",
 		breaker: newGroupBreaker(group),
 	}
 	s.publish()
@@ -159,7 +160,7 @@ func TestHandleFuncBreakerIgnoresPlain500(t *testing.T) {
 
 func withGroupHandlerAndBreaker(group string, h http.Handler, cb *gobreaker.CircuitBreaker[struct{}]) *GrafanaRouter {
 	s := NewGrafanaRouter(stubLoader{})
-	s.served[group] = &handlerEntry{handler: h, lastRV: "1", breaker: cb}
+	s.served[group] = &handlerEntry{handler: h, lastKey: "1", breaker: cb}
 	s.publish()
 	return s
 }
@@ -295,11 +296,11 @@ func tripBreaker(cb *gobreaker.CircuitBreaker[struct{}]) {
 	_, _ = cb.Execute(func() (struct{}, error) { return struct{}{}, errors.New("forced failure") })
 }
 
-// TestReconcileUnchangedRVPreservesBreakerState pins that a group whose RV
+// TestReconcileUnchangedKeyPreservesBreakerState pins that a group whose key
 // hasn't changed is left completely untouched by reconcile -- including an
 // already-tripped breaker -- same as the existing backend/handler/pool
 // preservation.
-func TestReconcileUnchangedRVPreservesBreakerState(t *testing.T) {
+func TestReconcileUnchangedKeyPreservesBreakerState(t *testing.T) {
 	group := "dashboard.grafana.app"
 	cb := gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
 		Name:        group,
@@ -311,9 +312,9 @@ func TestReconcileUnchangedRVPreservesBreakerState(t *testing.T) {
 	}
 
 	r := NewGrafanaRouter(staticLoader{backends: []Backend{
-		&fakeBackend{group: group, rv: "5"},
+		&fakeBackend{group: metav1.APIGroup{Name: group}, key: "5"},
 	}})
-	r.served[group] = &handlerEntry{handler: http.NotFoundHandler(), lastRV: "5", breaker: cb}
+	r.served[group] = &handlerEntry{handler: http.NotFoundHandler(), lastKey: "5", breaker: cb}
 
 	if err := r.reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -321,17 +322,17 @@ func TestReconcileUnchangedRVPreservesBreakerState(t *testing.T) {
 
 	got := r.served[group]
 	if got.breaker != cb {
-		t.Errorf("breaker instance replaced on unchanged-RV reconcile; want the same pointer preserved")
+		t.Errorf("breaker instance replaced on unchanged-key reconcile; want the same pointer preserved")
 	}
 	if got.breaker.State() != gobreaker.StateOpen {
-		t.Errorf("breaker state = %v after unchanged-RV reconcile, want still open", got.breaker.State())
+		t.Errorf("breaker state = %v after unchanged-key reconcile, want still open", got.breaker.State())
 	}
 }
 
-// TestReconcileChangedRVResetsBreaker pins the opposite: an RV change rebuilds
+// TestReconcileChangedKeyResetsBreaker pins the opposite: a key change rebuilds
 // the group, and the breaker is reset to a fresh, closed instance -- even if
 // the old one was open -- because the target may have moved.
-func TestReconcileChangedRVResetsBreaker(t *testing.T) {
+func TestReconcileChangedKeyResetsBreaker(t *testing.T) {
 	group := "dashboard.grafana.app"
 	oldCB := gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
 		Name:        group,
@@ -343,9 +344,9 @@ func TestReconcileChangedRVResetsBreaker(t *testing.T) {
 	}
 
 	r := NewGrafanaRouter(staticLoader{backends: []Backend{
-		&fakeBackend{group: group, rv: "6"}, // changed from "5"
+		&fakeBackend{group: metav1.APIGroup{Name: group}, key: "6"}, // changed from "5"
 	}})
-	r.served[group] = &handlerEntry{handler: http.NotFoundHandler(), lastRV: "5", breaker: oldCB}
+	r.served[group] = &handlerEntry{handler: http.NotFoundHandler(), lastKey: "5", breaker: oldCB}
 
 	if err := r.reconcile(context.Background()); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -353,10 +354,10 @@ func TestReconcileChangedRVResetsBreaker(t *testing.T) {
 
 	got := r.served[group]
 	if got.breaker == oldCB {
-		t.Fatalf("breaker instance not replaced on changed-RV reconcile")
+		t.Fatalf("breaker instance not replaced on changed-key reconcile")
 	}
 	if got.breaker.State() != gobreaker.StateClosed {
-		t.Errorf("breaker state = %v after changed-RV rebuild, want closed (fresh instance)", got.breaker.State())
+		t.Errorf("breaker state = %v after changed-key rebuild, want closed (fresh instance)", got.breaker.State())
 	}
 }
 
@@ -394,7 +395,7 @@ func TestOpenAPIGroupVersionRoutesThroughBreaker(t *testing.T) {
 // TestOpenAPIGroupVersionCacheHitBypassesBreaker pins that a cache hit never
 // touches the breaker at all -- it never calls the backend, so there's
 // nothing to protect. Even with the breaker forced open, a cached doc at the
-// matching RV must still be served successfully from cache.
+// matching key must still be served successfully from cache.
 func TestOpenAPIGroupVersionCacheHitBypassesBreaker(t *testing.T) {
 	group := "dashboard.grafana.app"
 	upstream := &countingHandler{body: `{"openapi":"3.0.0"}`}
@@ -420,7 +421,7 @@ func TestOpenAPIGroupVersionCacheHitBypassesBreaker(t *testing.T) {
 		t.Fatalf("precondition: breaker state = %v, want open", cb.State())
 	}
 
-	// Second request, same RV: must still be served from cache, untouched by
+	// Second request, same key: must still be served from cache, untouched by
 	// the open breaker.
 	rec2 := httptest.NewRecorder()
 	s.HandleFunc(rec2, httptest.NewRequest(http.MethodGet, path, nil), next)

--- a/pkg/router/discovery.go
+++ b/pkg/router/discovery.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/kube-openapi/pkg/handler3"
 )
 
-// cachedDoc is a pre-marshaled JSON response body plus its RV-derived ETag.
+// cachedDoc is a pre-marshaled JSON response body plus its key-derived ETag.
 // Built once per reconcile cycle by buildAPIGroupList/buildOpenAPIV3Index and
 // stored via atomic.Pointer for lock-free concurrent reads from the serving
 // path.
@@ -28,7 +28,7 @@ func quoteETag(s string) string {
 }
 
 // buildAPIGroupList synthesizes the /apis root document (APIGroupList) from
-// each backend's Manifest — Group, served Versions, PreferredVersion. No
+// each backend's APIGroup. No
 // backend round-trip: this is pure local synthesis, called once per
 // reconcile cycle alongside the handler snapshot.
 func buildAPIGroupList(backends []Backend) cachedDoc {
@@ -37,30 +37,9 @@ func buildAPIGroupList(backends []Backend) cachedDoc {
 	groups := make([]metav1.APIGroup, 0, len(sorted))
 	var hashInput strings.Builder
 	for _, b := range sorted {
-		m := b.Manifest()
-		versions := make([]metav1.GroupVersionForDiscovery, 0, len(m.Versions))
-		for _, v := range m.Versions {
-			if !v.Served {
-				continue
-			}
-			versions = append(versions, metav1.GroupVersionForDiscovery{
-				GroupVersion: m.Group + "/" + v.Name,
-				Version:      v.Name,
-			})
-		}
-		var preferred metav1.GroupVersionForDiscovery
-		if m.PreferredVersion != "" {
-			preferred = metav1.GroupVersionForDiscovery{
-				GroupVersion: m.Group + "/" + m.PreferredVersion,
-				Version:      m.PreferredVersion,
-			}
-		}
-		groups = append(groups, metav1.APIGroup{
-			Name:             m.Group,
-			Versions:         versions,
-			PreferredVersion: preferred,
-		})
-		fmt.Fprintf(&hashInput, "%s=%s;", b.Group(), b.RV())
+		group := b.Group()
+		groups = append(groups, group)
+		fmt.Fprintf(&hashInput, "%s=%s;", group.Name, b.Key())
 	}
 
 	list := metav1.APIGroupList{
@@ -82,12 +61,12 @@ func buildAPIGroupList(backends []Backend) cachedDoc {
 func sortedManifestBackends(backends []Backend) []Backend {
 	out := make([]Backend, 0, len(backends))
 	out = append(out, backends...)
-	sort.Slice(out, func(i, j int) bool { return out[i].Group() < out[j].Group() })
+	sort.Slice(out, func(i, j int) bool { return out[i].Group().Name < out[j].Group().Name })
 	return out
 }
 
 // hashHex returns a short hex digest of s, used to build a cachedDoc's ETag
-// from the sorted group/RV pairs that went into it.
+// from the sorted group/key pairs that went into it.
 func hashHex(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])[:16]
@@ -96,23 +75,20 @@ func hashHex(s string) string {
 // buildOpenAPIV3Index synthesizes the /openapi/v3 root document: a small
 // path -> {serverRelativeURL} map (never a merged schema — see AGENTS.md
 // "Discovery endpoints" / the design spec's "no cross-group merge" decision).
-// One entry per served group/version, hash-busted by that group's RV.
+// One entry per served group/version, hash-busted by that group's key.
 func buildOpenAPIV3Index(backends []Backend) cachedDoc {
 	sorted := sortedManifestBackends(backends)
 
 	paths := make(map[string]handler3.OpenAPIV3DiscoveryGroupVersion, len(sorted))
 	var hashInput strings.Builder
 	for _, b := range sorted {
-		m := b.Manifest()
-		for _, v := range m.Versions {
-			if !v.Served {
-				continue
+		group := b.Group()
+		for _, v := range group.Versions {
+			path := "apis/" + v.GroupVersion
+			paths[path] = handler3.OpenAPIV3DiscoveryGroupVersion{
+				ServerRelativeURL: fmt.Sprintf("/openapi/v3/%s?hash=%s", path, b.Key()),
 			}
-			key := fmt.Sprintf("apis/%s/%s", m.Group, v.Name)
-			paths[key] = handler3.OpenAPIV3DiscoveryGroupVersion{
-				ServerRelativeURL: fmt.Sprintf("/openapi/v3/%s?hash=%s", key, b.RV()),
-			}
-			fmt.Fprintf(&hashInput, "%s=%s;", key, b.RV())
+			fmt.Fprintf(&hashInput, "%s=%s;", path, b.Key())
 		}
 	}
 

--- a/pkg/router/discovery_test.go
+++ b/pkg/router/discovery_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/handler3"
 )
@@ -23,15 +22,13 @@ func TestQuoteETag(t *testing.T) {
 // unused by discovery tests (zero value is fine); the per-group-version
 // cache tests in a later task set it.
 type fakeBackend struct {
-	group    string
-	rv       string
-	manifest app.ManifestData
-	handler  http.Handler
+	group   metav1.APIGroup
+	key     string
+	handler http.Handler
 }
 
-func (b *fakeBackend) RV() string                 { return b.rv }
-func (b *fakeBackend) Group() string              { return b.group }
-func (b *fakeBackend) Manifest() app.ManifestData { return b.manifest }
+func (b *fakeBackend) Key() string            { return b.key }
+func (b *fakeBackend) Group() metav1.APIGroup { return b.group }
 func (b *fakeBackend) Load(context.Context) (http.Handler, error) {
 	if b.handler != nil {
 		return b.handler, nil
@@ -41,19 +38,18 @@ func (b *fakeBackend) Load(context.Context) (http.Handler, error) {
 
 func TestBuildAPIGroupList(t *testing.T) {
 	backends := []Backend{
-		&fakeBackend{group: "dashboard.grafana.app", rv: "10", manifest: app.ManifestData{
-			Group:            "dashboard.grafana.app",
-			PreferredVersion: "v1alpha1",
-			Versions: []app.ManifestVersion{
-				{Name: "v0alpha1", Served: true},
-				{Name: "v1alpha1", Served: true},
-				{Name: "v2alpha1", Served: false}, // unserved: must be excluded
+		&fakeBackend{key: "10", group: metav1.APIGroup{
+			Name:             "dashboard.grafana.app",
+			PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "dashboard.grafana.app/v1alpha1", Version: "v1alpha1"},
+			Versions: []metav1.GroupVersionForDiscovery{
+				{GroupVersion: "dashboard.grafana.app/v0alpha1", Version: "v0alpha1"},
+				{GroupVersion: "dashboard.grafana.app/v1alpha1", Version: "v1alpha1"},
 			},
 		}},
-		&fakeBackend{group: "folder.grafana.app", rv: "3", manifest: app.ManifestData{
-			Group:            "folder.grafana.app",
-			PreferredVersion: "v0alpha1",
-			Versions:         []app.ManifestVersion{{Name: "v0alpha1", Served: true}},
+		&fakeBackend{key: "3", group: metav1.APIGroup{
+			Name:             "folder.grafana.app",
+			PreferredVersion: metav1.GroupVersionForDiscovery{GroupVersion: "folder.grafana.app/v0alpha1", Version: "v0alpha1"},
+			Versions:         []metav1.GroupVersionForDiscovery{{GroupVersion: "folder.grafana.app/v0alpha1", Version: "v0alpha1"}},
 		}},
 	}
 
@@ -67,14 +63,14 @@ func TestBuildAPIGroupList(t *testing.T) {
 		t.Errorf("got Kind=%q APIVersion=%q, want APIGroupList/v1", list.Kind, list.APIVersion)
 	}
 	if len(list.Groups) != 2 {
-		t.Fatalf("got %d groups, want 2 (broken.grafana.app must be skipped): %+v", len(list.Groups), list.Groups)
+		t.Fatalf("got %d groups, want 2: %+v", len(list.Groups), list.Groups)
 	}
 	// sorted alphabetically: dashboard before folder
 	if list.Groups[0].Name != "dashboard.grafana.app" {
 		t.Errorf("got Groups[0].Name=%q, want dashboard.grafana.app", list.Groups[0].Name)
 	}
 	if len(list.Groups[0].Versions) != 2 {
-		t.Errorf("got %d served versions for dashboard.grafana.app, want 2 (v2alpha1 unserved excluded): %+v",
+		t.Errorf("got %d served versions for dashboard.grafana.app, want 2: %+v",
 			len(list.Groups[0].Versions), list.Groups[0].Versions)
 	}
 	wantPreferred := metav1.GroupVersionForDiscovery{GroupVersion: "dashboard.grafana.app/v1alpha1", Version: "v1alpha1"}
@@ -86,27 +82,26 @@ func TestBuildAPIGroupList(t *testing.T) {
 	}
 }
 
-func TestBuildAPIGroupListETagChangesWithRV(t *testing.T) {
-	mk := func(rv string) []Backend {
-		return []Backend{&fakeBackend{group: "dashboard.grafana.app", rv: rv, manifest: app.ManifestData{
-			Group:    "dashboard.grafana.app",
-			Versions: []app.ManifestVersion{{Name: "v1alpha1", Served: true}},
+func TestBuildAPIGroupListETagChangesWithKey(t *testing.T) {
+	mk := func(key string) []Backend {
+		return []Backend{&fakeBackend{key: key, group: metav1.APIGroup{
+			Name:     "dashboard.grafana.app",
+			Versions: []metav1.GroupVersionForDiscovery{{GroupVersion: "dashboard.grafana.app/v1alpha1", Version: "v1alpha1"}},
 		}}}
 	}
 	a := buildAPIGroupList(mk("1"))
 	b := buildAPIGroupList(mk("2"))
 	if a.etag == b.etag {
-		t.Errorf("etag did not change when RV changed: both %q", a.etag)
+		t.Errorf("etag did not change when key changed: both %q", a.etag)
 	}
 }
 
 func TestBuildOpenAPIV3Index(t *testing.T) {
 	backends := []Backend{
-		&fakeBackend{group: "dashboard.grafana.app", rv: "10", manifest: app.ManifestData{
-			Group: "dashboard.grafana.app",
-			Versions: []app.ManifestVersion{
-				{Name: "v0alpha1", Served: true},
-				{Name: "v1alpha1", Served: false}, // unserved: excluded
+		&fakeBackend{key: "10", group: metav1.APIGroup{
+			Name: "dashboard.grafana.app",
+			Versions: []metav1.GroupVersionForDiscovery{
+				{GroupVersion: "dashboard.grafana.app/v0alpha1", Version: "v0alpha1"},
 			},
 		}},
 	}

--- a/pkg/router/dummy.go
+++ b/pkg/router/dummy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/grafana/grafana-app-sdk/app"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type dummyRoutesLoader struct {
@@ -28,42 +28,24 @@ type dummyBackend struct {
 	group string
 }
 
-func (d *dummyBackend) Group() string {
-	return d.group
+func (d *dummyBackend) Group() metav1.APIGroup {
+	return metav1.APIGroup{
+		Name: d.group,
+		Versions: []metav1.GroupVersionForDiscovery{{
+			GroupVersion: fmt.Sprintf("%s/v0alpha1", d.group),
+			Version:      "v0alpha1",
+		}, {
+			GroupVersion: fmt.Sprintf("%s/v0alpha2", d.group),
+			Version:      "v0alpha2",
+		}},
+	}
 }
 
 func (d *dummyBackend) Load(context.Context) (http.Handler, error) {
 	return d, nil
 }
 
-func (d *dummyBackend) Manifest() app.ManifestData {
-	return app.ManifestData{
-		Group: d.group,
-		Versions: []app.ManifestVersion{
-			{
-				Name:   "v0alpha1",
-				Served: true,
-				Kinds: []app.ManifestVersionKind{
-					{
-						Kind:   "x",
-						Plural: "xs",
-						Scope:  "namespaced",
-					},
-				},
-			},
-			{
-				Name:   "v0alpha2",
-				Served: true,
-			},
-			{
-				Name:   "v0alpha3",
-				Served: false,
-			},
-		},
-	}
-}
-
-func (d *dummyBackend) RV() string {
+func (d *dummyBackend) Key() string {
 	return "static"
 }
 

--- a/pkg/router/forward.go
+++ b/pkg/router/forward.go
@@ -7,7 +7,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	"github.com/grafana/grafana-app-sdk/app"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/grafana/grafana-app-sdk/app/appmanifest/v1alpha2"
 )
 
@@ -16,10 +17,9 @@ import (
 // construction failure in buildErr so a bad config serves a 500 rather than
 // failing the whole reconcile; Handler and Ready both surface it.
 type forwardBackend struct {
-	group        string
-	manifest     app.ManifestData
+	group        metav1.APIGroup
+	key          string
 	routeBackend v1alpha2.RouteBackendSpec
-	rv           string
 
 	// the only output of instantiation which is cached
 	proxy *httputil.ReverseProxy
@@ -27,18 +27,18 @@ type forwardBackend struct {
 
 var _ Backend = &forwardBackend{}
 
-func NewForwardBackend(manifest app.ManifestData, routeBackend v1alpha2.RouteBackendSpec, rv string, transport *http.Transport) (Backend, error) {
+func NewForwardBackend(group metav1.APIGroup, routeBackend v1alpha2.RouteBackendSpec, key string, transport *http.Transport) (Backend, error) {
 	if routeBackend.Mode != v1alpha2.RouteBackendSpecModeForward {
 		return nil, fmt.Errorf("unsupported route backend mode %q", routeBackend.Mode)
 	}
 
 	if transport == nil {
-		return nil, fmt.Errorf("transport cannot be nil for a forward backend, group %s", manifest.Group)
+		return nil, fmt.Errorf("transport cannot be nil for a forward backend, group %s", group.Name)
 	}
 
 	u, err := url.Parse(routeBackend.Forward.Url)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing backend url: group=%s, err=%w", manifest.Group, err)
+		return nil, fmt.Errorf("error parsing backend url: group=%s, err=%w", group.Name, err)
 	}
 	// url.Parse alone accepts empty and relative values without error (e.g.
 	// "" or "/just/a/path" parse fine with no scheme/host). Reject those here,
@@ -46,14 +46,13 @@ func NewForwardBackend(manifest app.ManifestData, routeBackend v1alpha2.RouteBac
 	// and fails every request at proxy time instead (502, tripping the
 	// per-group breaker) rather than being caught when the route is built.
 	if u.Scheme == "" || u.Host == "" {
-		return nil, fmt.Errorf("backend url must be absolute (scheme and host required): group=%s, url=%q", manifest.Group, routeBackend.Forward.Url)
+		return nil, fmt.Errorf("backend url must be absolute (scheme and host required): group=%s, url=%q", group.Name, routeBackend.Forward.Url)
 	}
 
 	return &forwardBackend{
-		group:        manifest.Group,
-		manifest:     manifest,
+		group:        group,
 		routeBackend: routeBackend,
-		rv:           rv,
+		key:          key,
 		proxy: &httputil.ReverseProxy{
 			Rewrite:        func(pr *httputil.ProxyRequest) { pr.SetURL(u) },
 			Transport:      transport,
@@ -62,16 +61,12 @@ func NewForwardBackend(manifest app.ManifestData, routeBackend v1alpha2.RouteBac
 	}, nil
 }
 
-func (b *forwardBackend) Manifest() app.ManifestData {
-	return b.manifest
-}
-
-func (b *forwardBackend) Group() string {
+func (b *forwardBackend) Group() metav1.APIGroup {
 	return b.group
 }
 
-func (b *forwardBackend) RV() string {
-	return b.rv
+func (b *forwardBackend) Key() string {
+	return b.key
 }
 
 // if backend does CAP token auth when BaaS comes in, will

--- a/pkg/router/forward_test.go
+++ b/pkg/router/forward_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/app/appmanifest/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func forwardSpec(url string) v1alpha2.RouteBackendSpec {
@@ -16,7 +16,7 @@ func forwardSpec(url string) v1alpha2.RouteBackendSpec {
 }
 
 func TestNewForwardBackendAcceptsValidURL(t *testing.T) {
-	_, err := NewForwardBackend(app.ManifestData{Group: "dashboard.grafana.app"}, forwardSpec("https://backend.internal:8080"), "1", &http.Transport{})
+	_, err := NewForwardBackend(metav1.APIGroup{Name: "dashboard.grafana.app"}, forwardSpec("https://backend.internal:8080"), "1", &http.Transport{})
 	if err != nil {
 		t.Fatalf("NewForwardBackend() = %v, want nil for a valid absolute URL", err)
 	}
@@ -35,7 +35,7 @@ func TestNewForwardBackendRejectsURLsWithoutHost(t *testing.T) {
 		"backend:8080", // no scheme -- url.Parse treats "backend" as the scheme, not the host
 	}
 	for _, url := range cases {
-		_, err := NewForwardBackend(app.ManifestData{Group: "dashboard.grafana.app"}, forwardSpec(url), "1", &http.Transport{})
+		_, err := NewForwardBackend(metav1.APIGroup{Name: "dashboard.grafana.app"}, forwardSpec(url), "1", &http.Transport{})
 		if err == nil {
 			t.Errorf("NewForwardBackend(url=%q) = nil error, want an error (no scheme/host)", url)
 		}

--- a/pkg/router/openapi_cache.go
+++ b/pkg/router/openapi_cache.go
@@ -6,18 +6,18 @@ import (
 )
 
 // openapiCacheEntry is one cached per-group-version OpenAPI v3 document.
-// Valid only while rv matches the backend's current RV (checked by the
-// caller); a stale rv is a cache miss, not an eviction — the sync.Map entry
+// Valid only while key matches the backend's current key (checked by the
+// caller); a stale key is a cache miss, not an eviction — the sync.Map entry
 // is simply overwritten on the next successful fetch.
 type openapiCacheEntry struct {
-	rv   string
+	key  string
 	etag string
 	body []byte
 }
 
 // stripConditionalHeaders removes conditional-GET headers from a request
 // before proxying it upstream on a cache miss. Without this, a client's
-// If-None-Match that didn't match our RV-based ETag (so we decided to proxy)
+// If-None-Match that didn't match our key-based ETag (so we decided to proxy)
 // could still coincidentally match the backend's own unrelated ETag scheme,
 // producing a bodyless 304 we'd have no way to distinguish from "unchanged"
 // — a phantom empty response with nothing to cache or serve. Stripping
@@ -29,13 +29,13 @@ func stripConditionalHeaders(req *http.Request) {
 
 // stripHashQueryParam removes the "hash" query parameter before proxying a
 // request upstream. Our discovery doc (buildOpenAPIV3Index) hash-busts each
-// group-version's serverRelativeURL with our own RV, an opaque cache token
+// group-version's serverRelativeURL with our own key, an opaque cache token
 // with no relation to the backend's content. But kube-openapi's own
 // handler3 treats a client-supplied "hash" as a claim about ITS content
 // hash and 301-redirects to the correct one on mismatch -- a redirect
-// rejectBackendRedirects then turns into a 502. Since our RV essentially
+// rejectBackendRedirects then turns into a 502. Since our key essentially
 // never matches the backend's real hash, forwarding it verbatim breaks
-// every cold-cache request. Stripping it here keeps the RV-based
+// every cold-cache request. Stripping it here keeps the key-based
 // busting meaningful for our own cache/ETag while never surfacing our
 // token to a protocol that expects its own.
 func stripHashQueryParam(req *http.Request) {

--- a/pkg/router/openapi_cache_test.go
+++ b/pkg/router/openapi_cache_test.go
@@ -22,16 +22,16 @@ func (h *countingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // buildRouterWithBackend seeds a router with one real handlerEntry (fake
-// upstream handler + given rv) via publish, so snapshot carries a real RV —
-// unlike withGroups' fixed lastRV:"1", these tests need to bump RV mid-test.
-func buildRouterWithBackend(group, rv string, upstream http.Handler) *GrafanaRouter {
+// upstream handler + given key) via publish, so snapshot carries a real key —
+// unlike withGroups' fixed lastKey:"1", these tests need to bump it mid-test.
+func buildRouterWithBackend(group, key string, upstream http.Handler) *GrafanaRouter {
 	s := NewGrafanaRouter(stubLoader{})
-	s.served[group] = &handlerEntry{handler: upstream, lastRV: rv, breaker: newGroupBreaker(group)}
+	s.served[group] = &handlerEntry{handler: upstream, lastKey: key, breaker: newGroupBreaker(group)}
 	s.publish()
 	return s
 }
 
-func TestOpenAPIGroupVersionCachesUntilRVChanges(t *testing.T) {
+func TestOpenAPIGroupVersionCachesUntilKeyChanges(t *testing.T) {
 	upstream := &countingHandler{body: `{"openapi":"3.0.0"}`}
 	s := buildRouterWithBackend("dashboard.grafana.app", "5", upstream)
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusTeapot) })
@@ -49,7 +49,7 @@ func TestOpenAPIGroupVersionCachesUntilRVChanges(t *testing.T) {
 		t.Fatalf("after first request, upstream hits = %d, want 1", got)
 	}
 
-	// Second request, same RV: served from cache, no new upstream hit.
+	// Second request, same key: served from cache, no new upstream hit.
 	rec2 := httptest.NewRecorder()
 	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, path, nil))
 	if rec2.Code != http.StatusOK || rec2.Body.String() != upstream.body {
@@ -59,9 +59,9 @@ func TestOpenAPIGroupVersionCachesUntilRVChanges(t *testing.T) {
 		t.Fatalf("after second request, upstream hits = %d, want still 1 (cache hit)", got)
 	}
 
-	// Bump RV (simulates reconcile picking up a manifest change) and re-request:
+	// Bump the key (simulates reconcile picking up a route change) and re-request:
 	// cache must be treated as stale, upstream hit again.
-	s.served["dashboard.grafana.app"] = &handlerEntry{handler: upstream, lastRV: "6", breaker: newGroupBreaker("dashboard.grafana.app")}
+	s.served["dashboard.grafana.app"] = &handlerEntry{handler: upstream, lastKey: "6", breaker: newGroupBreaker("dashboard.grafana.app")}
 	s.publish()
 	rec3 := httptest.NewRecorder()
 	h.ServeHTTP(rec3, httptest.NewRequest(http.MethodGet, path, nil))
@@ -69,7 +69,7 @@ func TestOpenAPIGroupVersionCachesUntilRVChanges(t *testing.T) {
 		t.Fatalf("third request: got code=%d, want 200", rec3.Code)
 	}
 	if got := upstream.hits.Load(); got != 2 {
-		t.Fatalf("after RV bump, upstream hits = %d, want 2 (cache invalidated)", got)
+		t.Fatalf("after key change, upstream hits = %d, want 2 (cache invalidated)", got)
 	}
 }
 
@@ -137,7 +137,7 @@ func TestOpenAPIGroupVersionStripsConditionalHeaders(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) { s.HandleFunc(w, req, next) })
 
 	req := httptest.NewRequest(http.MethodGet, "/openapi/v3/apis/dashboard.grafana.app/v1alpha1", nil)
-	// A stale/foreign If-None-Match that does NOT match our current RV-based
+	// A stale/foreign If-None-Match that does NOT match our current key-based
 	// ETag, so the router proceeds to proxy — the case that must strip it.
 	req.Header.Set("If-None-Match", `"some-other-etag"`)
 	rec := httptest.NewRecorder()

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -22,31 +22,31 @@ const (
 // handlerEntry is the router's persistent, reconcile-only record for one group:
 // the live Backend (kept so discovery synthesis reflects whatever is actually
 // being served — see publish — even when a later reload fails and the old
-// handler stays live), the built handler, and lastRV, the RouteConfig
-// fingerprint last applied. lastRV lets reconcile skip rebuilding a group
+// handler stays live), the built handler, and lastKey, the route
+// fingerprint last applied. lastKey lets reconcile skip rebuilding a group
 // whose config has not changed. Touched only by reconcile (single goroutine),
 // so it needs no lock.
 type handlerEntry struct {
 	backend Backend
 	handler http.Handler
-	lastRV  string
+	lastKey string
 
 	// breaker is a passive, per-group circuit breaker: it observes real
 	// proxied request outcomes (transport errors, 502/503/504) rather than
 	// running any active probe of its own -- see AGENTS.md "Passive circuit
 	// breaking". Reset to a fresh instance whenever this group is rebuilt for
-	// a changed RV (the target may have moved), but left untouched across an
-	// unchanged-RV reconcile, same as backend/handler above.
+	// a changed key (the target may have moved), but left untouched across an
+	// unchanged-key reconcile, same as backend/handler above.
 	breaker *gobreaker.CircuitBreaker[struct{}]
 }
 
 // servingEntry is the immutable per-group record published into snapshot: the
-// proxy handler plus the RV. RV is needed at serve time to validate/label the
+// proxy handler plus the key. The key is needed at serve time to validate/label the
 // per-group-version openapi cache; served (reconcile-goroutine-owned) isn't
-// safe to read from serving goroutines, so RV is duplicated here.
+// safe to read from serving goroutines, so it is duplicated here.
 type servingEntry struct {
 	handler http.Handler
-	rv      string
+	key     string
 	breaker *gobreaker.CircuitBreaker[struct{}]
 }
 
@@ -89,7 +89,7 @@ type GrafanaRouter struct {
 	snapshot atomic.Pointer[map[string]servingEntry]
 
 	// apiGroupList and openapiIndex are the router-synthesized root documents
-	// for /apis and /openapi/v3, rebuilt from served's Backend.Manifest() on
+	// for /apis and /openapi/v3, rebuilt from served's Backend.Group() on
 	// every reconcile and stored atomically alongside snapshot — never from the
 	// raw Load() result, so a group that failed to (re)load or a duplicate in a
 	// single Load never gets advertised inconsistently with what's actually
@@ -102,7 +102,7 @@ type GrafanaRouter struct {
 	// the owning backend, keyed by "group/version". Written by many
 	// concurrent serving goroutines on cache-miss (unlike snapshot/
 	// apiGroupList/openapiIndex, which have exactly one writer, reconcile),
-	// so it's a sync.Map rather than an atomic.Pointer swap. A stale rv is
+	// so it's a sync.Map rather than an atomic.Pointer swap. A stale key is
 	// simply overwritten on next fetch, not actively evicted.
 	openapiDocs sync.Map
 }
@@ -201,7 +201,7 @@ func (cr *GrafanaRouter) serveAPIGroupList(w http.ResponseWriter, req *http.Requ
 }
 
 // serveCachedDoc writes a synthesized document, honoring conditional GET via
-// If-None-Match against the document's RV-derived ETag. Shared by
+// If-None-Match against the document's key-derived ETag. Shared by
 // serveAPIGroupList and the /openapi/v3 root doc.
 func serveCachedDoc(w http.ResponseWriter, req *http.Request, doc *cachedDoc) {
 	w.Header().Set("Content-Type", "application/json")
@@ -231,7 +231,7 @@ func (cr *GrafanaRouter) serveOpenAPIV3(w http.ResponseWriter, req *http.Request
 }
 
 // serveOpenAPIGroupVersion serves one group's OpenAPI v3 document: a
-// conditional-GET-aware, RV-keyed cache in front of a plain proxy to the
+// conditional-GET-aware cache keyed by the backend fingerprint in front of a plain proxy to the
 // owning backend. Never merges across groups — this is one backend's
 // document, verbatim.
 func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *http.Request, next http.Handler, group, version string) {
@@ -242,7 +242,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 		return
 	}
 
-	etag := quoteETag(entry.rv)
+	etag := quoteETag(entry.key)
 	if req.Header.Get("If-None-Match") == etag {
 		w.Header().Set("ETag", etag)
 		w.WriteHeader(http.StatusNotModified)
@@ -252,7 +252,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 	cacheKey := group + "/" + version
 	if cached, ok := cr.openapiDocs.Load(cacheKey); ok {
 		c := cached.(openapiCacheEntry)
-		if c.rv == entry.rv {
+		if c.key == entry.key {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("ETag", c.etag)
 			w.WriteHeader(http.StatusOK)
@@ -261,7 +261,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 		}
 	}
 
-	// Cache miss or stale rv: proxy through, capturing the response so it can
+	// Cache miss or stale key: proxy through, capturing the response so it can
 	// be cached on success. Strip conditional headers first — see
 	// stripConditionalHeaders' doc comment for why. Gated by the same
 	// per-group breaker as the main dispatch — this is still a real proxy
@@ -281,7 +281,7 @@ func (cr *GrafanaRouter) serveOpenAPIGroupVersion(w http.ResponseWriter, req *ht
 
 	maps.Copy(w.Header(), rec.header)
 	if rec.statusCode == http.StatusOK {
-		cr.openapiDocs.Store(cacheKey, openapiCacheEntry{rv: entry.rv, etag: etag, body: rec.body.Bytes()})
+		cr.openapiDocs.Store(cacheKey, openapiCacheEntry{key: entry.key, etag: etag, body: rec.body.Bytes()})
 		w.Header().Set("ETag", etag)
 	}
 	w.WriteHeader(rec.statusCode)
@@ -404,7 +404,7 @@ func (r *GrafanaRouter) Alive(context.Context) error {
 }
 
 // reconcile re-reads the full desired route set and converges served to it:
-// rebuild changed/new groups, leave unchanged ones (RV match) untouched, drop
+// rebuild changed/new groups, leave unchanged ones (key match) untouched, drop
 // groups that disappeared, then publish a fresh snapshot. Level-triggered, so
 // it is safe to run on any wake.
 func (r *GrafanaRouter) reconcile(ctx context.Context) error {
@@ -417,7 +417,7 @@ func (r *GrafanaRouter) reconcile(ctx context.Context) error {
 	var errs []error
 	seen := make(map[string]struct{}, len(rawBackends))
 	for _, b := range rawBackends {
-		group := b.Group()
+		group := b.Group().Name
 		if _, dup := seen[group]; dup {
 			// One backend owns all versions of a group; a duplicate group in a
 			// single load is a config error. Last-wins, warn — do not crash the
@@ -429,7 +429,7 @@ func (r *GrafanaRouter) reconcile(ctx context.Context) error {
 		seen[group] = struct{}{}
 
 		e, ok := r.served[group]
-		if ok && e.lastRV == b.RV() {
+		if ok && e.lastKey == b.Key() {
 			continue // unchanged: keep the live Backend (and its pool)
 		}
 
@@ -437,28 +437,28 @@ func (r *GrafanaRouter) reconcile(ctx context.Context) error {
 		if err != nil {
 			// Load failed: keep last-known-good for this group (leave the
 			// existing entry, if any, untouched) and don't publish a nil
-			// handler. lastRV is not advanced, so a later wake retries. Because
-			// the old entry (old backend, old manifest) is left untouched,
+			// handler. lastKey is not advanced, so a later wake retries. Because
+			// the old entry (old backend, old API group) is left untouched,
 			// publish's discovery synthesis stays consistent with what's
-			// actually being served, not with this failed reload's manifest.
+			// actually being served, not with this failed reload's API group.
 			errs = append(errs, fmt.Errorf("router: backend load failed for group %q, keeping current route: %w", group, err))
 			continue
 		}
 
 		if !ok {
 			// New group: create the entry, starting with a fresh, closed breaker.
-			r.served[group] = &handlerEntry{backend: b, handler: handler, lastRV: b.RV(), breaker: newGroupBreaker(group)}
+			r.served[group] = &handlerEntry{backend: b, handler: handler, lastKey: b.Key(), breaker: newGroupBreaker(group)}
 			continue
 		}
 		// Changed: swap the backend/handler in place. The transport (and its
 		// pool) is reused from the shared cache when the TLS key is unchanged,
 		// so the pool survives. The breaker is reset to a fresh instance,
-		// though: an RV change can mean the target itself moved, so any prior
+		// though: a key change can mean the target itself moved, so any prior
 		// trip state would be stale -- see AGENTS.md "Passive circuit
 		// breaking".
 		e.backend = b
 		e.handler = handler
-		e.lastRV = b.RV()
+		e.lastKey = b.Key()
 		e.breaker = newGroupBreaker(group)
 	}
 
@@ -483,7 +483,7 @@ func (r *GrafanaRouter) publish() {
 	snap := make(map[string]servingEntry, len(r.served))
 	backends := make([]Backend, 0, len(r.served))
 	for group, e := range r.served {
-		snap[group] = servingEntry{handler: e.handler, rv: e.lastRV, breaker: e.breaker}
+		snap[group] = servingEntry{handler: e.handler, key: e.lastKey, breaker: e.breaker}
 		if e.backend != nil {
 			backends = append(backends, e.backend)
 		}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana-app-sdk/app"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // stubLoader satisfies RoutesLoader; the routing tests seed the snapshot
@@ -29,7 +29,7 @@ func withGroups(groups ...string) *GrafanaRouter {
 			handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte(g))
 			}),
-			lastRV:  "1",
+			lastKey: "1",
 			breaker: newGroupBreaker(g),
 		}
 	}
@@ -302,11 +302,10 @@ func TestReadyFailsAfterTotallyFailedInitialReconcile(t *testing.T) {
 
 // failingBackend always fails Load, for testing partial-failure reconcile
 // scenarios (one group loads, another doesn't).
-type failingBackend struct{ group, rv string }
+type failingBackend struct{ group, key string }
 
-func (b failingBackend) RV() string                 { return b.rv }
-func (b failingBackend) Group() string              { return b.group }
-func (b failingBackend) Manifest() app.ManifestData { return app.ManifestData{} }
+func (b failingBackend) Key() string            { return b.key }
+func (b failingBackend) Group() metav1.APIGroup { return metav1.APIGroup{Name: b.group} }
 func (b failingBackend) Load(context.Context) (http.Handler, error) {
 	return nil, errors.New("load failed")
 }
@@ -318,8 +317,8 @@ func (b failingBackend) Load(context.Context) (http.Handler, error) {
 // unrelated group's failure.
 func TestReadyOKWithPartialLoadFailureGivenAtLeastOneServedGroup(t *testing.T) {
 	loader := staticLoader{backends: []Backend{
-		&fakeBackend{group: "good.grafana.app", rv: "1"},
-		failingBackend{group: "bad.grafana.app", rv: "1"},
+		&fakeBackend{group: metav1.APIGroup{Name: "good.grafana.app"}, key: "1"},
+		failingBackend{group: "bad.grafana.app", key: "1"},
 	}}
 	r := NewGrafanaRouter(loader)
 	r.storeServing(r.reconcile(context.Background()))

--- a/pkg/router/types.go
+++ b/pkg/router/types.go
@@ -4,27 +4,24 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/grafana/grafana-app-sdk/app"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Backend interface {
-	// The resource version string -- if this changes, you know that something has changed
-	RV() string
+	// The backend fingerprint; a change means the route must be rebuilt.
+	Key() string
 
 	// The group this route serves (must not contain /)
-	Group() string
+	Group() metav1.APIGroup
 
 	// How the prefix is handled. Handler support /apis/{group}* and /openapi/v3/{group}*
 	Load(context.Context) (http.Handler, error)
-
-	// Includes group, versions, resources, and custom route information
-	Manifest() app.ManifestData
 }
 
 type RoutesLoader interface {
 	// Load all known routes
 	// NOTE: this implies that the set of ALL routes is always reasonable to hold in memory
-	// and that comparing changes can depend on the RV to know if anything has changed for the prefix
+	// and that comparing changes can depend on the key to know if anything has changed for the prefix
 	Load(context.Context) ([]Backend, error)
 
 	// Something changed with routing... reload the configs. The channel is a pure


### PR DESCRIPTION
This makes two changes to the router-types:
1. rather than manifest, we use metav1.APIGroup
2. rename "RV" to "Key"

The APIGroup is much smaller and is the only part required by the router