### PR TITLE
Storage: Log only sent watch events

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2125,7 +2125,6 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				s.log.Debug("watch events closed")
 				return nil
 			}
-			s.log.Debug("Server Broadcasting", "type", event.Type, "rv", event.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "resource", event.Key.Resource, "name", event.Key.Name)
 			if event.ResourceVersion > since && matchesQueryKey(req.Options.Key, event.Key) {
 				if !checker(event.Key.Name, event.Folder) {
 					continue
@@ -2164,6 +2163,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				if err := srv.Send(resp); err != nil {
 					return err
 				}
+				s.log.Debug("Watch event sent", "type", event.Type, "rv", event.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "resource", event.Key.Resource, "name", event.Key.Name)
 				lastEmittedRV = event.ResourceVersion
 
 				if s.storageMetrics != nil && event.ResourceVersion > mostRecentRV {


### PR DESCRIPTION
**What is this feature?**

This change logs watch events only after successful client delivery.

**Why do we need this feature?**

A support investigation found many `Server Broadcasting` lines for the same resource versions. This pattern first appeared to show repeated resource changes.

The broadcaster sends cached events to each new watcher. The watch handler logs each event before its resource-version and key checks.

Old or unrelated cache entries appear in logs, but the handler rejects them before delivery. The storage stream records each actual change only once.

This is a logging issue only. It does not cause resource writes, repeated conversions, or repeated client events.

**Who is this feature for?**

Operators who use resource-server debug logs to examine resource changes.

**Related issues**

- grafana/support-escalations#24115
- grafana/git-ui-sync-project#1351

**Special notes for your reviewer:**

This change only moves and renames one debug log. Tests did not run.

_<sub>PR description generated with openai-codex:gpt-5.6-sol</sub>_
