### PR TITLE
unified-storage: update ListSince so it batches calls to eventstore

### DIFF
--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -21,6 +21,7 @@ import (
 const (
 	eventsSection        = kv.EventsSection
 	deleteEventBatchSize = 50
+	readEventBatchSize   = 50
 )
 
 // eventStore is a store for events.
@@ -219,37 +220,95 @@ func (n *eventStore) ListKeysSince(ctx context.Context, sinceRV int64, sortOrder
 	}
 }
 
-func (n *eventStore) ListSince(ctx context.Context, sinceRV int64, sortOrder SortOrder) iter.Seq2[Event, error] {
-	ctx, span := tracer.Start(ctx, "resource.eventStore.ListSince", trace.WithAttributes(
-		attribute.Int64("sinceRV", sinceRV),
-	))
+// ListSince returns events at or above sinceRV, in ascending key order.
+func (n *eventStore) ListSince(ctx context.Context, sinceRV int64) iter.Seq2[Event, error] {
 	return func(yield func(Event, error) bool) {
+		ctx, span := tracer.Start(ctx, "resource.eventStore.ListSince", trace.WithAttributes(
+			attribute.Int64("sinceRV", sinceRV),
+		))
 		defer span.End()
-		for evtKey, err := range n.ListKeysSince(ctx, sinceRV, sortOrder) {
+
+		if err := ctx.Err(); err != nil {
+			yield(Event{}, err)
+			return
+		}
+
+		batch := make([]string, 0, readEventBatchSize)
+		flush := func() bool {
+			if err := ctx.Err(); err != nil {
+				yield(Event{}, err)
+				return false
+			}
+			// Finish both KV iterators before yielding: consumers must not pin a DB cursor.
+			events, err := n.readEventPage(ctx, batch)
+			if err != nil {
+				yield(Event{}, err)
+				return false
+			}
+			for _, event := range events {
+				if !yield(event, nil) {
+					return false
+				}
+			}
+			batch = batch[:0]
+			return true
+		}
+
+		opts := ListOptions{StartKey: fmt.Sprintf("%d", sinceRV), Sort: SortOrderAsc}
+		for key, err := range pagedKeys(ctx, n.kv, eventsSection, opts, keyPageSize) {
 			if err != nil {
 				yield(Event{}, err)
 				return
 			}
-
-			reader, err := n.kv.Get(ctx, eventsSection, evtKey)
-			if err != nil {
-				yield(Event{}, err)
-				return
-			}
-
-			var event Event
-			if err := json.NewDecoder(reader).Decode(&event); err != nil {
-				_ = reader.Close()
-				yield(Event{}, err)
-				return
-			}
-
-			_ = reader.Close()
-			if !yield(event, nil) {
+			batch = append(batch, key)
+			if len(batch) == readEventBatchSize && !flush() {
 				return
 			}
 		}
+		if err := ctx.Err(); err != nil {
+			yield(Event{}, err)
+			return
+		}
+		if len(batch) > 0 {
+			flush()
+		}
 	}
+}
+
+func (n *eventStore) readEventPage(ctx context.Context, keys []string) ([]Event, error) {
+	events := make([]Event, 0, len(keys))
+	for pair, err := range n.kv.BatchGet(ctx, eventsSection, keys) {
+		if err != nil {
+			if pair.Value != nil {
+				_ = pair.Value.Close()
+			}
+			return nil, err
+		}
+		if pair.Value == nil {
+			return nil, fmt.Errorf("event record %q has no reader", pair.Key)
+		}
+		var event Event
+		err = json.NewDecoder(pair.Value).Decode(&event)
+		_ = pair.Value.Close()
+		if err != nil {
+			return nil, err
+		}
+		key := EventKey{
+			Namespace: event.Namespace, Group: event.Group, Resource: event.Resource, Name: event.Name,
+			ResourceVersion: event.ResourceVersion, Action: event.Action, Folder: event.Folder,
+		}
+		if err := key.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid event record %q: %w", pair.Key, err)
+		}
+		if key.String() != pair.Key {
+			return nil, fmt.Errorf("event record does not match key %q", pair.Key)
+		}
+		events = append(events, event)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
 }
 
 // CleanupOldEvents deletes events older than the specified retention period.

--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -3,7 +3,13 @@ package resource
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
 	"os"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -262,7 +268,7 @@ func testEventStoreSaveGet(t *testing.T, ctx context.Context, store *eventStore)
 			assert.Equal(t, event, retrievedEvent)
 
 			var listed []Event
-			for listedEvent, err := range store.ListSince(ctx, 0, SortOrderAsc) {
+			for listedEvent, err := range store.ListSince(ctx, 0) {
 				require.NoError(t, err)
 				listed = append(listed, listedEvent)
 			}
@@ -478,7 +484,7 @@ func testEventStoreListSince(t *testing.T, ctx context.Context, store *eventStor
 
 	// List events since RV 1500 (should get events with RV 2000 and 3000)
 	retrievedEvents := make([]Event, 0, 2)
-	for event, err := range store.ListSince(ctx, 1500, SortOrderAsc) {
+	for event, err := range store.ListSince(ctx, 1500) {
 		require.NoError(t, err)
 		retrievedEvents = append(retrievedEvents, event)
 	}
@@ -502,12 +508,419 @@ func testEventStoreListSinceEmpty(t *testing.T, ctx context.Context, store *even
 	testutil.SkipIntegrationTestInShortMode(t)
 	// List events when store is empty
 	retrievedEvents := make([]Event, 0) //nolint:prealloc
-	for event, err := range store.ListSince(ctx, 0, SortOrderAsc) {
+	for event, err := range store.ListSince(ctx, 0) {
 		require.NoError(t, err)
 		retrievedEvents = append(retrievedEvents, event)
 	}
 
 	assert.Empty(t, retrievedEvents)
+}
+
+func TestIntegrationEventStore_ListSince_Pages(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	runEventStoreTestWith(t, "badger", setupTestEventStore, testEventStoreListSincePages)
+	runEventStoreTestWith(t, "sqlkv", setupTestEventStoreSqlKv, testEventStoreListSincePages)
+}
+
+func testEventStoreListSincePages(t *testing.T, ctx context.Context, store *eventStore) {
+	events := eventStoreTestEvents(623)
+	for _, event := range slices.Backward(events) {
+		require.NoError(t, store.Save(ctx, event))
+	}
+
+	for _, since := range []int64{0, 1000, 1016, 1166, 1207, 1208} {
+		t.Run(fmt.Sprintf("since=%d", since), func(t *testing.T) {
+			probe := &eventStoreKVProbe{KV: store.kv, t: t}
+			var expected []Event
+			for _, event := range events {
+				if event.ResourceVersion >= since {
+					expected = append(expected, event)
+				}
+			}
+			var actual []Event
+			for event, err := range newEventStore(probe).ListSince(ctx, since) {
+				require.NoError(t, err)
+				probe.assertClosed()
+				actual = append(actual, event)
+			}
+			require.Equal(t, expected, actual)
+			require.Zero(t, probe.gets)
+			require.Len(t, probe.batches, (len(expected)+49)/50)
+			require.Len(t, probe.scans, len(expected)/500+1)
+			for i, batch := range probe.batches {
+				require.Len(t, batch, min(50, len(expected)-i*50))
+			}
+			for i, scan := range probe.scans {
+				require.Equal(t, SortOrderAsc, scan.Sort)
+				require.Equal(t, int64(500), scan.Limit)
+				if i == 0 {
+					require.Equal(t, fmt.Sprint(since), scan.StartKey)
+				} else {
+					cursor := eventStoreTestKey(expected[i*500-1])
+					require.Equal(t, PrefixRangeEnd(cursor), scan.StartKey)
+				}
+			}
+			probe.assertClosed()
+		})
+	}
+}
+
+func TestIntegrationEventStore_ListSince_PageBoundaries(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	for _, count := range []int{0, 1, 49, 50, 51, 100, 101, 123, 499, 500, 501} {
+		t.Run(fmt.Sprint(count), func(t *testing.T) {
+			test := func(t *testing.T, ctx context.Context, store *eventStore) {
+				events := eventStoreTestEvents(count)
+				for _, event := range events {
+					require.NoError(t, store.Save(ctx, event))
+				}
+				probe := &eventStoreKVProbe{KV: store.kv, t: t}
+				actual := make([]Event, 0, count)
+				for event, err := range newEventStore(probe).ListSince(ctx, 0) {
+					require.NoError(t, err)
+					probe.assertClosed()
+					actual = append(actual, event)
+				}
+				require.Equal(t, events, actual)
+				require.Len(t, probe.batches, (count+49)/50)
+				require.Len(t, probe.scans, count/500+1)
+				require.Zero(t, probe.gets)
+			}
+			runEventStoreTestWith(t, "badger", setupTestEventStore, test)
+			runEventStoreTestWith(t, "sqlkv", setupTestEventStoreSqlKv, test)
+		})
+	}
+}
+
+func TestIntegrationEventStore_ListSince_Stop(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	for _, tc := range []struct {
+		mode  string
+		count int
+	}{
+		{mode: "early stop", count: 1},
+		{mode: "stop at batch boundary", count: 50},
+		{mode: "stop at page boundary", count: 500},
+		{mode: "cancel and stop", count: 1},
+		{mode: "deleted cursor", count: 623},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			test := func(t *testing.T, ctx context.Context, store *eventStore) {
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				events := eventStoreTestEvents(623)
+				for _, event := range events {
+					require.NoError(t, store.Save(ctx, event))
+				}
+				probe := &eventStoreKVProbe{KV: store.kv, t: t}
+				var actual []Event
+				for event, err := range newEventStore(probe).ListSince(ctx, 0) {
+					probe.assertClosed()
+					require.NoError(t, err)
+					actual = append(actual, event)
+					if tc.mode == "cancel and stop" {
+						cancel()
+					}
+					if tc.mode == "deleted cursor" && len(actual) == 500 {
+						key := eventStoreTestKey(event)
+						require.NoError(t, store.kv.Delete(ctx, eventsSection, key))
+					}
+					if tc.mode != "deleted cursor" && len(actual) == tc.count {
+						break
+					}
+				}
+				probe.assertClosed()
+				require.Equal(t, events[:tc.count], actual)
+				require.Len(t, probe.scans, (tc.count+499)/500)
+				require.Len(t, probe.batches, (tc.count+49)/50)
+			}
+			runEventStoreTestWith(t, "badger", setupTestEventStore, test)
+			runEventStoreTestWith(t, "sqlkv", setupTestEventStoreSqlKv, test)
+		})
+	}
+}
+
+func TestIntegrationEventStore_ListSince_MissingRecords(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	for _, mode := range []string{"partial batches", "first batch", "first key page", "all records"} {
+		t.Run(mode, func(t *testing.T) {
+			test := func(t *testing.T, ctx context.Context, store *eventStore) {
+				events := eventStoreTestEvents(623)
+				partial := make(map[string]bool)
+				for i, event := range events {
+					require.NoError(t, store.Save(ctx, event))
+					partial[eventStoreTestKey(event)] = i%3 == 0
+				}
+				removed := make(map[string]bool)
+				probe := &eventStoreKVProbe{KV: store.kv, t: t}
+				probe.batch = func(ctx context.Context, section string, keys []string) iter.Seq2[kv.KeyValue, error] {
+					for _, key := range keys {
+						if mode == "all records" ||
+							(mode == "first batch" && len(probe.batches) == 1) ||
+							(mode == "first key page" && len(probe.batches) <= 10) ||
+							(mode == "partial batches" && partial[key]) {
+							// Delete after enumeration to exercise successful BatchGet omissions.
+							require.NoError(t, store.kv.Delete(ctx, section, key))
+							removed[key] = true
+						}
+					}
+					return store.kv.BatchGet(ctx, section, keys)
+				}
+				actual := make([]Event, 0, len(events))
+				for event, err := range newEventStore(probe).ListSince(ctx, 0) {
+					require.NoError(t, err)
+					probe.assertClosed()
+					actual = append(actual, event)
+				}
+				expected := make([]Event, 0, len(events))
+				for _, event := range events {
+					if !removed[eventStoreTestKey(event)] {
+						expected = append(expected, event)
+					}
+				}
+				require.Equal(t, expected, actual)
+				require.Len(t, probe.scans, 2)
+				require.Len(t, probe.batches, 13)
+				require.Zero(t, probe.gets)
+				probe.assertClosed()
+			}
+			runEventStoreTestWith(t, "badger", setupTestEventStore, test)
+			runEventStoreTestWith(t, "sqlkv", setupTestEventStoreSqlKv, test)
+		})
+	}
+}
+
+func TestIntegrationEventStore_ListSince_Failures(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	backendErr := errors.New("backend unavailable")
+	for _, mode := range []string{
+		"keys error", "batch error", "late batch error", "batch not found", "batch timeout",
+		"unexpected key", "wrong identity", "wrong RV", "invalid action", "invalid JSON", "reader error",
+		"cancel before scan", "cancel keys", "cancel batch", "cancel reader",
+	} {
+		t.Run(mode, func(t *testing.T) {
+			test := func(t *testing.T, ctx context.Context, store *eventStore) {
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				events := eventStoreTestEvents(2)
+				for _, event := range events {
+					require.NoError(t, store.Save(ctx, event))
+				}
+				probe := &eventStoreKVProbe{KV: store.kv, t: t}
+				probe.keys = func(ctx context.Context, section string, opts ListOptions) iter.Seq2[string, error] {
+					return func(yield func(string, error) bool) {
+						for key, err := range store.kv.Keys(ctx, section, opts) {
+							if !yield(key, err) {
+								return
+							}
+							if mode == "keys error" {
+								yield("", backendErr)
+								return
+							}
+							if mode == "cancel keys" {
+								cancel()
+								return
+							}
+						}
+					}
+				}
+				probe.batch = func(context.Context, string, []string) iter.Seq2[kv.KeyValue, error] {
+					return eventStoreFailureBatch(t, mode, events, cancel, backendErr)
+				}
+				if mode == "cancel before scan" {
+					cancel()
+				}
+				failures := 0
+				for event, err := range newEventStore(probe).ListSince(ctx, 0) {
+					probe.assertClosed()
+					require.Error(t, err)
+					require.Equal(t, Event{}, event)
+					switch mode {
+					case "keys error", "batch error", "late batch error", "reader error":
+						require.ErrorIs(t, err, backendErr)
+					case "batch not found":
+						require.ErrorIs(t, err, ErrNotFound)
+					case "batch timeout":
+						require.ErrorIs(t, err, context.DeadlineExceeded)
+					default:
+						require.NotErrorIs(t, err, ErrNotFound)
+						if strings.HasPrefix(mode, "cancel") {
+							require.ErrorIs(t, err, context.Canceled)
+						}
+					}
+					failures++
+				}
+				require.Equal(t, 1, failures)
+				if mode == "cancel before scan" {
+					require.Empty(t, probe.scans)
+				}
+				if mode == "cancel before scan" || mode == "cancel keys" || mode == "keys error" {
+					require.Empty(t, probe.batches)
+				}
+				probe.assertClosed()
+				require.Zero(t, probe.gets)
+			}
+			runEventStoreTestWith(t, "badger", setupTestEventStore, test)
+			runEventStoreTestWith(t, "sqlkv", setupTestEventStoreSqlKv, test)
+		})
+	}
+}
+
+func eventStoreFailureBatch(t *testing.T, mode string, events []Event, cancel context.CancelFunc, backendErr error) iter.Seq2[kv.KeyValue, error] {
+	t.Helper()
+	return func(yield func(kv.KeyValue, error) bool) {
+		switch mode {
+		case "batch error":
+			yield(kv.KeyValue{Value: io.NopCloser(strings.NewReader(""))}, backendErr)
+			return
+		case "batch not found":
+			yield(kv.KeyValue{}, ErrNotFound)
+			return
+		case "batch timeout":
+			yield(kv.KeyValue{}, context.DeadlineExceeded)
+			return
+		case "cancel batch":
+			cancel()
+			return
+		}
+		for _, event := range events {
+			key := eventStoreTestKey(event)
+			switch mode {
+			case "unexpected key":
+				key = "unexpected"
+			case "wrong identity":
+				event.Name = "wrong"
+			case "wrong RV":
+				event.ResourceVersion++
+			case "invalid action":
+				event.Action = "invalid"
+			}
+			data, err := json.Marshal(event)
+			require.NoError(t, err)
+			var reader io.Reader = strings.NewReader(string(data))
+			switch mode {
+			case "invalid JSON":
+				reader = strings.NewReader("{")
+			case "reader error":
+				reader = eventStoreErrorReader{err: backendErr}
+			case "cancel reader":
+				reader = eventStoreErrorReader{err: context.Canceled, cancel: cancel}
+			}
+			if !yield(kv.KeyValue{Key: key, Value: io.NopCloser(reader)}, nil) {
+				return
+			}
+		}
+		if mode == "late batch error" {
+			yield(kv.KeyValue{}, backendErr)
+		}
+	}
+}
+
+func eventStoreTestEvents(count int) []Event {
+	events := make([]Event, count)
+	actions := []kv.DataAction{DataActionCreated, DataActionUpdated, DataActionDeleted}
+	for i := range events {
+		events[i] = Event{
+			Namespace: "default", Group: "apps", Resource: "resource", Name: fmt.Sprintf("test-%03d", i),
+			ResourceVersion: 1000 + int64(i/3), Action: actions[i%len(actions)], Folder: "folder",
+		}
+	}
+	return events
+}
+
+func eventStoreTestKey(event Event) string {
+	return EventKey{
+		Namespace: event.Namespace, Group: event.Group, Resource: event.Resource, Name: event.Name,
+		ResourceVersion: event.ResourceVersion, Action: event.Action, Folder: event.Folder,
+	}.String()
+}
+
+type eventStoreKVProbe struct {
+	KV
+	t         *testing.T
+	gets      int
+	scans     []ListOptions
+	batches   [][]string
+	keysOpen  bool
+	batchOpen bool
+	readers   int
+	closed    int
+	keys      func(context.Context, string, ListOptions) iter.Seq2[string, error]
+	batch     func(context.Context, string, []string) iter.Seq2[kv.KeyValue, error]
+}
+
+func (p *eventStoreKVProbe) assertClosed() {
+	p.t.Helper()
+	assert.False(p.t, p.keysOpen, "key cursor is still open")
+	assert.False(p.t, p.batchOpen, "batch cursor is still open")
+	assert.Equal(p.t, p.readers, p.closed, "readers are still open")
+}
+
+func (p *eventStoreKVProbe) Get(ctx context.Context, section, key string) (io.ReadCloser, error) {
+	p.gets++
+	return p.KV.Get(ctx, section, key)
+}
+
+func (p *eventStoreKVProbe) Keys(ctx context.Context, section string, opts ListOptions) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		p.assertClosed()
+		assert.Equal(p.t, eventsSection, section)
+		p.scans = append(p.scans, opts)
+		p.keysOpen = true
+		defer func() { p.keysOpen = false }()
+		keys := p.KV.Keys
+		if p.keys != nil {
+			keys = p.keys
+		}
+		keys(ctx, section, opts)(yield)
+	}
+}
+
+func (p *eventStoreKVProbe) BatchGet(ctx context.Context, section string, keys []string) iter.Seq2[kv.KeyValue, error] {
+	return func(yield func(kv.KeyValue, error) bool) {
+		p.assertClosed()
+		assert.Equal(p.t, eventsSection, section)
+		p.batches = append(p.batches, slices.Clone(keys))
+		p.batchOpen = true
+		defer func() { p.batchOpen = false }()
+		batch := p.KV.BatchGet
+		if p.batch != nil {
+			batch = p.batch
+		}
+		for pair, err := range batch(ctx, section, keys) {
+			if pair.Value != nil {
+				p.readers++
+				pair.Value = &eventStoreProbeReader{ReadCloser: pair.Value, closed: &p.closed}
+			}
+			more := yield(pair, err)
+			assert.Equal(p.t, p.readers, p.closed)
+			if !more {
+				return
+			}
+		}
+	}
+}
+
+type eventStoreProbeReader struct {
+	io.ReadCloser
+	closed *int
+}
+
+func (r *eventStoreProbeReader) Close() error {
+	*r.closed++
+	return r.ReadCloser.Close()
+}
+
+type eventStoreErrorReader struct {
+	err    error
+	cancel context.CancelFunc
+}
+
+func (r eventStoreErrorReader) Read([]byte) (int, error) {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	return 0, r.err
 }
 
 func TestEvent_JSONSerialization(t *testing.T) {

--- a/pkg/storage/unified/resource/notifier.go
+++ b/pkg/storage/unified/resource/notifier.go
@@ -239,10 +239,12 @@ func (n *pollingNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan E
 			case <-time.After(currentInterval):
 				// Poll for new events since lastEmittedRV.
 				// ListSince is inclusive, so skip events at or below lastEmittedRV.
-				for evt, err := range n.eventStore.ListSince(ctx, lastEmittedRV, SortOrderAsc) {
+				listFailed := false
+				for evt, err := range n.eventStore.ListSince(ctx, lastEmittedRV) {
 					if err != nil {
 						n.log.Error("Failed to list events since", "error", err)
-						continue
+						listFailed = true
+						break
 					}
 					if evt.ResourceVersion <= lastEmittedRV {
 						continue
@@ -253,6 +255,13 @@ func (n *pollingNotifier) Watch(ctx context.Context, opts WatchOptions) <-chan E
 					}
 					seen[key] = true
 					buffer = append(buffer, evt)
+				}
+
+				// A partial scan may end within a shared RV. Retain the buffer, but
+				// do not advance lastEmittedRV past unread events until a scan succeeds.
+				if listFailed {
+					currentInterval = bo.NextDelay()
+					continue
 				}
 
 				// Sort buffer by RV

--- a/pkg/storage/unified/resource/notifier_test.go
+++ b/pkg/storage/unified/resource/notifier_test.go
@@ -3,6 +3,8 @@ package resource
 import (
 	"context"
 	"fmt"
+	"iter"
+	"slices"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -421,6 +424,97 @@ func testNotifierWatchMultipleEvents(t *testing.T, ctx context.Context, notifier
 	// resource-1 (rv1, -4s) < resource-3 (rv3, -3s) < resource-2 (rv2, -2s)
 	expectedNames := []string{"test-resource-1", "test-resource-3", "test-resource-2"}
 	assert.Equal(t, expectedNames, receivedEvents)
+}
+
+func TestIntegrationNotifier_Watch_EventPages(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	for _, failBatch := range []bool{false, true} {
+		t.Run(fmt.Sprintf("batch failure=%t", failBatch), func(t *testing.T) {
+			test := func(t *testing.T, ctx context.Context, notifier *pollingNotifier, store *eventStore) {
+				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				defer cancel()
+				initial := eventStoreTestEvents(1)[0]
+				initial.ResourceVersion = snowflakeFromTime(time.Now().Add(-time.Minute))
+				require.NoError(t, store.Save(ctx, initial))
+
+				seeded := make(chan struct{})
+				probe := &eventStoreKVProbe{KV: store.kv, t: t}
+				probe.keys = func(ctx context.Context, section string, opts ListOptions) iter.Seq2[string, error] {
+					return func(yield func(string, error) bool) {
+						if opts.Sort == SortOrderAsc {
+							select {
+							case <-seeded:
+							case <-ctx.Done():
+								yield("", ctx.Err())
+								return
+							}
+						}
+						store.kv.Keys(ctx, section, opts)(yield)
+					}
+				}
+				probe.batch = func(ctx context.Context, section string, keys []string) iter.Seq2[kv.KeyValue, error] {
+					if failBatch && len(probe.batches) == 2 {
+						return func(yield func(kv.KeyValue, error) bool) {
+							yield(kv.KeyValue{}, fmt.Errorf("temporary batch failure"))
+						}
+					}
+					return store.kv.BatchGet(ctx, section, keys)
+				}
+				notifier.eventStore = newEventStore(probe)
+				ch := notifier.Watch(ctx, WatchOptions{
+					SettleDelay: time.Millisecond, BufferSize: 1,
+					MinBackoff: time.Millisecond, MaxBackoff: 10 * time.Millisecond,
+				})
+				defer func() {
+					cancel()
+					for range ch {
+					}
+					probe.assertClosed()
+				}()
+
+				expected := eventStoreTestEvents(623)
+				for i := range expected {
+					expected[i].ResourceVersion += initial.ResourceVersion
+				}
+				for _, event := range slices.Backward(expected) {
+					require.NoError(t, store.Save(ctx, event))
+				}
+				close(seeded)
+				for _, event := range expected {
+					select {
+					case actual, ok := <-ch:
+						require.True(t, ok)
+						require.Equal(t, event, actual)
+					case <-ctx.Done():
+						t.Fatal("timed out waiting for paged events")
+					}
+				}
+
+				// A later event forces another poll through the inclusive lower bound.
+				last := expected[len(expected)-1]
+				last.ResourceVersion++
+				require.NoError(t, store.Save(ctx, last))
+				select {
+				case actual, ok := <-ch:
+					require.True(t, ok)
+					require.Equal(t, last, actual, "polling must not re-emit the previous page")
+				case <-ctx.Done():
+					t.Fatal("timed out waiting for the next poll")
+				}
+				cancel()
+				for event := range ch {
+					t.Errorf("unexpected extra event: %+v", event)
+				}
+				require.Zero(t, probe.gets)
+				require.GreaterOrEqual(t, len(probe.batches), 14)
+				for _, batch := range probe.batches {
+					require.LessOrEqual(t, len(batch), 50)
+				}
+			}
+			runNotifierTestWith(t, "badger", setupTestNotifier, test)
+			runNotifierTestWith(t, "sqlkv", setupTestNotifierSqlKv, test)
+		})
+	}
 }
 
 func TestChannelNotifier(t *testing.T) {

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -479,7 +479,7 @@ func TestKvStorageBackend_WriteEvent_ClientCancelAfterDataSave_PersistsEvent(t *
 	// The event must be persisted even though the client cancelled right after
 	// the data was committed.
 	found := false
-	for ev, err := range backend.eventStore.ListSince(context.Background(), 0, SortOrderAsc) {
+	for ev, err := range backend.eventStore.ListSince(context.Background(), 0) {
 		require.NoError(t, err)
 		if ev.Name == resourceName {
 			found = true
@@ -739,7 +739,7 @@ func TestKvStorageBackend_WatchWriteEvents_BatchesValueReads(t *testing.T) {
 	// hand: a DataKey carries the folder and action too, and guessing either makes
 	// the batched read silently miss.
 	batch := make([]Event, 0, numEvents)
-	for event, err := range backend.eventStore.ListSince(ctx, 0, SortOrderAsc) {
+	for event, err := range backend.eventStore.ListSince(ctx, 0) {
 		require.NoError(t, err)
 		batch = append(batch, event)
 	}
@@ -912,7 +912,7 @@ func TestKvStorageBackend_WatchWriteEvents_ReadFailuresAreNotReportedAsMissing(t
 		}
 
 		batch := make([]Event, 0, numEvents)
-		for event, err := range backend.eventStore.ListSince(ctx, 0, SortOrderAsc) {
+		for event, err := range backend.eventStore.ListSince(ctx, 0) {
 			require.NoError(t, err)
 			batch = append(batch, event)
 		}


### PR DESCRIPTION
for https://github.com/grafana/search-and-storage-team/issues/878

I'll have a follow up that actually addresses https://github.com/grafana/search-and-storage-team/issues/878, but this part is self contained and can be reviewed separately.

Use `BatchGet` instead of `Get` to retrieve event body while calling `ListSince`. This is only used by the notifier at the tail of the eventstore, so I don't expect this to move the needle at all. However the next PR will make use of this function to replace the broadcaster cache, so it may be called with an RV that is at most 30 minutes old