### PR TITLE
FlameGraph: keep the focus on the same node when the data changes

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/dataTransform.test.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/dataTransform.test.ts
@@ -144,6 +144,90 @@ describe('FlameGraphDataContainer', () => {
     const collapsedMap = container.getCollapsedMap();
     expect(Array.from(collapsedMap.keys()).length).toEqual(0);
   });
+
+  it('returns the call path of an item', () => {
+    const container = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+      [2/]
+    `)!;
+
+    const levels = container.getLevels();
+    expect(container.getItemPath(levels[0][0])).toEqual(['0']);
+    expect(container.getItemPath(levels[2][0])).toEqual(['0', '1', '2']);
+  });
+
+  it('finds an item by its call path', () => {
+    const container = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+      [2/]
+    `)!;
+
+    const levels = container.getLevels();
+    expect(container.getItemByPath(['0', '1', '2'])).toBe(levels[2][0]);
+    expect(container.getItemByPath(['0', '4'])).toBe(levels[1][1]);
+    expect(container.getItemByPath(['0'])).toBe(levels[0][0]);
+  });
+
+  it('distinguishes between items with the same label at different call sites', () => {
+    const container = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+      [2/] [2]
+    `)!;
+
+    const levels = container.getLevels();
+    const underOne = levels[2][0];
+    const underFour = levels[2][1];
+
+    expect(container.getNodesWithLabel('2')).toEqual([underOne, underFour]);
+    expect(container.getItemByPath(['0', '1', '2'])).toBe(underOne);
+    expect(container.getItemByPath(['0', '4', '2'])).toBe(underFour);
+  });
+
+  it('finds an item by its data frame indexes', () => {
+    const container = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+      [2/]
+    `)!;
+
+    const levels = container.getLevels();
+    expect(container.getItemByIndexes(levels[2][0].itemIndexes)).toBe(levels[2][0]);
+    expect(container.getItemByIndexes(levels[1][1].itemIndexes)).toBe(levels[1][1]);
+    expect(container.getItemByIndexes([999])).toBeUndefined();
+  });
+
+  it('re-maps a focused item onto the same call path when the data changes', () => {
+    const before = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+      [2/]
+    `)!;
+    const after = textToDataContainer(`
+      [0///////////]
+      [1///////][4/]
+      [3/][2/]
+    `)!;
+
+    const focused = before.getItemByPath(['0', '1', '2'])!;
+    const remapped = after.getItemByPath(before.getItemPath(focused))!;
+
+    expect(after.getItemPath(remapped)).toEqual(['0', '1', '2']);
+    expect(after.getItemByIndexes(focused.itemIndexes)).not.toBe(remapped);
+  });
+
+  it('returns undefined for a call path that does not exist', () => {
+    const container = textToDataContainer(`
+      [0//////]
+      [1//][4/]
+    `)!;
+
+    expect(container.getItemByPath(['0', '9'])).toBeUndefined();
+    expect(container.getItemByPath(['9'])).toBeUndefined();
+    expect(container.getItemByPath([])).toBeUndefined();
+  });
 });
 
 describe('CollapsedMapContainer', () => {

--- a/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
@@ -396,6 +396,67 @@ export class FlameGraphDataContainer {
     return this.uniqueLabelsMap![label];
   }
 
+  /**
+   * Returns the labels of the item's ancestors followed by the item's own label, i.e. the call path from the root to
+   * the item. This identifies a node much more precisely than its label alone, which can occur at many call sites.
+   */
+  getItemPath(item: LevelItem): string[] {
+    const path: string[] = [];
+    let current: LevelItem | undefined = item;
+
+    while (current) {
+      path.unshift(this.getLabel(current.itemIndexes[0]));
+      current = current.parents?.[0];
+    }
+
+    return path;
+  }
+
+  /**
+   * Finds the item with the given data frame indexes, or undefined if no item has them.
+   */
+  getItemByIndexes(itemIndexes: number[]): LevelItem | undefined {
+    for (const level of this.getLevels()) {
+      for (const item of level) {
+        if (
+          item.itemIndexes.length === itemIndexes.length &&
+          item.itemIndexes.every((val, idx) => val === itemIndexes[idx])
+        ) {
+          return item;
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Finds the item at the given call path (as returned by getItemPath), or undefined if the path does not exist in
+   * this data, for example because the profile changed.
+   */
+  getItemByPath(path: string[]): LevelItem | undefined {
+    this.initLevels();
+    const root = this.levels![0]?.[0];
+
+    if (!root || !path.length || this.getLabel(root.itemIndexes[0]) !== path[0]) {
+      return undefined;
+    }
+
+    let current = root;
+
+    for (const label of path.slice(1)) {
+      const child = current.children.find((c) => this.getLabel(c.itemIndexes[0]) === label);
+
+      if (!child) {
+        return undefined;
+      }
+
+      current = child;
+    }
+
+    return current;
+  }
+
   getCollapsedMap() {
     this.initLevels();
     return this.collapsedMap!;

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.focus.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.focus.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCallback } from 'react';
+
+import { createDataFrame, createTheme, FieldType } from '@grafana/data';
+
+import FlameGraphContainer from './FlameGraphContainer';
+
+import 'jest-canvas-mock';
+
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: jest.fn().mockReturnValue({ isLoading: false, isEnabled: false, openAssistant: jest.fn() }),
+  createAssistantContextItem: jest.fn(),
+  providePageContext: jest.fn(),
+}));
+
+const profileBefore = {
+  fields: [
+    { name: 'level', values: [0, 1, 2, 1, 2] },
+    { name: 'value', values: [100, 60, 60, 40, 40] },
+    { name: 'self', values: [0, 0, 60, 0, 40] },
+    { name: 'label', values: ['total', 'a', 'target', 'b', 'target'], type: FieldType.string },
+  ],
+};
+
+const profileAfter = {
+  fields: [
+    { name: 'level', values: [0, 1, 2, 2, 1, 2] },
+    { name: 'value', values: [100, 60, 20, 40, 35, 25] },
+    { name: 'self', values: [0, 0, 20, 40, 0, 25] },
+    { name: 'label', values: ['total', 'a', 'nc', 'target', 'b', 'target'], type: FieldType.string },
+  ],
+};
+
+const frame = (d: typeof profileBefore) => {
+  const f = createDataFrame(d);
+  f.meta = { custom: { ProfileTypeID: 'cpu:samples:count:cpu:nanoseconds' } };
+  return f;
+};
+
+const sameCallPathShare = '25% of total';
+const sameLabelShare = '40% of total';
+const sameRowIndexesShare = '35% of total';
+
+const Harness = ({ which, keepFocus = true }: { which: 'before' | 'after'; keepFocus?: boolean }) => {
+  const getTheme = useCallback(() => createTheme({ colors: { mode: 'dark' } }), []);
+  return (
+    <FlameGraphContainer
+      data={frame(which === 'before' ? profileBefore : profileAfter)}
+      getTheme={getTheme}
+      keepFocusOnDataChange={keepFocus}
+      disableCollapsing={true}
+    />
+  );
+};
+
+const focusTargetUnderB = async () => {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'clientWidth', { configurable: true, value: 500 });
+  const click = new MouseEvent('click', { bubbles: true });
+  Object.defineProperty(click, 'offsetX', { get: () => 400 });
+  Object.defineProperty(click, 'offsetY', { get: () => 2 * 22 + 11 });
+  fireEvent(await screen.findByTestId('flameGraph'), click);
+  await userEvent.click(screen.getByText('Focus block'));
+  await waitFor(() => expect(screen.getByText(sameLabelShare)).toBeInTheDocument());
+};
+
+it('keeps the focus on the same call path when the data changes', async () => {
+  const { rerender } = render(<Harness which="before" />);
+  await focusTargetUnderB();
+
+  rerender(<Harness which="after" />);
+
+  await waitFor(() => expect(screen.getByText(sameCallPathShare)).toBeInTheDocument());
+  expect(screen.queryByText(sameRowIndexesShare)).not.toBeInTheDocument();
+});
+
+it('drops the focus when the data changes and keepFocusOnDataChange is off', async () => {
+  const { rerender } = render(<Harness which="before" keepFocus={false} />);
+  await focusTargetUnderB();
+
+  rerender(<Harness which="after" keepFocus={false} />);
+
+  await waitFor(() => expect(screen.queryByText(/% of total/)).not.toBeInTheDocument());
+});

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
@@ -155,6 +155,30 @@ const FlameGraphContainer = ({
     return new FlameGraphDataContainer(data, { collapsing: !disableCollapsing }, theme);
   }, [data, theme, disableCollapsing]);
 
+  const previousDataContainerRef = useRef(dataContainer);
+  const focusedItemPathRef = useRef<string[] | undefined>(undefined);
+
+  useEffect(() => {
+    if (!dataContainer) {
+      return;
+    }
+
+    const dataChanged = previousDataContainerRef.current !== dataContainer;
+    previousDataContainerRef.current = dataContainer;
+
+    let item = focusedItemIndexes?.length ? dataContainer.getItemByIndexes(focusedItemIndexes) : undefined;
+
+    if (dataChanged) {
+      item =
+        keepFocusOnDataChange && focusedItemPathRef.current
+          ? dataContainer.getItemByPath(focusedItemPathRef.current)
+          : undefined;
+      setFocusedItemIndexes(item ? item.itemIndexes : undefined);
+    }
+
+    focusedItemPathRef.current = item && dataContainer.getItemPath(item);
+  }, [focusedItemIndexes, dataContainer, keepFocusOnDataChange]);
+
   const styles = getStyles(theme);
   const matchedLabels = useLabelSearch(search, dataContainer);
 

--- a/packages/grafana-flamegraph/src/FlameGraphPane.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphPane.tsx
@@ -56,6 +56,7 @@ const FlameGraphPane = ({
   setSharedSandwichItem,
 }: FlameGraphPaneProps) => {
   const [focusedItemData, setFocusedItemData] = useState<ClickedItemData>();
+  const focusedItemPathRef = useRef<string[] | undefined>(undefined);
   const [rangeMin, setRangeMin] = useState(0);
   const [rangeMax, setRangeMax] = useState(1);
   const [textAlign, setTextAlign] = useState<TextAlign>('left');
@@ -101,7 +102,9 @@ const FlameGraphPane = ({
     }
 
     if (dataContainer && focusedItemData) {
-      const item = dataContainer.getNodesWithLabel(focusedItemData.label)?.[0];
+      const item =
+        (focusedItemPathRef.current && dataContainer.getItemByPath(focusedItemPathRef.current)) ||
+        dataContainer.getNodesWithLabel(focusedItemData.label)?.[0];
 
       if (item) {
         setFocusedItemData({ ...focusedItemData, item });
@@ -129,6 +132,13 @@ const FlameGraphPane = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataContainer, keepFocusOnDataChange]);
 
+  useEffect(() => {
+    focusedItemPathRef.current =
+      focusedItemData && focusedItemData.item.itemIndexes.length
+        ? dataContainer?.getItemPath(focusedItemData.item)
+        : undefined;
+  }, [focusedItemData, dataContainer]);
+
   const weSetFocusRef = useRef(false);
 
   useEffect(() => {
@@ -149,22 +159,13 @@ const FlameGraphPane = ({
       }
     }
 
-    const levels = dataContainer.getLevels();
-    for (const level of levels) {
-      for (const item of level) {
-        if (
-          item.itemIndexes.length === focusedItemIndexes.length &&
-          item.itemIndexes.every((val, idx) => val === focusedItemIndexes[idx])
-        ) {
-          const label = dataContainer.getLabel(item.itemIndexes[0]);
-          const totalViewTicks = levels[0][0].value;
+    const item = dataContainer.getItemByIndexes(focusedItemIndexes);
+    if (item) {
+      const totalViewTicks = dataContainer.getLevels()[0][0].value;
 
-          setFocusedItemData({ label, item, posX: 0, posY: 0 });
-          setRangeMin(item.start / totalViewTicks);
-          setRangeMax((item.start + item.value) / totalViewTicks);
-          return;
-        }
-      }
+      setFocusedItemData({ label: dataContainer.getLabel(item.itemIndexes[0]), item, posX: 0, posY: 0 });
+      setRangeMin(item.start / totalViewTicks);
+      setRangeMax((item.start + item.value) / totalViewTicks);
     }
   }, [focusedItemIndexes, dataContainer, focusedItemData]);
 


### PR DESCRIPTION
With `keepFocusOnDataChange`, refreshing a query moved the focus to an unrelated part of the profile. Two pre-existing causes: the pane re-anchored on `getNodesWithLabel(label)[0]`, the first node sharing that label anywhere in the tree, and the focus shared between panes is stored as data frame row indexes, which point at whatever occupies those rows once the data is replaced.

Focus is now re-anchored on the node at the same call path, and `keepFocusOnDataChange={false}` drops the focus instead of silently restoring it onto an arbitrary node.

Observed on Profiles Drilldown: focusing a 38% gRPC handler and changing the time range landed the focus on `other` at 0% of total, collapsing the panel to a stub.

<!-- TODO: video of the focus jumping before the fix, and staying after -->
_Video: TODO_

Notes:
- The flag-off behaviour change affects consumers that never set it (Explore, the panel, the trace view): their focus currently survives a refresh on an arbitrary node, and now resets, which is what the prop has always implied.