### PR TITLE
Docs: Tempo quarterly update (FY27 Q3)

### DIFF
--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -18,6 +18,7 @@ labels:
 menuTitle: Tempo
 title: Tempo data source
 weight: 1400
+review_date: 2026-09-10
 refs:
   data-source-management:
     - pattern: /docs/grafana/
@@ -78,8 +79,10 @@ refs:
 
 # Tempo data source
 
-Grafana ships with built-in support for [Grafana Tempo](https://grafana.com/docs/tempo/<TEMPO_VERSION>/), a high-volume, minimal-dependency distributed tracing backend from Grafana Labs.
+Grafana ships preinstalled with the Tempo data source for [Grafana Tempo](https://grafana.com/docs/tempo/<TEMPO_VERSION>/), a high-volume, minimal-dependency distributed tracing backend from Grafana Labs. There's nothing to install to get started.
 Use the Tempo data source to search and visualize traces, correlate traces with logs, metrics, and profiles, and monitor service dependencies with the Service Graph.
+
+As of Grafana 13.2, Tempo is packaged as a standalone plugin so it can receive updates independently of Grafana releases. For details, refer to [Plugin updates](#plugin-updates).
 
 Want to learn more about traces and the other telemetry signals?
 Refer to [Understand your data](https://grafana.com/docs/grafana-cloud/telemetry-signals/).
@@ -104,7 +107,7 @@ The Tempo data source supports the following features:
 | Streaming          | Yes       | Display TraceQL results as they become available                       |
 | JSON trace upload  | Yes       | Upload and visualize trace files without a Tempo instance              |
 | Explore            | Yes       | Ad-hoc trace investigation without dashboards                          |
-| Alerting           | No        | Use TraceQL metrics in Prometheus for trace-based alerting             |
+| Alerting           | Experimental | Enable the `tempoAlerting` feature toggle to alert on TraceQL metrics queries, or use Prometheus metrics from the metrics generator |
 
 {{< admonition type="tip" >}}
 **New to tracing?** Learn what telemetry signals are and how they work together in [Understand your data](https://grafana.com/docs/grafana-cloud/telemetry-signals/) (Grafana Cloud), or read the [Introduction to tracing](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/) for core concepts like spans, traces, and instrumentation.
@@ -116,19 +119,47 @@ The Tempo data source supports the following features:
 
 The following pages help you set up and use the Tempo data source:
 
-- [Configure the Tempo data source](configure-tempo-data-source/): Connect Grafana to Tempo, set up authentication, and configure trace correlations.
-- [Query tracing data](query-editor/): Search for traces, use the TraceQL editor, and upload JSON trace files.
+- [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/): Connect Grafana to Tempo, set up authentication, and configure trace correlations.
+- [Query tracing data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/): Search for traces, use the TraceQL editor, and upload JSON trace files.
 - [Grafana Traces Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/): Explore tracing data visually using RED metrics, without writing queries.
-- [Service Graph and Service Graph view](service-graph/): Visualize service dependencies and monitor request rate, error rate, and duration. Requires a linked Prometheus data source with service graph metrics.
+- [Service Graph and Service Graph view](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/): Visualize service dependencies and monitor request rate, error rate, and duration. Requires a linked Prometheus data source with service graph metrics.
 
 ## Connect traces to other signals
 
 After you've connected Grafana to Tempo, you can configure correlations between traces and other signals:
 
-- [Trace to logs](configure-tempo-data-source/configure-trace-to-logs/): Navigate from spans to related logs in Loki, including bidirectional linking.
-- [Trace to metrics](configure-tempo-data-source/configure-trace-to-metrics/): Link spans to metrics queries in Prometheus or other metrics data sources.
-- [Trace to profiles](configure-tempo-data-source/configure-trace-to-profiles/): Link spans to profiling data in Grafana Pyroscope with embedded flame graphs.
-- [Trace correlations](configure-tempo-data-source/trace-correlations/): Create custom correlation links to any data source or external URL.
+- [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/): Navigate from spans to related logs in Loki, including bidirectional linking.
+- [Trace to metrics](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-metrics/): Link spans to metrics queries in Prometheus or other metrics data sources.
+- [Trace to profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-profiles/): Link spans to profiling data in Grafana Pyroscope with embedded flame graphs.
+- [Trace correlations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/trace-correlations/): Create custom correlation links to any data source or external URL.
+
+## Plugin updates
+
+Starting with Grafana v13.2, the Tempo data source is a standalone plugin, preinstalled in both Grafana OSS and Enterprise. This enables more frequent updates independent of Grafana releases. Grafana automatically checks the plugin catalog and installs the latest version on each server restart.
+
+To adjust this behavior:
+
+- **Opt out of auto-updates:** Set `preinstall_auto_update` to `false` in your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/).
+- **Update manually:** Update at any time from the **Administration > Plugins** page without restarting Grafana.
+
+The standalone plugin requires Grafana 12.3.0 or later. The Tempo data source bundled with Grafana 13.1 and earlier continues to work as before. These versions are unaffected by the externalization.
+
+Users running Grafana 12.3.x through 13.1.x can install the standalone plugin from the plugin catalog if they want the latest features before upgrading to Grafana 13.2. To use the standalone plugin with these versions, add the following to your [configuration file](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/):
+
+```ini
+[plugin.tempo]
+as_external = true
+
+[plugins]
+; Install the latest version on startup:
+preinstall_sync = tempo
+; Or install a specific version:
+; preinstall_sync = tempo@<version>
+```
+
+{{< admonition type="note" >}}
+On Grafana Cloud, the Tempo plugin is managed by Grafana and updates automatically.
+{{< /admonition >}}
 
 ## Related resources
 

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -39,18 +39,18 @@ Refer to [Understand your data](https://grafana.com/docs/grafana-cloud/telemetry
 
 The Tempo data source supports the following features:
 
-| Feature            | Supported | Notes                                                                  |
-| ------------------ | --------- | ---------------------------------------------------------------------- |
-| TraceQL queries    | Yes       | Query traces using TraceQL, the query language designed for traces     |
-| Search             | Yes       | Find traces by service name, span name, duration, and attributes       |
-| Service Graph      | Yes       | Visualize service dependencies and RED metrics                         |
-| Trace to logs      | Yes       | Navigate from spans to related logs in Loki and other log data sources |
-| Trace to metrics   | Yes       | Link spans to metrics queries in Prometheus                            |
-| Trace to profiles  | Yes       | Link spans to profiling data in Grafana Pyroscope                      |
-| Trace correlations | Yes       | Embed custom correlation links in trace views                          |
-| Streaming          | Yes       | Display TraceQL results as they become available                       |
-| JSON trace upload  | Yes       | Upload and visualize trace files without a Tempo instance              |
-| Explore            | Yes       | Ad-hoc trace investigation without dashboards                          |
+| Feature            | Supported    | Notes                                                                                                                               |
+| ------------------ | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| TraceQL queries    | Yes          | Query traces using TraceQL, the query language designed for traces                                                                  |
+| Search             | Yes          | Find traces by service name, span name, duration, and attributes                                                                    |
+| Service Graph      | Yes          | Visualize service dependencies and RED metrics                                                                                      |
+| Trace to logs      | Yes          | Navigate from spans to related logs in Loki and other log data sources                                                              |
+| Trace to metrics   | Yes          | Link spans to metrics queries in Prometheus                                                                                         |
+| Trace to profiles  | Yes          | Link spans to profiling data in Grafana Pyroscope                                                                                   |
+| Trace correlations | Yes          | Embed custom correlation links in trace views                                                                                       |
+| Streaming          | Yes          | Display TraceQL results as they become available                                                                                    |
+| JSON trace upload  | Yes          | Upload and visualize trace files without a Tempo instance                                                                           |
+| Explore            | Yes          | Ad-hoc trace investigation without dashboards                                                                                       |
 | Alerting           | Experimental | Enable the `tempoAlerting` feature toggle to alert on TraceQL metrics queries, or use Prometheus metrics from the metrics generator |
 
 {{< admonition type="tip" >}}

--- a/docs/sources/datasources/tempo/_index.md
+++ b/docs/sources/datasources/tempo/_index.md
@@ -19,62 +19,6 @@ menuTitle: Tempo
 title: Tempo data source
 weight: 1400
 review_date: 2026-09-10
-refs:
-  data-source-management:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
-  build-dashboards:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/
-  node-graph:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/node-graph/
-    - pattern: /docs/grafana-cloud/
-      destination: https://grafana.com/docs/grafana-cloud/visualizations/panels-visualizations/visualizations/node-graph/
-  configure-tempo-data-source:
-    - pattern: /docs/grafana/
-      destination: https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#provision-the-data-source
-    - pattern: /docs/grafana-cloud/
-      destination: https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/
-  exemplars:
-    - pattern: /docs/grafana/
-      destination: https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
-    - pattern: /docs/grafana-cloud/
-      destination: https://grafana.com/docs/grafana/<GRAFANA_VERSION>/fundamentals/exemplars/
-  variable-syntax:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/variables/variable-syntax/
-    - pattern: /docs/grafana-cloud/
-      destination: https://grafana.com/docs/grafana-cloud/visualizations/dashboards/variables/variable-syntax/
-  explore-trace-integration:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/trace-integration/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/trace-integration/
-  configure-grafana-feature-toggles:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#feature_toggles
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#feature_toggles
-  provisioning-data-sources:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
-  explore:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/explore/
-  troubleshooting:
-    - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/troubleshooting/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/troubleshooting/
 ---
 
 # Tempo data source
@@ -167,6 +111,6 @@ On Grafana Cloud, the Tempo plugin is managed by Grafana and updates automatical
 - [Best practices for traces](https://grafana.com/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/instrument-send/best-practices/): Guidance on planning spans, attributes, and trace structure for effective tracing data.
 - [TraceQL query examples](query-editor/traceql-query-examples/)
 - [TraceQL query language reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/)
-  If you encounter issues with the Tempo data source, refer to [Troubleshoot Tempo data source issues](ref:troubleshooting).
+  If you encounter issues with the Tempo data source, refer to [Troubleshoot Tempo data source issues](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/troubleshooting/).
 
 {{< section withDescriptions="true">}}

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/_index.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/_index.md
@@ -13,6 +13,7 @@ labels:
 menuTitle: Configure Tempo
 title: Configure the Tempo data source
 weight: 200
+review_date: 2026-09-10
 aliases:
   - link-trace-id/
   - ../link-trace-id/
@@ -69,7 +70,7 @@ Follow these steps to set up a new Tempo data source:
    - Under **Connection**, enter the **URL** of the Tempo instance. Refer to the [connection](#connection) section for URL format examples.
    - Complete the [**Authentication** section](#authentication).
 
-1. Optional: Configure other sections to add capabilities to your tracing data. Refer to the [Configure trace correlations](trace-correlations/) and [Other settings](#other-settings) sections for available options.
+1. Optional: Configure other sections to add capabilities to your tracing data. Refer to the [Configure trace correlations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/trace-correlations/) and [Other settings](#other-settings) sections for available options.
 1. Select **Save & test**.
 
 This video explains how to add data sources, including Loki, Tempo, and Mimir, to Grafana and Grafana Cloud. Tempo data source setup starts at 4:58 in the video.
@@ -176,11 +177,11 @@ Grafana provides several ways to link traces to other telemetry signals. The fol
 
 The Tempo data source settings page includes three sections for linking from spans to other signals. Each corresponds to a section in the settings form:
 
-- [Trace to logs](configure-trace-to-logs/): Navigate from spans to related logs in Loki or another log data source.
-- [Trace to metrics](configure-trace-to-metrics/): Link spans to metrics queries in Prometheus or other metrics data sources.
-- [Trace to profiles](configure-trace-to-profiles/): Link spans to profiling data in Grafana Pyroscope with embedded flame graphs.
+- [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/): Navigate from spans to related logs in Loki or another log data source.
+- [Trace to metrics](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-metrics/): Link spans to metrics queries in Prometheus or other metrics data sources.
+- [Trace to profiles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-profiles/): Link spans to profiling data in Grafana Pyroscope with embedded flame graphs.
 
-For more flexible, rule-based correlations that can target any data source or external URL, use Grafana [Trace correlations](trace-correlations/). Trace correlations are configured under **Configuration > Correlations**, not in the Tempo data source settings.
+For more flexible, rule-based correlations that can target any data source or external URL, use Grafana [Trace correlations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/trace-correlations/). Trace correlations are configured under **Configuration > Correlations**, not in the Tempo data source settings.
 
 To link _from_ logs or metrics _to_ traces (the reverse direction), refer to:
 
@@ -189,8 +190,8 @@ To link _from_ logs or metrics _to_ traces (the reverse direction), refer to:
 
 ## Other settings
 
-- [Additional settings](additional-settings/): Configure Service graph, node graph, search, TraceID query, span bar, and other settings.
-- [Provision the Tempo data source](provision/): Configure the Tempo data source using a YAML file and clone provisioned data sources.
+- [Additional settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/additional-settings/): Configure Service graph, node graph, search, TraceID query, span bar, and other settings.
+- [Provision the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/): Configure the Tempo data source using a YAML file and clone provisioned data sources.
 
 ## Custom query variables
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
@@ -14,6 +14,7 @@ labels:
 menuTitle: Additional settings
 title: Additional settings
 weight: 700
+review_date: 2026-09-10
 aliases:
   - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#additional-settings
 ---

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Trace to logs
 title: Configure trace to logs correlation
 weight: 300
+review_date: 2026-09-10
 ---
 
 # Configure trace to logs correlation

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs.md
@@ -52,6 +52,10 @@ Refer to [Provision trace to logs settings](#provision-trace-to-logs-settings) f
 These settings control how Grafana queries your log data source when you click a span in the trace view.
 This guide uses Loki, but Trace to logs also supports Elasticsearch, Splunk, OpenSearch, Falcon LogScale, Google Cloud Logging, and VictoriaMetrics Logs.
 
+{{< admonition type="note" >}}
+To change the target log data source, for example from Elasticsearch to Loki, select the new data source from the **Data source** drop-down in the following steps and update the tags and custom query to match its query language. The reverse direction, from a log line back to a trace, is configured on the log data source itself, and the mechanism differs by type: Loki uses [Derived fields](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/loki/configure-loki-data-source/#derived-fields), while Elasticsearch and Splunk use [Data links](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/elasticsearch/configure/#data-links).
+{{< /admonition >}}
+
 1. Go to **Connections** > **Data sources** and select your Tempo data source.
 1. Scroll to the **Trace to logs** section.
 1. Select your Loki data source from the **Data source** drop-down list.

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-metrics.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-metrics.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Trace to metrics
 title: Configure trace to metrics correlation
 weight: 400
+review_date: 2026-09-10
 aliases:
   - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-metrics
 ---
@@ -62,7 +63,7 @@ To use a basic configuration, follow these steps:
    The tags you configure must be present in the spans attributes or resources for a trace to metrics span link to appear. You can optionally configure a new name for the tag. This is useful if the tag has dots in the name and the target data source doesn't allow using dots in labels. For example, you can remap `service.name` to `service_name`.
 
 1. Don't select **Add query**.
-1. Select **Save and Test**.
+1. Select **Save & test**.
 
 ## Set up custom queries
 
@@ -93,7 +94,7 @@ To use custom queries with the configuration, follow these steps:
      Interpolate tags using the `$__tags` keyword.
      For example, when you configure the query `requests_total{$__tags}` with the tags `k8s.pod=pod` and `cluster`, the result looks like `requests_total{pod="nginx-554b9", cluster="us-east-1"}`.
 
-1. Select **Save and Test**.
+1. Select **Save & test**.
 
 ## Configuration options
 

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-profiles.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/configure-trace-to-profiles.md
@@ -16,6 +16,7 @@ labels:
 menuTitle: Trace to profiles
 title: Configure trace to profiles correlation
 weight: 500
+review_date: 2026-09-10
 aliases:
   - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#trace-to-profiles
 ---

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
@@ -14,6 +14,7 @@ labels:
 menuTitle: Provision
 title: Provision the Tempo data source
 weight: 800
+review_date: 2026-09-10
 aliases:
   - /docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#provision-the-data-source
 ---

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
@@ -44,7 +44,7 @@ To make changes, you can either:
 ## Example file
 
 This example provisioning YAML file sets up the equivalents of the options available in the Tempo data source UI.
-Replace `grafana-pyroscope-datasource` with the actual UID of your Pyroscope datasource, and verify the other `datasource Uid` values match what's actually provisioned.
+Replace `grafana-pyroscope-datasource` with the actual UID of your Pyroscope data source, and verify the other `datasource Uid` values match what's actually provisioned.
 
 ```yaml
 apiVersion: 1

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/trace-correlations.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/trace-correlations.md
@@ -14,6 +14,7 @@ labels:
 menuTitle: Trace correlations
 title: Trace correlations
 weight: 900
+review_date: 2026-09-10
 aliases:
   - ../traces-in-grafana/trace-correlations/
 ---
@@ -79,7 +80,7 @@ To use trace correlations, you need:
 
 1. Select **Save** to save the correlation.
 
-## Verifying correlations in Explore
+## Verify correlations in Explore
 
 1. Open **Explore** and select your Tempo tracing source.
 

--- a/docs/sources/datasources/tempo/query-editor/_index.md
+++ b/docs/sources/datasources/tempo/query-editor/_index.md
@@ -18,6 +18,7 @@ labels:
 menuTitle: Query tracing data
 title: Query tracing data
 weight: 300
+review_date: 2026-09-10
 ---
 
 # Query tracing data
@@ -37,7 +38,7 @@ You can compose TraceQL queries in Grafana and Grafana Cloud using **Explore** a
 
 {{< admonition type="note" >}}
 Before running queries, verify that your Tempo data source is configured and connected.
-If queries return no results or errors, refer to [Configure the Tempo data source](../configure-tempo-data-source/) to check your connection and authentication settings.
+If queries return no results or errors, refer to [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/) to check your connection and authentication settings.
 {{< /admonition >}}
 
 You don't have to know TraceQL to create a query.
@@ -63,7 +64,7 @@ Start here if you're exploring data or learning TraceQL.
 The **Search** query builder provides drop-down lists and text fields to build a query visually without needing to know TraceQL syntax.
 Your selections automatically generate a TraceQL query that you can copy to the editor for further refinement.
 
-Refer to [Search traces using the query builder](traceql-search/) for more information.
+Refer to [Search traces using the query builder](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-search/) for more information.
 
 ![The Search query builder](/media/docs/grafana/data-sources/tempo/query-editor/tempo-ds-query-search-v11.png)
 
@@ -73,8 +74,8 @@ Use the **TraceQL** editor when you need complex filters, structural queries acr
 The editor provides autocomplete for attribute names, scopes, and operators.
 You can also search for a trace ID by entering it directly into the query field.
 
-For copy-paste query examples, refer to [TraceQL query examples](traceql-query-examples/).
-Refer to [Write TraceQL queries with the editor](traceql-editor/) for more information.
+For copy-paste query examples, refer to [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/).
+Refer to [Write TraceQL queries with the editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-editor/) for more information.
 
 ![The TraceQL query editor](/media/docs/grafana/data-sources/tempo/query-editor/tempo-ds-query-traceql-v11.png)
 
@@ -221,8 +222,8 @@ For information about Tempo configuration requirements, refer to the [Cross-tena
 
 ## Next steps
 
-- [TraceQL query examples](traceql-query-examples/) - Copy-paste query examples for common use cases
+- [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/) - Copy-paste query examples for common use cases
 - [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/) - Full TraceQL syntax, scopes, and operators
-- [Service Graph and Service Graph view](../service-graph/) - Visualize service dependencies and RED metrics
-- [Span filters](../span-filters/) - Refine trace results after querying
-- [Configure the Tempo data source](../configure-tempo-data-source/) - Connection, authentication, and feature settings
+- [Service Graph and Service Graph view](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/) - Visualize service dependencies and RED metrics
+- [Span filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/span-filters/) - Refine trace results after querying
+- [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/) - Connection, authentication, and feature settings

--- a/docs/sources/datasources/tempo/query-editor/traceql-editor.md
+++ b/docs/sources/datasources/tempo/query-editor/traceql-editor.md
@@ -15,11 +15,12 @@ labels:
 menuTitle: Write TraceQL queries
 title: Write TraceQL queries with the editor
 weight: 400
+review_date: 2026-09-10
 ---
 
 # Write TraceQL queries with the editor
 
-Use the **TraceQL** editor when you need structural queries across parent and child spans, aggregations, or other features that the [Search query builder](../traceql-search/) doesn't support.
+Use the **TraceQL** editor when you need structural queries across parent and child spans, aggregations, or other features that the [Search query builder](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-search/) doesn't support.
 TraceQL queries follow the pattern `{ conditions } | pipeline`.
 Refer to [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/) for the full syntax.
 
@@ -31,9 +32,9 @@ To get started, paste this query into the editor and select **Run query**:
 
 This returns all error spans from the `frontend` service.
 Replace `frontend` with your service name.
-For more examples, refer to [TraceQL query examples](../traceql-query-examples/).
+For more examples, refer to [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/).
 
-If queries return no results, check that your [Tempo data source is configured and connected](../../configure-tempo-data-source/).
+If queries return no results, check that your [Tempo data source is configured and connected](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/).
 
 [//]: # 'Shared content for the TraceQL query editor'
 [//]: # 'This content is located in /docs/sources/shared/datasources/tempo-editor-traceql.md'
@@ -42,8 +43,8 @@ If queries return no results, check that your [Tempo data source is configured a
 
 ## Next steps
 
-- [TraceQL query examples](../traceql-query-examples/): Copy-paste query examples for common use cases
-- [Search traces using the query builder](../traceql-search/): Build queries visually
+- [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/): Copy-paste query examples for common use cases
+- [Search traces using the query builder](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-search/): Build queries visually
 - [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/): Full TraceQL syntax reference
-- [Service Graph and Service Graph view](../../service-graph/): Visualize service dependencies
-- [Span filters](../../span-filters/): Refine results in the trace detail view
+- [Service Graph and Service Graph view](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/): Visualize service dependencies
+- [Span filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/span-filters/): Refine results in the trace detail view

--- a/docs/sources/datasources/tempo/query-editor/traceql-query-examples.md
+++ b/docs/sources/datasources/tempo/query-editor/traceql-query-examples.md
@@ -14,6 +14,7 @@ labels:
 menuTitle: TraceQL query examples
 title: TraceQL query examples
 weight: 500
+review_date: 2026-09-10
 ---
 
 # TraceQL query examples
@@ -167,5 +168,5 @@ For example, using a `$service` variable:
 
 - [TraceQL cookbook for Grafana Cloud Traces](https://grafana.com/docs/grafana-cloud/send-data/traces/traces-query-editor/traceql-cookbook/) - Extended recipe collection with additional examples
 - [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/) - Full TraceQL syntax, scopes, and operators
-- [Query tracing data](_index.md) - Query editor modes and options
-- [Service Graph and Service Graph view](../service-graph/) - Visualize service dependencies
+- [Query tracing data](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/) - Query editor modes and options
+- [Service Graph and Service Graph view](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/) - Visualize service dependencies

--- a/docs/sources/datasources/tempo/query-editor/traceql-search.md
+++ b/docs/sources/datasources/tempo/query-editor/traceql-search.md
@@ -14,25 +14,24 @@ labels:
 menuTitle: Search traces
 title: Search traces using the query builder
 weight: 300
+review_date: 2026-09-10
 ---
 
 # Search traces using the query builder
 
 The **Search** query builder lets you create TraceQL queries using drop-down lists and text fields instead of writing syntax directly.
 Each selection you make generates a TraceQL query behind the scenes.
-You can view the generated query and copy it to the [TraceQL editor](../traceql-editor/) at any time.
+You can view the generated query and copy it to the [TraceQL editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-editor/) at any time.
 
 Use Search when you're exploring data or learning TraceQL patterns.
-For complex queries involving structural operators, aggregations, or features that Search doesn't support, use the [TraceQL editor](../traceql-editor/).
+For complex queries involving structural operators, aggregations, or features that Search doesn't support, use the [TraceQL editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-editor/).
 To learn the full query syntax, refer to [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/).
 
-If queries return no results, check that your [Tempo data source is configured and connected](../configure-tempo-data-source/).
+If queries return no results, check that your [Tempo data source is configured and connected](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/).
 
-## Enable Search with the query builder
+## Availability
 
-This feature is automatically available in Grafana 10 (and newer) and Grafana Cloud.
-
-To enable the TraceQL query builder in self-managed Grafana through version 10.1, [enable the `traceqlSearch` feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/).
+The Search query builder is available by default in Grafana and Grafana Cloud. No feature toggle or additional configuration is required.
 
 [//]: # 'Shared content for the Search - TraceQL query builder'
 
@@ -76,12 +75,12 @@ Generated query:
 { span.http.response.status_code >= 500 }
 ```
 
-For more query examples, refer to [TraceQL query examples](../traceql-query-examples/).
+For more query examples, refer to [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/).
 
 ## Next steps
 
-- [TraceQL query examples](../traceql-query-examples/): Copy-paste query examples for common use cases
-- [Write TraceQL queries with the editor](../traceql-editor/): For complex queries the Search builder doesn't support
+- [TraceQL query examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-query-examples/): Copy-paste query examples for common use cases
+- [Write TraceQL queries with the editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-editor/): For complex queries the Search builder doesn't support
 - [Construct a TraceQL query](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/construct-traceql-queries/): Full TraceQL syntax reference
-- [Service Graph and Service Graph view](../../service-graph/): Visualize service dependencies
-- [Span filters](../../span-filters/): Refine results in the trace detail view
+- [Service Graph and Service Graph view](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/): Visualize service dependencies
+- [Span filters](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/span-filters/): Refine results in the trace detail view

--- a/docs/sources/datasources/tempo/service-graph.md
+++ b/docs/sources/datasources/tempo/service-graph.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Service Graph and Service Graph view
 title: Service Graph and Service Graph view
 weight: 500
+review_date: 2026-09-10
 ---
 
 # Service Graph and Service Graph view
@@ -104,7 +105,9 @@ The Service Graph view displays a table of RED metrics (rate, error rate, durati
 The table uses a different set of metrics from the node graph:
 
 - `traces_spanmetrics_calls_total`: Rate and error rate columns.
-- `traces_spanmetrics_duration_seconds_bucket`: Duration column.
+- `traces_spanmetrics_latency_bucket`: Duration column.
+
+Newer Tempo versions may emit the duration histogram as `traces_spanmetrics_duration_seconds_bucket` instead. If your metrics use only the renamed metric, the Duration column shows no data. For more information, refer to [Service Graph view table is empty](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/troubleshooting/#service-graph-view-table-is-empty).
 
 These span metrics must be present in your linked Prometheus data source.
 Span metrics generation must be enabled in your Tempo or Alloy configuration. Refer to [Enable service graphs](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/service_graphs/enable-service-graphs/) in the Tempo documentation.

--- a/docs/sources/datasources/tempo/span-filters.md
+++ b/docs/sources/datasources/tempo/span-filters.md
@@ -13,6 +13,7 @@ labels:
 menuTitle: Span filters
 title: Span filters
 weight: 600
+review_date: 2026-09-10
 ---
 
 # Span filters
@@ -25,7 +26,7 @@ Whether you're looking to identify spans from a certain service, those exceeding
 The more filters you add, the more specific the results become.
 
 {{< admonition type="tip" >}}
-If you arrived from the [Service Graph](../service-graph/), use **service.name** and **status = error** filters to drill into the specific service nodes showing errors.
+If you arrived from the [Service Graph](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/), use **service.name** and **status = error** filters to drill into the specific service nodes showing errors.
 {{< /admonition >}}
 
 ![The Filters section in the trace timeline viewer showing the filter drop-down, quick filter pills for Critical path, Errors, and High latency, navigation arrows, match count, and Show all spans toggle.](/media/docs/grafana/data-sources/tempo/screenshot-tempo-datasource-span-filters.png)
@@ -47,7 +48,7 @@ Available filter keys include:
 For most attribute keys, the available operators are `=`, `!=`, `=~` (regular expression match), and `!~` (regular expression not match).
 
 {{< admonition type="note" >}}
-The same attributes available as filter keys (for example, `span.name`, `service.name`, `duration`) can be used directly in [TraceQL queries](../query-editor/traceql-editor/).
+The same attributes available as filter keys (for example, `span.name`, `service.name`, `duration`) can be used directly in [TraceQL queries](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/traceql-editor/).
 {{< /admonition >}}
 
 ## Quick filter pills
@@ -101,6 +102,6 @@ To narrow to the critical path only, click the **Critical path** pill, then turn
 
 ## Next steps
 
-- [Service Graph](../service-graph/): Visualize service relationships and identify error-producing nodes.
-- [Query editor](../query-editor/): Build TraceQL queries using the same attributes available as span filter keys.
-- [Configure the Tempo data source](../configure-tempo-data-source/): Set up your Tempo data source and trace correlations.
+- [Service Graph](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/service-graph/): Visualize service relationships and identify error-producing nodes.
+- [Query editor](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/): Build TraceQL queries using the same attributes available as span filter keys.
+- [Configure the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/): Set up your Tempo data source and trace correlations.

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -444,8 +444,8 @@ These issues relate to the correlation features that link traces to other teleme
 
 1. Adjust the **Span start time shift** and **Span end time shift** to widen the time range.
 1. Verify that log or metric labels match the span attributes.
-1. Check that the tag mappings correctly translate attribute names between data sources. Span attributes use dots (for example, `service.name`) but Loki labels use underscores (for example, `service_name`). Ensure tag mappings account for this difference. Refer to [Trace to logs](ref:trace-to-logs) for tag mapping configuration.
-1. If a tag like `pod` is stored as Loki [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) rather than an indexed label, the auto-generated stream selector `{pod="..."}` returns no results. Enable **Use custom query** and move the tag to a pipeline filter. Refer to [Trace to logs](ref:trace-to-logs) for a custom query example.
+1. Check that the tag mappings correctly translate attribute names between data sources. Span attributes use dots (for example, `service.name`) but Loki labels use underscores (for example, `service_name`). Ensure tag mappings account for this difference. Refer to [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/) for tag mapping configuration.
+1. If a tag like `pod` is stored as Loki [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/) rather than an indexed label, the auto-generated stream selector `{pod="..."}` returns no results. Enable **Use custom query** and move the tag to a pipeline filter. Refer to [Trace to logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/configure-trace-to-logs/) for a custom query example.
 1. Run the generated query directly in the target data source's Explore view to confirm it returns data outside of the trace context.
 1. Use the Query Inspector to view the generated query and verify it's correct.
 

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot Tempo data source issues
 weight: 600
+review_date: 2026-09-10
 ---
 
 # Troubleshoot Tempo data source issues
@@ -25,9 +26,9 @@ This document provides solutions to common issues you may encounter when configu
 
 This guide covers issues related to connecting Grafana to Tempo and using the data source features. It applies to the following setups:
 
-- **Self-managed Grafana + self-managed Tempo**—you manage both Grafana (OSS or Enterprise) and Tempo.
-- **Grafana Cloud + Cloud Traces**—you use Grafana Cloud with the managed Tempo backend (Grafana Cloud Traces). Some configuration (streaming, metrics generator) is handled automatically.
-- **Grafana Cloud + self-managed Tempo via PDC**—you use Grafana Cloud but connect to your own Tempo instance through [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
+- **Self-managed Grafana + self-managed Tempo:** you manage both Grafana (OSS or Enterprise) and Tempo.
+- **Grafana Cloud + Cloud Traces:** you use Grafana Cloud with the managed Tempo backend (Grafana Cloud Traces). Some configuration (streaming, metrics generator) is handled automatically.
+- **Grafana Cloud + self-managed Tempo via PDC:** you use Grafana Cloud but connect to your own Tempo instance through [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
 
 Where troubleshooting steps differ between these setups, the guide calls it out. Sections labeled _Grafana Cloud only_ or _self-managed Tempo_ apply only to those environments.
 
@@ -40,7 +41,7 @@ For issues with Tempo itself (not the data source), refer to the Tempo product d
 - [Too many requests error](https://grafana.com/docs/tempo/<TEMPO_VERSION>/troubleshooting/querying/too-many-requests-error/) - Query capacity limits and 429 errors.
 - [Query issues](https://grafana.com/docs/tempo/<TEMPO_VERSION>/troubleshooting/querying/) - Server-side query failures, bad blocks, and performance tuning.
 
-### Resources for troubleshooting tracings in Grafana Cloud
+### Resources for troubleshooting traces in Grafana Cloud
 
 Additional resources for Grafana Cloud:
 
@@ -202,7 +203,7 @@ These errors occur when there are issues with TraceQL queries or trace lookups.
 1. Use the **Search** query builder to explore available attributes and values.
 1. Start with a broader query and progressively add filters to narrow results.
 1. Try [Grafana Traces Drilldown](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/simplified-exploration/traces/), a queryless app that lets you explore tracing data using RED metrics without writing TraceQL.
-1. Note that Tempo search is non-deterministic—identical queries can return different results because Tempo scans in parallel and returns the first matching traces. Refer to [Understand search behavior](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/) for details.
+1. Note that Tempo search is non-deterministic. Identical queries can return different results because Tempo scans in parallel and returns the first matching traces. Refer to [Understand search behavior](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/query-editor/) for details.
 1. Verify traces are being ingested into Tempo by querying for a known trace ID.
 
 ### Traces not appearing after successful connection
@@ -261,7 +262,7 @@ For more information, refer to [Streaming](https://grafana.com/docs/grafana/<GRA
 **Solution:**
 
 1. For self-managed Tempo, verify that you're using the required Tempo version (v2.2 or later for search streaming, v2.7 or later for metrics streaming) and that streaming is enabled in your configuration (`stream_over_http_enabled: true`). Refer to [Tempo gRPC API](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/#tempo-grpc-api) in the Tempo documentation. Streaming is available for Grafana Cloud users by default.
-1. Verify that **Streaming** is enabled in your [Tempo data source settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#streaming). The **Search queries** and **Metrics queries** toggles are independent—check that the toggle for the query type you're using is enabled.
+1. Verify that **Streaming** is enabled in your [Tempo data source settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/#streaming). The **Search queries** and **Metrics queries** toggles are independent. Check that the toggle for the query type you're using is enabled.
 1. If your Tempo instance is behind a load balancer or proxy that doesn't support gRPC or HTTP2, streaming may not work. Disable streaming and use standard HTTP queries instead.
 1. If you're using [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to reach Tempo, verify that the PDC tunnel is running and the Tempo instance is reachable from the PDC agent. PDC connectivity issues can present as streaming timeouts.
 
@@ -363,7 +364,7 @@ These issues relate to the correlation features that link traces to other teleme
 
 ### Loki log lines don't show a trace link
 
-**Cause:** The reverse direction—navigating from a Loki log line to a trace—isn't working. No trace link appears on log lines.
+**Cause:** The reverse direction, navigating from a Loki log line to a trace, isn't working. No trace link appears on log lines.
 
 **Solution:**
 
@@ -461,7 +462,7 @@ The following issues don't produce specific error messages but are commonly enco
 
 ### Data source settings disappear after restart
 
-**Cause:** You configured settings in the Grafana UI (such as trace-to-logs links, service graph, or span time shifts), but they disappear after Grafana restarts. This happens when the data source is provisioned via a YAML configuration file, Helm chart, or Terraform. Provisioned data sources are read-only in the UI—any changes you make through the UI aren't persisted and silently revert on the next restart.
+**Cause:** You configured settings in the Grafana UI (such as trace-to-logs links, service graph, or span time shifts), but they disappear after Grafana restarts. This happens when the data source is provisioned via a YAML configuration file, Helm chart, or Terraform. Provisioned data sources are read-only in the UI. Any changes you make through the UI aren't persisted and silently revert on the next restart.
 
 You can tell a data source is provisioned if the settings form is read-only and the button reads **Test** instead of **Save & test**.
 

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -118,7 +118,7 @@ These errors occur when there are issues with authentication credentials or perm
 1. For Grafana Cloud, verify that your Cloud Access Policy token has the `traces:read` scope. Refer to [Create a Cloud Access Policy token](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/add-access-policy/) for setup instructions. To find your stack URL and credentials, refer to [Locate your stack URL, user, and password](https://grafana.com/docs/grafana-cloud/send-data/traces/set-up/locate-url-user-password/).
 1. For self-managed Tempo, ensure the credentials match those configured in the Tempo `server` block or reverse proxy.
 
-### Save and test returns 404
+### Save & test returns 404
 
 **Error message:** `Tempo echo endpoint returned status 404` when selecting **Save & test**
 
@@ -145,6 +145,25 @@ These errors occur when there are issues with authentication credentials or perm
 1. For cross-tenant queries, ensure all specified tenants are accessible.
 
 For more information, refer to [Enable multi-tenancy](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/multitenancy/) and [Tenant IDs](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/tenant-ids/).
+
+## Configuration errors
+
+These issues occur when configuring the Tempo data source itself, before you run queries or set up correlations.
+
+### Can't edit a provisioned data source (read-only)
+
+**Symptoms:**
+
+- The data source settings form is read-only and the button reads **Test** instead of **Save & test**.
+- You get a read-only error when you try to configure trace to logs correlation, enable **Filter by trace ID**, or change service graph or node graph settings.
+- Changes you make in the UI silently revert after Grafana restarts.
+
+**Cause:** The data source is provisioned through a YAML configuration file, Helm chart, or Terraform. Provisioned data sources are read-only in the Grafana UI, so the UI can't save changes and any edits revert on the next restart or provisioning reload.
+
+**Solutions:**
+
+1. **Clone the data source to get an editable copy.** This is the quickest fix when you need to configure correlation, **Filter by trace ID**, or service graph settings through the UI. The clone isn't provisioned, so you can edit and save it normally. Refer to [Clone a provisioned data source for Grafana Cloud](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/#clone-a-provisioned-data-source-for-grafana-cloud) for the steps, which also apply to self-managed Grafana.
+1. **Edit the provisioning file** to change settings permanently. Any setting available in the UI can be set in the YAML file, including trace to logs, trace to metrics, **Filter by trace ID**, and service graph configuration. Edit the file, then restart Grafana or wait for the provisioning system to reload. Refer to [Provision the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/) for the full YAML reference.
 
 ## Query errors
 
@@ -248,6 +267,23 @@ These errors occur when there are issues with TraceQL queries or trace lookups.
 
 1. For Grafana Cloud, the `local-blocks` processor is enabled by default. If you still see this error, contact [Grafana Support](https://grafana.com/contact/).
 1. Verify that the metrics generator is running and healthy by checking the Tempo metrics-generator logs for errors.
+
+### TraceQL metrics query exceeds the maximum time range
+
+**Error message:** `metrics query time range exceeds the maximum allowed duration of <DURATION>`
+
+**Symptoms:**
+
+- A TraceQL metrics query, such as `{ } | rate()`, fails when the selected time range is too wide.
+- Shorter time ranges run successfully, but range queries over long periods return the error.
+
+**Cause:** Tempo limits the time range for TraceQL metrics queries. The default maximum is 24 hours. Tempo enforces this limit, not the data source, so you can't change it from the Grafana UI.
+
+**Solutions:**
+
+1. Reduce the query time range to within the configured maximum, which is 24 hours by default.
+1. For self-managed Tempo, raise the maximum metrics query duration in your Tempo configuration, then restart Tempo. Refer to [TraceQL metrics queries](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/metrics-queries/) in the Tempo documentation.
+1. For Grafana Cloud Traces, contact [Grafana Support](https://grafana.com/contact/) to request a higher limit. You can't change this limit yourself.
 
 ## Streaming issues
 
@@ -409,6 +445,29 @@ These issues relate to the correlation features that link traces to other teleme
 1. Run the generated query directly in the target data source's Explore view to confirm it returns data outside of the trace context.
 1. Use the Query Inspector to view the generated query and verify it's correct.
 
+### Trace links break after renaming a provisioned data source
+
+**Symptoms:**
+
+- Log-to-trace or trace-to-log links stop working after you rename a provisioned Tempo or Loki data source.
+- Correlations or derived fields that previously resolved now point to a data source that no longer exists.
+
+**Cause:** Correlations, derived fields, and trace to logs, metrics, and profiles settings reference the target data source by its `uid`, not its name. When a provisioned data source doesn't set an explicit `uid`, Grafana derives one from the data source name. Renaming the data source in the provisioning file changes the derived `uid`, so every link that referenced the old `uid` breaks.
+
+**Solutions:**
+
+1. Set an explicit, stable `uid` for each provisioned data source in the YAML file so the `uid` doesn't change when you rename the data source:
+
+   ```yaml
+   datasources:
+     - name: Tempo
+       type: tempo
+       uid: tempo-prod
+   ```
+
+1. After you add or correct the `uid`, update the correlations, derived fields, and trace to logs, metrics, and profiles settings that reference it to use the current `uid`.
+1. To confirm a data source's `uid`, open its settings page. The `uid` appears in the page URL.
+
 ## Performance issues
 
 These issues relate to slow queries or high resource usage.
@@ -459,17 +518,6 @@ The following issues don't produce specific error messages but are commonly enco
 1. Check the **Tags time range** setting in the [data source settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/additional-settings/) to ensure it covers a period with recent trace data.
 1. Increase the **Tag limit** setting if you have many unique attributes.
 1. Verify the Tempo data source connection is working by selecting **Save & test** in the data source settings.
-
-### Data source settings disappear after restart
-
-**Cause:** You configured settings in the Grafana UI (such as trace-to-logs links, service graph, or span time shifts), but they disappear after Grafana restarts. This happens when the data source is provisioned via a YAML configuration file, Helm chart, or Terraform. Provisioned data sources are read-only in the UI. Any changes you make through the UI aren't persisted and silently revert on the next restart.
-
-You can tell a data source is provisioned if the settings form is read-only and the button reads **Test** instead of **Save & test**.
-
-**Solution:**
-
-1. To change settings permanently, edit the provisioning YAML file and restart Grafana (or wait for the provisioning system to reload). Any setting available in the UI can be set in the YAML file, including trace-to-logs, trace-to-metrics, and service graph configuration. Refer to [Provision the Tempo data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/) for the full YAML reference.
-1. For Grafana Cloud, you can clone the provisioned data source to create an editable copy that persists UI changes. Refer to [Clone a provisioned data source for Grafana Cloud](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/#clone-a-provisioned-data-source-for-grafana-cloud) for the steps.
 
 ### TraceQL alerting not available
 

--- a/docs/sources/datasources/tempo/troubleshooting/index.md
+++ b/docs/sources/datasources/tempo/troubleshooting/index.md
@@ -32,6 +32,10 @@ This guide covers issues related to connecting Grafana to Tempo and using the da
 
 Where troubleshooting steps differ between these setups, the guide calls it out. Sections labeled _Grafana Cloud only_ or _self-managed Tempo_ apply only to those environments.
 
+{{< admonition type="note" >}}
+The error messages in this guide are representative examples. Recent versions of the Tempo data source return clearer, more descriptive messages that add context, such as the query time range or the specific reason a request failed, so the exact wording you see might differ from these examples. Match on the general error rather than the exact string.
+{{< /admonition >}}
+
 ### Resources for troubleshooting Tempo
 
 For issues with Tempo itself (not the data source), refer to the Tempo product documentation:


### PR DESCRIPTION
Quarterly documentation review for the Tempo data source (FY27 Q3), aligned with data source documentation conventions. The existing topic-page structure is retained; changes focus on accuracy, reconciling the docs against the now-externalized `grafana/grafana-tempo-datasource` plugin and `grafana/grafana`. All 15 pages received a `review_date`, relative/`.md` links were converted to fully qualified URLs, `ref:` shortcodes were removed ahead of the docs moving to a standalone repo, and em dashes were eliminated.

**_index.md:**
Reworded the built-in claim to "preinstalled," noted Tempo is a standalone plugin as of Grafana 13.2, added a "Plugin updates" section (auto-update on restart, `preinstall_auto_update` opt-out, manual updates, version requirement, `as_external`/`preinstall_sync` config, Cloud-managed note), updated the Supported features table Alerting row to Experimental with `tempoAlerting` toggle guidance, converted relative links to fully qualified URLs, removed the unused `refs:` frontmatter block and converted the lone troubleshooting `ref:` link

**configure-tempo-data-source/_index.md:**
Converted relative/`.md` links to fully qualified URLs

**configure-tempo-data-source/additional-settings.md:**
Added `review_date`

**configure-tempo-data-source/configure-trace-to-logs.md:**
Added admonition on switching the target log data source (Loki uses Derived fields; Elasticsearch/Splunk use Data links for the reverse direction)

**configure-tempo-data-source/configure-trace-to-metrics.md:**
Fixed "Save and Test" to "Save & test"

**configure-tempo-data-source/configure-trace-to-profiles.md:**
Added `review_date`

**configure-tempo-data-source/provision.md:**
Fixed "datasource" to "data source" in prose

**configure-tempo-data-source/trace-correlations.md:**
Fixed gerund heading "Verifying correlations in Explore" to "Verify correlations in Explore"

**query-editor/_index.md:**
Converted relative/`.md` links to fully qualified URLs

**query-editor/traceql-editor.md:**
Converted relative/`.md` links to fully qualified URLs

**query-editor/traceql-query-examples.md:**
Converted relative/`.md` links to fully qualified URLs

**query-editor/traceql-search.md:**
Replaced the stale "Enable Search with the query builder" section (Grafana 10 / `traceqlSearch` toggle) with an "Availability" section noting Search is available by default with no toggle; converted links

**service-graph.md:**
Corrected the Service Graph view Duration column metric name to `traces_spanmetrics_latency_bucket`, added a note that newer Tempo may emit `duration_seconds_bucket` with a link to the relevant troubleshooting entry

**span-filters.md:**
Converted relative/`.md` links to fully qualified URLs

**troubleshooting/index.md:**
Added a new "Configuration errors" section and moved the most-common provisioned issue into it (retitled "Data source settings disappear after restart" to "Can't edit a provisioned data source (read-only)" with a symptom-led structure and clone-first workaround), added "Trace links break after renaming a provisioned data source" and "TraceQL metrics query exceeds the maximum time range," renamed the "Save & test returns 404" heading, added a scope note clarifying that error wording is representative, removed em dashes, fixed a "tracings" typo, and converted two broken `ref:trace-to-logs` links to fully qualified URLs

**Zendesk issues addressed:**
- Provisioned data source read-only (cluster of 8 tickets): retitled and restructured entry, promoted to the Configuration errors section
- Trace links breaking after a provisioned data source rename: new entry, grounded in uid derivation
- TraceQL metrics query exceeding the maximum time range: new entry using the actual server-side error string
- Switching the target log data source in trace to logs: clarification admonition

**Technical accuracy verified against:**
- `pkg/setting/setting_plugins.go` (Tempo shipped as a preinstalled plugin)
- `pkg/services/featuremgmt/registry.go` (`tempoAlerting` experimental feature toggle)
- `pkg/services/provisioning/datasources/types.go` (`safeUIDFromName` uid derivation behind the rename-breaks-links entry)
- `grafana/grafana-tempo-datasource` `src/graphTransform.ts` (Service Graph view span-metric name)
- `grafana/grafana-tempo-datasource` `src/utils.ts` (TraceQL metrics max-range error string)
- `grafana/grafana-tempo-datasource` `src/datasource.ts`, `src/configuration/TagLimitSettings.tsx` (default values)
- `grafana/grafana-tempo-datasource` `CHANGELOG.md` (reviewed the April to September 2026 window; changes were overwhelmingly bug/security/dependency fixes with no documentation impact)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
