### PR TITLE
Dashboards/UI: make existing tests tolerate asynchronous rendering, part 2

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksInlineEditor.test.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksInlineEditor.test.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { DataLinksInlineEditor } from './DataLinksInlineEditor';
 
 describe('DataLinksInlineEditor', () => {
-  it('renders existing links and add button', () => {
-    render(
+  it('renders existing links and add button', async () => {
+    const { container } = render(
       <DataLinksInlineEditor
         links={[{ title: 'My Link', url: '/link' }]}
         onChange={jest.fn()}
@@ -13,6 +13,10 @@ describe('DataLinksInlineEditor', () => {
         getSuggestions={() => []}
       />
     );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+    });
 
     expect(screen.getByText('My Link')).toBeInTheDocument();
     expect(screen.getByText('Add link')).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksInlineEditorBase.test.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksInlineEditorBase.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataLink } from '@grafana/data';
@@ -12,19 +12,26 @@ const mockChildren = jest.fn((_item, _index, onSave, onCancel) => (
   </div>
 ));
 
-function setup(items?: DataLink[]) {
+async function setup(items?: DataLink[]) {
   const onChange = jest.fn();
-  render(
+  const { container } = render(
     <DataLinksInlineEditorBase<DataLink> type="link" items={items} onChange={onChange} data={[]}>
       {mockChildren}
     </DataLinksInlineEditorBase>
   );
+  await waitFor(() => {
+    expect(container.querySelector('[data-rfd-droppable-id="sortable-links"]')).toBeInTheDocument();
+  });
+  await waitFor(() => {
+    expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(items?.length ?? 0);
+  });
+
   return { onChange };
 }
 
 describe('DataLinksInlineEditorBase', () => {
-  it('renders existing items', () => {
-    setup([
+  it('renders existing items', async () => {
+    await setup([
       { title: 'Link A', url: '/a' },
       { title: 'Link B', url: '/b' },
     ]);
@@ -34,7 +41,7 @@ describe('DataLinksInlineEditorBase', () => {
   });
 
   it('opens add modal when add button is clicked', async () => {
-    setup();
+    await setup();
 
     await userEvent.click(screen.getByText('Add link'));
 
@@ -43,7 +50,7 @@ describe('DataLinksInlineEditorBase', () => {
   });
 
   it('opens edit modal when edit button is clicked', async () => {
-    setup([{ title: 'My Link', url: '/link' }]);
+    await setup([{ title: 'My Link', url: '/link' }]);
 
     await userEvent.click(screen.getByRole('button', { name: /edit/i }));
 
@@ -52,7 +59,7 @@ describe('DataLinksInlineEditorBase', () => {
   });
 
   it('calls onChange without the removed item', async () => {
-    const { onChange } = setup([
+    const { onChange } = await setup([
       { title: 'Keep', url: '/keep' },
       { title: 'Remove', url: '/remove' },
     ]);

--- a/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItem.test.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItem.test.tsx
@@ -1,5 +1,5 @@
 import { DragDropContext, Droppable } from '@hello-pangea/dnd';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { DataLinksListItem, type DataLinksListItemProps } from './DataLinksListItem';
 
@@ -10,7 +10,7 @@ const baseLink = {
   onClick: jest.fn(),
 };
 
-function setupTestContext(options: Partial<DataLinksListItemProps>) {
+async function setupTestContext(options: Partial<DataLinksListItemProps>) {
   const defaults: DataLinksListItemProps = {
     index: 0,
     item: baseLink,
@@ -24,7 +24,7 @@ function setupTestContext(options: Partial<DataLinksListItemProps>) {
   const onDragEnd = jest.fn();
 
   const props = { ...defaults, ...options };
-  const { rerender } = render(
+  const { container, rerender } = render(
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="sortable-links" direction="vertical">
         {(provided) => (
@@ -36,29 +36,33 @@ function setupTestContext(options: Partial<DataLinksListItemProps>) {
     </DragDropContext>
   );
 
+  await waitFor(() => {
+    expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+  });
+
   return { rerender, props };
 }
 
 describe('DataLinksListItem', () => {
   describe('when link has title', () => {
-    it('then the link title should be visible', () => {
+    it('then the link title should be visible', async () => {
       const item = {
         ...baseLink,
         title: 'Some Data Link Title',
       };
-      setupTestContext({ item });
+      await setupTestContext({ item });
 
       expect(screen.getByText(/some data link title/i)).toBeInTheDocument();
     });
   });
 
   describe('when link has url', () => {
-    it('then the link url should be visible', () => {
+    it('then the link url should be visible', async () => {
       const item = {
         ...baseLink,
         url: 'http://localhost:3000',
       };
-      setupTestContext({ item });
+      await setupTestContext({ item });
 
       expect(screen.getByText(/http:\/\/localhost\:3000/i)).toBeInTheDocument();
       expect(screen.getByTitle(/http:\/\/localhost\:3000/i)).toBeInTheDocument();

--- a/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItemBase.test.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksInlineEditor/DataLinksListItemBase.test.tsx
@@ -1,12 +1,12 @@
 import { DragDropContext, Droppable } from '@hello-pangea/dnd';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataLink } from '@grafana/data';
 
 import { DataLinksListItemBase, type DataLinksListItemBaseProps } from './DataLinksListItemBase';
 
-function setup(overrides?: Partial<DataLinksListItemBaseProps<DataLink>>) {
+async function setup(overrides?: Partial<DataLinksListItemBaseProps<DataLink>>) {
   const defaults: DataLinksListItemBaseProps<DataLink> = {
     index: 0,
     item: { title: 'My link', url: 'http://localhost' },
@@ -18,7 +18,7 @@ function setup(overrides?: Partial<DataLinksListItemBaseProps<DataLink>>) {
     ...overrides,
   };
 
-  render(
+  const { container } = render(
     <DragDropContext onDragEnd={jest.fn()}>
       <Droppable droppableId="test" direction="vertical">
         {(provided) => (
@@ -30,32 +30,36 @@ function setup(overrides?: Partial<DataLinksListItemBaseProps<DataLink>>) {
     </DragDropContext>
   );
 
+  await waitFor(() => {
+    expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+  });
+
   return defaults;
 }
 
 describe('DataLinksListItemBase', () => {
-  it('renders title and url', () => {
-    setup();
+  it('renders title and url', async () => {
+    await setup();
 
     expect(screen.getByText('My link')).toBeInTheDocument();
     expect(screen.getByText('http://localhost')).toBeInTheDocument();
   });
 
-  it('shows placeholder when title is empty', () => {
-    setup({ item: { title: '', url: 'http://localhost' } });
+  it('shows placeholder when title is empty', async () => {
+    await setup({ item: { title: '', url: 'http://localhost' } });
 
     expect(screen.getByText('Title not provided')).toBeInTheDocument();
   });
 
-  it('shows placeholder when url is empty', () => {
-    setup({ item: { title: 'Title', url: '' } });
+  it('shows placeholder when url is empty', async () => {
+    await setup({ item: { title: 'Title', url: '' } });
 
     expect(screen.getByText('Data link url not provided')).toBeInTheDocument();
   });
 
   it('calls onEdit when edit button is clicked', async () => {
     const onEdit = jest.fn();
-    setup({ onEdit });
+    await setup({ onEdit });
 
     await userEvent.click(screen.getByRole('button', { name: /edit/i }));
 
@@ -64,15 +68,15 @@ describe('DataLinksListItemBase', () => {
 
   it('calls onRemove when remove button is clicked', async () => {
     const onRemove = jest.fn();
-    setup({ onRemove });
+    await setup({ onRemove });
 
     await userEvent.click(screen.getByRole('button', { name: /remove/i }));
 
     expect(onRemove).toHaveBeenCalled();
   });
 
-  it('shows one-click badge when oneClick is true', () => {
-    setup({ item: { title: 'Link', url: '/url', oneClick: true } });
+  it('shows one-click badge when oneClick is true', async () => {
+    await setup({ item: { title: 'Link', url: '/url', oneClick: true } });
 
     expect(screen.getByText('One click')).toBeInTheDocument();
   });

--- a/public/app/core/components/OptionsUI/actions.test.tsx
+++ b/public/app/core/components/OptionsUI/actions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ActionType, HttpRequestMethod, type Action, VariableOrigin, VariableSuggestionsScope } from '@grafana/data';
@@ -14,15 +14,21 @@ const makeAction = (title: string): Action => ({
 });
 
 describe('ActionsValueEditor', () => {
-  it('renders the actions editor container and add button', () => {
-    render(<ActionsValueEditor value={[]} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />);
+  it('renders the actions editor container and add button', async () => {
+    const { container } = render(
+      <ActionsValueEditor value={[]} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-rfd-droppable-id="sortable-links"]')).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId('actions-inline')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add action/i })).toBeInTheDocument();
   });
 
-  it('displays existing action titles in the list', () => {
-    render(
+  it('displays existing action titles in the list', async () => {
+    const { container } = render(
       <ActionsValueEditor
         value={[makeAction('Send Alert'), makeAction('Open Dashboard')]}
         onChange={jest.fn()}
@@ -30,6 +36,10 @@ describe('ActionsValueEditor', () => {
         item={editorItem}
       />
     );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(2);
+    });
 
     expect(screen.getByText('Send Alert')).toBeInTheDocument();
     expect(screen.getByText('Open Dashboard')).toBeInTheDocument();

--- a/public/app/core/components/OptionsUI/links.test.tsx
+++ b/public/app/core/components/OptionsUI/links.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { type DataLink, VariableOrigin, VariableSuggestionsScope } from '@grafana/data';
@@ -11,20 +11,32 @@ const editorItem = { settings: {} } as EditorItem;
 const makeLink = (title: string): DataLink => ({ title, url: 'https://grafana.com' });
 
 describe('DataLinksValueEditor', () => {
-  it('renders the links editor container and add button', () => {
-    render(<DataLinksValueEditor value={[]} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />);
+  it('renders the links editor container and add button', async () => {
+    const { container } = render(
+      <DataLinksValueEditor value={[]} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-rfd-droppable-id="sortable-links"]')).toBeInTheDocument();
+    });
 
     expect(screen.getByTestId('links-inline')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /add link/i })).toBeInTheDocument();
   });
 
-  it('displays existing link titles in the list', () => {
+  it('displays existing link titles in the list', async () => {
     const links: DataLink[] = [
       { title: 'Grafana Homepage', url: 'https://grafana.com' },
       { title: 'Docs', url: 'https://grafana.com/docs' },
     ];
 
-    render(<DataLinksValueEditor value={links} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />);
+    const { container } = render(
+      <DataLinksValueEditor value={links} onChange={jest.fn()} context={{ data: [] }} item={editorItem} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(2);
+    });
 
     expect(screen.getByText('Grafana Homepage')).toBeInTheDocument();
     expect(screen.getByText('Docs')).toBeInTheDocument();

--- a/public/app/features/actions/ActionsInlineEditor.test.tsx
+++ b/public/app/features/actions/ActionsInlineEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -45,17 +45,25 @@ describe('ActionsInlineEditor', () => {
     mockOnChange.mockClear();
   });
 
-  it('renders the add-action button with no actions', () => {
-    render(<ActionsInlineEditor {...defaultProps} />);
+  it('renders the add-action button with no actions', async () => {
+    const { container } = render(<ActionsInlineEditor {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-rfd-droppable-id="sortable-links"]')).toBeInTheDocument();
+    });
 
     expect(screen.getByRole('button', { name: /Add action/i })).toBeInTheDocument();
     expect(screen.getByTestId('actions-inline')).toBeInTheDocument();
   });
 
-  it('renders existing actions', () => {
+  it('renders existing actions', async () => {
     const actions = [buildFetchAction({ title: 'First action' }), buildFetchAction({ title: 'Second action' })];
 
-    render(<ActionsInlineEditor {...defaultProps} actions={actions} />);
+    const { container } = render(<ActionsInlineEditor {...defaultProps} actions={actions} />);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(2);
+    });
 
     expect(screen.getByText('First action')).toBeInTheDocument();
     expect(screen.getByText('Second action')).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/steps/Step1AlertmanagerResources.test.tsx
@@ -121,12 +121,15 @@ describe('Step1AlertmanagerResources', () => {
   });
 
   describe('Step1Content rendering', () => {
-    it('should render permission warning when canImport=false', () => {
+    it('should render permission warning when canImport=false', async () => {
       render(
         <TestWrapper>
           <Step1Content {...defaultStep1Props} canImport={false} />
         </TestWrapper>
       );
+
+      // The YAML source mounts a lazy template dropzone even without import permission.
+      expect(await screen.findByText(/drop template files here or click to upload/i)).toBeInTheDocument();
 
       expect(screen.getByText(/you do not have permission to import notification resources/i)).toBeInTheDocument();
       expect(screen.getByText(/insufficient permissions/i)).toBeInTheDocument();
@@ -185,7 +188,7 @@ describe('Step1AlertmanagerResources', () => {
       expect(screen.getByText(/select data source/i)).toBeInTheDocument();
     });
 
-    it('should render the notification templates uploader for the YAML source', () => {
+    it('should render the notification templates uploader for the YAML source', async () => {
       render(
         <TestWrapper defaultValues={{ notificationsSource: 'yaml' }}>
           <Step1Content {...defaultStep1Props} />
@@ -193,7 +196,7 @@ describe('Step1AlertmanagerResources', () => {
       );
 
       expect(screen.getByText(/notification templates/i)).toBeInTheDocument();
-      expect(screen.getByText(/drop template files here or click to upload/i)).toBeInTheDocument();
+      expect(await screen.findByText(/drop template files here or click to upload/i)).toBeInTheDocument();
     });
 
     it('should NOT render the templates uploader for the datasource source', () => {
@@ -215,7 +218,7 @@ describe('Step1AlertmanagerResources', () => {
       );
 
       // The dropzone's file input inherits the Field id, so its label resolves to it
-      const input = screen.getByLabelText(/notification templates/i);
+      const input = await screen.findByLabelText(/notification templates/i);
 
       await user.upload(input, [
         new File(['a'], 'dupe.tmpl', { type: 'text/plain' }),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList/DraggableList.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/DraggableList/DraggableList.test.tsx
@@ -33,8 +33,12 @@ function getDragHandle(label: string): HTMLElement | null {
 }
 
 describe('DraggableList', () => {
-  it('renders every item via renderItem', () => {
-    renderList();
+  it('renders every item via renderItem', async () => {
+    const { container } = renderList();
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(2);
+    });
 
     expect(screen.getByText('Item A')).toBeInTheDocument();
     expect(screen.getByText('Item B')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/QueriesAndTransformationsView.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 
 import { type DataQuery } from '@grafana/schema';
 
@@ -19,12 +19,16 @@ describe('QueryEditorSidebar', () => {
     jest.clearAllMocks();
   });
 
-  it('should always render transformations section even when no transformations exist', () => {
+  it('should always render transformations section even when no transformations exist', async () => {
     const queries: DataQuery[] = [{ refId: 'A', datasource: { type: 'test', uid: 'test' } }];
 
     renderWithQueryEditorProvider(<QueriesAndTransformationsView />, {
       queries,
       selectedQuery: queries[0],
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-rfd-droppable-id="query-sidebar-queries"]')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Transformations')).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -192,7 +192,7 @@ async function renderForm(dashboard: DashboardScene, changedSaveModel?: Dashboar
   cleanUp();
   cleanUp = dashboard.activate();
   dashboard.onEnterEditMode();
-  dashboard.openSaveDrawer({});
+  await dashboard.openSaveDrawer({});
 
   const drawer = dashboard.state.overlay as SaveDashboardDrawer;
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -1,3 +1,5 @@
+import { waitFor } from '@testing-library/react';
+
 import {
   CoreApp,
   type GrafanaConfig,
@@ -339,7 +341,7 @@ describe('DashboardScene', () => {
         expect(scene.state.meta.version).toEqual(2);
       });
 
-      it('Should exit edit mode after saving from unsaved changes modal when dashboardNewLayouts is enabled', () => {
+      it('Should exit edit mode after saving from unsaved changes modal when dashboardNewLayouts is enabled', async () => {
         const originalFeatureToggle = config.featureToggles.dashboardNewLayouts;
         config.featureToggles.dashboardNewLayouts = true;
 
@@ -348,29 +350,31 @@ describe('DashboardScene', () => {
         const publishSpy = jest.spyOn(appEvents, 'publish');
         const hasActualSaveChangesSpy = jest.spyOn(utils, 'hasActualSaveChanges').mockReturnValue(true);
 
-        scene.setState({ title: 'Updated title' });
-        expect(scene.state.isDirty).toBe(true);
-        scene.exitEditMode({ skipConfirm: false });
+        try {
+          scene.setState({ title: 'Updated title' });
+          expect(scene.state.isDirty).toBe(true);
+          scene.exitEditMode({ skipConfirm: false });
 
-        const modalCall = publishSpy.mock.calls.find((call) => call[0] instanceof ShowConfirmModalEvent);
-        expect(modalCall).toBeDefined();
+          const modalCall = publishSpy.mock.calls.find((call) => call[0] instanceof ShowConfirmModalEvent);
+          expect(modalCall).toBeDefined();
 
-        const modalEvent = modalCall![0] as ShowConfirmModalEvent;
-        expect(modalEvent.payload.altActionText).toBeDefined();
+          const modalEvent = modalCall![0] as ShowConfirmModalEvent;
+          expect(modalEvent.payload.altActionText).toBeDefined();
 
-        modalEvent.payload.onAltAction?.();
+          modalEvent.payload.onAltAction?.();
 
-        expect(scene.state.overlay).toBeDefined();
+          await waitFor(() => expect(scene.state.overlay).toBeInstanceOf(SaveDashboardDrawer));
 
-        const overlay = scene.state.overlay as SaveDashboardDrawer;
-        expect(overlay.state.onSaveSuccess).toBeDefined();
+          const overlay = scene.state.overlay as SaveDashboardDrawer;
+          expect(overlay.state.onSaveSuccess).toBeDefined();
 
-        overlay.state.onSaveSuccess!();
-        expect(scene.state.isEditing).toBe(false);
-
-        publishSpy.mockRestore();
-        hasActualSaveChangesSpy.mockRestore();
-        config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+          overlay.state.onSaveSuccess!();
+          expect(scene.state.isEditing).toBe(false);
+        } finally {
+          publishSpy.mockRestore();
+          hasActualSaveChangesSpy.mockRestore();
+          config.featureToggles.dashboardNewLayouts = originalFeatureToggle;
+        }
       });
 
       it('Should not show Save option in unsaved changes modal when user cannot save', () => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { render, userEvent } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -81,8 +81,12 @@ describe('RowItemRenderer', () => {
     expect(await navigator.clipboard.readText()).toContain('drow=My-row');
   });
 
-  it('hides the copy link button while editing', () => {
+  it('hides the copy link button while editing', async () => {
     renderRow({ isEditing: true });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-rfd-drag-handle-draggable-id="row-1"]')).toBeInTheDocument();
+    });
 
     expect(screen.queryByRole('button', { name: 'Copy link to row' })).not.toBeInTheDocument();
   });

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
 import { SceneTimeRange } from '@grafana/scenes';
@@ -9,7 +9,7 @@ import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager
 import { TabItem } from './TabItem';
 import { TabsLayoutManager } from './TabsLayoutManager';
 
-function renderTab({ title = 'Overview', key = 'tab-1' } = {}) {
+async function renderTab({ title = 'Overview', key = 'tab-1' } = {}) {
   const tab = new TabItem({
     key,
     title,
@@ -20,29 +20,31 @@ function renderTab({ title = 'Overview', key = 'tab-1' } = {}) {
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
     body: tabsLayout,
   });
-  render(<scene.Component model={scene} />);
+  await act(async () => {
+    render(<scene.Component model={scene} />);
+  });
   return { tab, tabsLayout };
 }
 
 describe('TabItemRenderer', () => {
-  it('stamps data-dashboard-element-key and data-dashboard-element-type on the tab', () => {
-    renderTab({ key: 'tab-1', title: 'Overview' });
+  it('stamps data-dashboard-element-key and data-dashboard-element-type on the tab', async () => {
+    await renderTab({ key: 'tab-1', title: 'Overview' });
 
     const tabEl = document.querySelector('[data-dashboard-element-key="tab-1"]');
     expect(tabEl).toBeInTheDocument();
     expect(tabEl).toHaveAttribute('data-dashboard-element-type', 'tab');
   });
 
-  it('stamps the element key for a second tab', () => {
-    renderTab({ key: 'tab-abc', title: 'Performance' });
+  it('stamps the element key for a second tab', async () => {
+    await renderTab({ key: 'tab-abc', title: 'Performance' });
 
     const tabEl = document.querySelector('[data-dashboard-element-key="tab-abc"]');
     expect(tabEl).toBeInTheDocument();
     expect(tabEl).toHaveAttribute('data-dashboard-element-type', 'tab');
   });
 
-  it('renders the tab title in the accessible label', () => {
-    renderTab({ title: 'Overview' });
+  it('renders the tab title in the accessible label', async () => {
+    await renderTab({ title: 'Overview' });
 
     expect(screen.getByRole('tab', { name: /Overview/i })).toBeInTheDocument();
   });

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
@@ -150,7 +150,7 @@ describe('VariableEditableElement', () => {
 
     renderVariableSidebar(dashboard);
 
-    await user.click(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
+    await user.click(await screen.findByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
     expect(dashboard.state.sidebar.state.openPane).toBeInstanceOf(VariableTypeChangePane);
     expect(screen.getByText('Change variable type')).toBeInTheDocument();
   });

--- a/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableTypeSelectionPane.test.tsx
@@ -118,7 +118,7 @@ describe('VariableTypeChangePane', () => {
 
     renderVariableSidebar(dashboard);
 
-    await user.click(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
+    await user.click(await screen.findByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
 
     await user.click(
       within(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.variableType('constant'))).getByRole(
@@ -149,7 +149,7 @@ describe('VariableTypeChangePane', () => {
 
     renderVariableSidebar(dashboard);
 
-    await user.click(screen.getByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
+    await user.click(await screen.findByTestId(selectors.components.PanelEditor.ElementEditPane.changeVariableType));
     expect(dashboard.state.sidebar.state.openPane).toBeInstanceOf(VariableTypeChangePane);
 
     await user.click(

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableMultiPropStaticOptionsForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableMultiPropStaticOptionsForm.test.tsx
@@ -35,8 +35,15 @@ function renderForm(props: Partial<VariableMultiPropStaticOptionsFormProps>) {
 
 describe('<VariableMultiPropStaticOptionsForm />', () => {
   describe('Rendering', () => {
-    test('renders a grid with column headers matching the properties and an "Add new option" button', () => {
-      const { getByRole, getAllByRole } = renderForm({ options: [], properties: ['text', 'value', 'color'] });
+    test('renders a grid with column headers matching the properties and an "Add new option" button', async () => {
+      const { container, getByRole, getAllByRole } = renderForm({
+        options: [],
+        properties: ['text', 'value', 'color'],
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('[data-rfd-droppable-id="static-options-list"]')).toBeInTheDocument();
+      });
 
       const grid = getByRole('grid', { name: 'Static options' });
       expect(grid).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/DashboardSidebarRenderer.test.tsx
@@ -200,7 +200,7 @@ describe('DashboardSidebarRenderer', () => {
 
       // Select the panel programmatically (clicking a panel in real UX)
       const panel = scene.state.body.getVizPanels()[0];
-      act(() => scene.state.sidebar.selectObject(panel));
+      await act(async () => scene.state.sidebar.selectObject(panel));
 
       // Sidebar pops up — effective isDocked is false during temp-show
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardFiltersList.test.tsx
@@ -80,14 +80,18 @@ afterEach(() => {
 });
 
 describe('<DashboardFiltersList />', () => {
-  test('renders 3 sections (one per filter display type)', () => {
+  test('renders 3 sections (one per filter display type)', async () => {
     const { visibleFilter1, visibleFilter2, controlsMenuFilter1, hiddenFilter1 } = buildTestFilters();
-    const { getByRole, elements } = renderFiltersList([
+    const { container, getByRole, elements } = renderFiltersList([
       hiddenFilter1,
       controlsMenuFilter1,
       visibleFilter2,
       visibleFilter1,
     ]);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(4);
+    });
 
     [/above dashboard/i, /controls menu/i, /hidden/i].forEach((name) => {
       expect(getByRole('heading', { name })).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardLinksList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardLinksList.test.tsx
@@ -81,9 +81,13 @@ afterEach(() => {
 });
 
 describe('<DashboardLinksList />', () => {
-  test('renders 2 sections (one per link display type)', () => {
+  test('renders 2 sections (one per link display type)', async () => {
     const { visibleLink1, visibleLink2, controlsMenuLink1 } = buildLinks();
-    const { getByRole, elements } = renderLinksList([controlsMenuLink1, visibleLink2, visibleLink1]);
+    const { container, getByRole, elements } = renderLinksList([controlsMenuLink1, visibleLink2, visibleLink1]);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(3);
+    });
 
     [/above dashboard/i, /controls menu/i].forEach((name) => {
       expect(getByRole('heading', { name })).toBeInTheDocument();
@@ -96,9 +100,13 @@ describe('<DashboardLinksList />', () => {
     expect(controlsMenuNames).toEqual(['controlsMenuLink1']);
   });
 
-  test('always renders the 2 section titles even if one is empty', () => {
+  test('always renders the 2 section titles even if one is empty', async () => {
     const { controlsMenuLink1 } = buildLinks();
-    const { getByRole } = renderLinksList([controlsMenuLink1]);
+    const { container, getByRole } = renderLinksList([controlsMenuLink1]);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+    });
 
     [/above dashboard/i, /controls menu/i].forEach((name) => {
       expect(getByRole('heading', { name })).toBeInTheDocument();

--- a/public/app/features/dashboard-scene/sidebar/dashboard/DashboardVariablesList.test.tsx
+++ b/public/app/features/dashboard-scene/sidebar/dashboard/DashboardVariablesList.test.tsx
@@ -100,9 +100,18 @@ afterEach(() => {
 });
 
 describe('<DashboardVariablesList />', () => {
-  test('renders 3 sections (one per variable display type)', () => {
+  test('renders 3 sections (one per variable display type)', async () => {
     const { visibleVar1, visibleVar2, controlsMenuVar1, hiddenVar1 } = buildTestVariables();
-    const { getByRole, elements } = renderVariablesList([hiddenVar1, controlsMenuVar1, visibleVar2, visibleVar1]);
+    const { container, getByRole, elements } = renderVariablesList([
+      hiddenVar1,
+      controlsMenuVar1,
+      visibleVar2,
+      visibleVar1,
+    ]);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(4);
+    });
 
     [/above dashboard/i, /controls menu/i, /hidden/i].forEach((name) => {
       expect(getByRole('heading', { name })).toBeInTheDocument();
@@ -118,16 +127,24 @@ describe('<DashboardVariablesList />', () => {
     expect(hiddenNames).toEqual(['ninjaVar1']);
   });
 
-  test('uses custom top placement label when provided', () => {
+  test('uses custom top placement label when provided', async () => {
     const { visibleVar1 } = buildTestVariables();
-    const { getByRole } = renderVariablesList([visibleVar1], { topPlacementLabel: 'Top of row' });
+    const { container, getByRole } = renderVariablesList([visibleVar1], { topPlacementLabel: 'Top of row' });
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+    });
 
     expect(getByRole('heading', { name: /top of row/i })).toBeInTheDocument();
   });
 
-  test('always renders all 3 section titles even when some are empty', () => {
+  test('always renders all 3 section titles even when some are empty', async () => {
     const { hiddenVar1 } = buildTestVariables();
-    const { getByRole } = renderVariablesList([hiddenVar1]);
+    const { container, getByRole } = renderVariablesList([hiddenVar1]);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(1);
+    });
 
     [/above dashboard/i, /controls menu/i, /hidden/i].forEach((name) => {
       expect(getByRole('heading', { name })).toBeInTheDocument();

--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingsEditorModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
@@ -41,12 +41,23 @@ const setup = (spy?: jest.Mock, propOverrides?: Partial<Props>) => {
 
   Object.assign(props, propOverrides);
 
-  render(<ValueMappingsEditorModal {...props} />);
+  return render(<ValueMappingsEditorModal {...props} />);
 };
 
 describe('ValueMappingsEditorModal', () => {
-  it('should render component', () => {
-    setup();
+  it('renders the existing value and range mappings with drag handles', async () => {
+    const { baseElement } = setup();
+
+    await waitFor(() => {
+      expect(baseElement.querySelectorAll('[data-rfd-drag-handle-draggable-id]')).toHaveLength(2);
+    });
+
+    expect(screen.getByPlaceholderText('Exact value to match')).toHaveValue('20');
+    expect(screen.getByPlaceholderText('From')).toHaveValue('21');
+    expect(screen.getByPlaceholderText('To')).toHaveValue('30');
+    const displayTextInputs = screen.getAllByPlaceholderText('Optional display text');
+    expect(displayTextInputs[0]).toHaveValue('Ok');
+    expect(displayTextInputs[1]).toHaveValue('Meh');
   });
 
   describe('On remove mapping', () => {


### PR DESCRIPTION
follow-up to https://github.com/grafana/grafana/pull/132304

extracting more tests from the now-green https://github.com/grafana/grafana/pull/131737

AI says:
---

## Description

### What changed?

This tests-only PR prepares existing tests for the lazy-loading changes in #131737. It changes 22 test files without changing production code.

The changes retain compatibility with eager components on main and introduce readiness waits for the asynchronous loading in the follow-up PR.

### Drag-and-drop readiness

Several list tests now wait for the expected number of elements with `data-rfd-drag-handle-draggable-id`.

These assertions establish readiness before existing interactions and assertions. They do not simulate a drag gesture or add new drag-and-drop behavior.

In the follow-up PR, a temporary implementation renders list content before the real drag-and-drop implementation loads. Visible text alone therefore does not establish readiness. The real implementation can subsequently remount that content.

- **Populated lists:** tests wait for the expected drag-handle count.
- **Empty lists:** tests wait for a specific, nonempty `data-rfd-droppable-id`, because zero drag handles cannot establish readiness.
- **Shared helpers:** affected render helpers and their callers now await initialization, with async `act` where appropriate.

These changes cover data links, actions, value mappings, query lists, and dashboard sidebar lists. Existing content, ordering, and interaction assertions remain.

### Other changes

- Use awaited queries for editor controls and template-upload inputs that can appear asynchronously.
- Await save-drawer creation before inspecting its state or invoking its callbacks.
- Restore feature flags and spies in `finally`, so failed assertions do not affect later tests.
- Wait for the template dropzone even in the permission-warning test, because that screen still mounts the uploader.

The changes use observable readiness conditions rather than fixed delays. They do not suppress console output or replace lazy components with synchronous mocks.

### Why a separate PR?

These test changes do not depend on the production refactors. A separate PR reduces the test-related diff in #131737 and keeps main’s existing imports and mocks.

### Validation

- The patch applies cleanly to main at `c6d5a2beff9053125bf80624bd34418e7b729f17`.
- Whitespace checks pass.
- A Git merge simulation confirms that #131737 merges cleanly on top, with no change to its final tree.
- Runtime tests remain unverified locally because project dependencies and Yarn are unavailable. CI must validate the tests on main.