### PR TITLE
Combobox: Fix async option loading with controlled isOpen

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -489,6 +489,28 @@ describe('Combobox', () => {
       expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
     });
 
+    it('preserves the search when opening a controlled Combobox is delayed', async () => {
+      const asyncOptions = jest.fn((searchTerm: string) =>
+        Promise.resolve(searchTerm === 'O' ? [{ value: 'Only match' }] : [{ value: 'Unfiltered option' }])
+      );
+
+      const { rerender } = render(
+        <Combobox options={asyncOptions} value={null} onChange={onChangeHandler} isOpen={false} />
+      );
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'O');
+      await act(async () => jest.advanceTimersByTimeAsync(DEBOUNCE_TIME_MS));
+
+      rerender(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} isOpen />);
+      await act(async () => jest.advanceTimersByTimeAsync(DEBOUNCE_TIME_MS));
+
+      expect(input).toHaveValue('O');
+      expect(asyncOptions).toHaveBeenCalledTimes(1);
+      expect(asyncOptions).toHaveBeenCalledWith('O');
+      expect(screen.getByRole('option', { name: 'Only match' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: 'Unfiltered option' })).not.toBeInTheDocument();
+    });
+
     it('should allow async options', async () => {
       const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
       render(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} />);

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -449,6 +449,46 @@ describe('Combobox', () => {
     // Assume that most apis only return with the value
     const simpleAsyncOptions = [{ value: 'Option 1' }, { value: 'Option 2' }, { value: 'Option 3' }];
 
+    it('loads async options when mounted with controlled isOpen', async () => {
+      const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
+      render(
+        <React.StrictMode>
+          <Combobox options={asyncOptions} value={null} onChange={onChangeHandler} isOpen />
+        </React.StrictMode>
+      );
+
+      await act(async () => jest.advanceTimersByTimeAsync(DEBOUNCE_TIME_MS));
+
+      expect(asyncOptions).toHaveBeenCalledTimes(1);
+      expect(asyncOptions).toHaveBeenCalledWith('');
+      expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+    });
+
+    it('loads async options once when opening a controlled Combobox', async () => {
+      const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
+
+      function ControlledCombobox() {
+        const [isOpen, setIsOpen] = React.useState(false);
+        return (
+          <Combobox
+            options={asyncOptions}
+            value={null}
+            onChange={onChangeHandler}
+            isOpen={isOpen}
+            onIsOpenChange={setIsOpen}
+          />
+        );
+      }
+
+      render(<ControlledCombobox />);
+      await user.click(screen.getByRole('combobox'));
+      await act(async () => jest.advanceTimersByTimeAsync(DEBOUNCE_TIME_MS));
+
+      expect(asyncOptions).toHaveBeenCalledTimes(1);
+      expect(asyncOptions).toHaveBeenCalledWith('');
+      expect(screen.getByRole('option', { name: 'Option 1' })).toBeInTheDocument();
+    });
+
     it('should allow async options', async () => {
       const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
       render(<Combobox options={asyncOptions} value={null} onChange={onChangeHandler} />);

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { useVirtualizer, type Range } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
-import React, { type ComponentProps, useCallback, useEffect, useId, useMemo, useState } from 'react';
+import React, { type ComponentProps, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -194,15 +194,17 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     resetSearch,
   } = useOptions(allOptions, createCustomValue, customValueDescription);
   const isAsync = typeof allOptions === 'function';
+  const searchTermRef = useRef('');
 
   useEffect(() => {
     if (isOpenProp === undefined) {
       return;
     }
 
-    if (isOpenProp) {
+    if (isOpenProp && searchTermRef.current === '') {
       updateOptions('');
-    } else {
+    } else if (!isOpenProp) {
+      searchTermRef.current = '';
       resetSearch();
     }
   }, [isOpenProp, resetSearch, updateOptions]);
@@ -253,6 +255,7 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
         }
 
         if (!changes.isOpen) {
+          searchTermRef.current = '';
           resetSearch();
         }
       }
@@ -364,10 +367,13 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
       setShowFocusRing(isKeyboardEvent(type));
 
       switch (type) {
-        case useCombobox.stateChangeTypes.InputChange:
-          updateOptions(newInputValue ?? '');
+        case useCombobox.stateChangeTypes.InputChange: {
+          const searchTerm = newInputValue ?? '';
+          searchTermRef.current = searchTerm;
+          updateOptions(searchTerm);
 
           break;
+        }
         default:
           break;
       }

--- a/packages/grafana-ui/src/components/Combobox/Combobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { useVirtualizer, type Range } from '@tanstack/react-virtual';
 import { useCombobox } from 'downshift';
-import React, { type ComponentProps, useCallback, useId, useMemo, useState } from 'react';
+import React, { type ComponentProps, useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 
@@ -195,6 +195,18 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
   } = useOptions(allOptions, createCustomValue, customValueDescription);
   const isAsync = typeof allOptions === 'function';
 
+  useEffect(() => {
+    if (isOpenProp === undefined) {
+      return;
+    }
+
+    if (isOpenProp) {
+      updateOptions('');
+    } else {
+      resetSearch();
+    }
+  }, [isOpenProp, resetSearch, updateOptions]);
+
   const selectedItemIndex = useMemo(() => {
     if (isAsync) {
       return null;
@@ -235,15 +247,17 @@ export const Combobox = <T extends string | number>(props: ComboboxProps<T>) => 
     (changes: { isOpen: boolean; inputValue?: string }) => {
       onIsOpenChangeProp?.(changes.isOpen);
 
-      if (changes.isOpen && (changes.inputValue ?? '') === '') {
-        updateOptions('');
-      }
+      if (isOpenProp === undefined) {
+        if (changes.isOpen && (changes.inputValue ?? '') === '') {
+          updateOptions('');
+        }
 
-      if (!changes.isOpen) {
-        resetSearch();
+        if (!changes.isOpen) {
+          resetSearch();
+        }
       }
     },
-    [onIsOpenChangeProp, updateOptions, resetSearch]
+    [isOpenProp, onIsOpenChangeProp, updateOptions, resetSearch]
   );
 
   // Injects the group header for the first rendered item into the range to render.


### PR DESCRIPTION
**What is this feature?**

Makes async option loading follow controlled `isOpen` state changes. Opening loads the initial options when no search is active, while preserving searches started before the parent opens the Combobox. Closing resets the search.

Uncontrolled Combobox behavior remains unchanged.

**Why do we need this feature?**

Async loading previously depended on Downshift requesting an open-state change. When a consumer opened the Combobox directly through the controlled `isOpen` prop, that callback did not run and the menu could open without loading any options.

Controlled opening can also be delayed after a user starts searching, so opening must not replace the active search with an unfiltered request.

**Who is this feature for?**

Consumers using an async Combobox with controlled open state.

**Special notes for your reviewer:**

Added coverage for initially open, immediately opened, and delayed controlled Comboboxes, including duplicate-load and search-preservation cases.

Tested with:

`yarn jest packages/grafana-ui/src/components/Combobox/Combobox.test.tsx --watchAll=false`