### PR TITLE
Alerting: Back-date default silence startsAt to tolerate client clock

### DIFF
--- a/public/app/features/alerting/unified/components/silences/utils.test.ts
+++ b/public/app/features/alerting/unified/components/silences/utils.test.ts
@@ -1,0 +1,24 @@
+import { getDefaultSilenceFormValues } from './utils';
+
+describe('getDefaultSilenceFormValues', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('back-dates startsAt by 60 seconds to tolerate the browser clock running ahead of the Alertmanager server', () => {
+    const { startsAt } = getDefaultSilenceFormValues();
+
+    expect(startsAt).toBe('2024-01-01T11:59:00.000Z');
+  });
+
+  it('keeps the default silence duration at 2 hours from the back-dated startsAt', () => {
+    const { startsAt, endsAt } = getDefaultSilenceFormValues();
+
+    expect(startsAt).toBe('2024-01-01T11:59:00.000Z');
+    expect(endsAt).toBe('2024-01-01T13:59:00.000Z');
+  });
+});

--- a/public/app/features/alerting/unified/components/silences/utils.ts
+++ b/public/app/features/alerting/unified/components/silences/utils.ts
@@ -7,6 +7,9 @@ import { MatcherOperator, type Silence } from 'app/plugins/datasource/alertmanag
 
 import { contextSrv } from '../../../../../core/services/context_srv';
 
+// Tolerance for the browser clock running ahead of the Alertmanager server clock when creating a new silence.
+const CLOCK_SKEW_BUFFER_SECONDS = 60;
+
 /**
  * Parse query params and return default silence form values
  */
@@ -63,10 +66,11 @@ export const getFormFieldsForSilence = (silence: Silence): SilenceFormFields => 
 export const getDefaultSilenceFormValues = (partial?: Partial<SilenceFormFields>): SilenceFormFields => {
   const now = new Date();
 
-  const endsAt = addDurationToDate(now, { hours: 2 }); // Default time period is now + 2h
+  const startsAt = addDurationToDate(now, { seconds: -CLOCK_SKEW_BUFFER_SECONDS });
+  const endsAt = addDurationToDate(startsAt, { hours: 2 });
   return {
     id: '',
-    startsAt: now.toISOString(),
+    startsAt: startsAt.toISOString(),
     endsAt: endsAt.toISOString(),
     comment: `created ${dateTime().format('YYYY-MM-DD HH:mm')}`,
     createdBy: contextSrv.user.name,


### PR DESCRIPTION
What is this feature?
Back-dates the default startsAt for a new silence by 60 seconds instead of using the browser's local clock unbuffered.

Why do we need this feature?

Silences created from a notification's silence link used the browser's local clock for startsAt with no tolerance. If the client clock ran even slightly ahead of the Alertmanager server clock, the created silence landed in pending state instead of active and suppressed nothing until real time caught up, making it look like silencing had no effect.

Which issue(s) does this PR fix?
Fixes #90447

Special notes for your reviewer:
Regression test added in utils.test.ts, verified to fail on main without this change and pass with it.