### PR TITLE
PR automation: route squad PRs to their project board

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -44,6 +44,27 @@
   {
     "type": "changedfiles",
     "matches": [
+      "pkg/services/ssosettings/**/*",
+      "pkg/services/auth/**/*",
+      "pkg/services/authn/**/*",
+      "pkg/services/ldap/**/*",
+      "pkg/services/login/**/*",
+      "pkg/services/loginattempt/**/*",
+      "pkg/services/oauthtoken/**/*",
+      "pkg/services/serviceaccounts/**/*",
+      "pkg/services/signingkeys/**/*",
+      "pkg/services/scimutil/**/*",
+      "pkg/login/**/*",
+      "public/app/features/auth-config/**/*",
+      "conf/ldap.toml",
+      "conf/ldap_multiple.toml"
+    ],
+    "action": "updateLabel",
+    "addLabel": "area/auth"
+  },
+  {
+    "type": "changedfiles",
+    "matches": [
       "pkg/services/sqlstore/migrations/**/*",
       "**/*_mig.go"
     ],
@@ -301,6 +322,14 @@
     "action": "addToProject",
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/190"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/660"
     }
   },
   {


### PR DESCRIPTION
## Summary
- External and internal PRs touching identity-squad-owned auth code (`pkg/services/ssosettings`, `auth`, `authn`, `ldap`, `login`, `serviceaccounts`, `signingkeys`, `scimutil`, `pkg/login`, the `auth-config` UI feature, and the LDAP conf files) only ever picked up the generic `area/backend` label from the existing catch-all `**/*.go` rule, so they never got tagged with anything identity-squad-specific.
- The issues side (`.github/commands.json`) already has a rule mapping the `area/auth` label to a project, but PRs had no equivalent in `.github/pr-commands.json` — neither a path-based rule to apply the label, nor a label-based rule to add the project.
- Adds both: a `changedfiles` rule that labels matching PRs `area/auth`, and a `label` rule that adds `area/auth` PRs to https://github.com/orgs/grafana/projects/660.
- Deliberately targets project 660 only. `commands.json`'s `area/auth` entry also points at project 86, but that project is closed — a separate, pre-existing inconsistency on the issues side that's out of scope here.
