### PR TITLE
Search: count result formats

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -33,6 +33,7 @@ type BleveIndexMetrics struct {
 	IndexDiskCleanupDirsDeleted *prometheus.CounterVec
 
 	SearchCapabilityViolations *prometheus.CounterVec
+	SearchResultFormats        *prometheus.CounterVec
 
 	BuildPhaseSeconds *prometheus.CounterVec
 	BuildDocuments    *prometheus.CounterVec
@@ -193,6 +194,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Name: "index_server_search_capability_violations_total",
 			Help: "Number of search requests that used a field in a way its declaration does not allow. Counted whether or not the request was rejected.",
 		}, []string{"resource", "capability"}),
+		SearchResultFormats: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_search_result_format_total",
+			Help: "Number of search responses by result format.",
+		}, []string{"format"}),
 	}
 
 	// Always-on label series. Snapshot-specific series are initialised separately
@@ -200,6 +205,8 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 	// is disabled — see InitSnapshotMetrics for rationale.
 	m.OpenIndexes.WithLabelValues("file").Set(0)
 	m.OpenIndexes.WithLabelValues("memory").Set(0)
+	m.SearchResultFormats.WithLabelValues("resource_table").Add(0)
+	m.SearchResultFormats.WithLabelValues("field_values").Add(0)
 	return m
 }
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2248,6 +2248,13 @@ func (b *bleveIndex) CountManagedObjects(ctx context.Context, stats *resource.Se
 	return vals, nil
 }
 
+func (b *bleveIndex) observeSearchResultFormat(response *resourcepb.ResourceSearchResponse) {
+	if b.indexMetrics == nil || response.GetResultFormat() == resourcepb.ResourceSearchRequest_UNSPECIFIED {
+		return
+	}
+	b.indexMetrics.SearchResultFormats.WithLabelValues(strings.ToLower(response.ResultFormat.String())).Inc()
+}
+
 func (b *bleveIndex) initialSearchResponse(req *resourcepb.ResourceSearchRequest) *resourcepb.ResourceSearchResponse {
 	resultFormat, err := selectedResultFormat(req.ResultFormat)
 	if err != nil {
@@ -2274,14 +2281,17 @@ func (b *bleveIndex) Search(
 	req *resourcepb.ResourceSearchRequest,
 	federate []resource.ResourceIndex, // For federated queries, these will match the values in req.federate
 	stats *resource.SearchStats,
-) (*resourcepb.ResourceSearchResponse, error) {
+) (response *resourcepb.ResourceSearchResponse, _ error) {
 	ctx, span := tracer.Start(ctx, "search.bleveIndex.Search")
 	defer span.End()
 
-	response := b.initialSearchResponse(req)
+	response = b.initialSearchResponse(req)
 	if response.Error != nil {
 		return response, nil
 	}
+	defer func() {
+		b.observeSearchResultFormat(response)
+	}()
 
 	// Verifies the index federation
 	index, err := b.getIndex(ctx, req, federate)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	authlib "github.com/grafana/authlib/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	apischema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
@@ -690,6 +692,40 @@ func TestFieldValueSearchResults(t *testing.T) {
 	})
 }
 
+func TestSearchResultFormatMetric(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	metrics := resource.ProvideIndexMetrics(reg)
+	index := newTestDashboardsIndexWithMetrics(t, threshold, 0, noop, metrics)
+
+	for _, tc := range []struct {
+		requestFormat resourcepb.ResourceSearchRequest_ResultFormat
+		resultFormat  resourcepb.ResourceSearchRequest_ResultFormat
+		label         string
+	}{
+		{requestFormat: resourcepb.ResourceSearchRequest_UNSPECIFIED, resultFormat: resourcepb.ResourceSearchRequest_RESOURCE_TABLE, label: "resource_table"},
+		{requestFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES, resultFormat: resourcepb.ResourceSearchRequest_FIELD_VALUES, label: "field_values"},
+	} {
+		req := newTestQuery("")
+		req.ResultFormat = tc.requestFormat
+
+		res, err := index.Search(t.Context(), nil, req, nil, nil)
+		require.NoError(t, err)
+		require.Nil(t, res.Error)
+		require.Equal(t, tc.resultFormat, res.ResultFormat)
+		require.Equal(t, 1.0, testutil.ToFloat64(metrics.SearchResultFormats.WithLabelValues(tc.label)))
+	}
+
+	invalid := newTestQuery("")
+	invalid.Fields = []string{"does_not_exist"}
+	invalid.ResultFormat = resourcepb.ResourceSearchRequest_FIELD_VALUES
+	res, err := index.Search(t.Context(), nil, invalid, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, res.Error)
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.SearchResultFormats.WithLabelValues("field_values")), "a response without a result format is not counted")
+
+	require.Equal(t, 2, testutil.CollectAndCount(metrics.SearchResultFormats, "index_server_search_result_format_total"))
+}
+
 func newQueryByTitle(query string) *resourcepb.ResourceSearchRequest {
 	return &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{
@@ -1045,6 +1081,10 @@ func TestPublicFieldNameTextQuery(t *testing.T) {
 }
 
 func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer resource.BuildFn) resource.ResourceIndex {
+	return newTestDashboardsIndexWithMetrics(t, threshold, size, writer, nil)
+}
+
+func newTestDashboardsIndexWithMetrics(t testing.TB, threshold int64, size int64, writer resource.BuildFn, metrics *resource.BleveIndexMetrics) resource.ResourceIndex {
 	key := &resourcepb.ResourceKey{
 		Namespace: "default",
 		Group:     "dashboard.grafana.app",
@@ -1057,7 +1097,7 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 		SearchFields: resource.NewSearchFieldsRegistry(nil, nil, map[resource.LowerGroupResource]resource.SearchFieldsProvider{
 			resource.NewLowerGroupResource("dashboard.grafana.app", "dashboards"): search.DashboardSearchFieldsProviderForTest(),
 		}),
-	}, nil)
+	}, metrics)
 	require.NoError(t, err)
 
 	t.Cleanup(backend.Stop)


### PR DESCRIPTION
Adds `index_server_search_result_format_total`, counting search responses by their returned result format.

This lets us confirm adoption of field-value results while the client migrations remain behind rollout controls. Responses without a result format are not counted.

Part of https://github.com/grafana/search-and-storage-team/issues/890