### PR TITLE
Profile: Improve settings heading semantics

### DIFF
--- a/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.test.tsx
@@ -45,7 +45,7 @@ const selectComboboxOptionInTest = async (
 };
 
 const setup = async () => {
-  const view = render(<SharedPreferences resourceUri="user" preferenceType="user" />);
+  const view = render(<SharedPreferences resourceUri="user" preferenceType="user" legend="Preferences" />);
   const themeSelect = await screen.findByRole('combobox', { name: /Interface theme/ });
   await waitFor(() => expect(themeSelect).not.toBeDisabled());
   return view;
@@ -211,7 +211,7 @@ describe('SharedPreferences', () => {
     server.use(
       preferencesHandlers.listPreferencesHandler(HttpResponse.json({ message: 'Server error' }, { status: 500 }))
     );
-    render(<SharedPreferences resourceUri="user" preferenceType="user" />);
+    render(<SharedPreferences resourceUri="user" preferenceType="user" legend="Preferences" />);
     expect(await screen.findByText('Error loading preferences')).toBeInTheDocument();
   });
   it('shows an error alert when saving preferences fails', async () => {
@@ -227,7 +227,7 @@ describe('SharedPreferences', () => {
     const onConfirm = jest.fn().mockResolvedValue(false);
     const capture = captureRequests((r) => r.url.includes('/preferences') && r.method === 'PATCH');
 
-    render(<SharedPreferences resourceUri="user" preferenceType="user" onConfirm={onConfirm} />);
+    render(<SharedPreferences resourceUri="user" preferenceType="user" onConfirm={onConfirm} legend="Preferences" />);
     const themeSelect = await screen.findByRole('combobox', { name: /Interface theme/ });
     await waitFor(() => expect(themeSelect).not.toBeDisabled());
 
@@ -239,7 +239,7 @@ describe('SharedPreferences', () => {
     expect(mockReload).not.toHaveBeenCalled();
   });
   it('renders all form fields as disabled when disabled prop is true', async () => {
-    render(<SharedPreferences resourceUri="user" preferenceType="user" disabled />);
+    render(<SharedPreferences resourceUri="user" preferenceType="user" disabled legend="Preferences" />);
     const themeSelect = await screen.findByRole('combobox', { name: /Interface theme/ });
     await waitFor(() => expect(themeSelect).toBeDisabled());
 

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -1,5 +1,5 @@
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import { memo, useState, useEffect } from 'react';
+import { memo, useState, useEffect, type ReactNode } from 'react';
 
 import { FeatureState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -32,8 +32,12 @@ import { homeDashboardChanged, languageChanged, saveButtonClicked, themeChanged 
 import { useSharedPreferences } from './useSharedPreferences';
 import { getLanguageOptions, getStyles, getTranslatedThemeName, type PrefsState, type Props } from './utils';
 
-export const SharedPreferences = memo((props: Props) => {
-  const { resourceUri, preferenceType } = props;
+type SharedPreferencesProps = Props & {
+  legend: ReactNode;
+};
+
+export const SharedPreferences = memo((props: SharedPreferencesProps) => {
+  const { resourceUri, preferenceType, legend } = props;
 
   const [updatePreferences, { preferences: prefs, isLoading, isError, isUpdating, isUpdateError }] =
     useSharedPreferences(resourceUri);
@@ -177,14 +181,7 @@ export const SharedPreferences = memo((props: Props) => {
           title={t('shared-preferences.error.update-preferences', 'Error updating preferences')}
         />
       )}
-      <FieldSet
-        label={
-          <span role="heading" aria-level={2}>
-            <Trans i18nKey="shared-preferences.title">Preferences</Trans>
-          </span>
-        }
-        disabled={props.disabled}
-      >
+      <FieldSet label={legend} disabled={props.disabled}>
         <Stack direction="column" gap={2}>
           {preferenceType === 'user' && <VisualRefreshInfo />}
           <Field

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -177,7 +177,14 @@ export const SharedPreferences = memo((props: Props) => {
           title={t('shared-preferences.error.update-preferences', 'Error updating preferences')}
         />
       )}
-      <FieldSet label={<Trans i18nKey="shared-preferences.title">Preferences</Trans>} disabled={props.disabled}>
+      <FieldSet
+        label={
+          <span role="heading" aria-level={2}>
+            <Trans i18nKey="shared-preferences.title">Preferences</Trans>
+          </span>
+        }
+        disabled={props.disabled}
+      >
         <Stack direction="column" gap={2}>
           {preferenceType === 'user' && <VisualRefreshInfo />}
           <Field

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -30,11 +30,15 @@ import { getSelectableThemes } from '../ThemeSelector/getSelectableThemes';
 
 import { homeDashboardChanged, languageChanged, saveButtonClicked, themeChanged } from './analytics/main';
 import { useSharedPreferences } from './useSharedPreferences';
-import { getLanguageOptions, getStyles, getTranslatedThemeName, type PrefsState, type Props } from './utils';
+import { getLanguageOptions, getStyles, getTranslatedThemeName, type PrefsState } from './utils';
 
-type SharedPreferencesProps = Props & {
+interface SharedPreferencesProps {
+  resourceUri: string;
+  disabled?: boolean;
+  preferenceType: 'org' | 'team' | 'user';
+  onConfirm?: () => Promise<boolean>;
   legend: ReactNode;
-};
+}
 
 export const SharedPreferences = memo((props: SharedPreferencesProps) => {
   const { resourceUri, preferenceType, legend } = props;

--- a/public/app/core/components/SharedPreferences/useSharedPreferences.ts
+++ b/public/app/core/components/SharedPreferences/useSharedPreferences.ts
@@ -6,9 +6,7 @@ import {
   type PreferencesSpec,
 } from '@grafana/api-clients/rtkq/preferences/v1';
 
-import { type Props } from './utils';
-
-export const useSharedPreferences = (preferencesName: Props['resourceUri']) => {
+export const useSharedPreferences = (preferencesName: string) => {
   const { data, isLoading, isError } = useListPreferencesQuery({ fieldSelector: `metadata.name=${preferencesName}` });
   const [updatePreferences, { data: updateData, isLoading: isUpdating, isError: isUpdateError }] =
     useUpdatePreferencesMutation();

--- a/public/app/core/components/SharedPreferences/utils.ts
+++ b/public/app/core/components/SharedPreferences/utils.ts
@@ -5,13 +5,6 @@ import { type ThemeRegistryItem } from '@grafana/data';
 import { LANGUAGES, PSEUDO_LOCALE, t } from '@grafana/i18n';
 import { type ComboboxOption } from '@grafana/ui';
 
-export interface Props {
-  resourceUri: string;
-  disabled?: boolean;
-  preferenceType: 'org' | 'team' | 'user';
-  onConfirm?: () => Promise<boolean>;
-}
-
 export type PrefsState = UserPreferencesDTO;
 
 const compareStrings = (() => {

--- a/public/app/features/org/OrgDetailsPage.tsx
+++ b/public/app/features/org/OrgDetailsPage.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect } from 'react';
 import { type ConnectedProps, connect } from 'react-redux';
 
 import { t } from '@grafana/i18n';
-import { Stack } from '@grafana/ui';
+import { Stack, Text } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
@@ -65,6 +65,11 @@ export const OrgDetailsPage = memo(function OrgDetailsPage({
             {canReadOrg && <OrgProfile onSubmit={onUpdateOrganization} orgName={organization.name} />}
             {canReadPreferences && (
               <SharedPreferences
+                legend={
+                  <Text element="h2" variant="h3">
+                    {t('shared-preferences.title', 'Preferences')}
+                  </Text>
+                }
                 resourceUri={orgResourceUri}
                 disabled={!canWritePreferences}
                 preferenceType="org"

--- a/public/app/features/org/OrgDetailsPage.tsx
+++ b/public/app/features/org/OrgDetailsPage.tsx
@@ -66,7 +66,7 @@ export const OrgDetailsPage = memo(function OrgDetailsPage({
             {canReadPreferences && (
               <SharedPreferences
                 legend={
-                  <Text element="h2" variant="h3">
+                  <Text element="h2" variant="h2">
                     {t('shared-preferences.title', 'Preferences')}
                   </Text>
                 }

--- a/public/app/features/profile/UserOrganizations.tsx
+++ b/public/app/features/profile/UserOrganizations.tsx
@@ -1,18 +1,19 @@
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Button, LoadingPlaceholder, ScrollContainer, Text } from '@grafana/ui';
+import { Button, LoadingPlaceholder, ScrollContainer } from '@grafana/ui';
 import { type UserDTO, type UserOrg } from 'app/types/user';
 
 interface Props {
   user: UserDTO | null;
   orgs: UserOrg[];
   isLoading: boolean;
+  heading: ReactNode;
   setUserOrg: (org: UserOrg) => void;
 }
 
-const UserOrganizations = memo<Props>(({ isLoading, orgs, user, setUserOrg }) => {
+const UserOrganizations = memo<Props>(({ isLoading, orgs, user, setUserOrg, heading }) => {
   if (isLoading) {
     return (
       <LoadingPlaceholder
@@ -27,11 +28,7 @@ const UserOrganizations = memo<Props>(({ isLoading, orgs, user, setUserOrg }) =>
 
   return (
     <div>
-      <div>
-        <Text variant="h2" element="h2">
-          <Trans i18nKey="user-orgs.title">Organizations</Trans>
-        </Text>
-      </div>
+      {heading}
 
       <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
         <table className="filter-table form-inline" data-testid={selectors.components.UserProfile.orgsTable}>

--- a/public/app/features/profile/UserOrganizations.tsx
+++ b/public/app/features/profile/UserOrganizations.tsx
@@ -27,7 +27,7 @@ const UserOrganizations = memo<Props>(({ isLoading, orgs, user, setUserOrg }) =>
 
   return (
     <div>
-      <div className="page-sub-heading">
+      <div>
         <Text variant="h2" element="h2">
           <Trans i18nKey="user-orgs.title">Organizations</Trans>
         </Text>

--- a/public/app/features/profile/UserOrganizations.tsx
+++ b/public/app/features/profile/UserOrganizations.tsx
@@ -28,7 +28,7 @@ const UserOrganizations = memo<Props>(({ isLoading, orgs, user, setUserOrg }) =>
   return (
     <div>
       <div className="page-sub-heading">
-        <Text variant="h3" element="h2">
+        <Text variant="h2" element="h2">
           <Trans i18nKey="user-orgs.title">Organizations</Trans>
         </Text>
       </div>

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -209,11 +209,11 @@ describe('UserProfileEditPage', () => {
       expect(saveProfile()).toBeInTheDocument();
     });
 
-    it('should show shared preferences', async () => {
+    it('should show Preferences as a level-two heading in its group', async () => {
       await getTestContext();
 
-      // SharedPreferences itself is tested, so here just make sure it's being rendered
-      expect(screen.getByLabelText('Home Dashboard')).toBeInTheDocument();
+      const preferences = await screen.findByRole('group', { name: 'Preferences' });
+      expect(within(preferences).getByRole('heading', { name: 'Preferences', level: 2 })).toBeInTheDocument();
     });
 
     describe('and teams are loading', () => {
@@ -229,7 +229,7 @@ describe('UserProfileEditPage', () => {
         await getTestContext();
 
         const { teamsTable, teamsRow } = getSelectors();
-        expect(screen.getByRole('heading', { name: /teams/i })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: /teams/i, level: 2 })).toBeInTheDocument();
         expect(teamsTable()).toBeInTheDocument();
         expect(teamsRow()).toBeInTheDocument();
       });

--- a/public/app/features/profile/UserProfileEditPage.test.tsx
+++ b/public/app/features/profile/UserProfileEditPage.test.tsx
@@ -217,10 +217,11 @@ describe('UserProfileEditPage', () => {
     });
 
     describe('and teams are loading', () => {
-      it('should show teams loading placeholder', async () => {
+      it('should show teams loading placeholder without a Teams heading', async () => {
         await getTestContext({ teamsAreLoading: true });
 
         expect(screen.getByText(/loading teams\.\.\./i)).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Teams', level: 2 })).not.toBeInTheDocument();
       });
     });
 
@@ -232,6 +233,15 @@ describe('UserProfileEditPage', () => {
         expect(screen.getByRole('heading', { name: /teams/i, level: 2 })).toBeInTheDocument();
         expect(teamsTable()).toBeInTheDocument();
         expect(teamsRow()).toBeInTheDocument();
+      });
+    });
+
+    describe('and no teams are loaded', () => {
+      it('should not show a Teams heading', async () => {
+        await getTestContext({ teams: [] });
+
+        expect(screen.getByRole('heading', { name: 'Preferences', level: 2 })).toBeInTheDocument();
+        expect(screen.queryByRole('heading', { name: 'Teams', level: 2 })).not.toBeInTheDocument();
       });
     });
 

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -81,14 +81,16 @@ export function UserProfileEditPage({
               }
             />
             <Stack direction="column" gap={6}>
-              {!teamsAreLoading && teams.length > 0 && (
-                <div className="page-sub-heading">
-                  <Text element="h2" variant="h2">
-                    <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
-                  </Text>
-                </div>
+              {(teamsAreLoading || teams.length > 0) && (
+                <section>
+                  {!teamsAreLoading && teams.length > 0 && (
+                    <Text element="h2" variant="h2">
+                      <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
+                    </Text>
+                  )}
+                  <UserTeams isLoading={teamsAreLoading} teams={teams} />
+                </section>
               )}
-              <UserTeams isLoading={teamsAreLoading} teams={teams} />
               <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
               <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
             </Stack>

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -69,8 +69,9 @@ export function UserProfileEditPage({
     <Page navId="profile/settings">
       <Page.Contents isLoading={!user || isLoading}>
         <UserProfileEditTabs components={components}>
-          <Stack direction="column" gap={2} data-testid="user-profile-edit-page">
+          <Stack direction="column" gap={6} data-testid="user-profile-edit-page">
             <UserProfileEditForm updateProfile={updateUserProfile} isSavingUser={isUpdating} user={user} />
+
             <SharedPreferences
               resourceUri={userResourceUri}
               preferenceType="user"
@@ -80,20 +81,39 @@ export function UserProfileEditPage({
                 </Text>
               }
             />
-            <Stack direction="column" gap={6}>
-              {(teamsAreLoading || teams.length > 0) && (
-                <section>
-                  {!teamsAreLoading && teams.length > 0 && (
-                    <Text element="h2" variant="h2">
-                      <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
-                    </Text>
-                  )}
-                  <UserTeams isLoading={teamsAreLoading} teams={teams} />
-                </section>
-              )}
-              <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
-              <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />
-            </Stack>
+
+            <UserTeams
+              isLoading={teamsAreLoading}
+              teams={teams}
+              heading={
+                <Text element="h2" variant="h2">
+                  <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
+                </Text>
+              }
+            />
+
+            <UserOrganizations
+              isLoading={orgsAreLoading}
+              setUserOrg={changeUserOrg}
+              orgs={orgs}
+              user={user}
+              heading={
+                <Text variant="h2" element="h2">
+                  <Trans i18nKey="user-orgs.title">Organizations</Trans>
+                </Text>
+              }
+            />
+
+            <UserSessions
+              isLoading={sessionsAreLoading}
+              revokeUserSession={revokeUserSession}
+              sessions={sessions}
+              heading={
+                <Text variant="h2" element="h2">
+                  <Trans i18nKey="profile.user-sessions.sessions">Sessions</Trans>
+                </Text>
+              }
+            />
           </Stack>
         </UserProfileEditTabs>
       </Page.Contents>

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -75,7 +75,7 @@ export function UserProfileEditPage({
               resourceUri={userResourceUri}
               preferenceType="user"
               legend={
-                <Text element="h2" variant="h3">
+                <Text element="h2" variant="h2">
                   <Trans i18nKey="shared-preferences.title">Preferences</Trans>
                 </Text>
               }
@@ -83,7 +83,7 @@ export function UserProfileEditPage({
             <Stack direction="column" gap={6}>
               {!teamsAreLoading && teams.length > 0 && (
                 <div className="page-sub-heading">
-                  <Text element="h2" variant="h3">
+                  <Text element="h2" variant="h2">
                     <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
                   </Text>
                 </div>

--- a/public/app/features/profile/UserProfileEditPage.tsx
+++ b/public/app/features/profile/UserProfileEditPage.tsx
@@ -2,8 +2,9 @@ import { connect, type ConnectedProps } from 'react-redux';
 import { useMount } from 'react-use';
 
 import { PluginExtensionPoints } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { usePluginComponents } from '@grafana/runtime';
-import { Stack } from '@grafana/ui';
+import { Stack, Text } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { type StoreState } from 'app/types/store';
 
@@ -70,8 +71,23 @@ export function UserProfileEditPage({
         <UserProfileEditTabs components={components}>
           <Stack direction="column" gap={2} data-testid="user-profile-edit-page">
             <UserProfileEditForm updateProfile={updateUserProfile} isSavingUser={isUpdating} user={user} />
-            <SharedPreferences resourceUri={userResourceUri} preferenceType="user" />
+            <SharedPreferences
+              resourceUri={userResourceUri}
+              preferenceType="user"
+              legend={
+                <Text element="h2" variant="h3">
+                  <Trans i18nKey="shared-preferences.title">Preferences</Trans>
+                </Text>
+              }
+            />
             <Stack direction="column" gap={6}>
+              {!teamsAreLoading && teams.length > 0 && (
+                <div className="page-sub-heading">
+                  <Text element="h2" variant="h3">
+                    <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
+                  </Text>
+                </div>
+              )}
               <UserTeams isLoading={teamsAreLoading} teams={teams} />
               <UserOrganizations isLoading={orgsAreLoading} setUserOrg={changeUserOrg} orgs={orgs} user={user} />
               <UserSessions isLoading={sessionsAreLoading} revokeUserSession={revokeUserSession} sessions={sessions} />

--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -26,7 +26,7 @@ const UserSessions = memo<Props>(({ isLoading, sessions, revokeUserSession }) =>
       {sessions.length > 0 && (
         <>
           <div className="page-sub-heading">
-            <Text variant="h3" element="h2">
+            <Text variant="h2" element="h2">
               <Trans i18nKey="profile.user-sessions.sessions">Sessions</Trans>
             </Text>
           </div>

--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -25,7 +25,7 @@ const UserSessions = memo<Props>(({ isLoading, sessions, revokeUserSession }) =>
     <div className={styles.wrapper}>
       {sessions.length > 0 && (
         <>
-          <div className="page-sub-heading">
+          <div>
             <Text variant="h2" element="h2">
               <Trans i18nKey="profile.user-sessions.sessions">Sessions</Trans>
             </Text>

--- a/public/app/features/profile/UserSessions.tsx
+++ b/public/app/features/profile/UserSessions.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Button, Icon, LoadingPlaceholder, ScrollContainer, Text, useStyles2 } from '@grafana/ui';
+import { Button, Icon, LoadingPlaceholder, ScrollContainer, useStyles2 } from '@grafana/ui';
 import { TagBadge } from 'app/core/components/TagFilter/TagBadge';
 import { formatDate } from 'app/core/internationalization/dates';
 import { type UserSession } from 'app/types/user';
@@ -11,89 +11,85 @@ import { type UserSession } from 'app/types/user';
 interface Props {
   sessions: UserSession[];
   isLoading: boolean;
+  heading: ReactNode;
   revokeUserSession: (tokenId: number) => void;
 }
 
-const UserSessions = memo<Props>(({ isLoading, sessions, revokeUserSession }) => {
+const UserSessions = memo<Props>(({ isLoading, sessions, revokeUserSession, heading }) => {
   const styles = useStyles2(getStyles);
 
   if (isLoading) {
     return <LoadingPlaceholder text={<Trans i18nKey="user-sessions.loading">Loading sessions...</Trans>} />;
   }
 
+  if (sessions.length === 0) {
+    return null;
+  }
+
   return (
     <div className={styles.wrapper}>
-      {sessions.length > 0 && (
-        <>
-          <div>
-            <Text variant="h2" element="h2">
-              <Trans i18nKey="profile.user-sessions.sessions">Sessions</Trans>
-            </Text>
-          </div>
-          <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
-            <table className="filter-table form-inline" data-testid={selectors.components.UserProfile.sessionsTable}>
-              <thead>
-                <tr>
-                  <th>
-                    <Trans i18nKey="user-session.seen-at-column">Last seen</Trans>
-                  </th>
-                  <th>
-                    <Trans i18nKey="user-session.created-at-column">Logged on</Trans>
-                  </th>
-                  <th>
-                    <Trans i18nKey="user-session.ip-column">IP address</Trans>
-                  </th>
-                  <th>
-                    <Trans i18nKey="user-session.browser-column">Browser & OS</Trans>
-                  </th>
-                  <th>
-                    <Trans i18nKey="user-session.identity-provider-column">Identity Provider</Trans>
-                  </th>
-                  <th></th>
-                </tr>
-              </thead>
+      {heading}
 
-              <tbody>
-                {sessions.map((session: UserSession, index) => (
-                  <tr key={index}>
-                    {session.isActive ? (
-                      <td>
-                        <Trans i18nKey="profile.user-sessions.now">Now</Trans>
-                      </td>
-                    ) : (
-                      <td>{session.seenAt}</td>
-                    )}
-                    <td>{formatDate(session.createdAt, { dateStyle: 'long' })}</td>
-                    <td>{session.clientIp}</td>
-                    <td>
-                      <Trans
-                        i18nKey="profile.user-sessions.browser-details"
-                        values={{ browser: session.browser, os: session.os, osVersion: session.osVersion }}
-                      >
-                        {'{{browser}}'} on {'{{os}}'} {'{{osVersion}}'}
-                      </Trans>
-                    </td>
-                    <td>
-                      {session.authModule && <TagBadge label={session.authModule} removeIcon={false} count={0} />}
-                    </td>
-                    <td>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        tooltip={t('user-session.revoke', 'Revoke user session')}
-                        onClick={() => revokeUserSession(session.id)}
-                        aria-label={t('user-session.revoke', 'Revoke user session')}
-                      >
-                        <Icon name="power" />
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ScrollContainer>
-        </>
-      )}
+      <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+        <table className="filter-table form-inline" data-testid={selectors.components.UserProfile.sessionsTable}>
+          <thead>
+            <tr>
+              <th>
+                <Trans i18nKey="user-session.seen-at-column">Last seen</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="user-session.created-at-column">Logged on</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="user-session.ip-column">IP address</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="user-session.browser-column">Browser & OS</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="user-session.identity-provider-column">Identity Provider</Trans>
+              </th>
+              <th></th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {sessions.map((session: UserSession, index) => (
+              <tr key={index}>
+                {session.isActive ? (
+                  <td>
+                    <Trans i18nKey="profile.user-sessions.now">Now</Trans>
+                  </td>
+                ) : (
+                  <td>{session.seenAt}</td>
+                )}
+                <td>{formatDate(session.createdAt, { dateStyle: 'long' })}</td>
+                <td>{session.clientIp}</td>
+                <td>
+                  <Trans
+                    i18nKey="profile.user-sessions.browser-details"
+                    values={{ browser: session.browser, os: session.os, osVersion: session.osVersion }}
+                  >
+                    {'{{browser}}'} on {'{{os}}'} {'{{osVersion}}'}
+                  </Trans>
+                </td>
+                <td>{session.authModule && <TagBadge label={session.authModule} removeIcon={false} count={0} />}</td>
+                <td>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    tooltip={t('user-session.revoke', 'Revoke user session')}
+                    onClick={() => revokeUserSession(session.id)}
+                    aria-label={t('user-session.revoke', 'Revoke user session')}
+                  >
+                    <Icon name="power" />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </ScrollContainer>
     </div>
   );
 });

--- a/public/app/features/profile/UserTeams.tsx
+++ b/public/app/features/profile/UserTeams.tsx
@@ -19,46 +19,41 @@ export const UserTeams = memo<Props>(({ isLoading, teams }) => {
   }
 
   return (
-    <div>
-      <h2 className="page-sub-heading">
-        <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
-      </h2>
-      <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
-        <table
-          className="filter-table form-inline"
-          aria-label={t('profile.user-teams.aria-label-user-teams-table', 'User teams table')}
-        >
-          <thead>
-            <tr>
-              <th />
-              <th>
-                <Trans i18nKey="profile.user-teams.name">Name</Trans>
-              </th>
-              <th>
-                <Trans i18nKey="profile.user-teams.email">Email</Trans>
-              </th>
-              <th>
-                <Trans i18nKey="profile.user-teams.members">Members</Trans>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {teams.map((team: Team, index) => {
-              return (
-                <tr key={index}>
-                  <td className="width-4 text-center">
-                    <img className="filter-table__avatar" src={team.avatarUrl} alt="" />
-                  </td>
-                  <td>{team.name}</td>
-                  <td>{team.email}</td>
-                  <td>{team.memberCount}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </ScrollContainer>
-    </div>
+    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+      <table
+        className="filter-table form-inline"
+        aria-label={t('profile.user-teams.aria-label-user-teams-table', 'User teams table')}
+      >
+        <thead>
+          <tr>
+            <th />
+            <th>
+              <Trans i18nKey="profile.user-teams.name">Name</Trans>
+            </th>
+            <th>
+              <Trans i18nKey="profile.user-teams.email">Email</Trans>
+            </th>
+            <th>
+              <Trans i18nKey="profile.user-teams.members">Members</Trans>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {teams.map((team: Team, index) => {
+            return (
+              <tr key={index}>
+                <td className="width-4 text-center">
+                  <img className="filter-table__avatar" src={team.avatarUrl} alt="" />
+                </td>
+                <td>{team.name}</td>
+                <td>{team.email}</td>
+                <td>{team.memberCount}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </ScrollContainer>
   );
 });
 

--- a/public/app/features/profile/UserTeams.tsx
+++ b/public/app/features/profile/UserTeams.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { LoadingPlaceholder, ScrollContainer } from '@grafana/ui';
@@ -7,9 +7,10 @@ import { type Team } from 'app/types/teams';
 export interface Props {
   teams: Team[];
   isLoading: boolean;
+  heading: ReactNode;
 }
 
-export const UserTeams = memo<Props>(({ isLoading, teams }) => {
+export const UserTeams = memo<Props>(({ isLoading, teams, heading }) => {
   if (isLoading) {
     return <LoadingPlaceholder text={t('profile.user-teams.text-loading-teams', 'Loading teams...')} />;
   }
@@ -19,41 +20,45 @@ export const UserTeams = memo<Props>(({ isLoading, teams }) => {
   }
 
   return (
-    <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
-      <table
-        className="filter-table form-inline"
-        aria-label={t('profile.user-teams.aria-label-user-teams-table', 'User teams table')}
-      >
-        <thead>
-          <tr>
-            <th />
-            <th>
-              <Trans i18nKey="profile.user-teams.name">Name</Trans>
-            </th>
-            <th>
-              <Trans i18nKey="profile.user-teams.email">Email</Trans>
-            </th>
-            <th>
-              <Trans i18nKey="profile.user-teams.members">Members</Trans>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {teams.map((team: Team, index) => {
-            return (
-              <tr key={index}>
-                <td className="width-4 text-center">
-                  <img className="filter-table__avatar" src={team.avatarUrl} alt="" />
-                </td>
-                <td>{team.name}</td>
-                <td>{team.email}</td>
-                <td>{team.memberCount}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </ScrollContainer>
+    <div>
+      {heading}
+
+      <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
+        <table
+          className="filter-table form-inline"
+          aria-label={t('profile.user-teams.aria-label-user-teams-table', 'User teams table')}
+        >
+          <thead>
+            <tr>
+              <th />
+              <th>
+                <Trans i18nKey="profile.user-teams.name">Name</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="profile.user-teams.email">Email</Trans>
+              </th>
+              <th>
+                <Trans i18nKey="profile.user-teams.members">Members</Trans>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team: Team, index) => {
+              return (
+                <tr key={index}>
+                  <td className="width-4 text-center">
+                    <img className="filter-table__avatar" src={team.avatarUrl} alt="" />
+                  </td>
+                  <td>{team.name}</td>
+                  <td>{team.email}</td>
+                  <td>{team.memberCount}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </ScrollContainer>
+    </div>
   );
 });
 

--- a/public/app/features/profile/UserTeams.tsx
+++ b/public/app/features/profile/UserTeams.tsx
@@ -20,9 +20,9 @@ export const UserTeams = memo<Props>(({ isLoading, teams }) => {
 
   return (
     <div>
-      <h3 className="page-sub-heading">
+      <h2 className="page-sub-heading">
         <Trans i18nKey="profile.user-teams.teams">Teams</Trans>
-      </h3>
+      </h2>
       <ScrollContainer overflowY="visible" overflowX="auto" width="100%">
         <table
           className="filter-table form-inline"

--- a/public/app/features/teams/TeamSettings.tsx
+++ b/public/app/features/teams/TeamSettings.tsx
@@ -101,7 +101,7 @@ const TeamSettings = ({ team }: Props) => {
       </form>
       <SharedPreferences
         legend={
-          <Text element="h2" variant="h3">
+          <Text element="h2" variant="h2">
             {t('shared-preferences.title', 'Preferences')}
           </Text>
         }

--- a/public/app/features/teams/TeamSettings.tsx
+++ b/public/app/features/teams/TeamSettings.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { Button, Field, FieldSet, Input, Stack } from '@grafana/ui';
+import { Button, Field, FieldSet, Input, Stack, Text } from '@grafana/ui';
 import { TeamRolePicker } from 'app/core/components/RolePicker/TeamRolePicker';
 import { useRoleOptions } from 'app/core/components/RolePicker/hooks';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -99,7 +99,16 @@ const TeamSettings = ({ team }: Props) => {
           <Trans i18nKey="teams.team-settings.save">Save team details</Trans>
         </Button>
       </form>
-      <SharedPreferences resourceUri={teamResourceUri} disabled={!canWriteTeamSettings} preferenceType="team" />
+      <SharedPreferences
+        legend={
+          <Text element="h2" variant="h3">
+            {t('shared-preferences.title', 'Preferences')}
+          </Text>
+        }
+        resourceUri={teamResourceUri}
+        disabled={!canWriteTeamSettings}
+        preferenceType="team"
+      />
     </Stack>
   );
 };


### PR DESCRIPTION
## What changed

 - Fixes the heading hierarchy on the user preferences page (specifically - the Teams heading being H3 while everything else was H2)
 - Moves the page headings out of the leaf components and up into the page, so the page can control the page structure/heading hierarchy
 - Removes legacy `page-sub-heading` spacing from Profile section headings
 - Fixes inconsistent spacing between each of the sections by grouping them into individual sections, spaced using a single `<Stack />`

## Why

So reusable components do not define the page outline or section spacing.

Part of [grafana/grafana#117836](https://github.com/grafana/grafana/issues/117836)

## Evidence

- `yarn jest --no-watch public/app/features/profile/UserProfileEditPage.test.tsx`
- Browser: Teams heading and table share one section. Profile headings use matching H2 typography.