### PR TITLE
unified-storage: progress watch bookmark regardless of event delivery

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2041,8 +2041,8 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 
 	lastBookmarkRV := int64(-1)
 	sendBookmark := func(rv int64) error {
-		// Don't send repeated bookmarks if no new events were received.
-		if rv <= 0 || rv == lastBookmarkRV {
+		// Don't send repeated or regressing bookmarks.
+		if rv <= 0 || rv <= lastBookmarkRV {
 			return nil
 		}
 
@@ -2057,7 +2057,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 		return nil
 	}
 
-	var lastEmittedRV int64 // tracks the most recent RV sent to the client
+	var processedRV int64 // Includes events deliberately excluded by watch filters.
 	if req.SendInitialEvents {
 		// Backfill the stream by adding every existing entities.
 		initialEventsRV, err := s.backend.ListIterator(ctx, &resourcepb.ListRequest{Options: req.Options}, func(iter ListIterator) error {
@@ -2084,9 +2084,9 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 			return err
 		}
 
-		lastEmittedRV = initialEventsRV
+		processedRV = initialEventsRV
 		if req.AllowWatchBookmarks {
-			if err := sendBookmark(lastEmittedRV); err != nil {
+			if err := sendBookmark(processedRV); err != nil {
 				return err
 			}
 		}
@@ -2095,12 +2095,14 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	var since int64 // resource version to start watching from
 	switch {
 	case req.SendInitialEvents:
-		since = lastEmittedRV
+		since = processedRV
 	case req.Since == 0:
 		since = mostRecentRV
 	default:
 		since = req.Since
 	}
+
+	_, isKVBackend := s.backend.(KVBackend)
 
 	// Set up periodic bookmark ticker when the client opted in.
 	var bookmarkC <-chan time.Time
@@ -2116,7 +2118,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 			return nil
 
 		case <-bookmarkC:
-			if err := sendBookmark(lastEmittedRV); err != nil {
+			if err := sendBookmark(processedRV); err != nil {
 				return err
 			}
 
@@ -2126,11 +2128,15 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				return nil
 			}
 			s.log.Debug("Server Broadcasting", "type", event.Type, "rv", event.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "resource", event.Key.Resource, "name", event.Key.Name)
-			if event.ResourceVersion > since && matchesQueryKey(req.Options.Key, event.Key) {
-				if !checker(event.Key.Name, event.Folder) {
-					continue
-				}
-
+			if event.ResourceVersion <= since {
+				continue
+			}
+			// KV notifiers settle and order events across collections. Legacy SQL polls
+			// group/resources separately, so other collections cannot establish progress.
+			if !isKVBackend && (event.Key.Group != key.Group || event.Key.Resource != key.Resource) {
+				continue
+			}
+			if matchesQueryKey(key, event.Key) && checker(event.Key.Name, event.Folder) {
 				value := event.Value
 				// remove the delete marker stored in the value for deleted objects
 				if event.Type == resourcepb.WatchEvent_DELETED {
@@ -2164,7 +2170,6 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				if err := srv.Send(resp); err != nil {
 					return err
 				}
-				lastEmittedRV = event.ResourceVersion
 
 				if s.storageMetrics != nil && event.ResourceVersion > mostRecentRV {
 					// record latency - resource version can be either a unix microsecond timestamp (SQL backend)
@@ -2175,6 +2180,8 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 					}
 				}
 			}
+			// Progress is not a delivery cutoff: keep using the fixed starting since.
+			processedRV = max(processedRV, event.ResourceVersion)
 		}
 	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -68,6 +68,10 @@ func (s *server) logIfServerError(ctx context.Context, op string, key *resourcep
 // to Watch clients that have AllowWatchBookmarks enabled.
 const defaultBookmarkFrequency = 10 * time.Second
 
+// filteredBookmarkDelay leaves a recovery window for late writes without
+// delaying progress from objects already sent to the client.
+const filteredBookmarkDelay = time.Minute
+
 // maxKeysPageSize caps a keys_only page by count. The byte budget also applies,
 // but it measures the wire and a key costs far less there (~20 bytes) than the
 // wrapper holding it does in memory (~120), so bytes alone would admit a page
@@ -2058,6 +2062,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	}
 
 	var processedRV int64 // Includes events deliberately excluded by watch filters.
+	var lastObjectRV int64
 	if req.SendInitialEvents {
 		// Backfill the stream by adding every existing entities.
 		initialEventsRV, err := s.backend.ListIterator(ctx, &resourcepb.ListRequest{Options: req.Options}, func(iter ListIterator) error {
@@ -2118,8 +2123,17 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 			return nil
 
 		case <-bookmarkC:
-			if err := sendBookmark(processedRV); err != nil {
-				return err
+			cutoff := time.Now().Add(-filteredBookmarkDelay)
+			cutoffRV := cutoff.UnixMicro()
+			if IsSnowflake(processedRV) {
+				cutoffRV = snowflakeFromTime(cutoff)
+			}
+			// Object sends have already advanced the client's cursor; only filtered progress is held back.
+			bookmarkRV := max(lastObjectRV, min(processedRV, cutoffRV))
+			if bookmarkRV > since {
+				if err := sendBookmark(bookmarkRV); err != nil {
+					return err
+				}
 			}
 
 		case event, ok := <-stream:
@@ -2170,6 +2184,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 				if err := srv.Send(resp); err != nil {
 					return err
 				}
+				lastObjectRV = max(lastObjectRV, event.ResourceVersion)
 
 				if s.storageMetrics != nil && event.ResourceVersion > mostRecentRV {
 					// record latency - resource version can be either a unix microsecond timestamp (SQL backend)

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1702,7 +1702,181 @@ func requireBookmarkEvent(t *testing.T, stream *bookmarkWatchServer, eventType r
 	require.Equal(t, rv, event.Resource.Version)
 }
 
+func advanceBookmarkClock() time.Time {
+	// synctest's clock starts before the Snowflake epoch.
+	time.Sleep(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Sub(time.Now()))
+	return time.Now()
+}
+
+func TestIncrementalBookmarksProgressLag(t *testing.T) {
+	for _, backend := range []string{"legacy_sql", "kv"} {
+		t.Run(backend, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				now := advanceBookmarkClock()
+				rvAt := func(at time.Time) int64 {
+					if backend == "kv" {
+						return snowflakeFromTime(at)
+					}
+					return at.UnixMicro()
+				}
+				req := bookmarkWatchRequest()
+				req.Since = rvAt(now.Add(-30 * time.Second))
+				events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
+					if backend == "kv" {
+						srv.backend = &kvStorageBackend{}
+					}
+					srv.bookmarkFrequency = 10 * time.Second
+					srv.mostRecentRV.Store(rvAt(now.Add(time.Hour)))
+				})
+				filteredEvent := func(rv int64) *WrittenEvent {
+					event := bookmarkWrittenEvent(rv)
+					if backend == "kv" {
+						event.Key.Group = "other.grafana.app"
+					} else {
+						event.Key.Namespace = "other"
+					}
+					return event
+				}
+
+				time.Sleep(10 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "the clock alone must not establish progress")
+				events <- filteredEvent(rvAt(time.Now()) + 1)
+				synctest.Wait()
+				time.Sleep(20 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "lagged progress must not repeat or precede Since")
+				time.Sleep(10 * time.Second)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rvAt(time.Now().Add(-time.Minute)))
+
+				// Continuous filtered traffic must advance an older cursor, not keep
+				// postponing all progress until the newest event is a minute old.
+				var lastProcessedRV int64
+				for range 8 {
+					lastProcessedRV = rvAt(time.Now()) + 1
+					events <- filteredEvent(lastProcessedRV)
+					synctest.Wait()
+					require.Empty(t, stream.events)
+					time.Sleep(10 * time.Second)
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rvAt(time.Now().Add(-time.Minute)))
+				}
+
+				// Once writes stop, withheld progress can age into eligibility, but
+				// the clock must never move the bookmark past what was processed.
+				for range 6 {
+					time.Sleep(10 * time.Second)
+					rv := min(lastProcessedRV, rvAt(time.Now().Add(-time.Minute)))
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rv)
+				}
+				time.Sleep(2 * time.Minute)
+				synctest.Wait()
+				require.Empty(t, stream.events)
+			})
+		})
+	}
+}
+
+func TestIncrementalBookmarksLagDoesNotDelayObjects(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := advanceBookmarkClock()
+		req := bookmarkWatchRequest()
+		req.Since = snowflakeFromTime(now.Add(-2 * time.Minute))
+		events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
+			srv.backend = &kvStorageBackend{}
+			srv.bookmarkFrequency = 10 * time.Second
+		})
+		objectRV := snowflakeFromTime(now)
+		events <- bookmarkWrittenEvent(objectRV)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, objectRV)
+		filtered := bookmarkWrittenEvent(objectRV + 1)
+		filtered.Key.Name = "other"
+		events <- filtered
+		synctest.Wait()
+		time.Sleep(10 * time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, objectRV)
+
+		// A lower matching RV still gets delivered, but cannot lower the
+		// bookmark floor established by an earlier successful object send.
+		olderRV := snowflakeFromTime(now.Add(-10 * time.Second))
+		events <- bookmarkWrittenEvent(olderRV)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, olderRV)
+		time.Sleep(50 * time.Second)
+		synctest.Wait()
+		require.Empty(t, stream.events)
+		time.Sleep(10 * time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, filtered.ResourceVersion)
+
+		objectRV = snowflakeFromTime(time.Now())
+		events <- bookmarkWrittenEvent(objectRV)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, objectRV)
+		time.Sleep(10 * time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, objectRV)
+	})
+}
+
+func TestIncrementalBookmarksLaggedResume(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := advanceBookmarkClock()
+		req := bookmarkWatchRequest()
+		req.Since = snowflakeFromTime(now.Add(-2 * time.Minute))
+		configure := func(srv *server, _ *bookmarkWatchServer) {
+			srv.backend = &kvStorageBackend{}
+			srv.bookmarkFrequency = 10 * time.Second
+		}
+		events, stream, done := startBookmarkWatch(t, req, configure)
+		foreign := bookmarkWrittenEvent(snowflakeFromTime(now))
+		foreign.Key.Resource = "other"
+		events <- foreign
+		synctest.Wait()
+		time.Sleep(10 * time.Second)
+		resumeRV := snowflakeFromTime(time.Now().Add(-time.Minute))
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, resumeRV)
+		close(events)
+		synctest.Wait()
+		require.NotEmpty(t, done)
+		require.NoError(t, <-done)
+
+		// The late notification's RV predates the unrelated event, but the
+		// lagged bookmark leaves it eligible on the replacement watch.
+		req = bookmarkWatchRequest()
+		req.Since = resumeRV
+		events, stream, _ = startBookmarkWatch(t, req, configure)
+		lateRV := snowflakeFromTime(now.Add(-5 * time.Second))
+		require.Greater(t, lateRV, resumeRV)
+		require.Less(t, lateRV, foreign.ResourceVersion)
+		events <- bookmarkWrittenEvent(lateRV)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, lateRV)
+		time.Sleep(10 * time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, lateRV)
+	})
+}
+
+func TestIncrementalBookmarksLagSinceZero(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		now := advanceBookmarkClock()
+		startRV := snowflakeFromTime(now)
+		req := bookmarkWatchRequest()
+		req.Since = 0
+		events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
+			srv.backend = &bookmarkKVListBackend{list: func(func(ListIterator) error) (int64, error) {
+				return startRV, nil
+			}}
+			srv.bookmarkFrequency = 10 * time.Second
+		})
+		filtered := bookmarkWrittenEvent(startRV + 1)
+		filtered.Key.Resource = "other"
+		events <- filtered
+		synctest.Wait()
+		time.Sleep(time.Minute)
+		synctest.Wait()
+		require.Empty(t, stream.events, "lagged bookmarks must not precede the backend's starting RV")
+		time.Sleep(10 * time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, filtered.ResourceVersion)
+	})
+}
+
 func TestIncrementalBookmarksFilteredEvents(t *testing.T) {
+	// These historical RVs are already older than the bookmark safety lag.
 	for _, backend := range []string{"legacy_sql", "kv"} {
 		for _, filter := range []string{"namespace", "name", "access", "group", "resource"} {
 			if backend == "legacy_sql" && (filter == "group" || filter == "resource") {
@@ -1945,6 +2119,7 @@ func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
 	for _, initial := range []string{"matching", "filtered", "empty", "backend error"} {
 		t.Run(initial, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
+				initialRV := snowflakeFromTime(advanceBookmarkClock())
 				req := bookmarkWatchRequest()
 				req.SendInitialEvents = true
 				req.Options.Key.Name = ""
@@ -1967,9 +2142,9 @@ func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
 							return 0, stream.Context().Err()
 						}
 						if initial == "backend error" {
-							return 100, listErr
+							return initialRV, listErr
 						}
-						return 100, nil
+						return initialRV, nil
 					}}
 					if initial == "filtered" {
 						srv.access = &callbackAccessClient{fn: func(req authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
@@ -1989,8 +2164,8 @@ func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
 					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 1)
 					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 2)
 				}
-				events <- bookmarkWrittenEvent(101)
-				foreign := bookmarkWrittenEvent(102)
+				events <- bookmarkWrittenEvent(initialRV + 1)
+				foreign := bookmarkWrittenEvent(initialRV + 2)
 				foreign.Key.Resource = "other"
 				events <- foreign
 				synctest.Wait()
@@ -2005,13 +2180,15 @@ func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
 					require.Empty(t, stream.events, "failed backfill must not claim completion")
 					return
 				}
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 100)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 101)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, initialRV+1)
 				time.Sleep(time.Second)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 102)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV+1)
 				time.Sleep(3 * time.Second)
 				synctest.Wait()
 				require.Empty(t, stream.events)
+				time.Sleep(time.Minute)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV+2)
 			})
 		})
 	}

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1726,7 +1726,6 @@ func TestIncrementalBookmarksProgressLag(t *testing.T) {
 						srv.backend = &kvStorageBackend{}
 					}
 					srv.bookmarkFrequency = 10 * time.Second
-					srv.mostRecentRV.Store(rvAt(now.Add(time.Hour)))
 				})
 				filteredEvent := func(rv int64) *WrittenEvent {
 					event := bookmarkWrittenEvent(rv)
@@ -1741,36 +1740,23 @@ func TestIncrementalBookmarksProgressLag(t *testing.T) {
 				time.Sleep(10 * time.Second)
 				synctest.Wait()
 				require.Empty(t, stream.events, "the clock alone must not establish progress")
+
 				events <- filteredEvent(rvAt(time.Now()) + 1)
 				synctest.Wait()
 				time.Sleep(20 * time.Second)
 				synctest.Wait()
-				require.Empty(t, stream.events, "lagged progress must not repeat or precede Since")
+				require.Empty(t, stream.events, "lagged progress must not precede Since")
 				time.Sleep(10 * time.Second)
 				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rvAt(time.Now().Add(-time.Minute)))
 
-				// Continuous filtered traffic must advance an older cursor, not keep
+				// Continuous filtered traffic advances the safe cutoff rather than
 				// postponing all progress until the newest event is a minute old.
-				var lastProcessedRV int64
-				for range 8 {
-					lastProcessedRV = rvAt(time.Now()) + 1
-					events <- filteredEvent(lastProcessedRV)
+				for range 2 {
+					events <- filteredEvent(rvAt(time.Now()) + 1)
 					synctest.Wait()
-					require.Empty(t, stream.events)
 					time.Sleep(10 * time.Second)
 					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rvAt(time.Now().Add(-time.Minute)))
 				}
-
-				// Once writes stop, withheld progress can age into eligibility, but
-				// the clock must never move the bookmark past what was processed.
-				for range 6 {
-					time.Sleep(10 * time.Second)
-					rv := min(lastProcessedRV, rvAt(time.Now().Add(-time.Minute)))
-					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rv)
-				}
-				time.Sleep(2 * time.Minute)
-				synctest.Wait()
-				require.Empty(t, stream.events)
 			})
 		})
 	}
@@ -1785,9 +1771,11 @@ func TestIncrementalBookmarksLagDoesNotDelayObjects(t *testing.T) {
 			srv.backend = &kvStorageBackend{}
 			srv.bookmarkFrequency = 10 * time.Second
 		})
+
 		objectRV := snowflakeFromTime(now)
 		events <- bookmarkWrittenEvent(objectRV)
 		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, objectRV)
+
 		filtered := bookmarkWrittenEvent(objectRV + 1)
 		filtered.Key.Name = "other"
 		events <- filtered
@@ -1795,22 +1783,13 @@ func TestIncrementalBookmarksLagDoesNotDelayObjects(t *testing.T) {
 		time.Sleep(10 * time.Second)
 		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, objectRV)
 
-		// A lower matching RV still gets delivered, but cannot lower the
-		// bookmark floor established by an earlier successful object send.
+		// A lower matching RV remains deliverable but cannot regress the bookmark.
 		olderRV := snowflakeFromTime(now.Add(-10 * time.Second))
 		events <- bookmarkWrittenEvent(olderRV)
 		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, olderRV)
-		time.Sleep(50 * time.Second)
+		time.Sleep(10 * time.Second)
 		synctest.Wait()
 		require.Empty(t, stream.events)
-		time.Sleep(10 * time.Second)
-		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, filtered.ResourceVersion)
-
-		objectRV = snowflakeFromTime(time.Now())
-		events <- bookmarkWrittenEvent(objectRV)
-		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, objectRV)
-		time.Sleep(10 * time.Second)
-		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, objectRV)
 	})
 }
 
@@ -1833,11 +1812,9 @@ func TestIncrementalBookmarksLaggedResume(t *testing.T) {
 		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, resumeRV)
 		close(events)
 		synctest.Wait()
-		require.NotEmpty(t, done)
 		require.NoError(t, <-done)
 
-		// The late notification's RV predates the unrelated event, but the
-		// lagged bookmark leaves it eligible on the replacement watch.
+		// The lagged bookmark leaves a late lower-RV notification eligible.
 		req = bookmarkWatchRequest()
 		req.Since = resumeRV
 		events, stream, _ = startBookmarkWatch(t, req, configure)
@@ -1846,264 +1823,152 @@ func TestIncrementalBookmarksLaggedResume(t *testing.T) {
 		require.Less(t, lateRV, foreign.ResourceVersion)
 		events <- bookmarkWrittenEvent(lateRV)
 		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, lateRV)
-		time.Sleep(10 * time.Second)
-		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, lateRV)
 	})
 }
 
-func TestIncrementalBookmarksLagSinceZero(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		now := advanceBookmarkClock()
-		startRV := snowflakeFromTime(now)
-		req := bookmarkWatchRequest()
-		req.Since = 0
-		events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
-			srv.backend = &bookmarkKVListBackend{list: func(func(ListIterator) error) (int64, error) {
-				return startRV, nil
-			}}
-			srv.bookmarkFrequency = 10 * time.Second
-		})
-		filtered := bookmarkWrittenEvent(startRV + 1)
-		filtered.Key.Resource = "other"
-		events <- filtered
-		synctest.Wait()
-		time.Sleep(time.Minute)
-		synctest.Wait()
-		require.Empty(t, stream.events, "lagged bookmarks must not precede the backend's starting RV")
-		time.Sleep(10 * time.Second)
-		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, filtered.ResourceVersion)
-	})
-}
-
-func TestIncrementalBookmarksFilteredEvents(t *testing.T) {
-	// These historical RVs are already older than the bookmark safety lag.
-	for _, backend := range []string{"legacy_sql", "kv"} {
-		for _, filter := range []string{"namespace", "name", "access", "group", "resource"} {
-			if backend == "legacy_sql" && (filter == "group" || filter == "resource") {
-				continue
-			}
-			t.Run(backend+"/"+filter, func(t *testing.T) {
-				synctest.Test(t, func(t *testing.T) {
-					events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, _ *bookmarkWatchServer) {
-						if backend == "kv" {
-							srv.backend = &kvStorageBackend{}
-						}
-						srv.mostRecentRV.Store(1000)
-						if filter == "access" {
-							srv.access = &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) { return deny() }}
-						}
-					})
-					filteredEvent := func(rv int64) *WrittenEvent {
-						event := bookmarkWrittenEvent(rv)
-						switch filter {
-						case "namespace":
-							event.Key.Namespace = "other"
-						case "name":
-							event.Key.Name = "other"
-						case "group":
-							event.Key.Group = "other.grafana.app"
-						case "resource":
-							event.Key.Resource = "other"
-						}
-						return event
-					}
-
-					// Neither startup nor events at/below the fixed cutoff establish progress.
-					events <- filteredEvent(99)
-					events <- filteredEvent(100)
-					synctest.Wait()
-					time.Sleep(3 * time.Second)
-					synctest.Wait()
-					require.Empty(t, stream.events)
-
-					for _, rv := range []int64{101, 102} {
-						events <- filteredEvent(rv)
-						synctest.Wait()
-						require.Empty(t, stream.events, "filtered objects must not be sent")
-						time.Sleep(time.Second)
-						requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rv)
-						time.Sleep(3 * time.Second)
-						synctest.Wait()
-						require.Empty(t, stream.events, "unchanged progress must not repeat")
-					}
-					events <- filteredEvent(101)
-					synctest.Wait()
-					time.Sleep(time.Second)
-					synctest.Wait()
-					require.Empty(t, stream.events, "progress must not regress")
-				})
-			})
-		}
+func TestIncrementalBookmarksFilteredProgress(t *testing.T) {
+	tests := []struct {
+		name      string
+		kv        bool
+		configure func(*server)
+		filter    func(*WrittenEvent)
+	}{
+		{
+			name: "legacy SQL namespace filter",
+			filter: func(event *WrittenEvent) {
+				event.Key.Namespace = "other"
+			},
+		},
+		{
+			name: "KV foreign collection",
+			kv:   true,
+			filter: func(event *WrittenEvent) {
+				event.Key.Resource = "other"
+			},
+		},
+		{
+			name: "authorization filter",
+			kv:   true,
+			configure: func(srv *server) {
+				srv.access = &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) {
+					return deny()
+				}}
+			},
+		},
 	}
-}
 
-func TestIncrementalBookmarksLegacySQLGroupResourceOrdering(t *testing.T) {
-	for _, other := range []string{"group", "resource"} {
-		t.Run(other, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
-				events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), nil)
-				foreign := bookmarkWrittenEvent(300)
-				if other == "group" {
-					foreign.Key.Group = "other.grafana.app"
-				} else {
-					foreign.Key.Resource = "other"
-				}
-				events <- foreign
-				synctest.Wait()
-				time.Sleep(3 * time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events, "other group/resource activity cannot establish progress")
-
-				// Legacy SQL can deliver another collection's higher RV before this one.
-				events <- bookmarkWrittenEvent(110)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 110)
-				time.Sleep(time.Second)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 110)
-
-				// Bookmark progress must not become a new live-delivery deduplication cutoff.
-				for _, rv := range []int64{105, 110} {
-					events <- bookmarkWrittenEvent(rv)
-					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, rv)
-					time.Sleep(time.Second)
-					synctest.Wait()
-					require.Empty(t, stream.events, "bookmarks must not regress or repeat")
-				}
-				filtered := bookmarkWrittenEvent(108)
-				filtered.Key.Namespace = "other"
-				events <- filtered
-				synctest.Wait()
-				time.Sleep(time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events)
-
-				events <- bookmarkWrittenEvent(111)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 111)
-				time.Sleep(time.Second)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 111)
-			})
-		})
-	}
-}
-
-func TestIncrementalBookmarksBlockedSend(t *testing.T) {
-	for _, backend := range []string{"legacy_sql", "kv"} {
-		for _, fail := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/send failure=%t", backend, fail), func(t *testing.T) {
-				synctest.Test(t, func(t *testing.T) {
-					entered, release := make(chan struct{}), make(chan struct{})
-					sendErr := errors.New("send failed")
-					events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, stream *bookmarkWatchServer) {
-						if backend == "kv" {
-							srv.backend = &kvStorageBackend{}
-						}
-						srv.mostRecentRV.Store(1000)
-						stream.beforeSend = func(event *resourcepb.WatchEvent) error {
-							if event.Type == resourcepb.WatchEvent_ADDED && event.Resource.Version == 101 {
-								close(entered)
-								select {
-								case <-release:
-								case <-stream.Context().Done():
-									return stream.Context().Err()
-								}
-								if fail {
-									return sendErr
-								}
-							}
-							return nil
-						}
-					})
-					events <- bookmarkWrittenEvent(101)
-					synctest.Wait()
-					select {
-					case <-entered:
-					default:
-						t.Fatal("matching send was not reached")
+				events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, _ *bookmarkWatchServer) {
+					if tt.kv {
+						srv.backend = &kvStorageBackend{}
 					}
-					pending := bookmarkWrittenEvent(102)
-					wantObjects := []int64{101, 102}
-					if backend == "kv" {
-						pending.Key.Group = "other.grafana.app"
-						wantObjects = []int64{101}
+					if tt.configure != nil {
+						tt.configure(srv)
 					}
-					events <- pending
-					synctest.Wait()
-					time.Sleep(5 * time.Second)
-					synctest.Wait()
-					require.Empty(t, stream.events, "neither the blocked nor pending event may be covered")
-
-					close(release)
-					synctest.Wait()
-					if fail {
-						require.NotEmpty(t, done)
-						require.ErrorIs(t, <-done, sendErr)
-						time.Sleep(3 * time.Second)
-						synctest.Wait()
-						require.Empty(t, stream.events, "failed sends cannot become successful progress")
-						return
-					}
-
-					time.Sleep(time.Second)
-					synctest.Wait()
-					var lastBookmarkRV int64
-					var objects []int64
-					for len(stream.events) > 0 {
-						event := <-stream.events
-						if event.Type == resourcepb.WatchEvent_BOOKMARK {
-							for _, rv := range wantObjects {
-								if rv <= event.Resource.Version {
-									require.Contains(t, objects, rv, "matching sends must precede covering bookmarks")
-								}
-							}
-							require.Greater(t, event.Resource.Version, lastBookmarkRV)
-							lastBookmarkRV = event.Resource.Version
-						} else {
-							objects = append(objects, event.Resource.Version)
-						}
-					}
-					require.Equal(t, wantObjects, objects)
-					require.Equal(t, int64(102), lastBookmarkRV)
 				})
+				event := bookmarkWrittenEvent(101)
+				if tt.filter != nil {
+					tt.filter(event)
+				}
+				events <- event
+				synctest.Wait()
+				require.Empty(t, stream.events, "filtered objects must not be sent")
+				time.Sleep(time.Second)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 101)
+				time.Sleep(2 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "unchanged progress must not repeat")
 			})
-		}
+		})
 	}
 }
 
-func TestIncrementalBookmarkSendError(t *testing.T) {
+func TestIncrementalBookmarksLegacySQLCollectionOrdering(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		sendErr := errors.New("bookmark send failed")
-		events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(_ *server, stream *bookmarkWatchServer) {
-			stream.beforeSend = func(*resourcepb.WatchEvent) error { return sendErr }
-		})
-		filtered := bookmarkWrittenEvent(101)
-		filtered.Key.Name = "other"
-		events <- filtered
+		events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), nil)
+		foreign := bookmarkWrittenEvent(300)
+		foreign.Key.Resource = "other"
+		events <- foreign
 		synctest.Wait()
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		require.Empty(t, stream.events, "other collections cannot establish SQL progress")
+
+		events <- bookmarkWrittenEvent(110)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 110)
+		time.Sleep(time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 110)
+
+		// Bookmark progress is not a new live-delivery cutoff.
+		events <- bookmarkWrittenEvent(105)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 105)
 		time.Sleep(time.Second)
 		synctest.Wait()
-		require.NotEmpty(t, done)
-		require.ErrorIs(t, <-done, sendErr)
-		require.Empty(t, stream.events)
+		require.Empty(t, stream.events, "bookmarks must not regress")
 	})
 }
 
-func TestIncrementalBookmarksPreviousReadFailure(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, _ *bookmarkWatchServer) {
-			srv.backend = &errorOnReadResourceBackend{readErr: &resourcepb.ErrorResult{
-				Code: http.StatusInternalServerError, Message: "read failed",
-			}}
+func TestIncrementalBookmarksWaitForSuccessfulSend(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(fmt.Sprintf("send failure=%t", fail), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				entered, release := make(chan struct{}), make(chan struct{})
+				sendErr := errors.New("send failed")
+				events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, stream *bookmarkWatchServer) {
+					srv.backend = &kvStorageBackend{}
+					stream.beforeSend = func(event *resourcepb.WatchEvent) error {
+						if event.Type == resourcepb.WatchEvent_ADDED {
+							close(entered)
+							select {
+							case <-release:
+							case <-stream.Context().Done():
+								return stream.Context().Err()
+							}
+							if fail {
+								return sendErr
+							}
+						}
+						return nil
+					}
+				})
+				events <- bookmarkWrittenEvent(101)
+				synctest.Wait()
+				select {
+				case <-entered:
+				default:
+					t.Fatal("matching send was not reached")
+				}
+				pending := bookmarkWrittenEvent(102)
+				pending.Key.Resource = "other"
+				events <- pending
+				time.Sleep(2 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "blocked events must not be covered")
+
+				close(release)
+				synctest.Wait()
+				if fail {
+					require.ErrorIs(t, <-done, sendErr)
+					require.Empty(t, stream.events)
+					return
+				}
+
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 101)
+				synctest.Wait()
+				require.NotEmpty(t, stream.events)
+				bookmark := <-stream.events
+				require.Equal(t, resourcepb.WatchEvent_BOOKMARK, bookmark.Type)
+				if bookmark.Resource.Version == 101 {
+					time.Sleep(time.Second)
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 102)
+				} else {
+					require.Equal(t, int64(102), bookmark.Resource.Version)
+				}
+			})
 		})
-		event := bookmarkWrittenEvent(101)
-		event.Type = resourcepb.WatchEvent_MODIFIED
-		event.PreviousRV = 100
-		events <- event
-		synctest.Wait()
-		require.NotEmpty(t, done)
-		require.ErrorContains(t, <-done, "resource version mismatch")
-		time.Sleep(3 * time.Second)
-		synctest.Wait()
-		require.Empty(t, stream.events, "a fatal previous-read failure must not establish progress")
-	})
+	}
 }
 
 type bookmarkKVListBackend struct {
@@ -2116,118 +1981,43 @@ func (b *bookmarkKVListBackend) ListIterator(_ context.Context, _ *resourcepb.Li
 }
 
 func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
-	for _, initial := range []string{"matching", "filtered", "empty", "backend error"} {
-		t.Run(initial, func(t *testing.T) {
-			synctest.Test(t, func(t *testing.T) {
-				initialRV := snowflakeFromTime(advanceBookmarkClock())
-				req := bookmarkWatchRequest()
-				req.SendInitialEvents = true
-				req.Options.Key.Name = ""
-				req.Options.Key.Namespace = ""
-				listed, release := make(chan struct{}), make(chan struct{})
-				listErr := errors.New("list failed")
-				events, stream, done := startBookmarkWatch(t, req, func(srv *server, stream *bookmarkWatchServer) {
-					srv.backend = &bookmarkKVListBackend{list: func(callback func(ListIterator) error) (int64, error) {
-						values := [][]byte{[]byte(`{"initial":1}`), []byte(`{"initial":2}`)}
-						if initial == "empty" {
-							values = nil
-						}
-						if err := callback(&docListIterator{values: values}); err != nil {
-							return 0, err
-						}
-						close(listed)
-						select {
-						case <-release:
-						case <-stream.Context().Done():
-							return 0, stream.Context().Err()
-						}
-						if initial == "backend error" {
-							return initialRV, listErr
-						}
-						return initialRV, nil
-					}}
-					if initial == "filtered" {
-						srv.access = &callbackAccessClient{fn: func(req authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
-							if req.Name == "name" {
-								return deny()
-							}
-							return allow()
-						}}
-					}
-				})
+	synctest.Test(t, func(t *testing.T) {
+		initialRV := snowflakeFromTime(advanceBookmarkClock())
+		req := bookmarkWatchRequest()
+		req.SendInitialEvents = true
+		req.Options.Key.Name = ""
+		req.Options.Key.Namespace = ""
+		listed, release := make(chan struct{}), make(chan struct{})
+		events, stream, _ := startBookmarkWatch(t, req, func(srv *server, stream *bookmarkWatchServer) {
+			srv.backend = &bookmarkKVListBackend{list: func(callback func(ListIterator) error) (int64, error) {
+				if err := callback(&docListIterator{values: [][]byte{[]byte(`{"initial":1}`), []byte(`{"initial":2}`)}}); err != nil {
+					return 0, err
+				}
+				close(listed)
 				select {
-				case <-listed:
-				default:
-					t.Fatal("initial list was not reached")
+				case <-release:
+				case <-stream.Context().Done():
+					return 0, stream.Context().Err()
 				}
-				if initial == "matching" || initial == "backend error" {
-					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 1)
-					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 2)
-				}
-				events <- bookmarkWrittenEvent(initialRV + 1)
-				foreign := bookmarkWrittenEvent(initialRV + 2)
-				foreign.Key.Resource = "other"
-				events <- foreign
-				synctest.Wait()
-				time.Sleep(5 * time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events, "no incremental bookmark or live event during backfill")
-				close(release)
-				synctest.Wait()
-				if initial == "backend error" {
-					require.NotEmpty(t, done)
-					require.ErrorIs(t, <-done, listErr)
-					require.Empty(t, stream.events, "failed backfill must not claim completion")
-					return
-				}
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, initialRV+1)
-				time.Sleep(time.Second)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV+1)
-				time.Sleep(3 * time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events)
-				time.Sleep(time.Minute)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV+2)
-			})
+				return initialRV, nil
+			}}
 		})
-	}
-}
+		<-listed
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 1)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 2)
 
-func TestIncrementalBookmarksFrequency(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		srv := newWatchTestServer(t, watchTestServerOpts{})
-		require.Equal(t, 10*time.Second, srv.bookmarkFrequency)
+		events <- bookmarkWrittenEvent(initialRV + 1)
+		synctest.Wait()
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		require.Empty(t, stream.events, "live events must wait for backfill")
+
+		close(release)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, initialRV+1)
+		time.Sleep(time.Second)
+		requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, initialRV+1)
 	})
-
-	for _, enabled := range []bool{true, false} {
-		t.Run(fmt.Sprintf("bookmarks enabled=%t", enabled), func(t *testing.T) {
-			synctest.Test(t, func(t *testing.T) {
-				req := bookmarkWatchRequest()
-				req.AllowWatchBookmarks = enabled
-				events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
-					srv.backend = &kvStorageBackend{}
-					srv.bookmarkFrequency = 5 * time.Second
-				})
-				events <- bookmarkWrittenEvent(101)
-				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 101)
-				filtered := bookmarkWrittenEvent(102)
-				filtered.Key.Resource = "other"
-				events <- filtered
-				synctest.Wait()
-				time.Sleep(4 * time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events)
-				time.Sleep(time.Second)
-				if enabled {
-					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 102)
-				}
-				time.Sleep(15 * time.Second)
-				synctest.Wait()
-				require.Empty(t, stream.events)
-			})
-		})
-	}
 }
 
 // stubWatchServer is a ResourceStore_WatchServer mock whose Send returns a

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1704,7 +1704,7 @@ func requireBookmarkEvent(t *testing.T, stream *bookmarkWatchServer, eventType r
 
 func advanceBookmarkClock() time.Time {
 	// synctest's clock starts before the Snowflake epoch.
-	time.Sleep(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC).Sub(time.Now()))
+	time.Sleep(time.Until(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)))
 	return time.Now()
 }
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/bwmarrin/snowflake"
@@ -1624,6 +1625,432 @@ func TestPeriodicBookmarks(t *testing.T) {
 
 		require.Empty(t, bookmarks)
 	})
+}
+
+type bookmarkWatchServer struct {
+	*mockWatchServer
+	beforeSend func(*resourcepb.WatchEvent) error
+}
+
+func (s *bookmarkWatchServer) Send(event *resourcepb.WatchEvent) error {
+	if s.beforeSend != nil {
+		if err := s.beforeSend(event); err != nil {
+			return err
+		}
+	}
+	return s.mockWatchServer.Send(event)
+}
+
+// startBookmarkWatch uses the real broadcaster with controlled events and sends.
+// Call it inside synctest so ticker assertions do not depend on scheduling delays.
+func startBookmarkWatch(t *testing.T, req *resourcepb.WatchRequest, configure func(*server, *bookmarkWatchServer)) (chan<- *WrittenEvent, *bookmarkWatchServer, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(authlib.WithAuthInfo(t.Context(), newWatchTestUser()))
+	events := make(chan *WrittenEvent, 10)
+	stream := &bookmarkWatchServer{mockWatchServer: newMockWatchServer(ctx)}
+	srv, err := NewUninitializedResourceServer(ResourceServerOptions{
+		Backend:           &UnimplementedStorageBackend{},
+		BookmarkFrequency: time.Second,
+	})
+	require.NoError(t, err)
+	srv.log = log.NewNopLogger()
+	srv.broadcaster = NewBroadcaster(ctx, events, newBroadcasterMetrics(prometheus.NewRegistry()), nil)
+	if configure != nil {
+		configure(srv, stream)
+	}
+	done := make(chan error, 1)
+	go func() { done <- srv.Watch(req, stream) }()
+	t.Cleanup(func() {
+		cancel()
+		srv.cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		default: // An error-path test already consumed the result.
+		}
+	})
+	synctest.Wait()
+	return events, stream, done
+}
+
+func bookmarkWatchRequest() *resourcepb.WatchRequest {
+	return &resourcepb.WatchRequest{
+		Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+			Group: watchTestGroup, Resource: watchTestResource, Namespace: watchTestNamespace, Name: "playlist",
+		}},
+		Since:               100,
+		AllowWatchBookmarks: true,
+	}
+}
+
+func bookmarkWrittenEvent(rv int64) *WrittenEvent {
+	return &WrittenEvent{
+		Key:             bookmarkWatchRequest().Options.Key,
+		Type:            resourcepb.WatchEvent_ADDED,
+		ResourceVersion: rv,
+		Value:           []byte(`{"metadata":{"name":"playlist"}}`),
+	}
+}
+
+func requireBookmarkEvent(t *testing.T, stream *bookmarkWatchServer, eventType resourcepb.WatchEvent_Type, rv int64) {
+	t.Helper()
+	synctest.Wait()
+	require.NotEmpty(t, stream.events, "expected %s at RV %d", eventType, rv)
+	event := <-stream.events
+	require.Equal(t, eventType, event.Type)
+	require.Equal(t, rv, event.Resource.Version)
+}
+
+func TestIncrementalBookmarksFilteredEvents(t *testing.T) {
+	for _, backend := range []string{"legacy_sql", "kv"} {
+		for _, filter := range []string{"namespace", "name", "access", "group", "resource"} {
+			if backend == "legacy_sql" && (filter == "group" || filter == "resource") {
+				continue
+			}
+			t.Run(backend+"/"+filter, func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, _ *bookmarkWatchServer) {
+						if backend == "kv" {
+							srv.backend = &kvStorageBackend{}
+						}
+						srv.mostRecentRV.Store(1000)
+						if filter == "access" {
+							srv.access = &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) { return deny() }}
+						}
+					})
+					filteredEvent := func(rv int64) *WrittenEvent {
+						event := bookmarkWrittenEvent(rv)
+						switch filter {
+						case "namespace":
+							event.Key.Namespace = "other"
+						case "name":
+							event.Key.Name = "other"
+						case "group":
+							event.Key.Group = "other.grafana.app"
+						case "resource":
+							event.Key.Resource = "other"
+						}
+						return event
+					}
+
+					// Neither startup nor events at/below the fixed cutoff establish progress.
+					events <- filteredEvent(99)
+					events <- filteredEvent(100)
+					synctest.Wait()
+					time.Sleep(3 * time.Second)
+					synctest.Wait()
+					require.Empty(t, stream.events)
+
+					for _, rv := range []int64{101, 102} {
+						events <- filteredEvent(rv)
+						synctest.Wait()
+						require.Empty(t, stream.events, "filtered objects must not be sent")
+						time.Sleep(time.Second)
+						requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, rv)
+						time.Sleep(3 * time.Second)
+						synctest.Wait()
+						require.Empty(t, stream.events, "unchanged progress must not repeat")
+					}
+					events <- filteredEvent(101)
+					synctest.Wait()
+					time.Sleep(time.Second)
+					synctest.Wait()
+					require.Empty(t, stream.events, "progress must not regress")
+				})
+			})
+		}
+	}
+}
+
+func TestIncrementalBookmarksLegacySQLGroupResourceOrdering(t *testing.T) {
+	for _, other := range []string{"group", "resource"} {
+		t.Run(other, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				events, stream, _ := startBookmarkWatch(t, bookmarkWatchRequest(), nil)
+				foreign := bookmarkWrittenEvent(300)
+				if other == "group" {
+					foreign.Key.Group = "other.grafana.app"
+				} else {
+					foreign.Key.Resource = "other"
+				}
+				events <- foreign
+				synctest.Wait()
+				time.Sleep(3 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "other group/resource activity cannot establish progress")
+
+				// Legacy SQL can deliver another collection's higher RV before this one.
+				events <- bookmarkWrittenEvent(110)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 110)
+				time.Sleep(time.Second)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 110)
+
+				// Bookmark progress must not become a new live-delivery deduplication cutoff.
+				for _, rv := range []int64{105, 110} {
+					events <- bookmarkWrittenEvent(rv)
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, rv)
+					time.Sleep(time.Second)
+					synctest.Wait()
+					require.Empty(t, stream.events, "bookmarks must not regress or repeat")
+				}
+				filtered := bookmarkWrittenEvent(108)
+				filtered.Key.Namespace = "other"
+				events <- filtered
+				synctest.Wait()
+				time.Sleep(time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events)
+
+				events <- bookmarkWrittenEvent(111)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 111)
+				time.Sleep(time.Second)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 111)
+			})
+		})
+	}
+}
+
+func TestIncrementalBookmarksBlockedSend(t *testing.T) {
+	for _, backend := range []string{"legacy_sql", "kv"} {
+		for _, fail := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/send failure=%t", backend, fail), func(t *testing.T) {
+				synctest.Test(t, func(t *testing.T) {
+					entered, release := make(chan struct{}), make(chan struct{})
+					sendErr := errors.New("send failed")
+					events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, stream *bookmarkWatchServer) {
+						if backend == "kv" {
+							srv.backend = &kvStorageBackend{}
+						}
+						srv.mostRecentRV.Store(1000)
+						stream.beforeSend = func(event *resourcepb.WatchEvent) error {
+							if event.Type == resourcepb.WatchEvent_ADDED && event.Resource.Version == 101 {
+								close(entered)
+								select {
+								case <-release:
+								case <-stream.Context().Done():
+									return stream.Context().Err()
+								}
+								if fail {
+									return sendErr
+								}
+							}
+							return nil
+						}
+					})
+					events <- bookmarkWrittenEvent(101)
+					synctest.Wait()
+					select {
+					case <-entered:
+					default:
+						t.Fatal("matching send was not reached")
+					}
+					pending := bookmarkWrittenEvent(102)
+					wantObjects := []int64{101, 102}
+					if backend == "kv" {
+						pending.Key.Group = "other.grafana.app"
+						wantObjects = []int64{101}
+					}
+					events <- pending
+					synctest.Wait()
+					time.Sleep(5 * time.Second)
+					synctest.Wait()
+					require.Empty(t, stream.events, "neither the blocked nor pending event may be covered")
+
+					close(release)
+					synctest.Wait()
+					if fail {
+						require.NotEmpty(t, done)
+						require.ErrorIs(t, <-done, sendErr)
+						time.Sleep(3 * time.Second)
+						synctest.Wait()
+						require.Empty(t, stream.events, "failed sends cannot become successful progress")
+						return
+					}
+
+					time.Sleep(time.Second)
+					synctest.Wait()
+					var lastBookmarkRV int64
+					var objects []int64
+					for len(stream.events) > 0 {
+						event := <-stream.events
+						if event.Type == resourcepb.WatchEvent_BOOKMARK {
+							for _, rv := range wantObjects {
+								if rv <= event.Resource.Version {
+									require.Contains(t, objects, rv, "matching sends must precede covering bookmarks")
+								}
+							}
+							require.Greater(t, event.Resource.Version, lastBookmarkRV)
+							lastBookmarkRV = event.Resource.Version
+						} else {
+							objects = append(objects, event.Resource.Version)
+						}
+					}
+					require.Equal(t, wantObjects, objects)
+					require.Equal(t, int64(102), lastBookmarkRV)
+				})
+			})
+		}
+	}
+}
+
+func TestIncrementalBookmarkSendError(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		sendErr := errors.New("bookmark send failed")
+		events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(_ *server, stream *bookmarkWatchServer) {
+			stream.beforeSend = func(*resourcepb.WatchEvent) error { return sendErr }
+		})
+		filtered := bookmarkWrittenEvent(101)
+		filtered.Key.Name = "other"
+		events <- filtered
+		synctest.Wait()
+		time.Sleep(time.Second)
+		synctest.Wait()
+		require.NotEmpty(t, done)
+		require.ErrorIs(t, <-done, sendErr)
+		require.Empty(t, stream.events)
+	})
+}
+
+func TestIncrementalBookmarksPreviousReadFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		events, stream, done := startBookmarkWatch(t, bookmarkWatchRequest(), func(srv *server, _ *bookmarkWatchServer) {
+			srv.backend = &errorOnReadResourceBackend{readErr: &resourcepb.ErrorResult{
+				Code: http.StatusInternalServerError, Message: "read failed",
+			}}
+		})
+		event := bookmarkWrittenEvent(101)
+		event.Type = resourcepb.WatchEvent_MODIFIED
+		event.PreviousRV = 100
+		events <- event
+		synctest.Wait()
+		require.NotEmpty(t, done)
+		require.ErrorContains(t, <-done, "resource version mismatch")
+		time.Sleep(3 * time.Second)
+		synctest.Wait()
+		require.Empty(t, stream.events, "a fatal previous-read failure must not establish progress")
+	})
+}
+
+type bookmarkKVListBackend struct {
+	KVBackend
+	list func(func(ListIterator) error) (int64, error)
+}
+
+func (b *bookmarkKVListBackend) ListIterator(_ context.Context, _ *resourcepb.ListRequest, callback func(ListIterator) error) (int64, error) {
+	return b.list(callback)
+}
+
+func TestIncrementalBookmarksInitialBackfill(t *testing.T) {
+	for _, initial := range []string{"matching", "filtered", "empty", "backend error"} {
+		t.Run(initial, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				req := bookmarkWatchRequest()
+				req.SendInitialEvents = true
+				req.Options.Key.Name = ""
+				req.Options.Key.Namespace = ""
+				listed, release := make(chan struct{}), make(chan struct{})
+				listErr := errors.New("list failed")
+				events, stream, done := startBookmarkWatch(t, req, func(srv *server, stream *bookmarkWatchServer) {
+					srv.backend = &bookmarkKVListBackend{list: func(callback func(ListIterator) error) (int64, error) {
+						values := [][]byte{[]byte(`{"initial":1}`), []byte(`{"initial":2}`)}
+						if initial == "empty" {
+							values = nil
+						}
+						if err := callback(&docListIterator{values: values}); err != nil {
+							return 0, err
+						}
+						close(listed)
+						select {
+						case <-release:
+						case <-stream.Context().Done():
+							return 0, stream.Context().Err()
+						}
+						if initial == "backend error" {
+							return 100, listErr
+						}
+						return 100, nil
+					}}
+					if initial == "filtered" {
+						srv.access = &callbackAccessClient{fn: func(req authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
+							if req.Name == "name" {
+								return deny()
+							}
+							return allow()
+						}}
+					}
+				})
+				select {
+				case <-listed:
+				default:
+					t.Fatal("initial list was not reached")
+				}
+				if initial == "matching" || initial == "backend error" {
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 1)
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 2)
+				}
+				events <- bookmarkWrittenEvent(101)
+				foreign := bookmarkWrittenEvent(102)
+				foreign.Key.Resource = "other"
+				events <- foreign
+				synctest.Wait()
+				time.Sleep(5 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events, "no incremental bookmark or live event during backfill")
+				close(release)
+				synctest.Wait()
+				if initial == "backend error" {
+					require.NotEmpty(t, done)
+					require.ErrorIs(t, <-done, listErr)
+					require.Empty(t, stream.events, "failed backfill must not claim completion")
+					return
+				}
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 100)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 101)
+				time.Sleep(time.Second)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 102)
+				time.Sleep(3 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events)
+			})
+		})
+	}
+}
+
+func TestIncrementalBookmarksFrequency(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		srv := newWatchTestServer(t, watchTestServerOpts{})
+		require.Equal(t, 10*time.Second, srv.bookmarkFrequency)
+	})
+
+	for _, enabled := range []bool{true, false} {
+		t.Run(fmt.Sprintf("bookmarks enabled=%t", enabled), func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				req := bookmarkWatchRequest()
+				req.AllowWatchBookmarks = enabled
+				events, stream, _ := startBookmarkWatch(t, req, func(srv *server, _ *bookmarkWatchServer) {
+					srv.backend = &kvStorageBackend{}
+					srv.bookmarkFrequency = 5 * time.Second
+				})
+				events <- bookmarkWrittenEvent(101)
+				requireBookmarkEvent(t, stream, resourcepb.WatchEvent_ADDED, 101)
+				filtered := bookmarkWrittenEvent(102)
+				filtered.Key.Resource = "other"
+				events <- filtered
+				synctest.Wait()
+				time.Sleep(4 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events)
+				time.Sleep(time.Second)
+				if enabled {
+					requireBookmarkEvent(t, stream, resourcepb.WatchEvent_BOOKMARK, 102)
+				}
+				time.Sleep(15 * time.Second)
+				synctest.Wait()
+				require.Empty(t, stream.events)
+			})
+		})
+	}
 }
 
 // stubWatchServer is a ResourceStore_WatchServer mock whose Send returns a


### PR DESCRIPTION
this is sort of related to https://github.com/grafana/search-and-storage-team/issues/878

bookmark has two objectives:

* mark the end of the initial event seeding when called with `sendInitialEvents`
* establish watch progress over time, so that on a subsequent watch the client has a newer RV on re-watch

The first point is sound right now, but the second one is not. We use the last event we sent on the watch stream as the bookmark RV. This PR changes it so we progress the bookmark RV regardless of whether we filtered out the event or not.

For example, with a grpc connection max age of 5 minutes, every consumer gets disconnected every 5 minutes, so they have to re-connect. clients will try to resume from the last seen RV. After I introduce the next PR (which will fix https://github.com/grafana/search-and-storage-team/issues/878) that catch up will be done by scanning the events in the event store. Every disconnect will have to scan a bigger chunk of the eventstore for no reason. This PR advances idle streams RV every minute, so we will need to scan and filter out less data on storage side, as we're skipping a bigger amount of events that it's guaranteed not to be theirs.

There's a workaround for the sql backend because that backend has group/resource independent RVs, so we can only progress bookmark when those advance.