### PR TITLE
Unified storage: always give search its index metrics

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -66,6 +66,8 @@ const (
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
 
+// ProvideIndexMetrics builds the index metrics. A nil reg leaves them
+// unregistered, so callers without a registry never have to check for nil.
 func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 	m := &BleveIndexMetrics{
 		IndexSize: promauto.With(reg).NewGauge(prometheus.GaugeOpts{

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -458,6 +458,11 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 		searchFields = NewSearchFieldsRegistry(nil, nil, nil)
 	}
 
+	// Recording sites should not have to check for nil.
+	if indexMetrics == nil {
+		indexMetrics = ProvideIndexMetrics(nil)
+	}
+
 	s := &searchServer{
 		access:         access,
 		storage:        storage,
@@ -1604,9 +1609,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 			rebuildReq := newRebuildRequest(key, minBuildTime, lastImportTime, s.minBuildVersion, sfields, expectedSearchFieldsHash, completeCh)
 			s.rebuildQueue.Add(rebuildReq)
 
-			if s.indexMetrics != nil {
-				s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
-			}
+			s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
 		}
 	}
 	return completeChs
@@ -1637,9 +1640,7 @@ func (s *searchServer) runIndexRebuilder(ctx context.Context) {
 			return
 		}
 
-		if s.indexMetrics != nil {
-			s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
-		}
+		s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
 
 		s.rebuildIndex(ctx, req)
 	}
@@ -1717,9 +1718,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 			// shouldRebuildIndex against the just-built BuildTime and either run
 			// another rebuild or close the deferred completion channels as a no-op.
 			s.rebuildQueue.Add(*deferred)
-			if s.indexMetrics != nil {
-				s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
-			}
+			s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
 		}
 	}()
 
@@ -1935,9 +1934,7 @@ func (s *searchServer) getOrCreateIndex(ctx context.Context, stats *SearchStats,
 	}
 	elapsed := time.Since(start)
 	stats.AddIndexUpdateTime(elapsed)
-	if s.indexMetrics != nil {
-		s.indexMetrics.SearchUpdateWaitTime.WithLabelValues(reason).Observe(elapsed.Seconds())
-	}
+	s.indexMetrics.SearchUpdateWaitTime.WithLabelValues(reason).Observe(elapsed.Seconds())
 	s.log.FromContext(ctx).Debug("Index updated before search", "namespace", key.Namespace, "group", key.Group, "resource", key.Resource, "reason", reason, "duration", elapsed, "rv", rv)
 	span.AddEvent("Index updated")
 
@@ -2316,9 +2313,7 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 	if err != nil {
 		logger.Warn("error getting doc count", "error", err)
 	}
-	if s.indexMetrics != nil {
-		s.indexMetrics.IndexedKinds.WithLabelValues(nsr.Resource).Add(float64(docCount))
-	}
+	s.indexMetrics.IndexedKinds.WithLabelValues(nsr.Resource).Add(float64(docCount))
 
 	return index, err
 }

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -1772,6 +1772,7 @@ func TestSearchServer_VectorSearch_ObservesDuration(t *testing.T) {
 	s := &searchServer{
 		log:           log.New("test-vector-search"),
 		vectorMetrics: m,
+		indexMetrics:  ProvideIndexMetrics(nil),
 	}
 
 	_, err := s.VectorSearch(context.Background(), &resourcepb.VectorSearchRequest{
@@ -1796,6 +1797,7 @@ func TestSearchServer_HybridSearch_ObservesDuration(t *testing.T) {
 	s := &searchServer{
 		log:           log.New("test-hybrid-search"),
 		vectorMetrics: m,
+		indexMetrics:  ProvideIndexMetrics(nil),
 	}
 
 	_, err := s.HybridSearch(context.Background(), &resourcepb.HybridSearchRequest{

--- a/pkg/storage/unified/resource/search_vector_test.go
+++ b/pkg/storage/unified/resource/search_vector_test.go
@@ -185,6 +185,7 @@ func newTestSearchServer(emb *embedder.Embedder, backend vector.VectorBackend, a
 		vectorBackend: backend,
 		embedder:      emb,
 		access:        ac,
+		indexMetrics:  ProvideIndexMetrics(nil),
 		// validKey()'s pair, allowed on both lists so tests exercise paths past the allowlist.
 		collectionAllowlist: vector.NewCollectionAllowlist([]string{"g/r"}, []string{"g/r"}),
 	}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -271,6 +271,10 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 	if opts.Root == "" {
 		return nil, fmt.Errorf("bleve backend missing root folder configuration")
 	}
+	// Recording sites should not have to check for nil.
+	if indexMetrics == nil {
+		indexMetrics = resource.ProvideIndexMetrics(nil)
+	}
 	absRoot, err := filepath.Abs(opts.Root)
 	if err != nil {
 		return nil, fmt.Errorf("error getting absolute path for bleve root folder %w", err)
@@ -375,10 +379,8 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		go be.cleanupDiskPeriodically(ctx)
 	}
 
-	if be.indexMetrics != nil {
-		be.bgTasksWg.Add(1)
-		go be.updateIndexSizeMetric(ctx, opts.Root)
-	}
+	be.bgTasksWg.Add(1)
+	go be.updateIndexSizeMetric(ctx, opts.Root)
 
 	return be, nil
 }
@@ -428,9 +430,7 @@ func (b *bleveBackend) closeIndex(idx *bleveIndex, key resource.NamespacedResour
 		b.log.Error("failed to close index", "key", key, "err", err)
 	}
 
-	if b.indexMetrics != nil {
-		b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Dec()
-	}
+	b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Dec()
 }
 
 // This function will periodically evict expired or un-owned indexes from the cache.
@@ -644,16 +644,11 @@ func (b *bleveBackend) runUploadSnapshots(ctx context.Context) {
 		}
 		b.setUploadTracking(key, time.Now())
 		b.recordSnapshotUploadStatus(snapshotUploadStatusSuccess)
-		if b.indexMetrics != nil {
-			b.indexMetrics.IndexSnapshotUploadDuration.Observe(time.Since(start).Seconds())
-		}
+		b.indexMetrics.IndexSnapshotUploadDuration.Observe(time.Since(start).Seconds())
 	}
 }
 
 func (b *bleveBackend) recordSnapshotUploadStatus(status string) {
-	if b.indexMetrics == nil {
-		return
-	}
 	b.indexMetrics.IndexSnapshotUploads.WithLabelValues(status).Inc()
 }
 
@@ -948,9 +943,7 @@ func (b *bleveBackend) BuildIndex(
 
 		idx.resourceVersion.Store(prepared.indexRV)
 
-		if b.indexMetrics != nil {
-			b.indexMetrics.IndexBuildSkipped.Inc()
-		}
+		b.indexMetrics.IndexBuildSkipped.Inc()
 	}
 
 	// Set expiration after building the index. Only expire in-memory indexes.
@@ -975,18 +968,14 @@ func (b *bleveBackend) BuildIndex(
 
 	// If there was a previous index in the cache, close it.
 	if prev != nil {
-		if b.indexMetrics != nil {
-			b.indexMetrics.OpenIndexes.WithLabelValues(prev.indexStorage).Dec()
-		}
+		b.indexMetrics.OpenIndexes.WithLabelValues(prev.indexStorage).Dec()
 
 		err := prev.stopUpdaterAndCloseIndex()
 		if err != nil {
 			logWithDetails.Error("failed to close previous index", "key", key, "err", err)
 		}
 	}
-	if b.indexMetrics != nil {
-		b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Inc()
-	}
+	b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Inc()
 
 	// Clean up the old index directories. If we have built a new file-based index, the new name is ignored.
 	// If we have created in-memory index and fileIndexName is empty, all old directories can be removed.
@@ -1365,17 +1354,13 @@ func countDocsForLog(index bleve.Index) uint64 {
 }
 
 func (b *bleveBackend) buildIndexFromScratch(idx buildResourceIndex, indexBuildReason string, builder resource.BuildFn, logger log.Logger) error {
-	if b.indexMetrics != nil {
-		b.indexMetrics.IndexBuilds.WithLabelValues(indexBuildReason).Inc()
-	}
+	b.indexMetrics.IndexBuilds.WithLabelValues(indexBuildReason).Inc()
 
 	start := time.Now()
 	listRV, err := builder(idx)
 	if err != nil {
 		logger.Error("Failed to build index", "err", err)
-		if b.indexMetrics != nil {
-			b.indexMetrics.IndexBuildFailures.Inc()
-		}
+		b.indexMetrics.IndexBuildFailures.Inc()
 		return fmt.Errorf("failed to build index: %w", err)
 	}
 	if err := idx.updateResourceVersion(listRV); err != nil {
@@ -1386,9 +1371,7 @@ func (b *bleveBackend) buildIndexFromScratch(idx buildResourceIndex, indexBuildR
 	elapsed := time.Since(start)
 	logger.Info("Finished building index", "elapsed", elapsed, "listRV", listRV)
 
-	if b.indexMetrics != nil {
-		b.indexMetrics.IndexCreationTime.WithLabelValues().Observe(elapsed.Seconds())
-	}
+	b.indexMetrics.IndexCreationTime.WithLabelValues().Observe(elapsed.Seconds())
 	return nil
 }
 
@@ -1693,9 +1676,7 @@ func (b *bleveBackend) closeAllIndexes() {
 		}
 		delete(b.cache, key)
 
-		if b.indexMetrics != nil {
-			b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Dec()
-		}
+		b.indexMetrics.OpenIndexes.WithLabelValues(idx.indexStorage).Dec()
 	}
 }
 
@@ -1815,10 +1796,8 @@ func (b *bleveBackend) newBleveIndex(
 		trashRetention:        b.opts.TrashRetention,
 	}
 	bi.updaterCond = sync.NewCond(&bi.updaterMu)
-	if b.indexMetrics != nil {
-		bi.updateLatency = b.indexMetrics.UpdateLatency
-		bi.updatedDocuments = b.indexMetrics.UpdatedDocuments
-	}
+	bi.updateLatency = b.indexMetrics.UpdateLatency
+	bi.updatedDocuments = b.indexMetrics.UpdatedDocuments
 	return bi
 }
 
@@ -1913,7 +1892,7 @@ func (b *bleveIndex) mapBatch(req *resource.BulkIndexRequest) (*bleve.Batch, err
 // recordPromotePhase reports what copying the index to disk cost, for the one
 // batch that crosses the threshold.
 func (a *adaptiveBuildIndex) recordPromotePhase(path string, d time.Duration) {
-	if a.bleveIndex == nil || a.indexMetrics == nil || path == "" {
+	if a.bleveIndex == nil || path == "" {
 		return
 	}
 	a.indexMetrics.BuildPhaseSeconds.WithLabelValues(resource.IndexPhasePromote, path, a.key.Group, a.key.Resource).Add(d.Seconds())
@@ -1925,7 +1904,7 @@ func (a *adaptiveBuildIndex) recordPromotePhase(path string, d time.Duration) {
 // spent; documents and bytes count what the write accepted, which only the
 // index knows. An empty path means the caller is not measuring.
 func (b *bleveIndex) recordBatchPhases(path string, mapped, commit time.Duration, indexedBytes uint64, documents int, committed bool) {
-	if b.indexMetrics == nil || path == "" {
+	if path == "" {
 		return
 	}
 	b.indexMetrics.BuildPhaseSeconds.WithLabelValues(resource.IndexPhaseMap, path, b.key.Group, b.key.Resource).Add(mapped.Seconds())
@@ -3405,9 +3384,7 @@ func (b *bleveIndex) checkSortCapability(req *resourcepb.ResourceSearchRequest) 
 		if b.sortableField(sort.Field) {
 			continue
 		}
-		if b.indexMetrics != nil {
-			b.indexMetrics.SearchCapabilityViolations.WithLabelValues(b.key.Resource, string(resource.SearchCapabilitySort)).Inc()
-		}
+		b.indexMetrics.SearchCapabilityViolations.WithLabelValues(b.key.Resource, string(resource.SearchCapabilitySort)).Inc()
 		if !b.enforceSortCapability {
 			b.logger.Warn("search sorts on a field that does not declare the sort capability", "field", sort.Field)
 			continue

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -248,12 +248,12 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	choices, err := selectFn(ctx)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
-		b.recordSnapshotDownloadOutcome(policy, outcome)
+		b.indexMetrics.IndexSnapshotDownloadAttempts.WithLabelValues(policy, outcome).Inc()
 		return nil, "", 0, err
 	}
 	if len(choices) == 0 {
 		outcome = snapshotStatusEmpty
-		b.recordSnapshotDownloadOutcome(policy, outcome)
+		b.indexMetrics.IndexSnapshotDownloadAttempts.WithLabelValues(policy, outcome).Inc()
 		return nil, "", 0, nil
 	}
 
@@ -284,7 +284,7 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 
 		idx, name, rv, attemptOutcome, err := b.downloadSnapshotCandidate(ctx, key, resourceDir, snapKey, meta, attemptLogger)
 		outcome = attemptOutcome
-		b.recordSnapshotDownloadOutcome(policy, outcome)
+		b.indexMetrics.IndexSnapshotDownloadAttempts.WithLabelValues(policy, outcome).Inc()
 		if err == nil {
 			logger = attemptLogger
 			return idx, name, rv, nil
@@ -346,9 +346,7 @@ func (b *bleveBackend) downloadSnapshotCandidate(
 		return nil, "", 0, snapshotStatusValidateError, fmt.Errorf("validating downloaded snapshot: %w", err)
 	}
 
-	if b.indexMetrics != nil {
-		b.indexMetrics.IndexSnapshotDownloadDuration.Observe(time.Since(downloadStart).Seconds())
-	}
+	b.indexMetrics.IndexSnapshotDownloadDuration.Observe(time.Since(downloadStart).Seconds())
 
 	uploadedAt := meta.UploadTimestamp
 	if downloadedMeta != nil && !downloadedMeta.UploadTimestamp.IsZero() {
@@ -530,13 +528,6 @@ func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 		return 0, fmt.Errorf("snapshot is missing required index features %v", missing)
 	}
 	return rv, nil
-}
-
-func (b *bleveBackend) recordSnapshotDownloadOutcome(policy, status string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexSnapshotDownloadAttempts.WithLabelValues(policy, status).Inc()
 }
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and
@@ -838,7 +829,7 @@ func (b *bleveBackend) coordinateColdStartBuild(
 			return b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
 		},
 		recordOutcome: func(outcome string) {
-			b.recordBuildCoordinationOutcome(snapshotBuildFlowColdStart, outcome)
+			b.indexMetrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowColdStart, outcome).Inc()
 		},
 	}, logger)
 }
@@ -903,7 +894,7 @@ func (b *bleveBackend) coordinateRebuild(
 			return b.tryDownloadRebuildSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
 		},
 		recordOutcome: func(outcome string) {
-			b.recordBuildCoordinationOutcome(snapshotBuildFlowRebuild, outcome)
+			b.indexMetrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowRebuild, outcome).Inc()
 		},
 	}, logger)
 }
@@ -933,11 +924,4 @@ func (b *bleveBackend) tryDownloadRebuildSnapshot(
 		return nil, "", 0, nil
 	}
 	return idx, name, rv, nil
-}
-
-func (b *bleveBackend) recordBuildCoordinationOutcome(flow, outcome string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexSnapshotBuildCoordinations.WithLabelValues(flow, outcome).Inc()
 }

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1027,6 +1027,7 @@ func TestBleveSortCapabilityCheck(t *testing.T) {
 			searchFields:          newKindSearchFields(provider, group, kindResource, []string{"spec.slug"}),
 			enforceSortCapability: enforce,
 			logger:                log.NewNopLogger(),
+			indexMetrics:          resource.ProvideIndexMetrics(nil),
 		}
 	}
 
@@ -1109,6 +1110,7 @@ func TestBleveSortCapabilityCheck(t *testing.T) {
 			fields:                resource.StandardSearchFields(),
 			enforceSortCapability: true,
 			logger:                log.NewNopLogger(),
+			indexMetrics:          resource.ProvideIndexMetrics(nil),
 		}
 		_, errResult := idx.toBleveSearchRequest(t.Context(), sortBy(resource.SEARCH_FIELD_TITLE), nil, false, nil)
 		require.Nil(t, errResult)

--- a/pkg/storage/unified/search/disk_cleanup.go
+++ b/pkg/storage/unified/search/disk_cleanup.go
@@ -92,7 +92,7 @@ func (b *bleveBackend) runDiskCleanup(ctx context.Context) {
 	root, err := os.OpenRoot(b.opts.Root)
 	if err != nil {
 		span.RecordError(err)
-		b.recordDiskCleanupRun(diskCleanupOutcomeError)
+		b.indexMetrics.IndexDiskCleanupRuns.WithLabelValues(diskCleanupOutcomeError).Inc()
 		b.log.Warn("Disk index cleanup failed: opening root", "root", b.opts.Root, "err", err)
 		return
 	}
@@ -103,7 +103,7 @@ func (b *bleveBackend) runDiskCleanup(ctx context.Context) {
 	if err != nil {
 		stats.errors++
 		span.RecordError(err)
-		b.recordDiskCleanupRun(diskCleanupOutcomeError)
+		b.indexMetrics.IndexDiskCleanupRuns.WithLabelValues(diskCleanupOutcomeError).Inc()
 		b.log.Warn("Disk index cleanup failed: reading root", "root", b.opts.Root, "err", err)
 		return
 	}
@@ -126,7 +126,7 @@ func (b *bleveBackend) runDiskCleanup(ctx context.Context) {
 	if stats.errors > 0 {
 		outcome = diskCleanupOutcomeError
 	}
-	b.recordDiskCleanupRun(outcome)
+	b.indexMetrics.IndexDiskCleanupRuns.WithLabelValues(outcome).Inc()
 	span.SetAttributes(
 		attribute.String("outcome", outcome),
 		attribute.Int("dirs_scanned", stats.scanned),
@@ -217,13 +217,13 @@ func (b *bleveBackend) tryRemoveCandidate(root *os.Root, rel, kind string, grace
 	}
 	if err := root.RemoveAll(rel); err != nil {
 		b.log.Warn("Disk index cleanup: removing dir", "kind", kind, "dir", abs, "err", err)
-		b.recordDiskCleanupDirsDeleted(kind, diskCleanupOutcomeError)
+		b.indexMetrics.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, diskCleanupOutcomeError).Inc()
 		stats.deleteFailures++
 		stats.errors++
 		return
 	}
 	b.log.Info("Disk index cleanup: removed dir", "kind", kind, "dir", abs)
-	b.recordDiskCleanupDirsDeleted(kind, diskCleanupOutcomeSuccess)
+	b.indexMetrics.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, diskCleanupOutcomeSuccess).Inc()
 	switch kind {
 	case diskCleanupKindIndex:
 		stats.deletedIndex++
@@ -483,18 +483,4 @@ func (b *bleveBackend) tryRemoveIfEmpty(root *os.Root, rel string, stats *diskCl
 // (which keys on absolute paths) rely on that precondition.
 func joinRoot(root *os.Root, rel string) string {
 	return filepath.Join(root.Name(), filepath.FromSlash(rel))
-}
-
-func (b *bleveBackend) recordDiskCleanupRun(outcome string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexDiskCleanupRuns.WithLabelValues(outcome).Inc()
-}
-
-func (b *bleveBackend) recordDiskCleanupDirsDeleted(kind, outcome string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, outcome).Inc()
 }

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -100,7 +100,7 @@ func (b *bleveBackend) runCleanup(ctx context.Context) {
 	if err != nil {
 		// We can't attribute this error to any single namespace, so it shows up
 		// as a single "error" cleanup. Logged at warn so operators see it.
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
+		b.indexMetrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusError).Inc()
 		span.SetAttributes(attribute.String("outcome", snapshotNamespaceCleanupStatusError))
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -125,7 +125,7 @@ func (b *bleveBackend) runCleanup(ctx context.Context) {
 		outcome, err := b.runNamespaceCleanup(ctx, ns)
 		// Cancellation usually means shutdown; keep it out of the namespace outcome metric.
 		if outcome != snapshotNamespaceCleanupStatusCanceled {
-			b.recordSnapshotNamespaceCleanupStatus(outcome)
+			b.indexMetrics.IndexSnapshotNamespaceCleanups.WithLabelValues(outcome).Inc()
 		}
 		if err != nil {
 			hadNamespaceError = true
@@ -297,12 +297,12 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 			return store.DeleteIndex(ctx, res, key)
 		}); err != nil {
 			logger.Warn("deleting index snapshot", "resource", res, "snapshot", key.String(), "err", err)
-			b.recordSnapshotDeleted(snapshotDeleteOutcomeError)
+			b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeError).Inc()
 			deleteFailures++
 			continue
 		}
 		logger.Info("deleted index snapshot", "resource", res, "snapshot", key.String(), "uploaded", metas[key].UploadTimestamp, "age", time.Since(metas[key].UploadTimestamp))
-		b.recordSnapshotDeleted(snapshotDeleteOutcomeSuccess)
+		b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeSuccess).Inc()
 	}
 
 	// CleanupIncompleteIndexSnapshots returns a partial cleaned count even on error;
@@ -311,7 +311,7 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 	// delete loop above: log, flag, continue — don't short-circuit the resource.
 	cleaned, incompleteErr := CleanupIncompleteIndexSnapshots(ctx, store, res, time.Now().Add(-cleanupIncompleteUploadsMinAge), logger)
 	for range cleaned {
-		b.recordIncompleteUploadCleaned()
+		b.indexMetrics.IndexSnapshotIncompleteUploadsCleaned.Inc()
 	}
 	if incompleteErr != nil {
 		logger.Warn("cleaning up incomplete uploads", "resource", res, "err", incompleteErr)
@@ -400,25 +400,4 @@ func selectSnapshotsToDelete(metas map[ulid.ULID]*IndexMeta, now time.Time, maxA
 	}
 
 	return toDelete
-}
-
-func (b *bleveBackend) recordSnapshotNamespaceCleanupStatus(status string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexSnapshotNamespaceCleanups.WithLabelValues(status).Inc()
-}
-
-func (b *bleveBackend) recordSnapshotDeleted(outcome string) {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(outcome).Inc()
-}
-
-func (b *bleveBackend) recordIncompleteUploadCleaned() {
-	if b.indexMetrics == nil {
-		return
-	}
-	b.indexMetrics.IndexSnapshotIncompleteUploadsCleaned.Inc()
 }


### PR DESCRIPTION
Every site recording an index metric first asked whether the metrics existed — twenty-eight `indexMetrics != nil` checks — because callers without a registry passed nil.

`NewBleveBackend` and `newSearchServer` now substitute `ProvideIndexMetrics(nil)`, which builds the collectors without registering them. Recording sites just record, and the two remaining checks are the constructor guards themselves.

Seven of the eight one-line helpers that wrapped a single metric call each (`recordDiskCleanupRun`, `recordSnapshotDownloadOutcome` and friends) existed only to hold those nil checks, so they go too — each had one to three call sites, and the call sites now name the metric directly.

`recordSnapshotUploadStatus` stays. It has thirteen call sites in a run of guard clauses, where spelling out `b.indexMetrics.IndexSnapshotUploads.WithLabelValues(...).Inc()` each time reads as plumbing rather than as intent.

Two things a reviewer may want to weigh:

- The invariant holds through the constructors, so struct literals bypass it. Three test files built `&bleveIndex{}` or `&searchServer{}` directly and panicked; they now set `indexMetrics: ProvideIndexMetrics(nil)`. Future literals will need the same, where before they were silently safe.
- Net 53 insertions against 125 deletions.
