### PR TITLE
TraceView: Align span tree chevron and dash with indent guides

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -29,6 +29,9 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
     label: 'SpanTreeOffset',
     color: autoColor(theme, '#000'),
     position: 'relative',
+    display: 'inline-flex',
+    alignSelf: 'stretch',
+    alignItems: 'stretch',
   }),
   SpanTreeOffsetParent: css({
     label: 'SpanTreeOffsetParent',
@@ -38,7 +41,7 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
   }),
   indentGuide: css({
     label: 'indentGuide',
-    /* The size of the indentGuide is based off of the iconWrapper */
+    /* 1px guide on the left, then 1rem for the chevron/dash */
     paddingRight: '1rem',
     height: '100%',
     display: 'inline-flex',
@@ -64,10 +67,13 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
     label: 'iconWrapper',
     position: 'absolute',
     right: 0,
-    height: '100%',
-    paddingTop: '1px',
+    top: 0,
+    bottom: 0,
     width: '1rem',
-    textAlign: 'center',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    lineHeight: 0,
   }),
 }));
 


### PR DESCRIPTION
**What is this feature?**

TraceView: Align span tree chevron and dash with indent guides

**Why do we need this feature?**

- Vertically and horizontally center the expand chevron and leaf `-` in the span tree offset column.
- Keep the indent guide on the left of each column (chevron/dash sit in the 1rem to its right).
- Stretch the offset to the row height so the guide line is continuous.

**Who is this feature for?**

Trace view users

**Special notes for your reviewer:**

Before 
<img width="114" height="59" alt="Screenshot 2026-09-11 at 12 55 27" src="https://github.com/user-attachments/assets/e5fe1239-fc6d-46b2-b118-a2cf485a616d" />


After
<img width="100" height="56" alt="Screenshot 2026-09-11 at 13 18 53" src="https://github.com/user-attachments/assets/dec54bc7-0637-48f2-b48e-db7864219247" />
