### PR TITLE
CI: Add '#vendor' branch as a source in mirrors

### DIFF
--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -17,6 +17,10 @@ on:
       - "main"
       - "v*.*.*"
       - "release-*.*.*"
+      # Vendor-targeting patches: authors PR against "<branch>#vendor" (published by
+      # security-patch-actions alongside "<branch>#patched") to modify a vendored dependency
+      # directly. "#" is not a path separator, so this also matches "release-*.*.*#vendor" etc.
+      - "*#vendor"
 
 concurrency:
   group: create-patch-${{ github.ref }}

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -237,7 +237,9 @@ jobs:
     - name: Verify generated clients
       run: |
         uncommited_error_message="ERROR! API client generation has not been committed. Please run 'yarn generate-apis', commit the changes and push again."
-        file_diff="$(git diff ':!conf' ':!go.mod' ':!go.sum')"
+        # LICENSE is swapped to the Enterprise License Agreement by the "Setup Enterprise"
+        # step above (grafana-enterprise's build.sh overlay), not by API client generation.
+        file_diff="$(git diff ':!conf' ':!go.mod' ':!go.sum' ':!LICENSE')"
         if [ -n "$file_diff" ]; then
             echo "$file_diff"
             echo "${uncommited_error_message}"

--- a/.policy.yml
+++ b/.policy.yml
@@ -178,7 +178,7 @@ approval_rules:
         paths:
           - ^\.github\/workflows\/create-security-patch-from-security-mirror\.yml$
       targets_branch:
-        pattern: (^main$|^v(?:[^/]*)\.(?:[^/]*)\.(?:[^/]*)$|^release-(?:[^/]*)\.(?:[^/]*)\.(?:[^/]*)$)
+        pattern: (^main$|^v(?:[^/]*)\.(?:[^/]*)\.(?:[^/]*)$|^release-(?:[^/]*)\.(?:[^/]*)\.(?:[^/]*)$|^(?:[^/]*)#vendor$)
     requires:
       conditions:
         has_workflow_result:


### PR DESCRIPTION
This branch is basically the same branch as a release branch, but with the vendor dir committed.