### PR TITLE
Alerting: Split ExpressionQuery into per-type schemas

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -232,8 +232,9 @@ function ExpressionPreview({ refId, model, evalData, isAlertCondition, isLoading
   const styles = useStyles2(getQueryBoxStyles);
 
   function renderPreview() {
-    // Read before the switch: every type is handled, so the compiler narrows `model` away to
-    // nothing in the default branch. That branch still matters for a model with an unknown type.
+    // Grab this before the switch. Every type is handled below, so by the default branch there is
+    // no type left for `model` to be - but that branch still runs if a rule has a type we do not
+    // know about.
     const unsupportedType: string = model.type;
 
     switch (model.type) {

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -12,6 +12,11 @@ import { type CombinedRule } from 'app/types/unified-alerting';
 
 import { type AlertDataQuery, type AlertQuery } from '../../../types/unified-alerting-dto';
 import { isExpressionQuery } from '../../expressions/guards';
+import type { ClassicExpressionQuery } from '../../expressions/schemas/classic';
+import type { MathExpressionQuery } from '../../expressions/schemas/math';
+import type { ReduceExpressionQuery } from '../../expressions/schemas/reduce';
+import type { ResampleExpressionQuery } from '../../expressions/schemas/resample';
+import type { ThresholdExpressionQuery } from '../../expressions/schemas/threshold';
 import {
   type ExpressionQuery,
   ExpressionQueryType,
@@ -227,6 +232,10 @@ function ExpressionPreview({ refId, model, evalData, isAlertCondition, isLoading
   const styles = useStyles2(getQueryBoxStyles);
 
   function renderPreview() {
+    // Read before the switch: every type is handled, so the compiler narrows `model` away to
+    // nothing in the default branch. That branch still matters for a model with an unknown type.
+    const unsupportedType: string = model.type;
+
     switch (model.type) {
       case ExpressionQueryType.math:
         return <MathExpressionViewer model={model} />;
@@ -248,7 +257,7 @@ function ExpressionPreview({ refId, model, evalData, isAlertCondition, isLoading
 
       default:
         return (
-          <Trans i18nKey="alerting.expression-preview.expression-not-supported" values={{ type: model.type }}>
+          <Trans i18nKey="alerting.expression-preview.expression-not-supported" values={{ type: unsupportedType }}>
             Expression not supported: {'{{type}}'}
           </Trans>
         );
@@ -356,7 +365,7 @@ const getQueryBoxStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-function ClassicConditionViewer({ model }: { model: ExpressionQuery }) {
+function ClassicConditionViewer({ model }: { model: ClassicExpressionQuery }) {
   const styles = useStyles2(getClassicConditionViewerStyles);
 
   const reducerFunctions = keyBy(alertDef.reducerTypes, (rt) => rt.value);
@@ -365,7 +374,7 @@ function ClassicConditionViewer({ model }: { model: ExpressionQuery }) {
 
   return (
     <div className={styles.container}>
-      {model.conditions?.map(({ query, operator, reducer, evaluator }, index) => {
+      {model.conditions.map(({ query, operator, reducer, evaluator }, index) => {
         const isRange = isRangeEvaluator(evaluator);
         const params = evaluator.params;
         let thresholdDisplay = '';
@@ -403,7 +412,7 @@ const getClassicConditionViewerStyles = (theme: GrafanaTheme2) => ({
   ...getCommonQueryStyles(theme),
 });
 
-function ReduceConditionViewer({ model }: { model: ExpressionQuery }) {
+function ReduceConditionViewer({ model }: { model: ReduceExpressionQuery }) {
   const styles = useStyles2(getReduceConditionViewerStyles);
 
   const { reducer, expression, settings } = model;
@@ -446,7 +455,7 @@ const getReduceConditionViewerStyles = (theme: GrafanaTheme2) => ({
   ...getCommonQueryStyles(theme),
 });
 
-function ResampleExpressionViewer({ model }: { model: ExpressionQuery }) {
+function ResampleExpressionViewer({ model }: { model: ResampleExpressionQuery }) {
   const styles = useStyles2(getResampleExpressionViewerStyles);
 
   const { expression, window, downsampler, upsampler } = model;
@@ -488,13 +497,13 @@ const getResampleExpressionViewerStyles = (theme: GrafanaTheme2) => ({
   ...getCommonQueryStyles(theme),
 });
 
-function ThresholdExpressionViewer({ model }: { model: ExpressionQuery }) {
+function ThresholdExpressionViewer({ model }: { model: ThresholdExpressionQuery }) {
   const styles = useStyles2(getExpressionViewerStyles);
 
   const { expression, conditions } = model;
 
-  const evaluator = conditions && conditions[0]?.evaluator;
-  const thresholdFunction = thresholdFunctions.find((tf) => tf.value === evaluator?.type);
+  const evaluator = conditions[0].evaluator;
+  const thresholdFunction = thresholdFunctions.find((tf) => tf.value === evaluator.type);
 
   const isRange = evaluator ? isRangeEvaluator(evaluator) : false;
 
@@ -562,7 +571,7 @@ const getExpressionViewerStyles = (theme: GrafanaTheme2) => {
   };
 };
 
-function MathExpressionViewer({ model }: { model: ExpressionQuery }) {
+function MathExpressionViewer({ model }: { model: MathExpressionQuery }) {
   const styles = useStyles2(getExpressionViewerStyles);
 
   const { expression } = model;

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -13,12 +13,12 @@ import { type CombinedRule } from 'app/types/unified-alerting';
 import { type AlertDataQuery, type AlertQuery } from '../../../types/unified-alerting-dto';
 import { isExpressionQuery } from '../../expressions/guards';
 import type { ClassicExpressionQuery } from '../../expressions/schemas/classic';
+import type { ExpressionQuery } from '../../expressions/schemas/expressionQuery';
 import type { MathExpressionQuery } from '../../expressions/schemas/math';
 import type { ReduceExpressionQuery } from '../../expressions/schemas/reduce';
 import type { ResampleExpressionQuery } from '../../expressions/schemas/resample';
 import type { ThresholdExpressionQuery } from '../../expressions/schemas/threshold';
 import {
-  type ExpressionQuery,
   ExpressionQueryType,
   ReducerMode,
   downsamplingTypes,

--- a/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
+++ b/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
@@ -41,25 +41,6 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
     {
       "datasourceUid": "__expr__",
       "model": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [],
-              "type": "gt",
-            },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [],
-            },
-            "reducer": {
-              "params": [],
-              "type": "last",
-            },
-            "type": "query",
-          },
-        ],
         "datasource": {
           "type": "__expr__",
           "uid": "__expr__",
@@ -83,19 +64,6 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
               ],
               "type": "gt",
             },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [
-                "C",
-              ],
-            },
-            "reducer": {
-              "params": [],
-              "type": "last",
-            },
-            "type": "query",
           },
         ],
         "datasource": {

--- a/public/app/features/alerting/unified/__snapshots__/RuleEditorGrafanaRecordingRules.test.tsx.snap
+++ b/public/app/features/alerting/unified/__snapshots__/RuleEditorGrafanaRecordingRules.test.tsx.snap
@@ -68,25 +68,6 @@ exports[`RuleEditor grafana recording rules can create new grafana recording rul
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -196,25 +177,6 @@ exports[`RuleEditor grafana recording rules can create new grafana recording rul
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -19,12 +19,8 @@ import { Math } from 'app/features/expressions/components/Math';
 import { Reduce } from 'app/features/expressions/components/Reduce';
 import { Resample } from 'app/features/expressions/components/Resample';
 import { Threshold } from 'app/features/expressions/components/Threshold';
-import {
-  type ExpressionQuery,
-  ExpressionQueryType,
-  expressionTypes,
-  getExpressionLabel,
-} from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType, expressionTypes, getExpressionLabel } from 'app/features/expressions/types';
 import { type AlertQuery, PromAlertingRuleState } from 'app/types/unified-alerting-dto';
 
 import { usePagination } from '../../hooks/usePagination';

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -102,6 +102,11 @@ export const Expression: FC<ExpressionProps> = ({
         .filter((q) => query.refId !== q.refId)
         .map((q) => ({ value: q.refId, label: q.refId }));
 
+      // Read before the switch: every type is handled below, so inside the default branch the
+      // compiler has narrowed `query` away to nothing. The branch still matters at runtime, for a
+      // model that somehow carries a type we do not know.
+      const unsupportedType: string = query.type;
+
       switch (query.type) {
         case ExpressionQueryType.math:
           return <Math onChange={onChangeQuery} query={query} labelWidth={'auto'} onRunQuery={() => {}} />;
@@ -150,7 +155,7 @@ export const Expression: FC<ExpressionProps> = ({
 
         default:
           return (
-            <Trans i18nKey="alerting.expression.not-supported" values={{ expression: query.type }}>
+            <Trans i18nKey="alerting.expression.not-supported" values={{ expression: unsupportedType }}>
               Expression not supported: {'{{expression}}'}
             </Trans>
           );

--- a/public/app/features/alerting/unified/components/expressions/Expression.tsx
+++ b/public/app/features/alerting/unified/components/expressions/Expression.tsx
@@ -98,9 +98,9 @@ export const Expression: FC<ExpressionProps> = ({
         .filter((q) => query.refId !== q.refId)
         .map((q) => ({ value: q.refId, label: q.refId }));
 
-      // Read before the switch: every type is handled below, so inside the default branch the
-      // compiler has narrowed `query` away to nothing. The branch still matters at runtime, for a
-      // model that somehow carries a type we do not know.
+      // Grab this before the switch. Every type is handled below, so by the default branch there
+      // is no type left for `query` to be - but that branch still runs if a rule has a type we do
+      // not know about.
       const unsupportedType: string = query.type;
 
       switch (query.type) {

--- a/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ExpressionsEditor.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { type GrafanaTheme2, type PanelData } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { Expression } from '../expressions/Expression';

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/formValuesToAppPlatform.ts
@@ -14,7 +14,12 @@ import { ExpressionQueryType } from 'app/features/expressions/types';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 
 import { type RuleFormValues } from '../../../types/rule-form';
-import { cleanAnnotations, cleanLabels, fixBothInstantAndRangeQuery } from '../../../utils/rule-form';
+import {
+  cleanAnnotations,
+  cleanLabels,
+  encodeExpressionModel,
+  fixBothInstantAndRangeQuery,
+} from '../../../utils/rule-form';
 import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificationPolicyRoute';
 
 const ALERT_RULE_API_VERSION = 'rules.alerting.grafana.app/v0alpha1';
@@ -156,7 +161,7 @@ export function toExpression(
   query: RuleFormValues['queries'][number],
   condition: RuleFormValues['condition']
 ): AlertRuleExpression {
-  const normalizedQuery = fixBothInstantAndRangeQuery(query);
+  const normalizedQuery = encodeExpressionModel(fixBothInstantAndRangeQuery(query));
   const isSource = normalizedQuery.refId === condition;
   const hasRelativeTimeRange = normalizedQuery.relativeTimeRange !== undefined;
   const isExpression = isExpressionQuery(normalizedQuery.model);

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
@@ -69,25 +69,6 @@ exports[`Can create a new grafana managed alert using simplified routing can cre
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -111,19 +92,6 @@ exports[`Can create a new grafana managed alert using simplified routing can cre
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {
@@ -243,25 +211,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -285,19 +234,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {
@@ -414,25 +350,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -456,19 +373,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {
@@ -588,25 +492,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -630,19 +515,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {
@@ -759,25 +631,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -801,19 +654,6 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {

--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -1,7 +1,8 @@
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
 import { Graph } from 'app/core/utils/dag';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
-import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {

--- a/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.test.ts
@@ -379,7 +379,6 @@ describe('getTargets', () => {
       refId: 'C',
       type: ExpressionQueryType.classic,
       datasource: ExpressionDatasourceRef,
-      expression: '',
       conditions: [
         {
           evaluator: {
@@ -413,6 +412,7 @@ describe('getTargets', () => {
       type: ExpressionQueryType.reduce,
       datasource: ExpressionDatasourceRef,
       expression: 'A',
+      reducer: 'last',
     };
 
     expect(getTargets(expression)).toEqual(['A']);

--- a/public/app/features/alerting/unified/components/rule-editor/dag.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.ts
@@ -2,7 +2,8 @@ import { compact, memoize, reject, uniq } from 'lodash';
 
 import { type Edge, Graph, type Node } from 'app/core/utils/dag';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 /**

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
@@ -69,25 +69,6 @@ exports[`PolicyTreeSelector new rule - collapsed default policy view adds __graf
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -111,19 +92,6 @@ exports[`PolicyTreeSelector new rule - collapsed default policy view adds __graf
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {
@@ -242,25 +210,6 @@ exports[`PolicyTreeSelector new rule - collapsed default policy view does not ad
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -284,19 +233,6 @@ exports[`PolicyTreeSelector new rule - collapsed default policy view does not ad
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -34,6 +34,7 @@ import { type AlertQuery } from 'app/types/unified-alerting-dto';
 import {
   areQueriesTransformableToSimpleCondition,
   isExpressionQueryInAlert,
+  validateExpressionQueries,
 } from '../../../rule-editor/formProcessing';
 import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
 import {
@@ -95,12 +96,17 @@ interface Props {
 
 export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mode }: Props) => {
   const {
+    register,
     setValue,
     getValues,
     watch,
     formState: { errors },
     control,
   } = useFormContext<RuleFormValues>();
+
+  // The queries field has no input of its own, so register it purely to attach the save-time check
+  // on the expression models. Errors surface through the form's existing invalid-submit handling.
+  register('queries', { validate: validateExpressionQueries });
 
   const { queryPreviewData, runQueries, cancelQueries, isPreviewLoading } = useAlertQueryRunner();
 
@@ -348,7 +354,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     if (newQueries[0].model) {
       if (isPromOrLokiQuery(newQueries[0].model)) {
         newQueries[0].model.expr = value;
-      } else {
+      } else if (!isExpressionQuery(newQueries[0].model)) {
         // first time we come from grafana-managed type
         // we need to convert the model to PromOrLokiQuery
         const promLoki: PromOrLokiQuery = {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -23,12 +23,8 @@ import {
   useStyles2,
 } from '@grafana/ui';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import {
-  ExpressionDatasourceUID,
-  type ExpressionQuery,
-  ExpressionQueryType,
-  expressionTypes,
-} from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionDatasourceUID, ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
@@ -2,10 +2,9 @@ import { render, screen } from 'test/test-utils';
 
 import { ReducerID } from '@grafana/data';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
-import { type ClassicCondition, type ExpressionQuery } from 'app/features/expressions/types';
+import { type ExpressionQuery, parseExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
-import { mockReduceExpression, mockThresholdExpression } from '../../../mocks';
 import { type SimpleCondition } from '../../../types/rule-form';
 
 import { SimpleConditionEditor } from './SimpleCondition';
@@ -15,128 +14,101 @@ const defaultSimpleCondition: SimpleCondition = {
   evaluator: { params: [0], type: EvalFunction.IsAbove },
 };
 
-function buildReduceExpressionWithConditions(
-  conditionOverrides?: Array<Partial<ClassicCondition>>
-): AlertQuery<ExpressionQuery> {
-  const conditions = conditionOverrides?.map((override) => ({
-    type: 'query' as const,
-    evaluator: { params: [0], type: EvalFunction.IsAbove },
-    query: { params: ['A'] },
-    ...override,
-  }));
+/**
+ * Builds a query the way the editor receives one: a raw model off the API, read through the same
+ * parse the rest of the app uses. The odd shapes below are all things real saved rules contain.
+ */
+function savedExpression(refId: string, model: unknown): AlertQuery<ExpressionQuery> {
+  const parsed = parseExpressionQuery(model);
 
-  return mockReduceExpression({
-    expression: 'A',
-    conditions: conditions as ClassicCondition[],
-  });
+  if (!parsed) {
+    throw new Error('fixture did not parse');
+  }
+
+  return { refId, queryType: 'expression', datasourceUid: '__expr__', model: parsed };
+}
+
+const threshold = savedExpression('C', {
+  type: 'threshold',
+  refId: 'C',
+  expression: 'B',
+  conditions: [{ evaluator: { type: 'gt', params: [0] } }],
+});
+
+function renderEditor(expressionQueries: Array<AlertQuery<ExpressionQuery>>, dispatch = jest.fn()) {
+  return render(
+    <SimpleConditionEditor
+      simpleCondition={defaultSimpleCondition}
+      onChange={jest.fn()}
+      expressionQueriesList={expressionQueries}
+      dispatch={dispatch}
+    />
+  );
 }
 
 describe('SimpleConditionEditor', () => {
-  it('should render without crashing when reduce expression conditions have no reducer object', () => {
-    const expressionQueries = [buildReduceExpressionWithConditions([{}]), mockThresholdExpression({ expression: 'B' })];
+  it('renders a reduce and threshold pair', () => {
+    const reduce = savedExpression('B', { type: 'reduce', refId: 'B', expression: 'A', reducer: 'last' });
 
-    expect(() =>
-      render(
-        <SimpleConditionEditor
-          simpleCondition={defaultSimpleCondition}
-          onChange={jest.fn()}
-          expressionQueriesList={expressionQueries}
-          dispatch={jest.fn()}
-        />
-      )
-    ).not.toThrow();
-  });
-
-  it('should render without crashing when reduce expression has empty conditions array', () => {
-    const expressionQueries = [
-      mockReduceExpression({ expression: 'A', conditions: [] }),
-      mockThresholdExpression({ expression: 'B' }),
-    ];
-
-    expect(() =>
-      render(
-        <SimpleConditionEditor
-          simpleCondition={defaultSimpleCondition}
-          onChange={jest.fn()}
-          expressionQueriesList={expressionQueries}
-          dispatch={jest.fn()}
-        />
-      )
-    ).not.toThrow();
-  });
-
-  it('should render without crashing when reduce expression has no conditions', () => {
-    const expressionQueries = [mockReduceExpression({ expression: 'A' }), mockThresholdExpression({ expression: 'B' })];
-
-    expect(() =>
-      render(
-        <SimpleConditionEditor
-          simpleCondition={defaultSimpleCondition}
-          onChange={jest.fn()}
-          expressionQueriesList={expressionQueries}
-          dispatch={jest.fn()}
-        />
-      )
-    ).not.toThrow();
-  });
-
-  it('should dispatch updated expression when changing reducer with missing conditions[0].reducer', async () => {
-    const dispatch = jest.fn();
-    const expressionQueries = [buildReduceExpressionWithConditions([{}]), mockThresholdExpression({ expression: 'B' })];
-
-    const { user } = render(
-      <SimpleConditionEditor
-        simpleCondition={defaultSimpleCondition}
-        onChange={jest.fn()}
-        expressionQueriesList={expressionQueries}
-        dispatch={dispatch}
-      />
-    );
-
-    // The WHEN select renders a react-select input — there is only one combobox in this component
-    const whenSelect = screen.getByRole('combobox');
-    await user.click(whenSelect);
-
-    const meanOption = await screen.findByText('Mean');
-    await user.click(meanOption);
-
-    // Verify dispatch was called — no crash occurred and the expression was updated
-    expect(dispatch).toHaveBeenCalled();
-  });
-
-  it('should render without crashing when threshold expression has empty conditions', () => {
-    const expressionQueries = [
-      mockReduceExpression({ expression: 'A' }),
-      mockThresholdExpression({ expression: 'B', conditions: [] }),
-    ];
-
-    expect(() =>
-      render(
-        <SimpleConditionEditor
-          simpleCondition={defaultSimpleCondition}
-          onChange={jest.fn()}
-          expressionQueriesList={expressionQueries}
-          dispatch={jest.fn()}
-        />
-      )
-    ).not.toThrow();
-  });
-
-  it('should render and function correctly with fully-populated expression data', () => {
-    const expressionQueries = [
-      buildReduceExpressionWithConditions([{ reducer: { params: [], type: 'last' } }]),
-      mockThresholdExpression({ expression: 'B' }),
-    ];
-
-    render(
-      <SimpleConditionEditor
-        simpleCondition={defaultSimpleCondition}
-        onChange={jest.fn()}
-        expressionQueriesList={expressionQueries}
-        dispatch={jest.fn()}
-      />
-    );
+    renderEditor([reduce, threshold]);
 
     expect(screen.getByText('Alert condition')).toBeInTheDocument();
+  });
+
+  it('renders when the saved reduce carries the leftover conditions array older versions wrote', () => {
+    const reduce = savedExpression('B', {
+      type: 'reduce',
+      refId: 'B',
+      expression: 'A',
+      reducer: 'last',
+      // Never read by anything, but plenty of saved rules have it - including ones where the
+      // condition has no reducer of its own.
+      conditions: [{ type: 'query', evaluator: { params: [0], type: 'gt' }, query: { params: ['A'] } }],
+    });
+
+    expect(() => renderEditor([reduce, threshold])).not.toThrow();
+  });
+
+  it('renders when the saved reduce has an empty conditions array', () => {
+    const reduce = savedExpression('B', {
+      type: 'reduce',
+      refId: 'B',
+      expression: 'A',
+      reducer: 'last',
+      conditions: [],
+    });
+
+    expect(() => renderEditor([reduce, threshold])).not.toThrow();
+  });
+
+  it('renders when the saved reduce has no reducer at all', () => {
+    const reduce = savedExpression('B', { type: 'reduce', refId: 'B', expression: 'A' });
+
+    expect(() => renderEditor([reduce, threshold])).not.toThrow();
+  });
+
+  it('renders when the saved threshold has no conditions', () => {
+    const emptyThreshold = savedExpression('C', {
+      type: 'threshold',
+      refId: 'C',
+      expression: 'B',
+      conditions: [],
+    });
+    const reduce = savedExpression('B', { type: 'reduce', refId: 'B', expression: 'A', reducer: 'last' });
+
+    expect(() => renderEditor([reduce, emptyThreshold])).not.toThrow();
+  });
+
+  it('dispatches an update when the reducer is changed', async () => {
+    const dispatch = jest.fn();
+    const reduce = savedExpression('B', { type: 'reduce', refId: 'B', expression: 'A', reducer: 'last' });
+
+    const { user } = renderEditor([reduce, threshold], dispatch);
+
+    // The WHEN select renders a react-select input — there is only one combobox in this component
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Mean'));
+
+    expect(dispatch).toHaveBeenCalled();
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -9,9 +9,10 @@ import { Trans, t } from '@grafana/i18n';
 import { InlineField, InlineFieldRow, Input, Select, Stack, Text, useStyles2 } from '@grafana/ui';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { ThresholdSelect } from 'app/features/expressions/components/ThresholdSelect';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import { toReduceReducerId } from 'app/features/expressions/schemas/reduce';
 import { toThresholdEvalFunction } from 'app/features/expressions/schemas/threshold';
-import { type ExpressionQuery, reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
+import { reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
 import {
   isRangeEvaluator,
   isReducerExpression,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -9,13 +9,14 @@ import { Trans, t } from '@grafana/i18n';
 import { InlineField, InlineFieldRow, Input, Select, Stack, Text, useStyles2 } from '@grafana/ui';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { ThresholdSelect } from 'app/features/expressions/components/ThresholdSelect';
+import { toReduceReducerId } from 'app/features/expressions/schemas/reduce';
+import { toThresholdEvalFunction } from 'app/features/expressions/schemas/threshold';
+import { type ExpressionQuery, reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
 import {
-  type ExpressionQuery,
-  ExpressionQueryType,
-  reducerTypes,
-  thresholdFunctions,
-} from 'app/features/expressions/types';
-import { getReducerType, isRangeEvaluator } from 'app/features/expressions/utils/expressionTypes';
+  isRangeEvaluator,
+  isReducerExpression,
+  isThresholdExpression,
+} from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { ToLabel } from '../../../../../expressions/components/ToLabel';
@@ -163,25 +164,19 @@ function updateReduceExpression(
   dispatch: Dispatch<UnknownAction>
 ) {
   // 1. make sure have have a reduce expression and that it is pointing to the data query
-  const reduceExpression = expressionQueriesList.find((query) => query.model.type === ExpressionQueryType.reduce);
+  const reduceModel = expressionQueriesList.map((query) => query.model).find(isReducerExpression);
 
-  const newReduceExpression = reduceExpression
-    ? produce(reduceExpression?.model, (draft) => {
-        if (draft && draft.conditions?.[0]) {
-          draft.reducer = reducer;
-          const reducerType = getReducerType(reducer) ?? ReducerID.last;
-          // API-loaded rules may have conditions without a reducer object (e.g. provisioned rules
-          // or rules created by older versions). Backfill it to keep conditions[0].reducer.type
-          // in sync with draft.reducer rather than silently skipping the update.
-          if (!draft.conditions[0].reducer) {
-            draft.conditions[0].reducer = { params: [], type: reducerType };
-          } else {
-            draft.conditions[0].reducer.type = reducerType;
-          }
-        }
-      })
-    : undefined;
-  newReduceExpression && dispatch(updateExpression(newReduceExpression));
+  if (!reduceModel) {
+    return;
+  }
+
+  // A reduce expression only has the one reducer. Some saved rules also carry a conditions[] here,
+  // left over from an older shape, but nothing reads it and the backend ignores it.
+  const newReduceExpression = produce(reduceModel, (draft) => {
+    draft.reducer = toReduceReducerId(reducer);
+  });
+
+  dispatch(updateExpression(newReduceExpression));
 }
 
 function updateThresholdFunction(
@@ -189,14 +184,17 @@ function updateThresholdFunction(
   expressionQueriesList: Array<AlertQuery<ExpressionQuery>>,
   dispatch: Dispatch<UnknownAction>
 ) {
-  const thresholdExpression = expressionQueriesList.find((query) => query.model.type === ExpressionQueryType.threshold);
+  const thresholdModel = expressionQueriesList.map((query) => query.model).find(isThresholdExpression);
 
-  const newThresholdExpression = produce(thresholdExpression, (draft) => {
-    if (draft && draft.model.conditions?.[0]) {
-      draft.model.conditions[0].evaluator.type = evaluator;
-    }
+  if (!thresholdModel) {
+    return;
+  }
+
+  const newThresholdExpression = produce(thresholdModel, (draft) => {
+    draft.conditions[0].evaluator.type = toThresholdEvalFunction(evaluator);
   });
-  newThresholdExpression && dispatch(updateExpression(newThresholdExpression.model));
+
+  dispatch(updateExpression(newThresholdExpression));
 }
 
 function updateThresholdValue(
@@ -205,25 +203,28 @@ function updateThresholdValue(
   expressionQueriesList: Array<AlertQuery<ExpressionQuery>>,
   dispatch: Dispatch<UnknownAction>
 ) {
-  const thresholdExpression = expressionQueriesList.find((query) => query.model.type === ExpressionQueryType.threshold);
+  const thresholdModel = expressionQueriesList.map((query) => query.model).find(isThresholdExpression);
 
-  const newThresholdExpression = produce(thresholdExpression, (draft) => {
-    if (draft && draft.model.conditions?.[0]) {
-      draft.model.conditions[0].evaluator.params[index] = value;
-    }
+  if (!thresholdModel) {
+    return;
+  }
+
+  const newThresholdExpression = produce(thresholdModel, (draft) => {
+    draft.conditions[0].evaluator.params[index] = value;
   });
-  newThresholdExpression && dispatch(updateExpression(newThresholdExpression.model));
+
+  dispatch(updateExpression(newThresholdExpression));
 }
 
 export function getSimpleConditionFromExpressions(expressions: Array<AlertQuery<ExpressionQuery>>): SimpleCondition {
-  const reduceExpression = expressions.find((query) => query.model.type === ExpressionQueryType.reduce);
-  const thresholdExpression = expressions.find((query) => query.model.type === ExpressionQueryType.threshold);
-  const conditionsFromThreshold = thresholdExpression?.model.conditions ?? [];
-  const whenField = reduceExpression?.model.reducer;
-  const params = conditionsFromThreshold[0]?.evaluator?.params
-    ? [...conditionsFromThreshold[0]?.evaluator?.params]
-    : [0];
-  const type = conditionsFromThreshold[0]?.evaluator?.type ?? EvalFunction.IsAbove;
+  const models = expressions.map((query) => query.model);
+  const reduceModel = models.find(isReducerExpression);
+  const thresholdModel = models.find(isThresholdExpression);
+
+  const thresholdEvaluator = thresholdModel?.conditions[0].evaluator;
+  const whenField = reduceModel?.reducer;
+  const params = thresholdEvaluator ? [...thresholdEvaluator.params] : [0];
+  const type = thresholdEvaluator?.type ?? EvalFunction.IsAbove;
 
   return {
     whenField: whenField,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/areQueriesTransformableToSimpleCondition.test.ts
@@ -10,7 +10,8 @@ import {
 import { areQueriesTransformableToSimpleCondition } from 'app/features/alerting/unified/rule-editor/formProcessing';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
-import { type ExpressionQuery, ReducerMode } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ReducerMode } from 'app/features/expressions/types';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
 const reduceExpression = mockReduceExpression({ expression: 'A', settings: { mode: ReducerMode.Strict } });

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/__snapshots__/reducer.test.tsx.snap
@@ -14,28 +14,6 @@ exports[`Query and expressions reducer should add a new expression 1`] = `
     {
       "datasourceUid": "__expr__",
       "model": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                0,
-                0,
-              ],
-              "type": "gt",
-            },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [],
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg",
-            },
-            "type": "query",
-          },
-        ],
         "datasource": {
           "name": "Expression",
           "type": "__expr__",
@@ -101,28 +79,6 @@ exports[`Query and expressions reducer should add reduce expression if there is 
     {
       "datasourceUid": "__expr__",
       "model": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                0,
-                0,
-              ],
-              "type": "gt",
-            },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [],
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg",
-            },
-            "type": "query",
-          },
-        ],
         "datasource": {
           "name": "Expression",
           "type": "__expr__",
@@ -139,6 +95,16 @@ exports[`Query and expressions reducer should add reduce expression if there is 
     {
       "datasourceUid": "__expr__",
       "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+              ],
+              "type": "gt",
+            },
+          },
+        ],
         "expression": "reducer",
         "refId": "C",
         "type": "threshold",
@@ -207,6 +173,16 @@ exports[`Query and expressions reducer should remove first reducer 1`] = `
     {
       "datasourceUid": "__expr__",
       "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+              ],
+              "type": "gt",
+            },
+          },
+        ],
         "expression": "A",
         "refId": "C",
         "type": "threshold",
@@ -232,6 +208,16 @@ exports[`Query and expressions reducer should remove reducer even if reducer is 
     {
       "datasourceUid": "__expr__",
       "model": {
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                0,
+              ],
+              "type": "gt",
+            },
+          },
+        ],
         "expression": "A",
         "refId": "C",
         "type": "threshold",
@@ -270,9 +256,7 @@ exports[`Query and expressions reducer should rewire expressions 1`] = `
               "type": "and",
             },
             "query": {
-              "params": [
-                "C",
-              ],
+              "params": [],
             },
             "reducer": {
               "params": [],
@@ -286,7 +270,6 @@ exports[`Query and expressions reducer should rewire expressions 1`] = `
           "type": "__expr__",
           "uid": "__expr__",
         },
-        "expression": "",
         "refId": "B",
         "type": "classic_conditions",
       },
@@ -316,9 +299,7 @@ exports[`Query and expressions reducer should set data queries 1`] = `
               "type": "and",
             },
             "query": {
-              "params": [
-                "A",
-              ],
+              "params": [],
             },
             "reducer": {
               "params": [],
@@ -332,7 +313,6 @@ exports[`Query and expressions reducer should set data queries 1`] = `
           "type": "__expr__",
           "uid": "__expr__",
         },
-        "expression": "",
         "refId": "B",
         "type": "classic_conditions",
       },
@@ -349,30 +329,6 @@ exports[`Query and expressions reducer should update an expression 1`] = `
     {
       "datasourceUid": "__expr__",
       "model": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                0,
-                0,
-              ],
-              "type": "gt",
-            },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [
-                "A",
-              ],
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg",
-            },
-            "type": "query",
-          },
-        ],
         "datasource": {
           "name": "Expression",
           "type": "__expr__",
@@ -416,9 +372,7 @@ exports[`Query and expressions reducer should update an expression refId and rew
               "type": "and",
             },
             "query": {
-              "params": [
-                "C",
-              ],
+              "params": [],
             },
             "reducer": {
               "params": [],
@@ -432,7 +386,6 @@ exports[`Query and expressions reducer should update an expression refId and rew
           "type": "__expr__",
           "uid": "__expr__",
         },
-        "expression": "",
         "refId": "B",
         "type": "classic_conditions",
       },

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,12 +1,16 @@
 import { type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
-import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import {
+  changeExpressionType,
+  makeClassicExpression,
+  makeResampleExpression,
+} from 'app/features/expressions/schemas/factories';
 import {
   ExpressionDatasourceUID,
   type ExpressionQuery,
   ExpressionQueryType,
   ReducerMode,
 } from 'app/features/expressions/types';
-import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {
@@ -33,6 +37,7 @@ const reduceExpression: AlertQuery<ExpressionQuery> = {
     refId: 'B',
     settings: { mode: ReducerMode.Strict },
     expression: 'A',
+    reducer: 'last',
   },
 };
 const thresholdExpression: AlertQuery<ExpressionQuery> = {
@@ -42,6 +47,8 @@ const thresholdExpression: AlertQuery<ExpressionQuery> = {
   model: {
     type: ExpressionQueryType.threshold,
     refId: 'C',
+    expression: 'B',
+    conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [0] } }],
   },
 };
 
@@ -79,14 +86,9 @@ const alertQuery: AlertQuery = {
   },
 };
 
-const expressionQuery: AlertQuery = {
+const expressionQuery: AlertQuery<ExpressionQuery> = {
   datasourceUid: ExpressionDatasourceUID,
-  model: expressionDatasource.newQuery({
-    type: ExpressionQueryType.classic,
-    conditions: [{ ...defaultCondition, query: { params: ['A'] } }],
-    expression: '',
-    refId: 'B',
-  }),
+  model: makeClassicExpression({ refId: 'B' }),
   refId: 'B',
   queryType: '',
 };
@@ -177,10 +179,7 @@ describe('Query and expressions reducer', () => {
   });
 
   it('should update an expression', () => {
-    const newExpression: ExpressionQuery = {
-      ...expressionQuery.model,
-      type: ExpressionQueryType.math,
-    };
+    const newExpression = changeExpressionType(expressionQuery.model, ExpressionQueryType.math);
 
     const initialState: QueriesAndExpressionsState = {
       queries: [expressionQuery],
@@ -190,34 +189,20 @@ describe('Query and expressions reducer', () => {
     expect(newState).toMatchSnapshot();
   });
   it('should use time range from data source when updating an expression', () => {
-    const expressionQuery: AlertQuery = {
+    const expressionQuery: AlertQuery<ExpressionQuery> = {
       refId: 'B',
       queryType: 'expression',
       datasourceUid: '__expr__',
       relativeTimeRange: { from: 900, to: 1000 },
-      model: {
-        queryType: 'query',
-        datasource: '__expr__',
-        refId: 'B',
-        expression: 'C',
-        type: ExpressionQueryType.classic,
-        window: '10s',
-      } as ExpressionQuery,
+      model: makeResampleExpression({ refId: 'B' }, { expression: 'C', window: '10s' }),
     };
 
-    const expressionQuery2: AlertQuery = {
+    const expressionQuery2: AlertQuery<ExpressionQuery> = {
       refId: 'C',
       queryType: 'expression',
       datasourceUid: '__expr__',
       relativeTimeRange: { from: 1, to: 3 },
-      model: {
-        queryType: 'query',
-        datasource: '__expr__',
-        refId: 'C',
-        expression: 'A',
-        type: ExpressionQueryType.classic,
-        window: '10s',
-      } as ExpressionQuery,
+      model: makeResampleExpression({ refId: 'C' }, { expression: 'A', window: '10s' }),
     };
 
     const queryA: AlertQuery = {
@@ -227,10 +212,7 @@ describe('Query and expressions reducer', () => {
       model: { refId: 'A' },
       queryType: 'query',
     };
-    const newExpression: ExpressionQuery = {
-      ...expressionQuery2.model,
-      type: ExpressionQueryType.resample,
-    };
+    const newExpression = changeExpressionType(expressionQuery2.model, ExpressionQueryType.resample);
 
     const initialState: QueriesAndExpressionsState = {
       queries: [queryA, expressionQuery, expressionQuery2],
@@ -249,28 +231,15 @@ describe('Query and expressions reducer', () => {
         {
           datasourceUid: '__expr__',
           relativeTimeRange: { from: 900, to: 1000 },
-          model: {
-            datasource: '__expr__',
-            expression: 'C',
-            queryType: 'query',
-            refId: 'B',
-            type: 'classic_conditions',
-            window: '10s',
-          },
+          model: makeResampleExpression({ refId: 'B' }, { expression: 'C', window: '10s' }),
           queryType: 'expression',
           refId: 'B',
         },
         {
           datasourceUid: '__expr__',
+          // picked up from the data query it reads, which is the point of this test
           relativeTimeRange: { from: 900, to: 1000 },
-          model: {
-            datasource: '__expr__',
-            expression: 'A',
-            queryType: 'query',
-            refId: 'C',
-            type: 'resample',
-            window: '10s',
-          },
+          model: makeResampleExpression({ refId: 'C' }, { expression: 'A', window: '10s' }),
           queryType: 'expression',
           refId: 'C',
         },
@@ -293,6 +262,8 @@ describe('Query and expressions reducer', () => {
         expression: 'A',
         type: ExpressionQueryType.resample,
         window: '10s',
+        downsampler: 'mean',
+        upsampler: 'fillna',
       },
     };
     const customTimeRange: RelativeTimeRange = { from: 900, to: 1000 };
@@ -331,6 +302,8 @@ describe('Query and expressions reducer', () => {
             refId: 'B',
             type: ExpressionQueryType.resample,
             window: '10s',
+            downsampler: 'mean',
+            upsampler: 'fillna',
           },
           queryType: 'expression',
           refId: 'B',

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.test.tsx
@@ -1,16 +1,12 @@
 import { type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import {
   changeExpressionType,
   makeClassicExpression,
   makeResampleExpression,
 } from 'app/features/expressions/schemas/factories';
-import {
-  ExpressionDatasourceUID,
-  type ExpressionQuery,
-  ExpressionQueryType,
-  ReducerMode,
-} from 'app/features/expressions/types';
+import { ExpressionDatasourceUID, ExpressionQueryType, ReducerMode } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import {

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -10,9 +10,9 @@ import {
 import { type DataQuery } from '@grafana/schema';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { isClassicExpression } from 'app/features/expressions/schemas/expressionQuery';
+import { type ExpressionQuery, isClassicExpression } from 'app/features/expressions/schemas/expressionQuery';
 import { makeReduceExpression } from 'app/features/expressions/schemas/factories';
-import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionDatasourceUID, ExpressionQueryType } from 'app/features/expressions/types';
 import { isReducerExpression, isThresholdExpression } from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -1,7 +1,6 @@
 import { createAction, createReducer, original } from '@reduxjs/toolkit';
 
 import {
-  ReducerID,
   type RelativeTimeRange,
   getDataSourceRef,
   getDefaultRelativeTimeRange,
@@ -11,12 +10,10 @@ import {
 import { type DataQuery } from '@grafana/schema';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { isExpressionQuery } from 'app/features/expressions/guards';
+import { isClassicExpression } from 'app/features/expressions/schemas/expressionQuery';
+import { makeReduceExpression } from 'app/features/expressions/schemas/factories';
 import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
-import {
-  defaultCondition,
-  isReducerExpression,
-  isThresholdExpression,
-} from 'app/features/expressions/utils/expressionTypes';
+import { isReducerExpression, isThresholdExpression } from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { logError } from '../../../Analytics';
@@ -144,11 +141,9 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
     .addCase(addNewExpression, (state, { payload }) => {
       state.queries = addQuery(state.queries, {
         datasourceUid: ExpressionDatasourceUID,
-        model: expressionDatasource.newQuery({
-          type: payload,
-          conditions: [{ ...defaultCondition, query: { params: [] } }],
-          expression: '',
-        }),
+        // Types that need conditions get their default one from newQuery, so there is nothing to
+        // seed here - and the other types never wanted them in the first place.
+        model: expressionDatasource.newQuery({ type: payload, expression: '' }),
       });
     })
     .addCase(removeExpression, (state, { payload }) => {
@@ -258,7 +253,13 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
         );
 
         state.queries.splice(reduceExpressionIndex, 1);
-        state.queries[1].model.expression = dataQuery?.refId;
+
+        // Point whatever is now second at the data query directly. Classic conditions name their
+        // query per-condition, so they have nothing to repoint here.
+        const promotedModel = state.queries[1].model;
+        if (isExpressionQuery(promotedModel) && !isClassicExpression(promotedModel)) {
+          promotedModel.expression = dataQuery?.refId ?? '';
+        }
       }
 
       const shouldAddReduceExpression =
@@ -266,18 +267,18 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
       if (shouldAddReduceExpression) {
         // add reducer to the second position
         // we only update the refid and the model to point to the reducer expression
-        state.queries[1].model.expression = NEW_REDUCER_REF;
+        const thresholdModel = state.queries[1].model;
+        if (isExpressionQuery(thresholdModel) && !isClassicExpression(thresholdModel)) {
+          thresholdModel.expression = NEW_REDUCER_REF;
+        }
 
         // insert in second position the reducer expression
         state.queries.splice(1, 0, {
           datasourceUid: ExpressionDatasourceUID,
-          model: expressionDatasource.newQuery({
-            type: ExpressionQueryType.reduce,
-            reducer: ReducerID.last,
-            conditions: [{ ...defaultCondition, query: { params: [] } }],
-            expression: dataQuery?.refId,
-            refId: NEW_REDUCER_REF,
-          }),
+          model: makeReduceExpression(
+            { refId: NEW_REDUCER_REF },
+            { reducer: 'last', expression: dataQuery?.refId ?? '' }
+          ),
           refId: NEW_REDUCER_REF,
           queryType: 'expression',
         });

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { ReducerID } from '@grafana/data';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { areQueriesTransformableToSimpleCondition } from '../../../rule-editor/formProcessing';

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -1,4 +1,7 @@
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import type { ClassicExpressionQuery } from 'app/features/expressions/schemas/classic';
+import type { MathExpressionQuery } from 'app/features/expressions/schemas/math';
+import type { ThresholdExpressionQuery } from 'app/features/expressions/schemas/threshold';
 import { type ClassicCondition, type ExpressionQuery } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -128,20 +131,20 @@ describe('rule-editor', () => {
       const queries: AlertQuery[] = [dataSource, classicCondition];
       const rewiredQueries = queriesWithUpdatedReferences(queries, 'A', 'C');
 
-      const queryModel = rewiredQueries[1].model as ExpressionQuery;
+      const queryModel = rewiredQueries[1].model as ClassicExpressionQuery;
 
       const checkConditionParams = (condition: ClassicCondition) => {
         return expect(condition.query.params).toEqual(['C']);
       };
 
-      expect(queryModel.conditions?.every(checkConditionParams));
+      expect(queryModel.conditions.every(checkConditionParams));
     });
 
     it('should rewire math expressions', () => {
       const queries: AlertQuery[] = [dataSource, mathExpression];
       const rewiredQueries = queriesWithUpdatedReferences(queries, 'A', 'Query A');
 
-      const queryModel = rewiredQueries[1].model as ExpressionQuery;
+      const queryModel = rewiredQueries[1].model as MathExpressionQuery;
 
       expect(queryModel.expression).toBe('abs(${Query A}) + ${Query A}');
     });
@@ -150,7 +153,7 @@ describe('rule-editor', () => {
       const queries: AlertQuery[] = [dataSource, reduceExpression];
       const rewiredQueries = queriesWithUpdatedReferences(queries, 'A', 'C');
 
-      const queryModel = rewiredQueries[1].model as ExpressionQuery;
+      const queryModel = rewiredQueries[1].model as MathExpressionQuery;
       expect(queryModel.expression).toBe('C');
     });
 
@@ -158,7 +161,7 @@ describe('rule-editor', () => {
       const queries: AlertQuery[] = [dataSource, resampleExpression];
       const rewiredQueries = queriesWithUpdatedReferences(queries, 'A', 'C');
 
-      const queryModel = rewiredQueries[1].model as ExpressionQuery;
+      const queryModel = rewiredQueries[1].model as MathExpressionQuery;
       expect(queryModel.expression).toBe('C');
     });
 
@@ -166,7 +169,7 @@ describe('rule-editor', () => {
       const queries: AlertQuery[] = [dataSource, reduceExpression, thresholdExpression];
       const rewiredQueries = queriesWithUpdatedReferences(queries, 'B', NEW_REDUCER_REF);
 
-      const queryModel = rewiredQueries[2].model as ExpressionQuery;
+      const queryModel = rewiredQueries[2].model as ThresholdExpressionQuery;
       expect(queryModel.expression).toBe(NEW_REDUCER_REF);
     });
 

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -1,8 +1,8 @@
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
-import type { ClassicExpressionQuery } from 'app/features/expressions/schemas/classic';
+import { type ClassicCondition, type ClassicExpressionQuery } from 'app/features/expressions/schemas/classic';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import type { MathExpressionQuery } from 'app/features/expressions/schemas/math';
 import type { ThresholdExpressionQuery } from 'app/features/expressions/schemas/threshold';
-import { type ClassicCondition, type ExpressionQuery } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { NEW_REDUCER_REF } from './query-and-alert-condition/reducer';

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -12,7 +12,9 @@ import { config } from '@grafana/runtime';
 import { GraphThresholdsStyleMode } from '@grafana/schema';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { type ClassicCondition, ExpressionQueryType } from 'app/features/expressions/types';
+import { isClassicExpression, isThresholdExpression } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
+import { isRangeEvaluator } from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { createDagFromQueries, getOriginOfRefId } from './dag';
@@ -31,47 +33,48 @@ export function queriesWithUpdatedReferences(
       return query;
     }
 
-    const isMathExpression = query.model.type === 'math';
-    const isReduceExpression = query.model.type === 'reduce';
-    const isResampleExpression = query.model.type === 'resample';
-    const isClassicExpression = query.model.type === 'classic_conditions';
-    const isThresholdExpression = query.model.type === 'threshold';
+    const model = query.model;
 
-    if (isMathExpression) {
-      return {
-        ...query,
-        model: {
-          ...query.model,
-          expression: updateMathExpressionRefs(query.model.expression ?? '', previousRefId, newRefId),
-        },
-      };
+    switch (model.type) {
+      case ExpressionQueryType.math:
+        return {
+          ...query,
+          model: {
+            ...model,
+            expression: updateMathExpressionRefs(model.expression, previousRefId, newRefId),
+          },
+        };
+
+      case ExpressionQueryType.reduce:
+      case ExpressionQueryType.resample:
+      case ExpressionQueryType.threshold:
+        return {
+          ...query,
+          model: {
+            ...model,
+            expression: model.expression === previousRefId ? newRefId : model.expression,
+          },
+        };
+
+      case ExpressionQueryType.classic:
+        return {
+          ...query,
+          model: {
+            ...model,
+            conditions: model.conditions.map((condition) => ({
+              ...condition,
+              query: {
+                ...condition.query,
+                params: condition.query.params.map((param) => (param === previousRefId ? newRefId : param)),
+              },
+            })),
+          },
+        };
+
+      // SQL names its inputs inside the query text, which we do not rewrite.
+      case ExpressionQueryType.sql:
+        return query;
     }
-
-    if (isResampleExpression || isReduceExpression || isThresholdExpression) {
-      const isReferencing = query.model.expression === previousRefId;
-
-      return {
-        ...query,
-        model: {
-          ...query.model,
-          expression: isReferencing ? newRefId : query.model.expression,
-        },
-      };
-    }
-
-    if (isClassicExpression) {
-      const conditions = query.model.conditions?.map((condition) => ({
-        ...condition,
-        query: {
-          ...condition.query,
-          params: condition.query.params.map((param: string) => (param === previousRefId ? newRefId : param)),
-        },
-      }));
-
-      return { ...query, model: { ...query.model, conditions } };
-    }
-
-    return query;
   });
 }
 
@@ -134,7 +137,6 @@ export type ThresholdDefinitions = Record<string, ThresholdDefinition>;
  */
 export function getThresholdsForQueries(queries: AlertQuery[], condition: string | null) {
   const thresholds: ThresholdDefinitions = {};
-  const SUPPORTED_EXPRESSION_TYPES = [ExpressionQueryType.threshold, ExpressionQueryType.classic];
 
   if (!condition) {
     return thresholds;
@@ -145,35 +147,43 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
       continue;
     }
 
+    const model = query.model;
+
     // currently only supporting "threshold" & "classic_condition" expressions
-    if (!SUPPORTED_EXPRESSION_TYPES.includes(query.model.type)) {
+    if (!isThresholdExpression(model) && !isClassicExpression(model)) {
       continue;
     }
 
-    if (!Array.isArray(query.model.conditions)) {
+    if (model.refId !== condition) {
       continue;
     }
 
-    if (query.model.refId !== condition) {
-      continue;
-    }
+    // The two types name the query they read differently: a classic condition carries it per
+    // condition, a threshold has one expression for the whole thing. Flatten both to the same
+    // shape so the rest of this only has one case to handle.
+    const conditions = isClassicExpression(model)
+      ? model.conditions.map((condition) => ({
+          evaluator: condition.evaluator,
+          refId: condition.query.params[0],
+        }))
+      : model.conditions.map((condition) => ({
+          evaluator: condition.evaluator,
+          refId: model.expression,
+        }));
 
     // if any of the conditions are a "range" we switch to an "area" threshold view and ignore single threshold values
     // the time series panel does not support both.
-    const hasRangeThreshold = query.model.conditions.some(isRangeCondition);
+    const hasRangeThreshold = conditions.some(({ evaluator }) => isRangeEvaluator(evaluator.type));
 
-    query.model.conditions.forEach((condition) => {
-      const threshold = condition.evaluator.params;
-
-      // "classic_conditions" use `condition.query.params[]` and "threshold" uses `query.model.expression`
-      const refId = condition.query?.params?.[0] ?? query.model.expression;
+    conditions.forEach(({ evaluator, refId }) => {
+      const threshold = evaluator.params;
 
       // if an expression hasn't been linked to a data query yet, it won't have a refId
       if (!refId) {
         return;
       }
 
-      const isRangeThreshold = isRangeCondition(condition);
+      const isRangeThreshold = isRangeEvaluator(evaluator.type);
 
       try {
         // create a DAG so we can find the origin of the current expression
@@ -211,7 +221,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
             if (!threshold) {
               return;
             }
-            appendRangeThreshold(originRefID, threshold, condition.evaluator.type);
+            appendRangeThreshold(originRefID, threshold, evaluator.type);
             thresholds[originRefID].mode = GraphThresholdsStyleMode.LineAndArea;
           }
         });
@@ -341,15 +351,6 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
   }
 
   return thresholds;
-}
-
-function isRangeCondition(condition: ClassicCondition) {
-  return (
-    condition.evaluator.type === EvalFunction.IsWithinRange ||
-    condition.evaluator.type === EvalFunction.IsOutsideRange ||
-    condition.evaluator.type === EvalFunction.IsOutsideRangeIncluded ||
-    condition.evaluator.type === EvalFunction.IsWithinRangeIncluded
-  );
 }
 
 export function getStatusMessage(data: PanelData): string | undefined {

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -6,13 +6,15 @@ import {
   type DataSourcePluginMeta,
   type PluginExtensionLink,
   PluginExtensionTypes,
-  ReducerID,
 } from '@grafana/data';
 import { type DataQuery, defaultDashboard } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { MOCK_GRAFANA_ALERT_RULE_TITLE } from 'app/features/alerting/unified/mocks/server/handlers/grafanaRuler';
 import { type NotifiersState, type ReceiversState } from 'app/features/alerting/unified/types/alerting';
-import { type ExpressionQuery, ExpressionQueryType, ReducerMode } from 'app/features/expressions/types';
+import type { ReduceExpressionQuery } from 'app/features/expressions/schemas/reduce';
+import type { ResampleExpressionQuery } from 'app/features/expressions/schemas/resample';
+import { type ThresholdExpressionQuery, defaultThresholdCondition } from 'app/features/expressions/schemas/threshold';
+import { ExpressionQueryType, ReducerMode } from 'app/features/expressions/types';
 import {
   type AlertManagerCortexConfig,
   AlertState,
@@ -758,37 +760,47 @@ export const mockDataQuery = (partial: Partial<AlertDataQuery> = {}): AlertQuery
   model: { refId: 'A', ...partial },
 });
 
-export const mockReduceExpression = (partial: Partial<ExpressionQuery> = {}): AlertQuery<ExpressionQuery> => ({
+export const mockReduceExpression = (
+  partial: Partial<ReduceExpressionQuery> = {}
+): AlertQuery<ReduceExpressionQuery> => ({
   refId: 'B',
   queryType: 'expression',
   datasourceUid: '__expr__',
   model: {
     type: ExpressionQueryType.reduce,
     refId: 'B',
+    expression: 'A',
     settings: { mode: ReducerMode.Strict },
-    reducer: ReducerID.last,
+    reducer: 'last',
     ...partial,
   },
 });
 
-export const mockThresholdExpression = (partial: Partial<ExpressionQuery> = {}): AlertQuery<ExpressionQuery> => ({
+export const mockThresholdExpression = (
+  partial: Partial<ThresholdExpressionQuery> = {}
+): AlertQuery<ThresholdExpressionQuery> => ({
   refId: 'C',
   queryType: 'expression',
   datasourceUid: '__expr__',
   model: {
     type: ExpressionQueryType.threshold,
     refId: 'C',
+    expression: 'B',
+    conditions: [structuredClone(defaultThresholdCondition)],
     ...partial,
   },
 });
 
-export const mockResampleExpression = (partial: Partial<ExpressionQuery> = {}): AlertQuery<ExpressionQuery> => ({
+export const mockResampleExpression = (
+  partial: Partial<ResampleExpressionQuery> = {}
+): AlertQuery<ResampleExpressionQuery> => ({
   refId: 'B',
   queryType: 'expression',
   datasourceUid: '__expr__',
   model: {
     type: ExpressionQueryType.resample,
     refId: 'B',
+    expression: 'A',
     window: '10s',
     downsampler: 'mean',
     upsampler: 'fillna',

--- a/public/app/features/alerting/unified/rule-editor/__snapshots__/RuleEditorGrafanaRules.test.tsx.snap
+++ b/public/app/features/alerting/unified/rule-editor/__snapshots__/RuleEditorGrafanaRules.test.tsx.snap
@@ -71,25 +71,6 @@ exports[`RuleEditor grafana managed rules can create new grafana managed alert 1
               {
                 "datasourceUid": "__expr__",
                 "model": {
-                  "conditions": [
-                    {
-                      "evaluator": {
-                        "params": [],
-                        "type": "gt",
-                      },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
-                    },
-                  ],
                   "datasource": {
                     "type": "__expr__",
                     "uid": "__expr__",
@@ -113,19 +94,6 @@ exports[`RuleEditor grafana managed rules can create new grafana managed alert 1
                         ],
                         "type": "gt",
                       },
-                      "operator": {
-                        "type": "and",
-                      },
-                      "query": {
-                        "params": [
-                          "C",
-                        ],
-                      },
-                      "reducer": {
-                        "params": [],
-                        "type": "last",
-                      },
-                      "type": "query",
                     },
                   ],
                   "datasource": {

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.test.ts
@@ -473,10 +473,10 @@ describe('formValuesFromPrefill', () => {
     const result = formValuesFromPrefill(prefillData);
     const [query] = result.queries.filter(isExpressionQueryInAlert);
 
-    expect(query.model).toHaveProperty('type', 'classic_conditions');
-    expect(query.model.conditions).toHaveLength(2);
-    expect(query.model.conditions?.[0].evaluator.type).toBe('gt');
-    expect(query.model.conditions?.[1].evaluator.type).toBe('within_range');
+    expect(query.model).toMatchObject({
+      type: 'classic_conditions',
+      conditions: [{ evaluator: { type: 'gt' } }, { evaluator: { type: 'within_range' } }],
+    });
   });
 
   it('should preserve resample expression query structure', () => {

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.test.ts
@@ -1,0 +1,120 @@
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import { ExpressionDatasourceUID, ExpressionQueryType } from 'app/features/expressions/types';
+import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { validateExpressionQueries } from './formProcessing';
+
+function dataQuery(refId = 'A'): AlertQuery<AlertDataQuery> {
+  return { refId, datasourceUid: 'prom-uid', queryType: '', model: { refId } };
+}
+
+function expression(refId: string, model: unknown): AlertQuery<AlertDataQuery> {
+  return {
+    refId,
+    datasourceUid: ExpressionDatasourceUID,
+    queryType: 'expression',
+    model: model as AlertDataQuery,
+  };
+}
+
+describe('validateExpressionQueries', () => {
+  it('accepts a well-formed reduce and threshold pair', () => {
+    const queries = [
+      dataQuery(),
+      expression('B', { refId: 'B', type: ExpressionQueryType.reduce, expression: 'A', reducer: 'last' }),
+      expression('C', {
+        refId: 'C',
+        type: ExpressionQueryType.threshold,
+        expression: 'B',
+        conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [10] } }],
+      }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe(true);
+  });
+
+  it('ignores data queries', () => {
+    expect(validateExpressionQueries([dataQuery(), dataQuery('B')])).toBe(true);
+  });
+
+  it('reports a threshold that has no query to read', () => {
+    const queries = [
+      expression('C', {
+        refId: 'C',
+        type: ExpressionQueryType.threshold,
+        expression: '',
+        conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [10] } }],
+      }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe('C: Select a query to threshold.');
+  });
+
+  // The backend does not strip a leading $ for threshold the way it does for reduce and resample,
+  // so a rule saved like this never fires.
+  it('reports a threshold whose query name still has a $ prefix', () => {
+    const queries = [
+      expression('C', {
+        refId: 'C',
+        type: ExpressionQueryType.threshold,
+        expression: '$B',
+        conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [10] } }],
+      }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe('C: Reference the query by name only, without a leading "$".');
+  });
+
+  it('reports a range threshold given only one value', () => {
+    const queries = [
+      expression('C', {
+        refId: 'C',
+        type: ExpressionQueryType.threshold,
+        expression: 'B',
+        conditions: [{ evaluator: { type: EvalFunction.IsWithinRange, params: [5] } }],
+      }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe('C: Enter a threshold value.');
+  });
+
+  it('reports a reduce in replaceNN mode with no replacement value', () => {
+    const queries = [
+      expression('B', {
+        refId: 'B',
+        type: ExpressionQueryType.reduce,
+        expression: 'A',
+        reducer: 'last',
+        settings: { mode: 'replaceNN' },
+      }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe('B: Enter a replacement value.');
+  });
+
+  it('reports an empty math expression', () => {
+    const queries = [expression('B', { refId: 'B', type: ExpressionQueryType.math, expression: '' })];
+
+    expect(validateExpressionQueries(queries)).toBe('B: Enter a math expression.');
+  });
+
+  it('reports an empty SQL expression', () => {
+    const queries = [expression('B', { refId: 'B', type: ExpressionQueryType.sql, expression: '  ' })];
+
+    expect(validateExpressionQueries(queries)).toBe('B: Enter a SQL expression.');
+  });
+
+  // An expression with no usable type is setQueryEditorSettings' problem, not this check's.
+  it('leaves an unreadable expression to the editor-settings pass', () => {
+    expect(validateExpressionQueries([expression('B', { refId: 'B' })])).toBe(true);
+  });
+
+  it('reports the first problem it finds', () => {
+    const queries = [
+      expression('B', { refId: 'B', type: ExpressionQueryType.math, expression: '' }),
+      expression('C', { refId: 'C', type: ExpressionQueryType.sql, expression: '' }),
+    ];
+
+    expect(validateExpressionQueries(queries)).toBe('B: Enter a math expression.');
+  });
+});

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -2,14 +2,52 @@ import { isEmpty, omit } from 'lodash';
 
 import { ReducerID, getNextRefId } from '@grafana/data';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
-import { isStrictReducer } from 'app/features/expressions/utils/expressionTypes';
+import { parseExpressionQuery, validateExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { makeReduceExpression, makeThresholdExpression } from 'app/features/expressions/schemas/factories';
+import { toReduceReducerId } from 'app/features/expressions/schemas/reduce';
+import { toThresholdEvalFunction } from 'app/features/expressions/schemas/threshold';
+import { ExpressionDatasourceUID, type ExpressionQuery } from 'app/features/expressions/types';
+import {
+  isReducerExpression,
+  isStrictReducer,
+  isThresholdExpression,
+} from 'app/features/expressions/utils/expressionTypes';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { type KVObject, type RuleFormValues, type SimpleCondition } from '../types/rule-form';
 import { defaultAnnotations } from '../utils/constants';
 import { isSupportedExternalRulesSourceType } from '../utils/datasource';
 import { getInstantFromDataQuery } from '../utils/rule-form';
+
+/**
+ * Checks the expression models against the stricter rules the backend applies, and returns the
+ * first problem as a message.
+ *
+ * Deliberately only run on save: a half-finished expression is normal while someone is still
+ * editing, but it must not reach the backend, which would reject it with a much less helpful error.
+ */
+export function validateExpressionQueries(queries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>>) {
+  for (const query of queries) {
+    if (!isExpressionQuery(query.model)) {
+      continue;
+    }
+
+    const parsed = parseExpressionQuery(query.model);
+
+    // Something we cannot read at all is handled by setQueryEditorSettings, not here.
+    if (!parsed) {
+      continue;
+    }
+
+    const result = validateExpressionQuery(parsed);
+
+    if (!result.success) {
+      return `${query.refId}: ${result.error.issues[0].message}`;
+    }
+  }
+
+  return true;
+}
 
 export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
   // data queries only
@@ -97,6 +135,22 @@ export function setInstantOrRange(values: RuleFormValues): RuleFormValues {
 }
 
 /**
+ * Finds the first expression of a given type, keeping both the query's refId and the narrowed
+ * model, so callers can read type-specific fields without checking again.
+ */
+function findExpressionOfType<T extends ExpressionQuery>(
+  expressionQueries: Array<AlertQuery<ExpressionQuery>>,
+  isOfType: (model: ExpressionQuery) => model is T
+): { refId: string; model: T } | undefined {
+  for (const query of expressionQueries) {
+    if (isOfType(query.model)) {
+      return { refId: query.refId, model: query.model };
+    }
+  }
+  return undefined;
+}
+
+/**
  * A alert rule is "transformable" to a simple condition editor if
  * 1. we have a single data query
  * 2. we have _either_
@@ -121,14 +175,14 @@ export function areQueriesTransformableToSimpleCondition(
   const dataQuery = dataQueries.at(0);
 
   // find the reduce or threshold expressions
-  const reduceExpression = expressionQueries.find((query) => query.model.type === ExpressionQueryType.reduce);
-  const thresholdExpression = expressionQueries.find((query) => query.model.type === ExpressionQueryType.threshold);
+  const reduceExpression = findExpressionOfType(expressionQueries, isReducerExpression);
+  const thresholdExpression = findExpressionOfType(expressionQueries, isThresholdExpression);
 
   // reducer should be set to "strict" mode
   const reducerIsStrict = reduceExpression ? isStrictReducer(reduceExpression.model) : false;
   // threshold expression shouldn't have an unload evaluator (custom recovery threshold)
   const thresholdExpressionIsClean =
-    thresholdExpression?.model.conditions?.every((condition) => {
+    thresholdExpression?.model.conditions.every((condition) => {
       return isEmpty(condition.unloadEvaluator);
     }) ?? true;
 
@@ -174,31 +228,18 @@ export function createSimpleConditionExpressions(
   const tempQueries = [...dataQueries, { refId: reduceRefId, datasourceUid: '', queryType: '', model: {} }];
   const thresholdRefId = getNextRefId(tempQueries);
 
-  const reduceExpression: ExpressionQuery = {
-    refId: reduceRefId,
-    type: ExpressionQueryType.reduce,
-    datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID },
-    reducer: whenField,
-    expression: lastDataQueryRefId,
-  };
+  const reduceExpression = makeReduceExpression(
+    { refId: reduceRefId, datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID } },
+    { reducer: toReduceReducerId(whenField), expression: lastDataQueryRefId }
+  );
 
-  const thresholdExpression: ExpressionQuery = {
-    refId: thresholdRefId,
-    type: ExpressionQueryType.threshold,
-    datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: simpleCondition.evaluator.params,
-          type: simpleCondition.evaluator.type,
-        },
-        operator: { type: 'and' },
-        query: { params: [thresholdRefId] },
-        reducer: { params: [], type: 'last' as const },
-      },
-    ],
-    expression: reduceRefId,
+  const thresholdExpression = makeThresholdExpression(
+    { refId: thresholdRefId, datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID } },
+    { expression: reduceRefId }
+  );
+  thresholdExpression.conditions[0].evaluator = {
+    params: simpleCondition.evaluator.params,
+    type: toThresholdEvalFunction(simpleCondition.evaluator.type),
   };
 
   const expressionQueries: AlertQuery[] = [

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -2,11 +2,15 @@ import { isEmpty, omit } from 'lodash';
 
 import { ReducerID, getNextRefId } from '@grafana/data';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { parseExpressionQuery, validateExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import {
+  type ExpressionQuery,
+  parseExpressionQuery,
+  validateExpressionQuery,
+} from 'app/features/expressions/schemas/expressionQuery';
 import { makeReduceExpression, makeThresholdExpression } from 'app/features/expressions/schemas/factories';
 import { toReduceReducerId } from 'app/features/expressions/schemas/reduce';
 import { toThresholdEvalFunction } from 'app/features/expressions/schemas/threshold';
-import { ExpressionDatasourceUID, type ExpressionQuery } from 'app/features/expressions/types';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import {
   isReducerExpression,
   isStrictReducer,

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -24,11 +24,11 @@ import { isSupportedExternalRulesSourceType } from '../utils/datasource';
 import { getInstantFromDataQuery } from '../utils/rule-form';
 
 /**
- * Checks the expression models against the stricter rules the backend applies, and returns the
- * first problem as a message.
+ * Checks the expressions against the stricter rules the backend applies and returns the first
+ * problem found, as a message.
  *
- * Deliberately only run on save: a half-finished expression is normal while someone is still
- * editing, but it must not reach the backend, which would reject it with a much less helpful error.
+ * Only run on save. A half-finished expression is normal while someone is still editing it, but it
+ * should not reach the backend, which rejects it with a much less helpful error.
  */
 export function validateExpressionQueries(queries: Array<AlertQuery<AlertDataQuery | ExpressionQuery>>) {
   for (const query of queries) {

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -23,7 +23,8 @@ import {
 } from 'app/features/alerting/unified/components/settings/mocks/server';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { setupDataSources } from 'app/features/alerting/unified/testSetup/datasources';
-import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { type AlertingQueryResponse, AlertingQueryRunner } from './AlertingQueryRunner';

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -1,6 +1,7 @@
 import { type PromQuery } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
-import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionDatasourceUID, ExpressionQueryType } from 'app/features/expressions/types';
 import { type RuleWithLocation } from 'app/types/unified-alerting';
 import {
   type AlertDataQuery,

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -12,7 +12,7 @@ import {
 } from 'app/types/unified-alerting-dto';
 
 import { EvalFunction } from '../../state/alertDef';
-import { mockDataSource, mockRuleWithLocation, mockRulerGrafanaRecordingRule } from '../mocks';
+import { mockDataSource, mockRuleWithLocation, mockRulerGrafanaRecordingRule, mockRulerGrafanaRule } from '../mocks';
 import { getDefaultFormValues } from '../rule-editor/formDefaults';
 import { setupDataSources } from '../testSetup/datasources';
 import { type AlertManagerManualRouting, RuleFormType, type RuleFormValues } from '../types/rule-form';
@@ -30,6 +30,7 @@ import {
   getDefaultExpressions,
   getInstantFromDataQuery,
   getNotificationSettingsForDTO,
+  grafanaRuleDtoToFormValues,
   rulerRuleToFormValues,
 } from './rule-form';
 
@@ -681,127 +682,79 @@ function isExpressionQuery(model: unknown): model is ExpressionQuery {
 
 describe('getDefaultExpressions', () => {
   it('should create a reduce expression as the first query', () => {
-    const result = getDefaultExpressions('B', 'C');
-    const reduceQuery = result[0];
-    const { model } = reduceQuery;
+    const [reduceQuery] = getDefaultExpressions('B', 'C');
 
-    expect(reduceQuery.refId).toBe('B');
-    expect(reduceQuery.datasourceUid).toBe(ExpressionDatasourceUID);
-    expect(reduceQuery.queryType).toBe('expression');
-
-    if (!isExpressionQuery(model)) {
-      throw new Error('Expected ExpressionQuery');
-    }
-
-    expect(model.type).toBe(ExpressionQueryType.reduce);
-    expect(model.datasource?.uid).toBe(ExpressionDatasourceUID);
-    expect(model.reducer).toBe('last');
-  });
-
-  it('should create reduce expression with proper conditions structure', () => {
-    const result = getDefaultExpressions('B', 'C');
-    const reduceQuery = result[0];
-    const { model } = reduceQuery;
-
-    if (!isExpressionQuery(model)) {
-      throw new Error('Expected ExpressionQuery');
-    }
-
-    expect(model.conditions).toHaveLength(1);
-    expect(model.expression).toBe('A');
-    expect(model.conditions?.[0]).toEqual({
-      type: 'query',
-      evaluator: {
-        params: [],
-        type: EvalFunction.IsAbove,
-      },
-      operator: {
-        type: 'and',
-      },
-      query: {
-        params: [],
-      },
-      reducer: {
-        params: [],
-        type: 'last',
+    expect(reduceQuery).toMatchObject({
+      refId: 'B',
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: {
+        type: ExpressionQueryType.reduce,
+        refId: 'B',
+        datasource: { uid: ExpressionDatasourceUID },
+        reducer: 'last',
+        expression: 'A',
       },
     });
+  });
+
+  it('should not give the reduce expression a conditions array', () => {
+    const [reduceQuery] = getDefaultExpressions('B', 'C');
+
+    // Older versions wrote a full classic condition in here. The backend never read it, and the
+    // reduce editor never showed it.
+    expect(Object.keys(reduceQuery.model)).not.toContain('conditions');
   });
 
   it('should create a threshold expression as the second query', () => {
-    const result = getDefaultExpressions('B', 'C');
-    const thresholdQuery = result[1];
-    const { model } = thresholdQuery;
+    const [, thresholdQuery] = getDefaultExpressions('B', 'C');
 
-    expect(thresholdQuery.refId).toBe('C');
-    expect(thresholdQuery.datasourceUid).toBe(ExpressionDatasourceUID);
-    expect(thresholdQuery.queryType).toBe('expression');
-
-    if (!isExpressionQuery(model)) {
-      throw new Error('Expected ExpressionQuery');
-    }
-
-    expect(model.type).toBe(ExpressionQueryType.threshold);
-    expect(model.datasource?.uid).toBe(ExpressionDatasourceUID);
-  });
-
-  it('should create threshold expression with proper conditions structure', () => {
-    const result = getDefaultExpressions('B', 'C');
-    const thresholdQuery = result[1];
-    const { model } = thresholdQuery;
-
-    if (!isExpressionQuery(model)) {
-      throw new Error('Expected ExpressionQuery');
-    }
-
-    expect(model.conditions).toHaveLength(1);
-    expect(model.conditions?.[0]).toEqual({
-      type: 'query',
-      evaluator: {
-        params: [0],
-        type: EvalFunction.IsAbove,
-      },
-      operator: {
-        type: 'and',
-      },
-      query: {
-        params: ['C'],
-      },
-      reducer: {
-        params: [],
-        type: 'last',
+    expect(thresholdQuery).toMatchObject({
+      refId: 'C',
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: {
+        type: ExpressionQueryType.threshold,
+        refId: 'C',
+        datasource: { uid: ExpressionDatasourceUID },
+        expression: 'B',
       },
     });
   });
 
-  it('should reference the reduce expression in the threshold expression', () => {
-    const result = getDefaultExpressions('B', 'C');
-    const thresholdQuery = result[1];
-    const { model } = thresholdQuery;
+  it('should give the threshold expression exactly one condition, which is all the backend takes', () => {
+    const [, thresholdQuery] = getDefaultExpressions('B', 'C');
 
-    if (!isExpressionQuery(model)) {
-      throw new Error('Expected ExpressionQuery');
+    expect(thresholdQuery.model).toMatchObject({
+      conditions: [{ evaluator: { params: [0], type: EvalFunction.IsAbove } }],
+    });
+  });
+
+  it('should not give the threshold condition the classic-only fields', () => {
+    const [, thresholdQuery] = getDefaultExpressions('B', 'C');
+    const model = thresholdQuery.model;
+
+    if (!isExpressionQuery(model) || model.type !== ExpressionQueryType.threshold) {
+      throw new Error('Expected a threshold expression');
     }
 
-    expect(model.expression).toBe('B');
+    const [condition] = model.conditions;
+    expect(Object.keys(condition)).not.toContain('query');
+    expect(Object.keys(condition)).not.toContain('reducer');
+    expect(Object.keys(condition)).not.toContain('operator');
+  });
+
+  it('should read the source query from the third refId when one is given', () => {
+    const [reduceQuery] = getDefaultExpressions('B', 'C', 'Z');
+
+    expect(reduceQuery.model).toMatchObject({ expression: 'Z' });
   });
 
   it('should properly use different refIds throughout the structure', () => {
-    const result = getDefaultExpressions('X', 'Y');
-    const reduceModel = result[0].model;
-    const thresholdModel = result[1].model;
+    const [reduceQuery, thresholdQuery] = getDefaultExpressions('X', 'Y');
 
-    if (!isExpressionQuery(reduceModel) || !isExpressionQuery(thresholdModel)) {
-      throw new Error('Expected ExpressionQuery');
-    }
-
-    expect(result[0].refId).toBe('X');
-    expect(reduceModel.refId).toBe('X');
-    expect(reduceModel.conditions?.[0].query.params).toEqual([]);
-
-    expect(result[1].refId).toBe('Y');
-    expect(thresholdModel.refId).toBe('Y');
-    expect(thresholdModel.expression).toBe('X');
+    expect(reduceQuery).toMatchObject({ refId: 'X', model: { refId: 'X' } });
+    expect(thresholdQuery).toMatchObject({ refId: 'Y', model: { refId: 'Y', expression: 'X' } });
   });
 });
 
@@ -869,5 +822,254 @@ describe('fixMissingRefIdsInExpressionModel', () => {
 
     expect(result.grafana_alert.data[0].model.refId).toBe('A');
     expect(result.grafana_alert.data[1].model.refId).toBe('B');
+  });
+});
+
+describe('reading expression models out of a saved rule', () => {
+  /** A rule whose classic condition predates the reducer field, as provisioned rules often are. */
+  function ruleWithClassicConditionMissingReducer() {
+    return mockRulerGrafanaRule(
+      {},
+      {
+        condition: 'B',
+        data: [
+          { datasourceUid: 'prom-uid', refId: 'A', queryType: '', model: { refId: 'A' } },
+          {
+            datasourceUid: ExpressionDatasourceUID,
+            refId: 'B',
+            queryType: 'expression',
+            model: {
+              refId: 'B',
+              type: ExpressionQueryType.classic,
+              datasource: { type: '__expr__', uid: ExpressionDatasourceUID },
+              conditions: [
+                {
+                  type: 'query',
+                  evaluator: { params: [0], type: EvalFunction.IsAbove },
+                  query: { params: ['A'] },
+                },
+              ],
+            } as unknown as AlertDataQuery,
+          },
+        ],
+      }
+    );
+  }
+
+  // The editor reads condition.reducer.type without checking, so a rule saved without one used to
+  // break it. Filling that in is now the read boundary's job.
+  it('fills in a classic condition reducer via rulerRuleToFormValues', () => {
+    const rule = ruleWithClassicConditionMissingReducer();
+    const result = rulerRuleToFormValues(
+      mockRuleWithLocation(rule, {
+        ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+        namespace: 'Test Folder',
+        group: { name: 'my-group', interval: '1m', rules: [rule] },
+      })
+    );
+
+    expect(result.queries[1].model).toMatchObject({
+      conditions: [{ reducer: { params: [], type: 'avg' } }],
+    });
+  });
+
+  it('fills in a classic condition reducer via grafanaRuleDtoToFormValues', () => {
+    const result = grafanaRuleDtoToFormValues(ruleWithClassicConditionMissingReducer(), 'Test Folder');
+
+    expect(result.queries[1].model).toMatchObject({
+      conditions: [{ reducer: { params: [], type: 'avg' } }],
+    });
+  });
+
+  it('leaves data queries alone', () => {
+    const result = grafanaRuleDtoToFormValues(ruleWithClassicConditionMissingReducer(), 'Test Folder');
+
+    expect(result.queries[0].model).toEqual({ refId: 'A' });
+  });
+
+  it('keeps fields on the expression model that we do not describe', () => {
+    const rule = mockRulerGrafanaRule(
+      {},
+      {
+        condition: 'B',
+        data: [
+          {
+            datasourceUid: ExpressionDatasourceUID,
+            refId: 'B',
+            queryType: 'expression',
+            model: {
+              refId: 'B',
+              type: ExpressionQueryType.reduce,
+              expression: 'A',
+              reducer: 'last',
+              intervalMs: 1000,
+              maxDataPoints: 43200,
+            } as unknown as AlertDataQuery,
+          },
+        ],
+      }
+    );
+
+    const result = grafanaRuleDtoToFormValues(rule, 'Test Folder');
+
+    expect(result.queries[0].model).toMatchObject({ intervalMs: 1000, maxDataPoints: 43200 });
+  });
+
+  it('leaves an expression it cannot read in place, for setQueryEditorSettings to deal with', () => {
+    const rule = mockRulerGrafanaRule(
+      {},
+      {
+        condition: 'B',
+        data: [
+          {
+            datasourceUid: ExpressionDatasourceUID,
+            refId: 'B',
+            queryType: 'expression',
+            // No type at all - this can come from a dashboard panel or the API
+            model: { refId: 'B' } as unknown as AlertDataQuery,
+          },
+        ],
+      }
+    );
+
+    const result = grafanaRuleDtoToFormValues(rule, 'Test Folder');
+
+    expect(result.queries).toHaveLength(1);
+    expect(result.queries[0].model).toEqual({ refId: 'B' });
+  });
+});
+
+describe('writing expression models back out', () => {
+  function formValuesWithExpressions(model: unknown): RuleFormValues {
+    return {
+      ...getDefaultFormValues(),
+      name: 'test',
+      type: RuleFormType.grafana,
+      condition: 'B',
+      queries: [
+        { datasourceUid: 'prom-uid', refId: 'A', queryType: '', model: { refId: 'A' } },
+        {
+          datasourceUid: ExpressionDatasourceUID,
+          refId: 'B',
+          queryType: 'expression',
+          model: model as AlertDataQuery,
+        },
+      ],
+    };
+  }
+
+  // The backend rejects `settings: null` outright, so the key has to be absent rather than nulled.
+  it('leaves settings out of a reduce rather than sending null', () => {
+    const values = formValuesWithExpressions({
+      refId: 'B',
+      type: ExpressionQueryType.reduce,
+      expression: 'A',
+      reducer: 'last',
+    });
+
+    const dto = formValuesToRulerGrafanaRuleDTO(values);
+    const written = dto.grafana_alert.data[1].model;
+
+    expect(Object.keys(written)).not.toContain('settings');
+  });
+
+  it('keeps settings when the reduce actually has some', () => {
+    const values = formValuesWithExpressions({
+      refId: 'B',
+      type: ExpressionQueryType.reduce,
+      expression: 'A',
+      reducer: 'last',
+      settings: { mode: 'dropNN' },
+    });
+
+    const dto = formValuesToRulerGrafanaRuleDTO(values);
+
+    expect(dto.grafana_alert.data[1].model).toMatchObject({ settings: { mode: 'dropNN' } });
+  });
+
+  it('keeps hysteresis state on a threshold, so saving an unrelated edit does not re-fire the alert', () => {
+    const values = formValuesWithExpressions({
+      refId: 'B',
+      type: ExpressionQueryType.threshold,
+      expression: 'A',
+      conditions: [
+        {
+          evaluator: { type: EvalFunction.IsAbove, params: [10] },
+          unloadEvaluator: { type: EvalFunction.IsBelow, params: [5] },
+          loadedFingerprints: ['18446744073709551615'],
+        },
+      ],
+    });
+
+    const dto = formValuesToRulerGrafanaRuleDTO(values);
+
+    expect(dto.grafana_alert.data[1].model).toMatchObject({
+      conditions: [{ loadedFingerprints: ['18446744073709551615'] }],
+    });
+  });
+
+  it('keeps fields we do not describe', () => {
+    const values = formValuesWithExpressions({
+      refId: 'B',
+      type: ExpressionQueryType.reduce,
+      expression: 'A',
+      reducer: 'last',
+      intervalMs: 1000,
+    });
+
+    const dto = formValuesToRulerGrafanaRuleDTO(values);
+
+    expect(dto.grafana_alert.data[1].model).toMatchObject({ intervalMs: 1000 });
+  });
+
+  it('leaves data queries untouched', () => {
+    const values = formValuesWithExpressions({
+      refId: 'B',
+      type: ExpressionQueryType.reduce,
+      expression: 'A',
+      reducer: 'last',
+    });
+
+    const dto = formValuesToRulerGrafanaRuleDTO(values);
+
+    expect(dto.grafana_alert.data[0].model).toEqual({ refId: 'A' });
+  });
+});
+
+describe('round trip through the API shape', () => {
+  it('a rule read, written and read again comes back the same', () => {
+    const savedModel = {
+      refId: 'B',
+      type: ExpressionQueryType.threshold,
+      datasource: { type: '__expr__', uid: ExpressionDatasourceUID },
+      expression: 'A',
+      conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [10] } }],
+      intervalMs: 1000,
+    };
+
+    const rule = mockRulerGrafanaRule(
+      {},
+      {
+        condition: 'B',
+        data: [
+          { datasourceUid: 'prom-uid', refId: 'A', queryType: '', model: { refId: 'A' } },
+          {
+            datasourceUid: ExpressionDatasourceUID,
+            refId: 'B',
+            queryType: 'expression',
+            model: savedModel as unknown as AlertDataQuery,
+          },
+        ],
+      }
+    );
+
+    const firstRead = grafanaRuleDtoToFormValues(rule, 'Test Folder');
+    const written = formValuesToRulerGrafanaRuleDTO({ ...firstRead, name: 'test', condition: 'B' });
+    const secondRead = grafanaRuleDtoToFormValues(
+      { ...rule, grafana_alert: { ...rule.grafana_alert, data: written.grafana_alert.data } },
+      'Test Folder'
+    );
+
+    expect(secondRead.queries).toEqual(firstRead.queries);
   });
 });

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -494,12 +494,12 @@ export function fixMissingRefIdsInExpressionModel<T extends RulerRuleDTO>(rule: 
 }
 
 /**
- * Reads the expression models in a saved rule through the expression schemas, so everything
- * downstream gets a normalised model: fields older versions left out are filled in, and fields we
- * do not model are carried through untouched.
+ * Reads a saved rule's expressions through the expression schemas, so the rest of the app gets
+ * them in one shape: fields older versions left out are filled in, and fields we do not know about
+ * are passed along untouched.
  *
- * An expression we cannot read at all is left exactly as it was. `setQueryEditorSettings` already
- * knows how to deal with one of those, including fixing up which query is the condition.
+ * An expression we cannot read is left exactly as it was - `setQueryEditorSettings` already deals
+ * with those, including sorting out which query is the condition.
  */
 export function parseExpressionModels<T extends RulerRuleDTO>(rule: T): T {
   if (!rulerRuleType.grafana.rule(rule)) {
@@ -919,9 +919,8 @@ function getIntervals(range: TimeRange, lowLimit?: string, resolution?: number):
 }
 
 /**
- * Writes an expression model back out the way the backend wants it: `settings` left out rather than
- * sent as null, the `$` convention put back where it belongs, and anything we do not model carried
- * through. Data queries are returned untouched.
+ * Writes an expression back out the way the backend wants it: `settings` left out rather than sent
+ * as null, the `$` put back, and unknown fields carried through. Data queries are left alone.
  */
 export function encodeExpressionModel(query: AlertQuery): AlertQuery {
   if (!isExpressionQuery(query.model)) {

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -20,7 +20,10 @@ import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getQueryRunnerFor } from 'app/features/dashboard-scene/utils/getQueryRunnerFor';
 import { getDashboardSceneFor } from 'app/features/dashboard-scene/utils/utils';
 import { getPanelIdForVizPanel } from 'app/features/dashboard-scene/utils/utils-panels';
-import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { isExpressionQuery } from 'app/features/expressions/guards';
+import { encodeExpressionQuery, parseExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { makeReduceExpression, makeThresholdExpression } from 'app/features/expressions/schemas/factories';
+import { ExpressionDatasourceUID, type ExpressionQuery } from 'app/features/expressions/types';
 import { getTemplateSrv } from 'app/features/templating/template_srv';
 import { type RuleWithLocation } from 'app/types/unified-alerting';
 import {
@@ -38,7 +41,6 @@ import {
 } from 'app/types/unified-alerting-dto';
 
 import { type LokiQuery } from '../../../loki-helpers/types';
-import { EvalFunction } from '../../state/alertDef';
 import { NAMED_ROOT_LABEL_NAME } from '../components/notification-policies/useNotificationPolicyRoute';
 import { getDefaultFormValues } from '../rule-editor/formDefaults';
 import { normalizeDefaultAnnotations } from '../rule-editor/formProcessing';
@@ -196,7 +198,7 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
       grafana_alert: {
         title: name,
         condition,
-        data: queries.map(fixBothInstantAndRangeQuery),
+        data: queries.map(fixBothInstantAndRangeQuery).map(encodeExpressionModel),
         is_paused: Boolean(isPaused),
 
         // Alerting rule specific
@@ -221,7 +223,7 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
       grafana_alert: {
         title: name,
         condition,
-        data: queries.map(fixBothInstantAndRangeQuery),
+        data: queries.map(fixBothInstantAndRangeQuery).map(encodeExpressionModel),
         is_paused: Boolean(isPaused),
 
         // Recording rule specific
@@ -339,7 +341,7 @@ function getEditorSettingsFromDTO(ga: GrafanaRuleDefinition) {
 
 export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleFormValues {
   const { ruleSourceName, namespace, group, rule } = ruleWithLocation;
-  const normalizedRule = fixMissingRefIdsInExpressionModel(rule);
+  const normalizedRule = parseExpressionModels(fixMissingRefIdsInExpressionModel(rule));
 
   const isGrafanaRecordingRule = rulerRuleType.grafana.recordingRule(normalizedRule);
 
@@ -487,11 +489,41 @@ export function fixMissingRefIdsInExpressionModel<T extends RulerRuleDTO>(rule: 
   });
 }
 
+/**
+ * Reads the expression models in a saved rule through the expression schemas, so everything
+ * downstream gets a normalised model: fields older versions left out are filled in, and fields we
+ * do not model are carried through untouched.
+ *
+ * An expression we cannot read at all is left exactly as it was. `setQueryEditorSettings` already
+ * knows how to deal with one of those, including fixing up which query is the condition.
+ */
+export function parseExpressionModels<T extends RulerRuleDTO>(rule: T): T {
+  if (!rulerRuleType.grafana.rule(rule)) {
+    return rule;
+  }
+
+  return produce(rule, (draft) => {
+    draft.grafana_alert.data.forEach((query, index) => {
+      if (!isExpressionQuery(query.model)) {
+        return;
+      }
+
+      const parsed = parseExpressionQuery(query.model);
+
+      if (parsed) {
+        draft.grafana_alert.data[index] = { ...query, model: parsed };
+      }
+    });
+  });
+}
+
 export function grafanaRuleDtoToFormValues(rule: RulerGrafanaRuleDTO, namespace: string): RuleFormValues {
   const isGrafanaRecordingRule = rulerRuleType.grafana.recordingRule(rule);
   const defaultFormValues = getDefaultFormValues(isGrafanaRecordingRule ? RuleFormType.grafanaRecording : undefined);
 
-  const ga = rule.grafana_alert;
+  const normalizedRule = parseExpressionModels(fixMissingRefIdsInExpressionModel(rule));
+
+  const ga = normalizedRule.grafana_alert;
   const duration = rule.for;
   const keepFiringFor = rule.keep_firing_for;
   const annotations = rule.annotations;
@@ -612,70 +644,27 @@ export const getDefaultQueries = (isRecordingRule = false): AlertQuery[] => {
   ];
 };
 
+/** What the expression models themselves carry as their data source. */
+const expressionModelDatasource = {
+  uid: ExpressionDatasourceUID,
+  type: ExpressionDatasourceRef.type,
+};
+
 export const getDefaultExpressions = (...refIds: [string, string] | [string, string, string]): AlertQuery[] => {
   const refOne = refIds[0];
   const refTwo = refIds[1];
   // If a third parameter is provided, use it as the source query refId, otherwise default to 'A'
   const sourceRefId = refIds.length === 3 ? refIds[2] : 'A';
 
-  const reduceExpression: ExpressionQuery = {
-    refId: refIds[0],
-    type: ExpressionQueryType.reduce,
-    datasource: {
-      uid: ExpressionDatasourceUID,
-      type: ExpressionDatasourceRef.type,
-    },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: [],
-          type: EvalFunction.IsAbove,
-        },
-        operator: {
-          type: 'and',
-        },
-        query: {
-          params: [],
-        },
-        reducer: {
-          params: [],
-          type: 'last',
-        },
-      },
-    ],
-    reducer: 'last',
-    expression: sourceRefId,
-  };
+  const reduceExpression = makeReduceExpression(
+    { refId: refOne, datasource: expressionModelDatasource },
+    { expression: sourceRefId, reducer: 'last' }
+  );
 
-  const thresholdExpression: ExpressionQuery = {
-    refId: refTwo,
-    type: ExpressionQueryType.threshold,
-    datasource: {
-      uid: ExpressionDatasourceUID,
-      type: ExpressionDatasourceRef.type,
-    },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: [0],
-          type: EvalFunction.IsAbove,
-        },
-        operator: {
-          type: 'and',
-        },
-        query: {
-          params: [refTwo],
-        },
-        reducer: {
-          params: [],
-          type: 'last',
-        },
-      },
-    ],
-    expression: refOne,
-  };
+  const thresholdExpression = makeThresholdExpression(
+    { refId: refTwo, datasource: expressionModelDatasource },
+    { expression: refOne }
+  );
 
   return [
     {
@@ -694,35 +683,10 @@ export const getDefaultExpressions = (...refIds: [string, string] | [string, str
 };
 
 const getDefaultExpressionsForRecording = (refOne: string): Array<AlertQuery<ExpressionQuery>> => {
-  const reduceExpression: ExpressionQuery = {
-    refId: refOne,
-    type: ExpressionQueryType.reduce,
-    datasource: {
-      uid: ExpressionDatasourceUID,
-      type: ExpressionDatasourceRef.type,
-    },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: [],
-          type: EvalFunction.IsAbove,
-        },
-        operator: {
-          type: 'and',
-        },
-        query: {
-          params: [],
-        },
-        reducer: {
-          params: [],
-          type: 'last',
-        },
-      },
-    ],
-    reducer: 'last',
-    expression: 'A',
-  };
+  const reduceExpression = makeReduceExpression(
+    { refId: refOne, datasource: expressionModelDatasource },
+    { expression: 'A', reducer: 'last' }
+  );
 
   return [
     {
@@ -948,6 +912,26 @@ function getIntervals(range: TimeRange, lowLimit?: string, resolution?: number):
   }
 
   return rangeUtil.calculateInterval(range, resolution, lowLimit);
+}
+
+/**
+ * Writes an expression model back out the way the backend wants it: `settings` left out rather than
+ * sent as null, the `$` convention put back where it belongs, and anything we do not model carried
+ * through. Data queries are returned untouched.
+ */
+export function encodeExpressionModel(query: AlertQuery): AlertQuery {
+  if (!isExpressionQuery(query.model)) {
+    return query;
+  }
+
+  const parsed = parseExpressionQuery(query.model);
+
+  // Nothing we can read, so nothing to re-encode; send it on as-is rather than dropping it.
+  if (!parsed) {
+    return query;
+  }
+
+  return { ...query, model: encodeExpressionQuery(parsed) };
 }
 
 export function fixBothInstantAndRangeQuery(query: AlertQuery) {

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -21,9 +21,13 @@ import { getQueryRunnerFor } from 'app/features/dashboard-scene/utils/getQueryRu
 import { getDashboardSceneFor } from 'app/features/dashboard-scene/utils/utils';
 import { getPanelIdForVizPanel } from 'app/features/dashboard-scene/utils/utils-panels';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { encodeExpressionQuery, parseExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import {
+  type ExpressionQuery,
+  encodeExpressionQuery,
+  parseExpressionQuery,
+} from 'app/features/expressions/schemas/expressionQuery';
 import { makeReduceExpression, makeThresholdExpression } from 'app/features/expressions/schemas/factories';
-import { ExpressionDatasourceUID, type ExpressionQuery } from 'app/features/expressions/types';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 import { getTemplateSrv } from 'app/features/templating/template_srv';
 import { type RuleWithLocation } from 'app/types/unified-alerting';
 import {

--- a/public/app/features/alerting/unified/utils/timeRange.test.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.test.ts
@@ -1,6 +1,7 @@
 import { ReducerID } from '@grafana/data';
 import { defaultClassicCondition } from 'app/features/expressions/schemas/classic';
-import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { getTimeRangeForExpression } from './timeRange';

--- a/public/app/features/alerting/unified/utils/timeRange.test.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.test.ts
@@ -1,6 +1,6 @@
 import { ReducerID } from '@grafana/data';
+import { defaultClassicCondition } from 'app/features/expressions/schemas/classic';
 import { type ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
-import { defaultCondition } from 'app/features/expressions/utils/expressionTypes';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { getTimeRangeForExpression } from './timeRange';
@@ -15,9 +15,9 @@ describe('timeRange', () => {
           datasourceUid: '__expr__',
           model: {
             queryType: 'query',
-            datasource: '__expr__',
+            datasource: { type: '__expr__', uid: '__expr__' },
             refId: 'B',
-            conditions: [{ ...defaultCondition, query: { params: ['A'] } }],
+            conditions: [{ ...defaultClassicCondition, query: { params: ['A'] } }],
             type: ExpressionQueryType.classic,
           } as ExpressionQuery,
         };
@@ -43,11 +43,11 @@ describe('timeRange', () => {
           datasourceUid: '__expr__',
           model: {
             queryType: 'query',
-            datasource: '__expr__',
+            datasource: { type: '__expr__', uid: '__expr__' },
             refId: 'C',
             conditions: [
-              { ...defaultCondition, query: { params: ['A'] } },
-              { ...defaultCondition, query: { params: ['B'] } },
+              { ...defaultClassicCondition, query: { params: ['A'] } },
+              { ...defaultClassicCondition, query: { params: ['B'] } },
             ],
             type: ExpressionQueryType.classic,
           } as ExpressionQuery,
@@ -83,7 +83,7 @@ describe('timeRange', () => {
         datasourceUid: '__expr__',
         model: {
           queryType: 'query',
-          datasource: '__expr__',
+          datasource: { type: '__expr__', uid: '__expr__' },
           refId: 'B',
           expression: '$A > 10',
           type: ExpressionQueryType.math,
@@ -108,7 +108,7 @@ describe('timeRange', () => {
         datasourceUid: '__expr__',
         model: {
           queryType: 'query',
-          datasource: '__expr__',
+          datasource: { type: '__expr__', uid: '__expr__' },
           refId: 'C',
           expression: '$A > 10 && $queryB > 20',
           type: ExpressionQueryType.math,
@@ -145,7 +145,7 @@ describe('timeRange', () => {
         datasourceUid: '__expr__',
         model: {
           queryType: 'query',
-          datasource: '__expr__',
+          datasource: { type: '__expr__', uid: '__expr__' },
           refId: 'B',
           expression: 'A',
           type: ExpressionQueryType.resample,
@@ -178,7 +178,7 @@ describe('timeRange', () => {
         datasourceUid: '__expr__',
         model: {
           queryType: 'query',
-          datasource: '__expr__',
+          datasource: { type: '__expr__', uid: '__expr__' },
           refId: 'B',
           expression: 'A',
           type: ExpressionQueryType.reduce,

--- a/public/app/features/alerting/unified/utils/timeRange.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.ts
@@ -2,12 +2,13 @@ import { type RelativeTimeRange } from '@grafana/data';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import type { ClassicExpressionQuery } from '../../../expressions/schemas/classic';
+import type { ExpressionQuery } from '../../../expressions/schemas/expressionQuery';
 import type { MathExpressionQuery } from '../../../expressions/schemas/math';
 import type { ReduceExpressionQuery } from '../../../expressions/schemas/reduce';
 import type { ResampleExpressionQuery } from '../../../expressions/schemas/resample';
 import type { SqlExpressionQuery } from '../../../expressions/schemas/sql';
 import type { ThresholdExpressionQuery } from '../../../expressions/schemas/threshold';
-import { type ExpressionQuery, ExpressionQueryType } from '../../../expressions/types';
+import { ExpressionQueryType } from '../../../expressions/types';
 
 const FALL_BACK_TIME_RANGE = { from: 21600, to: 0 };
 

--- a/public/app/features/alerting/unified/utils/timeRange.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.ts
@@ -1,6 +1,12 @@
 import { type RelativeTimeRange } from '@grafana/data';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
+import type { ClassicExpressionQuery } from '../../../expressions/schemas/classic';
+import type { MathExpressionQuery } from '../../../expressions/schemas/math';
+import type { ReduceExpressionQuery } from '../../../expressions/schemas/reduce';
+import type { ResampleExpressionQuery } from '../../../expressions/schemas/resample';
+import type { SqlExpressionQuery } from '../../../expressions/schemas/sql';
+import type { ThresholdExpressionQuery } from '../../../expressions/schemas/threshold';
 import { type ExpressionQuery, ExpressionQueryType } from '../../../expressions/types';
 
 const FALL_BACK_TIME_RANGE = { from: 21600, to: 0 };
@@ -38,8 +44,8 @@ const getReferencedIds = (model: ExpressionQuery, queries: AlertQuery[]): string
   }
 };
 
-const getReferencedIdsForClassicCondition = (model: ExpressionQuery) => {
-  return model.conditions?.map((condition) => {
+const getReferencedIdsForClassicCondition = (model: ClassicExpressionQuery) => {
+  return model.conditions.map((condition) => {
     return condition.query.params[0];
   });
 };
@@ -63,17 +69,19 @@ const getTimeRanges = (referencedRefIds: string[], queries: AlertQuery[]) => {
   };
 };
 
-const getReferencedIdsForMath = (model: ExpressionQuery, queries: AlertQuery[]) => {
+const getReferencedIdsForMath = (model: MathExpressionQuery | SqlExpressionQuery, queries: AlertQuery[]) => {
   return (
     queries
       // filter queries of type query and filter expression on if it includes any refIds
-      .filter((q) => q.queryType === 'query' && model.expression?.includes(q.refId))
+      .filter((q) => q.queryType === 'query' && model.expression.includes(q.refId))
       .map((q) => {
         return q.refId;
       })
   );
 };
 
-const getReferencedIdsForReduce = (model: ExpressionQuery) => {
+const getReferencedIdsForReduce = (
+  model: ReduceExpressionQuery | ResampleExpressionQuery | ThresholdExpressionQuery
+) => {
   return model.expression ? [model.expression] : undefined;
 };

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -24,7 +24,6 @@ import { storeLastUsedDataSourceInLocalStorage } from 'app/features/datasources/
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionTypeDropdown } from 'app/features/expressions/components/ExpressionTypeDropdown';
 import { ExpressionQueryType } from 'app/features/expressions/types';
-import { getDefaults } from 'app/features/expressions/utils/expressionTypes';
 import { InspectTab } from 'app/features/inspector/types';
 import { GroupActionComponents } from 'app/features/query/components/QueryActionComponent';
 import { QueryEditorRows } from 'app/features/query/components/QueryEditorRows';
@@ -329,13 +328,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
 
   public onAddExpressionOfType = (type: ExpressionQueryType): string => {
     const queries = this.getQueries();
-    // Create base expression query with the specified type
-    const baseQuery = expressionDatasource.newQuery();
-    const queryWithType = { ...baseQuery, type };
-    // Apply defaults specific to the expression type
-    const queryWithDefaults = getDefaults(queryWithType);
-
-    const newQueries = addQuery(queries, queryWithDefaults);
+    const newQueries = addQuery(queries, expressionDatasource.newQuery({ type }));
     this.onQueriesChange(newQueries);
 
     return newQueries[newQueries.length - 1].refId;

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
@@ -41,25 +41,6 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
     {
       "datasourceUid": "__expr__",
       "model": {
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [],
-              "type": "gt",
-            },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [],
-            },
-            "reducer": {
-              "params": [],
-              "type": "last",
-            },
-            "type": "query",
-          },
-        ],
         "datasource": {
           "type": "__expr__",
           "uid": "__expr__",
@@ -83,19 +64,6 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
               ],
               "type": "gt",
             },
-            "operator": {
-              "type": "and",
-            },
-            "query": {
-              "params": [
-                "C",
-              ],
-            },
-            "reducer": {
-              "params": [],
-              "type": "last",
-            },
-            "type": "query",
           },
         ],
         "datasource": {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -7,7 +7,7 @@ import { type DataQuery } from '@grafana/schema';
 import { Button, Icon, Text, useStyles2, useTheme2 } from '@grafana/ui';
 import { NavToolbarSeparator } from 'app/core/components/AppChrome/NavToolbar/NavToolbarSeparator';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { getQueryEditorTypeConfig, type QueryEditorTypeConfig, QueryEditorType } from '../../constants';
 import {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContext.tsx
@@ -9,7 +9,8 @@ import {
 } from '@grafana/data';
 import { type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
-import { type ExpressionQuery, type ExpressionQueryType } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { type ExpressionQueryType } from 'app/features/expressions/types';
 import { type QueryGroupOptions } from 'app/types/query';
 
 import { type QueryEditorType, type QueryEditorTypeConfig } from '../constants';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.test.ts
@@ -33,10 +33,6 @@ jest.mock('app/features/expressions/ExpressionDatasource', () => ({
   },
 }));
 
-jest.mock('app/features/expressions/utils/expressionTypes', () => ({
-  getDefaults: jest.fn((query) => query),
-}));
-
 const mockUseAlertRulesForPanel = jest.fn();
 jest.mock('./hooks/useAlertRulesForPanel', () => ({
   useAlertRulesForPanel: (...args: unknown[]) => mockUseAlertRulesForPanel(...args),

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorContextWrapper.tsx
@@ -5,7 +5,7 @@ import { SceneDataTransformer } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { useTheme2 } from '@grafana/ui';
 import { useQueryLibraryContext } from 'app/features/explore/QueryLibrary/QueryLibraryContext';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { getQueryRunnerFor } from '../../../utils/getQueryRunnerFor';
 import { type PanelDataPaneNext } from '../PanelDataPaneNext';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingExpression.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingExpression.test.ts
@@ -4,19 +4,16 @@ import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { usePendingExpression } from './usePendingExpression';
 
-// Mock the expression datasource and defaults
+// Mock the expression datasource. newQuery decides the type now, so the mock has to honour the
+// type it is handed rather than returning a fixed one.
 jest.mock('app/features/expressions/ExpressionDatasource', () => ({
   dataSource: {
-    newQuery: jest.fn(() => ({
+    newQuery: jest.fn((query?: { type?: string }) => ({
       refId: '--',
       datasource: { type: '__expr__', uid: '__expr__' },
-      type: ExpressionQueryType.math,
+      type: query?.type ?? 'math',
     })),
   },
-}));
-
-jest.mock('app/features/expressions/utils/expressionTypes', () => ({
-  getDefaults: jest.fn((query) => query),
 }));
 
 interface MockOptions {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingExpression.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/usePendingExpression.ts
@@ -3,7 +3,6 @@ import { useCallback, useState } from 'react';
 import { type DataQuery } from '@grafana/schema';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { type ExpressionQueryType } from 'app/features/expressions/types';
-import { getDefaults } from 'app/features/expressions/utils/expressionTypes';
 
 import { type PendingExpression } from '../QueryEditorContext';
 
@@ -27,11 +26,7 @@ export function usePendingExpression({ addQuery, onCardSelectionChange }: UsePen
       const insertAfterRefId = pendingExpression?.insertAfter;
       setPendingExpressionState(null);
 
-      const baseQuery = expressionDatasource.newQuery();
-      const queryWithType = { ...baseQuery, type };
-      const queryWithDefaults = getDefaults(queryWithType);
-
-      const newRefId = addQuery(queryWithDefaults, insertAfterRefId);
+      const newRefId = addQuery(expressionDatasource.newQuery({ type }), insertAfterRefId);
       if (newRefId) {
         onCardSelectionChange(newRefId, null);
       }

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/hooks/useSelectionState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { type DataQuery } from '@grafana/schema';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { type SelectionModifiers } from '../QueryEditorContext';
 import { type Transformation } from '../types';

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
@@ -1,6 +1,7 @@
 import { createTheme } from '@grafana/data';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 import { makeExpression } from 'app/features/expressions/schemas/factories';
-import { ExpressionQueryType, type ExpressionQuery } from 'app/features/expressions/types';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 
 import { getExpressionSectionLabel, getHiddenMaskStyles } from './utils';
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.test.ts
@@ -1,4 +1,5 @@
 import { createTheme } from '@grafana/data';
+import { makeExpression } from 'app/features/expressions/schemas/factories';
 import { ExpressionQueryType, type ExpressionQuery } from 'app/features/expressions/types';
 
 import { getExpressionSectionLabel, getHiddenMaskStyles } from './utils';
@@ -19,7 +20,7 @@ describe('getHiddenMaskStyles', () => {
 
 describe('getExpressionSectionLabel', () => {
   function expressionQuery(type: ExpressionQueryType): ExpressionQuery {
-    return { refId: 'A', type };
+    return makeExpression(type, { refId: 'A' });
   }
 
   it.each([

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/utils.ts
@@ -11,7 +11,8 @@ import { t } from '@grafana/i18n';
 import { type CustomTransformerDefinition, SafeSerializableSceneObject, type VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { getExpressionLabel, type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
+import { getExpressionLabel } from 'app/features/expressions/types';
 
 import { getAlertStateColor, getQueryEditorTypeConfig, QueryEditorType } from '../constants';
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/actionItem.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/actionItem.ts
@@ -1,6 +1,6 @@
 import { type AlertState } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { type AlertRule, type Transformation } from './QueryEditor/types';
 import { getEditorType } from './QueryEditor/utils';

--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -14,6 +14,7 @@ import { DataSourceWithBackend } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { ExpressionDatasourceApi } from './ExpressionDatasource';
+import { makeMathExpression, makeResampleExpression } from './schemas/factories';
 import { type ExpressionQuery, ExpressionQueryType } from './types';
 
 const mockGetDatasource = jest.fn();
@@ -40,19 +41,16 @@ describe('ExpressionDatasourceApi', () => {
   describe('expression queries with template variables', () => {
     it('should interpolate template variables in expression query', () => {
       const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
-      const query = ds.applyTemplateVariables(
-        { type: ExpressionQueryType.math, refId: 'B', expression: '$input + 5 + $A' },
-        {}
-      );
-      expect(query.expression).toBe('10 + 5 + $A');
+      const query = ds.applyTemplateVariables(makeMathExpression({ refId: 'B' }, '$input + 5 + $A'), {});
+      expect(query).toMatchObject({ expression: '10 + 5 + $A' });
     });
     it('should interpolate template variables in expression query', () => {
       const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
       const query = ds.applyTemplateVariables(
-        { type: ExpressionQueryType.resample, refId: 'B', window: '$window' },
+        makeResampleExpression({ refId: 'B' }, { expression: 'A', window: '$window' }),
         {}
       );
-      expect(query.window).toBe('10s');
+      expect(query).toMatchObject({ window: '10s' });
     });
   });
 
@@ -272,5 +270,53 @@ describe('ExpressionDatasourceApi', () => {
       expect(differentNames.fields[0].config.displayNameFromDS).toBeUndefined();
       expect(missingValue.fields[0].config.displayNameFromDS).toBeUndefined();
     });
+  });
+});
+
+describe('newQuery', () => {
+  const ds = new ExpressionDatasourceApi({} as DataSourceInstanceSettings);
+
+  it('defaults to a math expression', () => {
+    expect(ds.newQuery()).toMatchObject({ type: ExpressionQueryType.math });
+  });
+
+  it('uses a placeholder refId, which the caller replaces', () => {
+    expect(ds.newQuery()).toMatchObject({ refId: '--' });
+  });
+
+  it('points the query at the expression data source', () => {
+    expect(ds.newQuery().datasource).toMatchObject({ uid: '__expr__' });
+  });
+
+  it.each(Object.values(ExpressionQueryType))('builds a %s expression', (type) => {
+    expect(ds.newQuery({ type })).toMatchObject({ type });
+  });
+
+  // Callers used to have to remember to pass these in themselves, and two of them disagreed.
+  it('gives a reduce the reducer the backend requires', () => {
+    expect(ds.newQuery({ type: ExpressionQueryType.reduce })).toMatchObject({ reducer: 'mean' });
+  });
+
+  it('gives a threshold the one condition the backend accepts', () => {
+    expect(ds.newQuery({ type: ExpressionQueryType.threshold })).toMatchObject({
+      conditions: [{ evaluator: { type: 'gt', params: [0] } }],
+    });
+  });
+
+  it('gives a classic expression a condition to start from', () => {
+    expect(ds.newQuery({ type: ExpressionQueryType.classic })).toMatchObject({
+      conditions: [{ type: 'query', reducer: { type: 'avg' } }],
+    });
+  });
+
+  it('carries through the refId and expression it is given', () => {
+    expect(ds.newQuery({ type: ExpressionQueryType.reduce, refId: 'B', expression: 'A' })).toMatchObject({
+      refId: 'B',
+      expression: 'A',
+    });
+  });
+
+  it('does not give a reduce a conditions array', () => {
+    expect(Object.keys(ds.newQuery({ type: ExpressionQueryType.reduce }))).not.toContain('conditions');
   });
 });

--- a/public/app/features/expressions/ExpressionDatasource.test.ts
+++ b/public/app/features/expressions/ExpressionDatasource.test.ts
@@ -14,8 +14,9 @@ import { DataSourceWithBackend } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
 
 import { ExpressionDatasourceApi } from './ExpressionDatasource';
+import type { ExpressionQuery } from './schemas/expressionQuery';
 import { makeMathExpression, makeResampleExpression } from './schemas/factories';
-import { type ExpressionQuery, ExpressionQueryType } from './types';
+import { ExpressionQueryType } from './types';
 
 const mockGetDatasource = jest.fn();
 

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -28,9 +28,9 @@ import { type DataQuery } from '@grafana/schema';
 import icnDatasourceSvg from 'img/icn-datasource.svg';
 
 import { ExpressionQueryEditor } from './ExpressionQueryEditor';
-import { isClassicExpression, isResampleExpression } from './schemas/expressionQuery';
+import { isClassicExpression, isResampleExpression, type ExpressionQuery } from './schemas/expressionQuery';
 import { makeExpression, makeSqlExpression } from './schemas/factories';
-import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from './types';
+import { ExpressionDatasourceUID, ExpressionQueryType } from './types';
 
 const SQL_DISPLAY_NAME_FIELD = '__display_name__';
 const SQL_VALUE_FIELD = '__value__';

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -28,6 +28,8 @@ import { type DataQuery } from '@grafana/schema';
 import icnDatasourceSvg from 'img/icn-datasource.svg';
 
 import { ExpressionQueryEditor } from './ExpressionQueryEditor';
+import { isClassicExpression, isResampleExpression } from './schemas/expressionQuery';
+import { makeExpression, makeSqlExpression } from './schemas/factories';
 import { ExpressionDatasourceUID, type ExpressionQuery, ExpressionQueryType } from './types';
 
 const SQL_DISPLAY_NAME_FIELD = '__display_name__';
@@ -96,13 +98,19 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     super(instanceSettings);
   }
 
-  applyTemplateVariables(query: ExpressionQuery, scopedVars: ScopedVars) {
+  applyTemplateVariables(query: ExpressionQuery, scopedVars: ScopedVars): ExpressionQuery {
     const templateSrv = getTemplateSrv();
-    return {
-      ...query,
-      expression: templateSrv.replace(query.expression, scopedVars),
-      window: templateSrv.replace(query.window, scopedVars),
-    };
+
+    // Classic conditions have no expression of their own - each condition names its own query.
+    if (isClassicExpression(query)) {
+      return query;
+    }
+
+    const interpolated = { ...query, expression: templateSrv.replace(query.expression, scopedVars) };
+
+    return isResampleExpression(interpolated)
+      ? { ...interpolated, window: templateSrv.replace(interpolated.window, scopedVars) }
+      : interpolated;
   }
 
   getCollapsedText(query: ExpressionQuery) {
@@ -128,25 +136,31 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     );
   }
 
-  newQuery(query?: Partial<ExpressionQuery>): ExpressionQuery {
-    return {
-      refId: '--', // Replaced with query
-      datasource: ExpressionDatasourceRef,
-      type: query?.type ?? ExpressionQueryType.math,
-      ...query,
-    };
+  /**
+   * Builds an empty expression. Types that need conditions get their default one from the
+   * factories, so callers no longer have to remember to seed them.
+   */
+  newQuery(query?: {
+    type?: ExpressionQueryType;
+    refId?: string;
+    hide?: boolean;
+    datasource?: ExpressionQuery['datasource'];
+    expression?: string;
+  }): ExpressionQuery {
+    return makeExpression(
+      query?.type ?? ExpressionQueryType.math,
+      {
+        refId: query?.refId ?? '--', // Replaced with query
+        hide: query?.hide,
+        datasource: query?.datasource,
+      },
+      query?.expression
+    );
   }
 
   runMetaSQLExprQuery(request: Partial<SQLQuery>, range: TimeRange, queries: DataQuery[]): Promise<DataFrame> {
     const refId = request.refId || 'meta';
-    const metaSqlExpressionQuery: ExpressionQuery = {
-      window: '',
-      hide: false,
-      expression: request.rawSql,
-      datasource: ExpressionDatasourceRef,
-      refId,
-      type: ExpressionQueryType.sql,
-    };
+    const metaSqlExpressionQuery = makeSqlExpression({ refId, hide: false }, { expression: request.rawSql ?? '' });
     return lastValueFrom(
       getBackendSrv()
         .fetch<BackendDataSourceResponse>({

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -19,8 +19,8 @@ import { Math } from './components/Math';
 import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
 import { Threshold } from './components/Threshold';
+import { changeExpressionType, getExpressionInput, withExpressionInput } from './schemas/factories';
 import { type ExpressionQuery, ExpressionQueryType, expressionTypes } from './types';
-import { getDefaults } from './utils/expressionTypes';
 
 export type ExpressionQueryEditorProps = QueryEditorProps<DataSourceApi<ExpressionQuery>, ExpressionQuery>;
 
@@ -109,16 +109,22 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
 
   const styles = useStyles2(getStyles);
 
+  // Classic conditions have no single input - each condition names its own query - so this is
+  // undefined for them.
+  const expressionInput = getExpressionInput(query);
+
   useEffect(() => {
-    setCachedExpression(query.type, query.expression);
-  }, [query.expression, query.type, setCachedExpression]);
+    setCachedExpression(query.type, expressionInput);
+  }, [expressionInput, query.type, setCachedExpression]);
 
   const onSelectExpressionType = useCallback(
     (value: ExpressionQueryType) => {
-      const cachedExpression = getCachedExpression(value!);
-      const defaults = getDefaults({ ...query, type: value! });
+      const cachedExpression = getCachedExpression(value);
+      // Build a fresh expression of the new type rather than relabelling the old one: the fields
+      // that only made sense for the previous type should not come along.
+      const next = changeExpressionType(query, value);
 
-      onChange({ ...defaults, expression: cachedExpression ?? defaults.expression });
+      onChange(cachedExpression === undefined ? next : withExpressionInput(next, cachedExpression));
     },
     [query, onChange, getCachedExpression]
   );

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -19,8 +19,9 @@ import { Math } from './components/Math';
 import { Reduce } from './components/Reduce';
 import { Resample } from './components/Resample';
 import { Threshold } from './components/Threshold';
+import type { ExpressionQuery } from './schemas/expressionQuery';
 import { changeExpressionType, getExpressionInput, withExpressionInput } from './schemas/factories';
-import { type ExpressionQuery, ExpressionQueryType, expressionTypes } from './types';
+import { ExpressionQueryType, expressionTypes } from './types';
 
 export type ExpressionQueryEditorProps = QueryEditorProps<DataSourceApi<ExpressionQuery>, ExpressionQuery>;
 

--- a/public/app/features/expressions/components/ClassicConditions.tsx
+++ b/public/app/features/expressions/components/ClassicConditions.tsx
@@ -2,60 +2,45 @@ import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Icon, InlineField, InlineFieldRow } from '@grafana/ui';
 
-import { type ClassicCondition, type ExpressionQuery } from '../types';
-import { defaultCondition } from '../utils/expressionTypes';
+import { type ClassicCondition, type ClassicExpressionQuery, defaultClassicCondition } from '../schemas/classic';
 
 import { Condition } from './Condition';
 
 interface Props {
-  query: ExpressionQuery;
+  query: ClassicExpressionQuery;
   refIds: Array<SelectableValue<string>>;
-  onChange: (query: ExpressionQuery) => void;
+  onChange: (query: ClassicExpressionQuery) => void;
 }
 
 export const ClassicConditions = ({ onChange, query, refIds }: Props) => {
   const onConditionChange = (condition: ClassicCondition, index: number) => {
-    if (query.conditions) {
-      onChange({
-        ...query,
-        conditions: [...query.conditions.slice(0, index), condition, ...query.conditions.slice(index + 1)],
-      });
-    }
+    onChange({
+      ...query,
+      conditions: [...query.conditions.slice(0, index), condition, ...query.conditions.slice(index + 1)],
+    });
   };
 
   const onAddCondition = () => {
-    if (query.conditions) {
-      const lastParams = query.conditions.at(-1)?.query?.params ?? [];
-      const newCondition: ClassicCondition = { ...defaultCondition, query: { params: lastParams } };
+    const lastParams = query.conditions.at(-1)?.query.params ?? [];
+    const newCondition: ClassicCondition = { ...defaultClassicCondition, query: { params: lastParams } };
 
-      onChange({
-        ...query,
-        conditions: query.conditions.length > 0 ? [...query.conditions, newCondition] : [newCondition],
-      });
-    }
+    onChange({ ...query, conditions: [...query.conditions, newCondition] });
   };
 
   const onRemoveCondition = (index: number) => {
-    if (query.conditions) {
-      const condition = query.conditions[index];
-      const conditions = query.conditions
-        .filter((c) => c !== condition)
-        .map((c, index) => {
-          if (index === 0) {
-            return {
-              ...c,
-              operator: {
-                type: 'when',
-              },
-            };
-          }
-          return c;
-        });
-      onChange({
-        ...query,
-        conditions,
+    const conditions = query.conditions
+      .filter((_, i) => i !== index)
+      .map((condition, i) => {
+        if (i === 0) {
+          // The first condition has no operator - the row is labelled "WHEN" - and the backend
+          // ignores whatever is there. Drop it rather than leaving a stale and/or behind.
+          const { operator, ...withoutOperator } = condition;
+          return withoutOperator;
+        }
+        return condition;
       });
-    }
+
+    onChange({ ...query, conditions });
   };
 
   return (
@@ -63,7 +48,7 @@ export const ClassicConditions = ({ onChange, query, refIds }: Props) => {
       <InlineFieldRow>
         <InlineField label={t('expressions.classic-conditions.label-conditions', 'Conditions')} labelWidth={14}>
           <div>
-            {query.conditions?.map((condition, index) => {
+            {query.conditions.map((condition, index) => {
               if (!condition) {
                 return;
               }

--- a/public/app/features/expressions/components/Condition.test.tsx
+++ b/public/app/features/expressions/components/Condition.test.tsx
@@ -21,22 +21,12 @@ const defaultProps = {
 };
 
 describe('Condition', () => {
-  it('should render without crashing when condition.reducer is undefined', () => {
-    const conditionWithoutReducer: ClassicCondition = {
-      ...baseCondition,
-      reducer: undefined,
-    };
-
-    expect(() => render(<Condition {...defaultProps} condition={conditionWithoutReducer} />)).not.toThrow();
+  it('should render without crashing for a condition carrying the default reducer', () => {
+    expect(() => render(<Condition {...defaultProps} condition={baseCondition} />)).not.toThrow();
   });
 
-  it('should show the WHEN label when condition.reducer is undefined', () => {
-    const conditionWithoutReducer: ClassicCondition = {
-      ...baseCondition,
-      reducer: undefined,
-    };
-
-    render(<Condition {...defaultProps} condition={conditionWithoutReducer} />);
+  it('should show the WHEN label for the first condition', () => {
+    render(<Condition {...defaultProps} condition={baseCondition} />);
 
     // Component should render with no selected reducer value in the Select
     expect(screen.getByText('WHEN')).toBeInTheDocument();

--- a/public/app/features/expressions/components/Condition.test.tsx
+++ b/public/app/features/expressions/components/Condition.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from 'test/test-utils';
 
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import { type ClassicCondition } from '../types';
+import type { ClassicCondition } from '../schemas/classic';
 
 import { Condition } from './Condition';
 

--- a/public/app/features/expressions/components/Condition.tsx
+++ b/public/app/features/expressions/components/Condition.tsx
@@ -7,7 +7,7 @@ import { Button, ButtonSelect, Icon, InlineFieldRow, Input, Select, useStyles2, 
 
 import alertDef, { EvalFunction } from '../../alerting/state/alertDef';
 import { type ClassicCondition, toClassicOperator } from '../schemas/classic';
-import { type ReducerType } from '../types';
+import type { ClassicReducerId } from '../schemas/common';
 
 interface Props {
   condition: ClassicCondition;
@@ -19,7 +19,7 @@ interface Props {
 
 const reducerFunctions = alertDef.reducerTypes.map<{
   label: string;
-  value: ReducerType;
+  value: ClassicReducerId;
 }>((rt) => ({ label: rt.text, value: rt.value }));
 const evalOperators = alertDef.evalOperators.map((eo) => ({ label: eo.text, value: eo.value }));
 const evalFunctions = alertDef.evalFunctions.map((ef) => ({ label: ef.text, value: ef.value }));
@@ -34,7 +34,7 @@ export const Condition = ({ condition, index, onChange, onRemoveCondition, refId
     });
   };
 
-  const onReducerFunctionChange = (conditionFunction: SelectableValue<ReducerType>) => {
+  const onReducerFunctionChange = (conditionFunction: SelectableValue<ClassicReducerId>) => {
     onChange({
       ...condition,
       reducer: { type: conditionFunction.value!, params: [] },
@@ -92,7 +92,7 @@ export const Condition = ({ condition, index, onChange, onRemoveCondition, refId
               value={evalOperators.find((ea) => ea.value === condition.operator!.type)}
             />
           )}
-          <Select<ReducerType>
+          <Select<ClassicReducerId>
             options={reducerFunctions}
             onChange={onReducerFunctionChange}
             width={20}

--- a/public/app/features/expressions/components/Condition.tsx
+++ b/public/app/features/expressions/components/Condition.tsx
@@ -6,7 +6,8 @@ import { Trans } from '@grafana/i18n';
 import { Button, ButtonSelect, Icon, InlineFieldRow, Input, Select, useStyles2, Stack } from '@grafana/ui';
 
 import alertDef, { EvalFunction } from '../../alerting/state/alertDef';
-import { type ClassicCondition, type ReducerType } from '../types';
+import { type ClassicCondition, toClassicOperator } from '../schemas/classic';
+import { type ReducerType } from '../types';
 
 interface Props {
   condition: ClassicCondition;
@@ -29,7 +30,7 @@ export const Condition = ({ condition, index, onChange, onRemoveCondition, refId
   const onEvalOperatorChange = (evalOperator: SelectableValue<string>) => {
     onChange({
       ...condition,
-      operator: { type: evalOperator.value! },
+      operator: { type: toClassicOperator(evalOperator.value) },
     });
   };
 

--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -6,12 +6,12 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Icon, InlineField, InlineLabel, TextArea, Toggletip, useStyles2, Stack, TextLink } from '@grafana/ui';
 
-import { type ExpressionQuery } from '../types';
+import type { MathExpressionQuery } from '../schemas/math';
 
 interface Props {
   labelWidth: number | 'auto';
-  query: ExpressionQuery;
-  onChange: (query: ExpressionQuery) => void;
+  query: MathExpressionQuery;
+  onChange: (query: MathExpressionQuery) => void;
   onRunQuery: () => void;
 }
 

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -5,7 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, useStyles2, Stack, InlineToast, Tooltip, Icon } from '@grafana/ui';
 
-import { type SqlExpressionQuery } from '../types';
+import type { SqlExpressionQuery } from '../schemas/sql';
 
 interface QueryToolboxProps {
   onFormatCode?: () => void;

--- a/public/app/features/expressions/components/Reduce.tsx
+++ b/public/app/features/expressions/components/Reduce.tsx
@@ -4,25 +4,26 @@ import { CoreApp, type SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, InlineField, InlineFieldRow, Input, Select, TextLink } from '@grafana/ui';
 
-import { type ExpressionQuery, type ExpressionQuerySettings, ReducerMode, reducerModes, reducerTypes } from '../types';
+import { type ExpressionQuerySettings, type ReduceExpressionQuery, toReduceReducerId } from '../schemas/reduce';
+import { ReducerMode, reducerModes, reducerTypes } from '../types';
 
 interface Props {
   app?: CoreApp;
   labelWidth?: number | 'auto';
   refIds: Array<SelectableValue<string>>;
-  query: ExpressionQuery;
-  onChange: (query: ExpressionQuery) => void;
+  query: ReduceExpressionQuery;
+  onChange: (query: ReduceExpressionQuery) => void;
 }
 
 export const Reduce = ({ labelWidth = 'auto', onChange, app, refIds, query }: Props) => {
   const reducer = reducerTypes.find((o) => o.value === query.reducer);
 
   const onRefIdChange = (value: SelectableValue<string>) => {
-    onChange({ ...query, expression: value.value });
+    onChange({ ...query, expression: value.value ?? '' });
   };
 
   const onSelectReducer = (value: SelectableValue<string>) => {
-    onChange({ ...query, reducer: value.value });
+    onChange({ ...query, reducer: toReduceReducerId(value.value) });
   };
 
   const onSettingsChanged = (settings: ExpressionQuerySettings) => {

--- a/public/app/features/expressions/components/Resample.tsx
+++ b/public/app/features/expressions/components/Resample.tsx
@@ -4,13 +4,14 @@ import { type SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
-import { downsamplingTypes, type ExpressionQuery, upsamplingTypes } from '../types';
+import { type ResampleExpressionQuery, toDownsamplerId, toUpsamplerId } from '../schemas/resample';
+import { downsamplingTypes, upsamplingTypes } from '../types';
 
 interface Props {
   refIds: Array<SelectableValue<string>>;
-  query: ExpressionQuery;
+  query: ResampleExpressionQuery;
   labelWidth?: number | 'auto';
-  onChange: (query: ExpressionQuery) => void;
+  onChange: (query: ResampleExpressionQuery) => void;
 }
 
 export const Resample = ({ labelWidth = 'auto', onChange, refIds, query }: Props) => {
@@ -22,15 +23,15 @@ export const Resample = ({ labelWidth = 'auto', onChange, refIds, query }: Props
   };
 
   const onRefIdChange = (value: SelectableValue<string>) => {
-    onChange({ ...query, expression: value.value });
+    onChange({ ...query, expression: value.value ?? '' });
   };
 
   const onSelectDownsampler = (value: SelectableValue<string>) => {
-    onChange({ ...query, downsampler: value.value });
+    onChange({ ...query, downsampler: toDownsamplerId(value.value) });
   };
 
   const onSelectUpsampler = (value: SelectableValue<string>) => {
-    onChange({ ...query, upsampler: value.value });
+    onChange({ ...query, upsampler: toUpsamplerId(value.value) });
   };
 
   return (

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -6,6 +6,7 @@ import { reportInteraction } from '@grafana/runtime';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { dataSource } from '../../ExpressionDatasource';
+import type { SqlExpressionQuery } from '../../schemas/sql';
 import { type ExpressionQuery, ExpressionQueryType } from '../../types';
 import { ALLOWED_FUNCTIONS, fetchSQLFields } from '../../utils/metaSqlExpr';
 
@@ -121,7 +122,7 @@ describe('SqlExpr', () => {
   it('initializes new expressions with default query', async () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
-    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+    const query = { refId: 'expr1', type: ExpressionQueryType.sql, expression: '' } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -135,7 +136,7 @@ describe('SqlExpr', () => {
 
   it('uses a placeholder table when initializing without refIds', async () => {
     const onChange = jest.fn();
-    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+    const query = { refId: 'expr1', type: ExpressionQueryType.sql, expression: '' } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={[]} query={query} queries={[]} />);
 
@@ -147,7 +148,11 @@ describe('SqlExpr', () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
     const existingExpression = 'SELECT 1 AS foo';
-    const query = { refId: 'expr1', type: 'sql', expression: existingExpression } as ExpressionQuery;
+    const query = {
+      refId: 'expr1',
+      type: ExpressionQueryType.sql,
+      expression: existingExpression,
+    } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -159,7 +164,11 @@ describe('SqlExpr', () => {
   it('uses the legacy SQL editor when sqlExpressionsCodeMirror is disabled', async () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
-    const query = { refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery;
+    const query = {
+      refId: 'expr1',
+      type: ExpressionQueryType.sql,
+      expression: 'SELECT * FROM A',
+    } as SqlExpressionQuery;
 
     const { findByTestId } = render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -179,7 +188,9 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'table A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM `table A`' } as ExpressionQuery}
+        query={
+          { refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM `table A`' } as SqlExpressionQuery
+        }
         queries={[]}
       />
     );
@@ -205,7 +216,11 @@ describe('SqlExpr', () => {
 
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
-    const query = { refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery;
+    const query = {
+      refId: 'expr1',
+      type: ExpressionQueryType.sql,
+      expression: 'SELECT * FROM A',
+    } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -224,7 +239,11 @@ describe('SqlExpr', () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
     const existingExpression = 'SELECT 1 AS foo';
-    const query = { refId: 'expr1', type: 'sql', expression: existingExpression } as ExpressionQuery;
+    const query = {
+      refId: 'expr1',
+      type: ExpressionQueryType.sql,
+      expression: existingExpression,
+    } as SqlExpressionQuery;
     const { findByTestId, getByRole, rerender } = render(
       <SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />
     );
@@ -243,7 +262,7 @@ describe('SqlExpr', () => {
   it('adds alerting format when alerting prop is true', async () => {
     const onChange = jest.fn();
     const refIds = [{ value: 'A' }];
-    const query = { refId: 'expr1', type: 'sql' } as ExpressionQuery;
+    const query = { refId: 'expr1', type: ExpressionQueryType.sql, expression: '' } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} alerting queries={[]} />);
 
@@ -258,7 +277,11 @@ describe('SqlExpr', () => {
 
     const onChange = jest.fn();
     const refIds = [{ label: 'Query A', value: 'A' }];
-    const query = { refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery;
+    const query = {
+      refId: 'expr1',
+      type: ExpressionQueryType.sql,
+      expression: 'SELECT * FROM A',
+    } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -281,7 +304,7 @@ describe('SqlExpr', () => {
 
     const onChange = jest.fn();
     const refIds = [{ label: 'table A', value: 'table A' }];
-    const query = { refId: 'expr1', type: 'sql', expression: '' } as ExpressionQuery;
+    const query = { refId: 'expr1', type: ExpressionQueryType.sql, expression: '' } as SqlExpressionQuery;
 
     render(<SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />);
 
@@ -331,7 +354,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={onChange}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[sourceQuery]}
           metadata={mockMetadata({ scopedVars, filters })}
         />
@@ -363,7 +386,7 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+        query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
         queries={[{ refId: 'A' }]}
       />
     );
@@ -396,7 +419,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[{ refId: 'A' }]}
         />
       );
@@ -421,7 +444,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[{ refId: 'A' }]}
         />
       );
@@ -451,7 +474,13 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'table A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT t. FROM `table A` as t' } as ExpressionQuery}
+          query={
+            {
+              refId: 'expr1',
+              type: ExpressionQueryType.sql,
+              expression: 'SELECT t. FROM `table A` as t',
+            } as SqlExpressionQuery
+          }
           queries={[{ refId: 'table A' }]}
         />
       );
@@ -481,7 +510,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[{ refId: 'A' }]}
         />
       );
@@ -514,7 +543,7 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+        query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
         queries={[]}
       />
     );
@@ -534,7 +563,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[]}
           metadata={
             {
@@ -557,7 +586,7 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[]}
           metadata={
             {
@@ -581,7 +610,7 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+        query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
         queries={[]}
         metadata={
           {
@@ -612,7 +641,7 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+        query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
         queries={[]}
         onRunQuery={onRunQuery}
       />
@@ -627,7 +656,7 @@ describe('SqlExpr', () => {
     });
     expect(reportInteraction).toHaveBeenCalledWith(
       'dashboards_expression_interaction',
-      expect.objectContaining({ action: 'execute_expression', expression_type: 'sql' })
+      expect.objectContaining({ action: 'execute_expression', expression_type: ExpressionQueryType.sql })
     );
   });
 
@@ -640,7 +669,7 @@ describe('SqlExpr', () => {
       <SqlExpr
         onChange={jest.fn()}
         refIds={[{ value: 'A' }]}
-        query={{ refId: 'expr1', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+        query={{ refId: 'expr1', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
         queries={[]}
         onRunQuery={onRunQuery}
       />
@@ -665,14 +694,14 @@ describe('SqlExpr', () => {
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'A' }]}
-          query={{ refId: 'exprA', type: 'sql', expression: 'SELECT * FROM A' } as ExpressionQuery}
+          query={{ refId: 'exprA', type: ExpressionQueryType.sql, expression: 'SELECT * FROM A' } as SqlExpressionQuery}
           queries={[]}
           onRunQuery={onRunQueryA}
         />
         <SqlExpr
           onChange={jest.fn()}
           refIds={[{ value: 'B' }]}
-          query={{ refId: 'exprB', type: 'sql', expression: 'SELECT * FROM B' } as ExpressionQuery}
+          query={{ refId: 'exprB', type: ExpressionQueryType.sql, expression: 'SELECT * FROM B' } as SqlExpressionQuery}
           queries={[]}
           onRunQuery={onRunQueryB}
         />

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -6,8 +6,9 @@ import { reportInteraction } from '@grafana/runtime';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { dataSource } from '../../ExpressionDatasource';
+import type { ExpressionQuery } from '../../schemas/expressionQuery';
 import type { SqlExpressionQuery } from '../../schemas/sql';
-import { type ExpressionQuery, ExpressionQueryType } from '../../types';
+import { ExpressionQueryType } from '../../types';
 import { ALLOWED_FUNCTIONS, fetchSQLFields } from '../../utils/metaSqlExpr';
 
 import { SqlEditor } from './SqlEditor/SqlEditor';

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -14,7 +14,7 @@ import { formatSQL, quoteIdentifierIfNecessary } from '@grafana/sql';
 import { Button, Stack, useStyles2 } from '@grafana/ui';
 
 import { type ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
-import { type SqlExpressionQuery } from '../../types';
+import type { SqlExpressionQuery } from '../../schemas/sql';
 import { ALLOWED_FUNCTIONS, fetchSQLFields, type FetchSQLFieldsOptions } from '../../utils/metaSqlExpr';
 import { SQL_EXPRESSIONS_DIALECT } from '../../utils/sqlIdentifier';
 import { QueryToolbox } from '../QueryToolbox';

--- a/public/app/features/expressions/components/Threshold.tsx
+++ b/public/app/features/expressions/components/Threshold.tsx
@@ -9,7 +9,8 @@ import { t } from '@grafana/i18n';
 import { InlineField, InlineFieldRow, InlineSwitch, Input, Select, Stack, useStyles2 } from '@grafana/ui';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import { type ClassicCondition, type ExpressionQuery, thresholdFunctions } from '../types';
+import type { ThresholdCondition, ThresholdExpressionQuery } from '../schemas/threshold';
+import { thresholdFunctions } from '../types';
 
 import { ThresholdSelect } from './ThresholdSelect';
 import { ToLabel } from './ToLabel';
@@ -26,40 +27,23 @@ import {
 interface Props {
   labelWidth: number | 'auto';
   refIds: Array<SelectableValue<string>>;
-  query: ExpressionQuery;
-  onChange: (query: ExpressionQuery) => void;
+  query: ThresholdExpressionQuery;
+  onChange: (query: ThresholdExpressionQuery) => void;
   onError?: (error: string | undefined) => void;
   useHysteresis?: boolean;
 }
 
 const defaultThresholdFunction = EvalFunction.IsAbove;
 
-const defaultEvaluator: ClassicCondition = {
-  type: 'query',
-  evaluator: {
-    type: defaultThresholdFunction,
-    params: [0, 0],
-  },
-  query: {
-    params: [],
-  },
-  reducer: {
-    params: [],
-    type: 'last',
-  },
-};
-
 export const Threshold = ({ labelWidth, onChange, refIds, query, onError, useHysteresis = false }: Props) => {
   const styles = useStyles2(getStyles);
 
-  const initialExpression = { ...query, conditions: query.conditions?.length ? query.conditions : [defaultEvaluator] };
-
   // this queryState is the source of truth for the threshold component.
   // All the changes are made to this object through the dispatch function with the thresholdReducer.
-  const [queryState, dispatch] = useReducer(thresholdReducer, initialExpression);
+  const [queryState, dispatch] = useReducer(thresholdReducer, query);
   const conditionInState = queryState.conditions[0];
 
-  const thresholdFunction = thresholdFunctions.find((fn) => fn.value === queryState.conditions[0].evaluator?.type);
+  const thresholdFunction = thresholdFunctions.find((fn) => fn.value === conditionInState.evaluator.type);
 
   const onRefIdChange = (value: SelectableValue<string>) => {
     dispatch(updateRefId(value.value));
@@ -178,7 +162,7 @@ export const Threshold = ({ labelWidth, onChange, refIds, query, onError, useHys
 
 interface RecoveryThresholdRowProps {
   isRange: boolean;
-  condition: ClassicCondition;
+  condition: ThresholdCondition;
   onError?: (error: string | undefined) => void;
   dispatch: React.Dispatch<AnyAction>;
   allowOnblur: React.MutableRefObject<boolean>;

--- a/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
+++ b/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
@@ -11,17 +11,6 @@ exports[`thresholdReducer Should update unlooadEvaluator when checking hysteresi
         ],
         "type": "gt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": {
         "params": [
           10,
@@ -31,6 +20,7 @@ exports[`thresholdReducer Should update unlooadEvaluator when checking hysteresi
       },
     },
   ],
+  "expression": "",
   "refId": "A",
   "type": "threshold",
 }
@@ -47,20 +37,10 @@ exports[`thresholdReducer Should update unlooadEvaluator when unchecking hystere
         ],
         "type": "gt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": undefined,
     },
   ],
+  "expression": "",
   "refId": "A",
   "type": "threshold",
 }
@@ -76,17 +56,6 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
         ],
         "type": "lt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": {
         "params": [
           10,
@@ -95,6 +64,7 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
       },
     },
   ],
+  "expression": "",
   "refId": "A",
   "type": "threshold",
 }
@@ -111,17 +81,6 @@ exports[`thresholdReducer should update expression with RefId 1`] = `
         ],
         "type": "gt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": {
         "params": [
           10,
@@ -148,17 +107,6 @@ exports[`thresholdReducer should update unloadParams no error when are invalid 1
         ],
         "type": "gt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": {
         "params": [
           20,
@@ -168,6 +116,7 @@ exports[`thresholdReducer should update unloadParams no error when are invalid 1
       },
     },
   ],
+  "expression": "",
   "refId": "A",
   "type": "threshold",
 }
@@ -184,17 +133,6 @@ exports[`thresholdReducer should update unloadParams with no error when are vali
         ],
         "type": "gt",
       },
-      "query": {
-        "params": [
-          "A",
-          "B",
-        ],
-      },
-      "reducer": {
-        "params": [],
-        "type": "avg",
-      },
-      "type": "query",
       "unloadEvaluator": {
         "params": [
           9,
@@ -204,6 +142,7 @@ exports[`thresholdReducer should update unloadParams with no error when are vali
       },
     },
   ],
+  "expression": "",
   "refId": "A",
   "type": "threshold",
 }

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -1,7 +1,7 @@
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import type { ThresholdCondition } from '../schemas/threshold';
-import { ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
+import { type ThresholdCondition, type ThresholdExpressionQuery } from '../schemas/threshold';
+import { ExpressionQueryType } from '../types';
 
 import {
   isInvalid,

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -1,6 +1,7 @@
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import { type ClassicCondition, ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
+import type { ThresholdCondition } from '../schemas/threshold';
+import { ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
 
 import {
   isInvalid,
@@ -13,96 +14,75 @@ import {
 
 describe('isInvalid', () => {
   it('returns an error message if unloadEvaluator.params[0] is undefined', () => {
-    const condition: ClassicCondition = {
+    const condition: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsAbove,
         params: [],
       },
       evaluator: { type: EvalFunction.IsAbove, params: [10] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition)).toEqual({ errorMsg: 'This value cannot be empty' });
   });
 
   it('When using is above, returns an error message if the value in unloadevaluator is above the threshold', () => {
-    const condition: ClassicCondition = {
+    const condition: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsAbove,
         params: [15],
       },
       evaluator: { type: EvalFunction.IsAbove, params: [10] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition)).toEqual({ errorMsg: 'Enter a number less than or equal to 10' });
   });
 
   it('When using is below, returns an error message if the value in unloadevaluator is below the threshold', () => {
-    const condition: ClassicCondition = {
+    const condition: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsAbove,
         params: [9],
       },
       evaluator: { type: EvalFunction.IsBelow, params: [10] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition)).toEqual({ errorMsg: 'Enter a number more than or equal to 10' });
   });
 
   it('When using is within range, returns an error message if the value in unloadevaluator is within the range', () => {
     // first parameter is wrong
-    const condition: ClassicCondition = {
+    const condition: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsOutsideRange,
         params: [11, 21],
       },
       evaluator: { type: EvalFunction.IsWithinRange, params: [10, 20] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition)).toEqual({ errorMsgFrom: 'Enter a number less than or equal to 10' });
     // second parameter is wrong
-    const condition2: ClassicCondition = {
+    const condition2: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsOutsideRange,
         params: [9, 19],
       },
       evaluator: { type: EvalFunction.IsWithinRange, params: [10, 20] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition2)).toEqual({ errorMsgTo: 'Enter a number be more than or equal to 20' });
   });
   it('When using is outside range, returns an error message if the value in unloadevaluator is outside the range', () => {
     // first parameter is wrong
-    const condition: ClassicCondition = {
+    const condition: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsWithinRange,
         params: [8, 19],
       },
       evaluator: { type: EvalFunction.IsOutsideRange, params: [10, 20] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition)).toEqual({ errorMsgFrom: 'Enter a number more than or equal to 10' });
     // second parameter is wrong
-    const condition2: ClassicCondition = {
+    const condition2: ThresholdCondition = {
       unloadEvaluator: {
         type: EvalFunction.IsWithinRange,
         params: [11, 21],
       },
       evaluator: { type: EvalFunction.IsOutsideRange, params: [10, 20] },
-      query: { params: ['A', 'B'] },
-      reducer: { type: 'avg', params: [] },
-      type: 'query',
     };
     expect(isInvalid(condition2)).toEqual({ errorMsgTo: 'Enter a number less than or equal to 20' });
   });
@@ -113,21 +93,19 @@ describe('thresholdReducer', () => {
     jest.clearAllMocks();
   });
   const onError = jest.fn();
-  const thresholdCondition: ClassicCondition = {
+  const thresholdCondition: ThresholdCondition = {
     evaluator: { type: EvalFunction.IsAbove, params: [10, 0] },
     unloadEvaluator: {
       type: EvalFunction.IsBelow,
       params: [10, 0],
     },
-    query: { params: ['A', 'B'] },
-    reducer: { type: 'avg', params: [] },
-    type: 'query',
   };
 
   it('should return initial state', () => {
     expect(thresholdReducer(undefined, { type: '' })).toEqual({
       type: ExpressionQueryType.threshold,
-      conditions: [],
+      conditions: [expect.any(Object)],
+      expression: '',
       refId: '',
     });
   });
@@ -135,6 +113,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -147,6 +126,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -167,6 +147,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -191,6 +172,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -213,6 +195,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -235,6 +218,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -257,6 +241,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -278,6 +263,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -293,6 +279,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -311,6 +298,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -329,6 +317,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -345,6 +334,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -358,6 +348,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [
         {
           ...thresholdCondition,
@@ -376,6 +367,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -390,6 +382,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 
@@ -403,6 +396,7 @@ describe('thresholdReducer', () => {
     const initialState: ThresholdExpressionQuery = {
       type: ExpressionQueryType.threshold,
       refId: 'A',
+      expression: '',
       conditions: [thresholdCondition],
     };
 

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -2,7 +2,9 @@ import { createAction, createReducer } from '@reduxjs/toolkit';
 
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import { type ClassicCondition, ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
+import type { ThresholdEvalFunction } from '../schemas/common';
+import { type ThresholdCondition, defaultThresholdCondition } from '../schemas/threshold';
+import { ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
 import { isRangeEvaluator } from '../utils/expressionTypes';
 
 export const updateRefId = createAction<string | undefined>('thresold/updateRefId');
@@ -22,10 +24,15 @@ export const updateUnloadParams = createAction<{
 }>('thresold/updateUnloadParams');
 
 export const thresholdReducer = createReducer<ThresholdExpressionQuery>(
-  { type: ExpressionQueryType.threshold, refId: '', conditions: [] },
+  {
+    type: ExpressionQueryType.threshold,
+    refId: '',
+    expression: '',
+    conditions: [structuredClone(defaultThresholdCondition)],
+  },
   (builder) => {
     builder.addCase(updateRefId, (state, action) => {
-      state.expression = action.payload;
+      state.expression = action.payload ?? '';
     });
     builder.addCase(updateThresholdType, (state, action) => {
       const typeInPayload = action.payload.evalFunction;
@@ -90,7 +97,7 @@ type OnError = ((error: string | undefined) => void) | undefined;
 
 // The recovery threshold has no field of its own, so its validation errors have to be pushed into
 // the form manually.
-function reportValidation(condition: ClassicCondition, onError: OnError) {
+function reportValidation(condition: ThresholdCondition, onError: OnError) {
   if (!onError) {
     return;
   }
@@ -101,7 +108,7 @@ function reportValidation(condition: ClassicCondition, onError: OnError) {
 // The recovery value defaults to the threshold value, which is not valid for every operator: for
 // "is equal to" an identical value makes the rule flap between Alerting and Normal on every
 // evaluation. So the default has to be validated, not assumed to be valid.
-function applyDefaultUnloadEvaluator(condition: ClassicCondition, onError: OnError) {
+function applyDefaultUnloadEvaluator(condition: ThresholdCondition, onError: OnError) {
   condition.unloadEvaluator = {
     type: getUnloadEvaluatorTypeFromEvaluatorType(condition.evaluator.type),
     // Copied, so that later edits to the threshold don't mutate the recovery value through a shared array.
@@ -110,7 +117,7 @@ function applyDefaultUnloadEvaluator(condition: ClassicCondition, onError: OnErr
   reportValidation(condition, onError);
 }
 
-function getUnloadEvaluatorTypeFromEvaluatorType(type: EvalFunction) {
+function getUnloadEvaluatorTypeFromEvaluatorType(type: EvalFunction): ThresholdEvalFunction {
   // we don't let the user change the unload evaluator type. We just change it to the opposite of the evaluator type
   if (type === EvalFunction.IsAbove) {
     return EvalFunction.IsBelow;
@@ -147,7 +154,7 @@ function getUnloadEvaluatorTypeFromEvaluatorType(type: EvalFunction) {
   return EvalFunction.IsBelow;
 }
 
-export function isInvalid(condition: ClassicCondition) {
+export function isInvalid(condition: ThresholdCondition) {
   // first check if the unload evaluator values are not empty
   const { unloadEvaluator, evaluator } = condition;
   if (!evaluator) {

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -3,8 +3,12 @@ import { createAction, createReducer } from '@reduxjs/toolkit';
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
 import type { ThresholdEvalFunction } from '../schemas/common';
-import { type ThresholdCondition, defaultThresholdCondition } from '../schemas/threshold';
-import { ExpressionQueryType, type ThresholdExpressionQuery } from '../types';
+import {
+  defaultThresholdCondition,
+  type ThresholdCondition,
+  type ThresholdExpressionQuery,
+} from '../schemas/threshold';
+import { ExpressionQueryType } from '../types';
 import { isRangeEvaluator } from '../utils/expressionTypes';
 
 export const updateRefId = createAction<string | undefined>('thresold/updateRefId');

--- a/public/app/features/expressions/guards.ts
+++ b/public/app/features/expressions/guards.ts
@@ -1,7 +1,9 @@
 import { isExpressionReference } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 
-import { type ExpressionQuery, ExpressionQueryType, type ReducerType } from './types';
+import type { ClassicReducerId } from './schemas/common';
+import type { ExpressionQuery } from './schemas/expressionQuery';
+import { ExpressionQueryType } from './types';
 
 export const isExpressionQuery = (dataQuery?: DataQuery): dataQuery is ExpressionQuery => {
   if (!dataQuery) {
@@ -20,7 +22,7 @@ export const isExpressionQuery = (dataQuery?: DataQuery): dataQuery is Expressio
   return Object.values(ExpressionQueryType).includes(expression.type);
 };
 
-export function isReducerType(value: string): value is ReducerType {
+export function isReducerType(value: string): value is ClassicReducerId {
   return [
     'avg',
     'min',

--- a/public/app/features/expressions/schemas/classic.ts
+++ b/public/app/features/expressions/schemas/classic.ts
@@ -16,15 +16,14 @@ import {
 } from './common';
 
 /**
- * The legacy condition type. Each condition reduces one query and compares it to a threshold, and
- * the conditions are combined with and/or.
+ * The old condition type. Each condition reduces one query, compares it to a number, and the
+ * results are combined with and/or.
  *
- * Differences from `threshold` that are easy to trip over:
+ * Three ways it differs from `threshold`, all easy to trip over:
  *
- * - the reducer names are not the same set, and this one is case-sensitive - see
- *   CLASSIC_REDUCER_IDS.
- * - range evaluators need exactly two parameters here, where threshold accepts two or more.
- * - `no_value` is only valid here.
+ * - the reducer names differ, and the spelling has to match exactly - see CLASSIC_REDUCER_IDS
+ * - a range comparison needs exactly two values here; threshold takes two or more
+ * - `no_value` only works here
  */
 
 export const CLASSIC_OPERATORS = ['and', 'or', 'logic-or'] as const;

--- a/public/app/features/expressions/schemas/classic.ts
+++ b/public/app/features/expressions/schemas/classic.ts
@@ -1,0 +1,135 @@
+import * as z from 'zod';
+
+import { EvalFunction } from '../../alerting/state/alertDef';
+import { ExpressionQueryType } from '../types';
+
+import {
+  type KnownFields,
+  CLASSIC_EVAL_FUNCTIONS,
+  CLASSIC_REDUCER_IDS,
+  type ClassicReducerId,
+  evaluatorMemory,
+  evaluatorWire,
+  isRangeEvalFunction,
+  queryBaseMemory,
+  queryBaseWire,
+} from './common';
+
+/**
+ * The legacy condition type. Each condition reduces one query and compares it to a threshold, and
+ * the conditions are combined with and/or.
+ *
+ * Differences from `threshold` that are easy to trip over:
+ *
+ * - the reducer names are not the same set, and this one is case-sensitive - see
+ *   CLASSIC_REDUCER_IDS.
+ * - range evaluators need exactly two parameters here, where threshold accepts two or more.
+ * - `no_value` is only valid here.
+ */
+
+export const CLASSIC_OPERATORS = ['and', 'or', 'logic-or'] as const;
+export type ClassicOperator = (typeof CLASSIC_OPERATORS)[number];
+
+const DEFAULT_CLASSIC_REDUCER: ClassicReducerId = 'avg';
+
+/** Turns a Select value into a valid operator, falling back to `and`. */
+export function toClassicOperator(value: unknown): ClassicOperator {
+  return CLASSIC_OPERATORS.find((operator) => operator === value) ?? 'and';
+}
+
+const conditionWireSchema = z.looseObject({
+  // The backend drops this, but saved rules carry it and a round trip should not remove it.
+  type: z.literal('query').catch('query'),
+  evaluator: evaluatorWire(CLASSIC_EVAL_FUNCTIONS).catch({
+    type: EvalFunction.IsAbove,
+    params: [],
+  }),
+  operator: z
+    .looseObject({ type: z.enum(CLASSIC_OPERATORS).catch('and') })
+    .optional()
+    .catch(undefined),
+  query: z.looseObject({ params: z.array(z.string()).catch([]) }).catch({ params: [] }),
+  /**
+   * Rules created by older versions, and provisioned ones, can be missing this entirely. The
+   * editor reads into it without checking, so fill it in on the way through.
+   */
+  reducer: z
+    .looseObject({
+      type: z.enum(CLASSIC_REDUCER_IDS).catch(DEFAULT_CLASSIC_REDUCER),
+      params: z.array(z.unknown()).catch([]),
+    })
+    .optional()
+    .catch(undefined),
+});
+
+const conditionMemorySchema = z.looseObject({
+  type: z.literal('query'),
+  evaluator: evaluatorMemory(CLASSIC_EVAL_FUNCTIONS),
+  operator: z.looseObject({ type: z.enum(CLASSIC_OPERATORS) }).optional(),
+  query: z.looseObject({ params: z.array(z.string()) }),
+  reducer: z.looseObject({
+    type: z.enum(CLASSIC_REDUCER_IDS),
+    params: z.array(z.unknown()),
+  }),
+});
+
+export type ClassicCondition = KnownFields<z.infer<typeof conditionMemorySchema>>;
+
+export const defaultClassicCondition: ClassicCondition = {
+  type: 'query',
+  reducer: { params: [], type: DEFAULT_CLASSIC_REDUCER },
+  operator: { type: 'and' },
+  query: { params: [] },
+  evaluator: { params: [0, 0], type: EvalFunction.IsAbove },
+};
+
+export const classicWireSchema = z.looseObject({
+  ...queryBaseWire,
+  type: z.literal(ExpressionQueryType.classic),
+  // The backend is happy with a missing or null list, so we have to be too.
+  conditions: z.array(conditionWireSchema).catch([]),
+});
+
+export const classicMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  type: z.literal(ExpressionQueryType.classic),
+  conditions: z.array(conditionMemorySchema),
+});
+
+export type ClassicExpressionQuery = KnownFields<z.infer<typeof classicMemorySchema>>;
+
+export const classicCodec = z.codec(classicWireSchema, classicMemorySchema, {
+  decode: (wire) => ({
+    ...wire,
+    conditions: wire.conditions.map((condition) => ({
+      ...condition,
+      reducer: condition.reducer ?? { params: [], type: DEFAULT_CLASSIC_REDUCER },
+    })),
+  }),
+  encode: (memory) => memory,
+});
+
+/** Range evaluators need exactly two parameters, `no_value` needs none, everything else needs one. */
+function classicEvaluatorParamCountOk(evaluator: ClassicCondition['evaluator']): boolean {
+  if (evaluator.type === EvalFunction.HasNoValue) {
+    return true;
+  }
+  if (isRangeEvalFunction(evaluator.type)) {
+    return evaluator.params.length === 2;
+  }
+  return evaluator.params.length >= 1;
+}
+
+export const classicSaveRules = classicMemorySchema
+  .refine((query) => query.conditions.length > 0, {
+    error: 'Add at least one condition.',
+    path: ['conditions'],
+  })
+  .refine((query) => query.conditions.every((condition) => condition.query.params[0]), {
+    error: 'Every condition needs a query to read from.',
+    path: ['conditions'],
+  })
+  .refine((query) => query.conditions.every((condition) => classicEvaluatorParamCountOk(condition.evaluator)), {
+    error: 'A range condition needs two values; the others need one.',
+    path: ['conditions'],
+  });

--- a/public/app/features/expressions/schemas/common.ts
+++ b/public/app/features/expressions/schemas/common.ts
@@ -3,31 +3,24 @@ import * as z from 'zod';
 import { EvalFunction } from '../../alerting/state/alertDef';
 
 /**
- * Shared pieces for the per-type expression schemas.
+ * Shared pieces for the per-type expression schemas. Each type gets three things:
  *
- * Every expression type is described by three layers:
+ *   - a schema for the saved JSON, which forgives anything malformed so a rule always opens
+ *   - a codec, which reads that JSON in and writes it back out
+ *   - save rules, the stricter checks that only run when someone saves
  *
- *   1. a *wire* schema  - what the backend actually accepts. Deliberately forgiving: extra fields
- *      are kept, and anything malformed falls back to a default rather than failing.
- *   2. a *codec*        - converts wire <-> in-memory and back. Shape and normalisation only.
- *   3. *save rules*     - the stricter checks we only want to run when the user saves.
+ * Keep the save rules separate from the codec. Zod runs a codec's checks when reading as well as
+ * writing, so a `.refine()` on the codec would stop an already-saved rule from opening at all.
  *
- * Keep the save rules out of the codec. Zod validates the in-memory side of a codec on the way in
- * as well as on the way out, so a `.refine()` attached to the codec would stop us from reading a
- * rule that is already saved and slightly wrong - which would mean a user could no longer open
- * their own alert rule.
- *
- * The shapes here mirror what `pkg/expr` accepts at runtime. There is a generated JSON schema at
- * `pkg/expr/query.types.json`, but it is built from a set of Go structs that the parser does not
- * actually use, and it disagrees with the parser in several places, so it is not a safe reference.
+ * These shapes follow what `pkg/expr` really accepts. Do not use
+ * `pkg/expr/query.types.json` as a reference - it is generated from Go structs the parser does not
+ * use, and it disagrees with the parser in several places.
  */
 
 /**
- * Drops the catch-all `[x: string]: unknown` that looseObject puts on the inferred type.
- *
- * We do want unknown fields kept at runtime, but we do not want the type to accept any field name:
- * without this, reading `query.conditions` off a math expression quietly comes back as `unknown`
- * instead of being the compile error that tells you to check the type first.
+ * `looseObject` lets the type accept any field name. We still want to keep unknown fields when
+ * reading and writing, but with that in place asking a math expression for `conditions` gives you
+ * `unknown` instead of the error you want. This drops it from the type only.
  */
 export type KnownFields<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
 
@@ -60,17 +53,16 @@ export const queryBaseMemory = {
 };
 
 /**
- * Reducers accepted by a `reduce` expression. The backend lower-cases the value before looking it
- * up, so `MAX` works, but the set is smaller than the classic-condition one below and notably has
- * no `avg`.
+ * Reducers a `reduce` expression accepts. The backend lower-cases these, so `MAX` is fine. Note
+ * there is no `avg` here - the average is called `mean`.
  */
 export const REDUCE_REDUCER_IDS = ['sum', 'mean', 'min', 'max', 'count', 'last', 'median'] as const;
 export type ReduceReducerId = (typeof REDUCE_REDUCER_IDS)[number];
 
 /**
- * Reducers accepted inside a classic condition. Overlaps with the `reduce` set but is not a
- * superset - this one has `avg` where `reduce` has `mean` - and the backend does not lower-case it,
- * so the casing here has to be exact.
+ * Reducers a classic condition accepts. Overlaps with the `reduce` list above but is not the same:
+ * the average is `avg` here and `mean` there. The backend does not lower-case these, so the
+ * spelling has to match exactly.
  */
 export const CLASSIC_REDUCER_IDS = [
   'avg',
@@ -120,8 +112,9 @@ export function isRangeEvalFunction(fn: EvalFunction): boolean {
 }
 
 /**
- * Resample only supports a subset of the reducers at execution time. The parser accepts anything,
- * so passing `count` or `median` here parses fine and then fails when the rule runs.
+ * The only downsamplers resample can actually do. It accepts any name when the rule is saved, and
+ * only complains later, when a bucket holds more than one point and it has to combine them - so a
+ * bad name here can sit unnoticed until the data lines up to expose it.
  */
 export const DOWNSAMPLER_IDS = ['sum', 'mean', 'min', 'max', 'last'] as const;
 export type DownsamplerId = (typeof DOWNSAMPLER_IDS)[number];
@@ -130,16 +123,15 @@ export const UPSAMPLER_IDS = ['pad', 'backfilling', 'fillna'] as const;
 export type UpsamplerId = (typeof UPSAMPLER_IDS)[number];
 
 /**
- * `reduce` and `resample` both strip a leading `$` from the expression they reference, so `$A` and
- * `A` mean the same thing to them. `threshold` does not, and a `$A` there ends up looking for a
- * query literally named `$A`. We normalise on read so the rest of the app only ever sees a bare
- * refId.
+ * `reduce` and `resample` ignore a leading `$` on the query they read, so `$A` and `A` mean the
+ * same to them. `threshold` does not, and would go looking for a query actually called `$A`. We
+ * strip it on the way in so the rest of the app only sees plain names.
  */
 export function stripRefIdPrefix(value: string): string {
   return value.startsWith('$') ? value.slice(1) : value;
 }
 
-/** A non-empty list of evaluators, which is what z.enum needs. */
+/** At least one evaluator, which is what `z.enum` needs. */
 type EvalFunctionList = readonly [EvalFunction, ...EvalFunction[]];
 
 /**

--- a/public/app/features/expressions/schemas/common.ts
+++ b/public/app/features/expressions/schemas/common.ts
@@ -1,0 +1,172 @@
+import * as z from 'zod';
+
+import { EvalFunction } from '../../alerting/state/alertDef';
+
+/**
+ * Shared pieces for the per-type expression schemas.
+ *
+ * Every expression type is described by three layers:
+ *
+ *   1. a *wire* schema  - what the backend actually accepts. Deliberately forgiving: extra fields
+ *      are kept, and anything malformed falls back to a default rather than failing.
+ *   2. a *codec*        - converts wire <-> in-memory and back. Shape and normalisation only.
+ *   3. *save rules*     - the stricter checks we only want to run when the user saves.
+ *
+ * Keep the save rules out of the codec. Zod validates the in-memory side of a codec on the way in
+ * as well as on the way out, so a `.refine()` attached to the codec would stop us from reading a
+ * rule that is already saved and slightly wrong - which would mean a user could no longer open
+ * their own alert rule.
+ *
+ * The shapes here mirror what `pkg/expr` accepts at runtime. There is a generated JSON schema at
+ * `pkg/expr/query.types.json`, but it is built from a set of Go structs that the parser does not
+ * actually use, and it disagrees with the parser in several places, so it is not a safe reference.
+ */
+
+/**
+ * Drops the catch-all `[x: string]: unknown` that looseObject puts on the inferred type.
+ *
+ * We do want unknown fields kept at runtime, but we do not want the type to accept any field name:
+ * without this, reading `query.conditions` off a math expression quietly comes back as `unknown`
+ * instead of being the compile error that tells you to check the type first.
+ */
+export type KnownFields<T> = { [K in keyof T as string extends K ? never : K]: T[K] };
+
+/**
+ * Matches DataSourceRef, so an expression query stays usable anywhere a DataQuery is expected.
+ */
+const datasourceRefSchema = z.looseObject({
+  type: z.string().optional(),
+  uid: z.string().optional(),
+  apiVersion: z.string().optional(),
+});
+
+/**
+ * Fields every query carries, expression or not. Unknown keys are kept on purpose: saved models
+ * carry things we do not model here (`intervalMs`, `maxDataPoints`, and similar) and dropping them
+ * on save would quietly change the rule.
+ */
+export const queryBaseWire = {
+  refId: z.string().catch(''),
+  hide: z.boolean().optional(),
+  queryType: z.string().optional(),
+  datasource: datasourceRefSchema.nullish().catch(undefined),
+};
+
+export const queryBaseMemory = {
+  refId: z.string(),
+  hide: z.boolean().optional(),
+  queryType: z.string().optional(),
+  datasource: datasourceRefSchema.nullish(),
+};
+
+/**
+ * Reducers accepted by a `reduce` expression. The backend lower-cases the value before looking it
+ * up, so `MAX` works, but the set is smaller than the classic-condition one below and notably has
+ * no `avg`.
+ */
+export const REDUCE_REDUCER_IDS = ['sum', 'mean', 'min', 'max', 'count', 'last', 'median'] as const;
+export type ReduceReducerId = (typeof REDUCE_REDUCER_IDS)[number];
+
+/**
+ * Reducers accepted inside a classic condition. Overlaps with the `reduce` set but is not a
+ * superset - this one has `avg` where `reduce` has `mean` - and the backend does not lower-case it,
+ * so the casing here has to be exact.
+ */
+export const CLASSIC_REDUCER_IDS = [
+  'avg',
+  'min',
+  'max',
+  'sum',
+  'count',
+  'last',
+  'median',
+  'diff',
+  'diff_abs',
+  'percent_diff',
+  'percent_diff_abs',
+  'count_non_null',
+] as const;
+export type ClassicReducerId = (typeof CLASSIC_REDUCER_IDS)[number];
+
+/** Threshold evaluators. `no_value` is missing on purpose - only classic conditions accept it. */
+export const THRESHOLD_EVAL_FUNCTIONS = [
+  EvalFunction.IsAbove,
+  EvalFunction.IsBelow,
+  EvalFunction.IsEqual,
+  EvalFunction.IsNotEqual,
+  EvalFunction.IsGreaterThanEqual,
+  EvalFunction.IsLessThanEqual,
+  EvalFunction.IsWithinRange,
+  EvalFunction.IsOutsideRange,
+  EvalFunction.IsWithinRangeIncluded,
+  EvalFunction.IsOutsideRangeIncluded,
+] as const;
+
+export type ThresholdEvalFunction = (typeof THRESHOLD_EVAL_FUNCTIONS)[number];
+
+/** Classic condition evaluators - the threshold set plus `no_value`. */
+export const CLASSIC_EVAL_FUNCTIONS = [...THRESHOLD_EVAL_FUNCTIONS, EvalFunction.HasNoValue] as const;
+
+/** Evaluators that need two parameters rather than one. */
+export const RANGE_EVAL_FUNCTIONS: readonly EvalFunction[] = [
+  EvalFunction.IsWithinRange,
+  EvalFunction.IsOutsideRange,
+  EvalFunction.IsWithinRangeIncluded,
+  EvalFunction.IsOutsideRangeIncluded,
+];
+
+export function isRangeEvalFunction(fn: EvalFunction): boolean {
+  return RANGE_EVAL_FUNCTIONS.includes(fn);
+}
+
+/**
+ * Resample only supports a subset of the reducers at execution time. The parser accepts anything,
+ * so passing `count` or `median` here parses fine and then fails when the rule runs.
+ */
+export const DOWNSAMPLER_IDS = ['sum', 'mean', 'min', 'max', 'last'] as const;
+export type DownsamplerId = (typeof DOWNSAMPLER_IDS)[number];
+
+export const UPSAMPLER_IDS = ['pad', 'backfilling', 'fillna'] as const;
+export type UpsamplerId = (typeof UPSAMPLER_IDS)[number];
+
+/**
+ * `reduce` and `resample` both strip a leading `$` from the expression they reference, so `$A` and
+ * `A` mean the same thing to them. `threshold` does not, and a `$A` there ends up looking for a
+ * query literally named `$A`. We normalise on read so the rest of the app only ever sees a bare
+ * refId.
+ */
+export function stripRefIdPrefix(value: string): string {
+  return value.startsWith('$') ? value.slice(1) : value;
+}
+
+/** A non-empty list of evaluators, which is what z.enum needs. */
+type EvalFunctionList = readonly [EvalFunction, ...EvalFunction[]];
+
+/**
+ * An evaluator, as carried by both threshold and classic conditions. `params` is a list of numbers
+ * whose length depends on the evaluator - see the save rules for each type.
+ */
+export function evaluatorWire(functions: EvalFunctionList) {
+  return z.looseObject({
+    type: z.enum(functions).catch(EvalFunction.IsAbove),
+    params: z.array(z.number()).catch([]),
+  });
+}
+
+export function evaluatorMemory(functions: EvalFunctionList) {
+  return z.looseObject({
+    type: z.enum(functions),
+    params: z.array(z.number()),
+  });
+}
+
+export type Evaluator = KnownFields<z.infer<ReturnType<typeof evaluatorMemory>>>;
+
+/**
+ * Does this evaluator have enough parameters to run? Range evaluators need two, everything else
+ * needs one. Extra parameters are ignored by the backend, so they are not an error.
+ */
+export function hasEnoughParams(evaluator: Evaluator): boolean {
+  const needed = isRangeEvalFunction(evaluator.type) ? 2 : 1;
+  return evaluator.params.length >= needed;
+}

--- a/public/app/features/expressions/schemas/expressionQuery.ts
+++ b/public/app/features/expressions/schemas/expressionQuery.ts
@@ -1,0 +1,119 @@
+import * as z from 'zod';
+
+import { logWarning } from '@grafana/runtime';
+
+import { ExpressionQueryType } from '../types';
+
+import { type ClassicExpressionQuery, classicCodec, classicSaveRules } from './classic';
+import { type MathExpressionQuery, mathCodec, mathSaveRules } from './math';
+import { type ReduceExpressionQuery, reduceCodec, reduceSaveRules } from './reduce';
+import { type ResampleExpressionQuery, resampleCodec, resampleSaveRules } from './resample';
+import { type SqlExpressionQuery, sqlCodec, sqlSaveRules } from './sql';
+import { type ThresholdExpressionQuery, thresholdCodec, thresholdSaveRules } from './threshold';
+
+/**
+ * Ties the per-type schemas together. Nothing is re-exported from here - this repo does not allow
+ * barrel files under public/app - so import the per-type pieces from their own file.
+ */
+
+/**
+ * One expression query, narrowed by its `type`. Reading a field that only some types have is a
+ * compile error until you check the type first, which is the whole point of splitting these up.
+ */
+export type ExpressionQuery =
+  | MathExpressionQuery
+  | ReduceExpressionQuery
+  | ResampleExpressionQuery
+  | ThresholdExpressionQuery
+  | ClassicExpressionQuery
+  | SqlExpressionQuery;
+
+/** Converts between the JSON stored in a rule and the in-memory form, in both directions. */
+export const expressionQueryCodec = z.discriminatedUnion('type', [
+  mathCodec,
+  reduceCodec,
+  resampleCodec,
+  thresholdCodec,
+  classicCodec,
+  sqlCodec,
+]);
+
+/** The JSON shape as stored in a rule, which is what encoding produces. */
+export type ExpressionQueryWireModel = z.input<typeof expressionQueryCodec>;
+
+const saveRulesByType = {
+  [ExpressionQueryType.math]: mathSaveRules,
+  [ExpressionQueryType.reduce]: reduceSaveRules,
+  [ExpressionQueryType.resample]: resampleSaveRules,
+  [ExpressionQueryType.threshold]: thresholdSaveRules,
+  [ExpressionQueryType.classic]: classicSaveRules,
+  [ExpressionQueryType.sql]: sqlSaveRules,
+} as const;
+
+/**
+ * Reads one expression model out of a saved rule.
+ *
+ * This never throws. Anything malformed falls back to a sensible default so a rule that was saved
+ * by an older version, or hand-edited, still opens in the editor. Unknown fields are kept.
+ *
+ * Returns undefined when the model has no `type` we recognise - there is nothing sensible to show
+ * for one of those, and callers already drop them.
+ */
+export function parseExpressionQuery(model: unknown): ExpressionQuery | undefined {
+  // safeParse on a codec runs the decode direction and accepts unknown, which is what we have
+  // here - callers read this straight off an API response.
+  const result = expressionQueryCodec.safeParse(model);
+
+  if (!result.success) {
+    logWarning('Could not read expression query model', {
+      type: typeof model === 'object' && model !== null && 'type' in model ? String(model.type) : 'missing',
+      issues: String(result.error.issues.length),
+    });
+    return undefined;
+  }
+
+  return result.data;
+}
+
+/**
+ * Turns an in-memory expression back into the JSON we send. Drops `settings` rather than sending
+ * null, puts the `$` convention back where it belongs, and keeps any unknown fields that came in.
+ */
+export function encodeExpressionQuery(query: ExpressionQuery): ExpressionQueryWireModel {
+  return z.encode(expressionQueryCodec, query);
+}
+
+/**
+ * The stricter checks, for when the user saves.
+ *
+ * Kept separate from the codec on purpose: Zod checks the in-memory side of a codec while reading
+ * as well as while writing, so putting these on the codec would stop an already-saved rule that
+ * breaks one of them from opening at all.
+ */
+export function validateExpressionQuery(query: ExpressionQuery) {
+  return saveRulesByType[query.type].safeParse(query);
+}
+
+export function isMathExpression(query: ExpressionQuery): query is MathExpressionQuery {
+  return query.type === ExpressionQueryType.math;
+}
+
+export function isReduceExpression(query: ExpressionQuery): query is ReduceExpressionQuery {
+  return query.type === ExpressionQueryType.reduce;
+}
+
+export function isResampleExpression(query: ExpressionQuery): query is ResampleExpressionQuery {
+  return query.type === ExpressionQueryType.resample;
+}
+
+export function isThresholdExpression(query: ExpressionQuery): query is ThresholdExpressionQuery {
+  return query.type === ExpressionQueryType.threshold;
+}
+
+export function isClassicExpression(query: ExpressionQuery): query is ClassicExpressionQuery {
+  return query.type === ExpressionQueryType.classic;
+}
+
+export function isSqlExpression(query: ExpressionQuery): query is SqlExpressionQuery {
+  return query.type === ExpressionQueryType.sql;
+}

--- a/public/app/features/expressions/schemas/expressionQuery.ts
+++ b/public/app/features/expressions/schemas/expressionQuery.ts
@@ -12,13 +12,8 @@ import { type SqlExpressionQuery, sqlCodec, sqlSaveRules } from './sql';
 import { type ThresholdExpressionQuery, thresholdCodec, thresholdSaveRules } from './threshold';
 
 /**
- * Ties the per-type schemas together. Nothing is re-exported from here - this repo does not allow
- * barrel files under public/app - so import the per-type pieces from their own file.
- */
-
-/**
- * One expression query, narrowed by its `type`. Reading a field that only some types have is a
- * compile error until you check the type first, which is the whole point of splitting these up.
+ * Any expression query. Check `type` first: reading a field that only some types have is an
+ * error until you do.
  */
 export type ExpressionQuery =
   | MathExpressionQuery
@@ -51,17 +46,15 @@ const saveRulesByType = {
 } as const;
 
 /**
- * Reads one expression model out of a saved rule.
+ * Reads one expression out of a saved rule. Never throws: anything malformed falls back to a
+ * sensible default, so an old or hand-edited rule still opens. Unknown fields are kept.
  *
- * This never throws. Anything malformed falls back to a sensible default so a rule that was saved
- * by an older version, or hand-edited, still opens in the editor. Unknown fields are kept.
- *
- * Returns undefined when the model has no `type` we recognise - there is nothing sensible to show
- * for one of those, and callers already drop them.
+ * Returns undefined if the `type` is one we do not know, since there is nothing useful to show for
+ * it. Callers already drop those.
  */
 export function parseExpressionQuery(model: unknown): ExpressionQuery | undefined {
-  // safeParse on a codec runs the decode direction and accepts unknown, which is what we have
-  // here - callers read this straight off an API response.
+  // `safeParse` reads rather than writes, and takes anything - which is what we have, since
+  // callers hand us whatever came back from the API.
   const result = expressionQueryCodec.safeParse(model);
 
   if (!result.success) {
@@ -76,19 +69,16 @@ export function parseExpressionQuery(model: unknown): ExpressionQuery | undefine
 }
 
 /**
- * Turns an in-memory expression back into the JSON we send. Drops `settings` rather than sending
- * null, puts the `$` convention back where it belongs, and keeps any unknown fields that came in.
+ * Turns an expression back into the JSON we send: leaves `settings` out rather than sending null,
+ * puts the `$` back where it belongs, and keeps any unknown fields that came in.
  */
 export function encodeExpressionQuery(query: ExpressionQuery): ExpressionQueryWireModel {
   return z.encode(expressionQueryCodec, query);
 }
 
 /**
- * The stricter checks, for when the user saves.
- *
- * Kept separate from the codec on purpose: Zod checks the in-memory side of a codec while reading
- * as well as while writing, so putting these on the codec would stop an already-saved rule that
- * breaks one of them from opening at all.
+ * The stricter checks, for when someone saves. Kept off the codec on purpose - Zod would run them
+ * while reading too, and an already-saved rule that breaks one would stop opening.
  */
 export function validateExpressionQuery(query: ExpressionQuery) {
   return saveRulesByType[query.type].safeParse(query);

--- a/public/app/features/expressions/schemas/factories.test.ts
+++ b/public/app/features/expressions/schemas/factories.test.ts
@@ -1,0 +1,133 @@
+import { EvalFunction } from '../../alerting/state/alertDef';
+import { ExpressionQueryType } from '../types';
+
+import {
+  changeExpressionType,
+  getExpressionInput,
+  makeExpression,
+  makeResampleExpression,
+  makeThresholdExpression,
+  withExpressionInput,
+} from './factories';
+
+describe('makeExpression', () => {
+  it.each(Object.values(ExpressionQueryType))('builds a %s expression that is valid to save', (type) => {
+    const query = makeExpression(type, { refId: 'B' });
+
+    expect(query.type).toBe(type);
+    expect(query.refId).toBe('B');
+    // Defaults to the expression data source, which is how the backend knows to evaluate it
+    // rather than sending it to a real data source.
+    expect(query.datasource).toMatchObject({ uid: '__expr__' });
+  });
+
+  it('gives a reduce expression a reducer, because the backend rejects one without', () => {
+    expect(makeExpression(ExpressionQueryType.reduce, { refId: 'B' })).toMatchObject({ reducer: 'mean' });
+  });
+
+  it('gives a resample expression both samplers', () => {
+    expect(makeExpression(ExpressionQueryType.resample, { refId: 'B' })).toMatchObject({
+      downsampler: 'mean',
+      upsampler: 'fillna',
+    });
+  });
+
+  it('gives a threshold expression exactly one condition, which is all the backend accepts', () => {
+    const query = makeThresholdExpression({ refId: 'C' });
+
+    expect(query).toMatchObject({
+      conditions: [{ evaluator: { type: EvalFunction.IsAbove, params: [0] } }],
+    });
+  });
+
+  it('gives a classic expression one condition to start from', () => {
+    const query = makeExpression(ExpressionQueryType.classic, { refId: 'B' });
+
+    expect(query).toMatchObject({ conditions: [{ type: 'query', reducer: { type: 'avg' } }] });
+  });
+
+  it('does not give a threshold expression the classic-only fields it used to carry', () => {
+    const query = makeThresholdExpression({ refId: 'C' });
+
+    // These were being written into every new rule and never read.
+    expect(Object.keys(query.conditions[0])).not.toContain('query');
+    expect(Object.keys(query.conditions[0])).not.toContain('reducer');
+  });
+
+  it('does not give a reduce expression a conditions array', () => {
+    expect(Object.keys(makeExpression(ExpressionQueryType.reduce, { refId: 'B' }))).not.toContain('conditions');
+  });
+
+  it('builds two expressions of the same type identically', () => {
+    expect(makeExpression(ExpressionQueryType.reduce, { refId: 'B' })).toEqual(
+      makeExpression(ExpressionQueryType.reduce, { refId: 'B' })
+    );
+  });
+
+  it('does not share condition objects between two expressions', () => {
+    const first = makeThresholdExpression({ refId: 'C' });
+    const second = makeThresholdExpression({ refId: 'D' });
+
+    first.conditions[0].evaluator.params[0] = 99;
+
+    expect(second.conditions[0].evaluator.params[0]).toBe(0);
+  });
+});
+
+describe('getExpressionInput', () => {
+  it('returns what the expression reads from', () => {
+    expect(getExpressionInput(makeExpression(ExpressionQueryType.reduce, { refId: 'B' }, 'A'))).toBe('A');
+  });
+
+  it('returns undefined for a classic condition, which names its query per condition', () => {
+    expect(getExpressionInput(makeExpression(ExpressionQueryType.classic, { refId: 'B' }))).toBeUndefined();
+  });
+});
+
+describe('withExpressionInput', () => {
+  it('repoints an expression at another query', () => {
+    const query = makeExpression(ExpressionQueryType.threshold, { refId: 'C' }, 'A');
+
+    expect(withExpressionInput(query, 'B')).toMatchObject({ expression: 'B' });
+  });
+
+  it('leaves a classic condition alone', () => {
+    const query = makeExpression(ExpressionQueryType.classic, { refId: 'B' });
+
+    expect(withExpressionInput(query, 'A')).toEqual(query);
+  });
+});
+
+describe('changeExpressionType', () => {
+  it('keeps the refId and carries the input across', () => {
+    const reduce = makeExpression(ExpressionQueryType.reduce, { refId: 'B' }, 'A');
+    const resampled = changeExpressionType(reduce, ExpressionQueryType.resample);
+
+    expect(resampled).toMatchObject({ type: ExpressionQueryType.resample, refId: 'B', expression: 'A' });
+  });
+
+  it('drops fields that only made sense for the old type', () => {
+    const resample = makeExpression(ExpressionQueryType.resample, { refId: 'B' }, 'A');
+    const math = changeExpressionType(resample, ExpressionQueryType.math);
+
+    expect(Object.keys(math)).not.toContain('window');
+    expect(Object.keys(math)).not.toContain('downsampler');
+  });
+
+  it('leaves the expression alone when the type is not actually changing', () => {
+    const resample = makeResampleExpression({ refId: 'B' }, { expression: 'A', window: '10s' });
+
+    // Re-picking the same type in the editor should not wipe the window the user set.
+    expect(changeExpressionType(resample, ExpressionQueryType.resample)).toEqual(resample);
+  });
+
+  it('gives the new type its own required fields', () => {
+    const math = makeExpression(ExpressionQueryType.math, { refId: 'B' }, '$A > 1');
+    const threshold = changeExpressionType(math, ExpressionQueryType.threshold);
+
+    expect(threshold).toMatchObject({
+      type: ExpressionQueryType.threshold,
+      conditions: [{ evaluator: { type: EvalFunction.IsAbove } }],
+    });
+  });
+});

--- a/public/app/features/expressions/schemas/factories.ts
+++ b/public/app/features/expressions/schemas/factories.ts
@@ -12,11 +12,8 @@ import type { SqlExpressionQuery } from './sql';
 import { type ThresholdExpressionQuery, defaultThresholdCondition } from './threshold';
 
 /**
- * Builders for new expressions.
- *
- * Before these existed, five different places built their own reduce-and-threshold pair by hand
- * and two of them had already drifted apart. Everything that creates an expression should come
- * through here so there is only one set of defaults to keep straight.
+ * Builders for new expressions. Five places used to write their own defaults by hand, and two had
+ * already drifted apart, so create expressions through here.
  */
 
 /** What every expression carries, whatever its type. */
@@ -109,21 +106,17 @@ export function getExpressionInput(query: ExpressionQuery): string | undefined {
   return isClassicExpression(query) ? undefined : query.expression;
 }
 
-/**
- * Sets what the expression reads from, when the type has such a field. Classic conditions are
- * returned unchanged.
- */
+/** Points the expression at a different query. Classic conditions come back unchanged. */
 export function withExpressionInput(query: ExpressionQuery, expression: string): ExpressionQuery {
   return isClassicExpression(query) ? query : { ...query, expression };
 }
 
 /**
- * Swaps an expression to a different type, keeping the refId and data source. Fields that only
- * made sense for the old type are dropped rather than carried over, which is what the editor wants
- * and what the old in-place `getDefaults` was trying to do by clearing them one at a time.
+ * Changes an expression to a different type, keeping its name and data source. Fields that only
+ * made sense for the old type are dropped rather than carried over.
  */
 export function changeExpressionType(query: ExpressionQuery, type: ExpressionQueryType): ExpressionQuery {
-  // Picking the type it already is should not throw away the settings that go with it.
+  // Re-picking the type it already is should not wipe the settings that go with it.
   if (query.type === type) {
     return query;
   }

--- a/public/app/features/expressions/schemas/factories.ts
+++ b/public/app/features/expressions/schemas/factories.ts
@@ -1,0 +1,132 @@
+import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+
+import { ExpressionQueryType } from '../types';
+
+import { type ClassicExpressionQuery, defaultClassicCondition } from './classic';
+import type { DownsamplerId, ReduceReducerId, UpsamplerId } from './common';
+import { type ExpressionQuery, isClassicExpression } from './expressionQuery';
+import type { MathExpressionQuery } from './math';
+import { DEFAULT_REDUCE_REDUCER, type ReduceExpressionQuery } from './reduce';
+import { DEFAULT_DOWNSAMPLER, DEFAULT_UPSAMPLER, type ResampleExpressionQuery } from './resample';
+import type { SqlExpressionQuery } from './sql';
+import { type ThresholdExpressionQuery, defaultThresholdCondition } from './threshold';
+
+/**
+ * Builders for new expressions.
+ *
+ * Before these existed, five different places built their own reduce-and-threshold pair by hand
+ * and two of them had already drifted apart. Everything that creates an expression should come
+ * through here so there is only one set of defaults to keep straight.
+ */
+
+/** What every expression carries, whatever its type. */
+export interface ExpressionBase {
+  refId: string;
+  hide?: boolean;
+  datasource?: ExpressionQuery['datasource'];
+}
+
+function base({ refId, hide, datasource = ExpressionDatasourceRef }: ExpressionBase) {
+  return hide === undefined ? { refId, datasource } : { refId, hide, datasource };
+}
+
+export function makeMathExpression(from: ExpressionBase, expression = ''): MathExpressionQuery {
+  return { ...base(from), type: ExpressionQueryType.math, expression };
+}
+
+export function makeReduceExpression(
+  from: ExpressionBase,
+  { expression = '', reducer = DEFAULT_REDUCE_REDUCER }: { expression?: string; reducer?: ReduceReducerId } = {}
+): ReduceExpressionQuery {
+  return { ...base(from), type: ExpressionQueryType.reduce, expression, reducer };
+}
+
+export function makeResampleExpression(
+  from: ExpressionBase,
+  {
+    expression = '',
+    window = '',
+    downsampler = DEFAULT_DOWNSAMPLER,
+    upsampler = DEFAULT_UPSAMPLER,
+  }: { expression?: string; window?: string; downsampler?: DownsamplerId; upsampler?: UpsamplerId } = {}
+): ResampleExpressionQuery {
+  return { ...base(from), type: ExpressionQueryType.resample, expression, window, downsampler, upsampler };
+}
+
+export function makeThresholdExpression(
+  from: ExpressionBase,
+  { expression = '' }: { expression?: string } = {}
+): ThresholdExpressionQuery {
+  return {
+    ...base(from),
+    type: ExpressionQueryType.threshold,
+    expression,
+    conditions: [structuredClone(defaultThresholdCondition)],
+  };
+}
+
+export function makeClassicExpression(from: ExpressionBase): ClassicExpressionQuery {
+  return {
+    ...base(from),
+    type: ExpressionQueryType.classic,
+    conditions: [structuredClone(defaultClassicCondition)],
+  };
+}
+
+export function makeSqlExpression(
+  from: ExpressionBase,
+  { expression = '', format }: { expression?: string; format?: 'alerting' } = {}
+): SqlExpressionQuery {
+  return format
+    ? { ...base(from), type: ExpressionQueryType.sql, expression, format }
+    : { ...base(from), type: ExpressionQueryType.sql, expression, format: undefined };
+}
+
+/** Builds an empty expression of the given type. */
+export function makeExpression(type: ExpressionQueryType, from: ExpressionBase, expression?: string): ExpressionQuery {
+  switch (type) {
+    case ExpressionQueryType.math:
+      return makeMathExpression(from, expression);
+    case ExpressionQueryType.reduce:
+      return makeReduceExpression(from, { expression });
+    case ExpressionQueryType.resample:
+      return makeResampleExpression(from, { expression });
+    case ExpressionQueryType.threshold:
+      return makeThresholdExpression(from, { expression });
+    case ExpressionQueryType.classic:
+      return makeClassicExpression(from);
+    case ExpressionQueryType.sql:
+      return makeSqlExpression(from, { expression });
+  }
+}
+
+/**
+ * What this expression reads from. For most types that is a single refId; for math it is a whole
+ * formula, and for SQL it is the query text. Classic conditions do not have one - each of their
+ * conditions names its own query.
+ */
+export function getExpressionInput(query: ExpressionQuery): string | undefined {
+  return isClassicExpression(query) ? undefined : query.expression;
+}
+
+/**
+ * Sets what the expression reads from, when the type has such a field. Classic conditions are
+ * returned unchanged.
+ */
+export function withExpressionInput(query: ExpressionQuery, expression: string): ExpressionQuery {
+  return isClassicExpression(query) ? query : { ...query, expression };
+}
+
+/**
+ * Swaps an expression to a different type, keeping the refId and data source. Fields that only
+ * made sense for the old type are dropped rather than carried over, which is what the editor wants
+ * and what the old in-place `getDefaults` was trying to do by clearing them one at a time.
+ */
+export function changeExpressionType(query: ExpressionQuery, type: ExpressionQueryType): ExpressionQuery {
+  // Picking the type it already is should not throw away the settings that go with it.
+  if (query.type === type) {
+    return query;
+  }
+
+  return makeExpression(type, query, getExpressionInput(query));
+}

--- a/public/app/features/expressions/schemas/math.ts
+++ b/public/app/features/expressions/schemas/math.ts
@@ -1,0 +1,39 @@
+import * as z from 'zod';
+
+import { ExpressionQueryType } from '../types';
+
+import { type KnownFields, queryBaseMemory, queryBaseWire } from './common';
+
+/**
+ * A free-form formula over other queries, referencing them as `$A`. Unlike the other types the
+ * expression here is a formula rather than a single refId, so there is no `$` stripping to do.
+ */
+
+const shape = {
+  type: z.literal(ExpressionQueryType.math),
+  expression: z.string(),
+};
+
+export const mathWireSchema = z.looseObject({
+  ...queryBaseWire,
+  ...shape,
+  expression: z.string().catch(''),
+});
+
+export const mathMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  ...shape,
+});
+
+export type MathExpressionQuery = KnownFields<z.infer<typeof mathMemorySchema>>;
+
+export const mathCodec = z.codec(mathWireSchema, mathMemorySchema, {
+  decode: (wire) => wire,
+  encode: (memory) => memory,
+});
+
+/** An empty formula fails to parse in the backend, so block it before the user saves. */
+export const mathSaveRules = mathMemorySchema.refine((query) => query.expression.trim() !== '', {
+  error: 'Enter a math expression.',
+  path: ['expression'],
+});

--- a/public/app/features/expressions/schemas/reduce.ts
+++ b/public/app/features/expressions/schemas/reduce.ts
@@ -1,0 +1,88 @@
+import * as z from 'zod';
+
+import { ExpressionQueryType, ReducerMode } from '../types';
+
+import {
+  type KnownFields,
+  REDUCE_REDUCER_IDS,
+  type ReduceReducerId,
+  queryBaseMemory,
+  queryBaseWire,
+  stripRefIdPrefix,
+} from './common';
+
+/** Turns each series from another query into a single number. */
+
+export const DEFAULT_REDUCE_REDUCER: ReduceReducerId = 'mean';
+
+/** The backend lower-cases the reducer before looking it up, so `MAX` and `max` both work. */
+export function toReduceReducerId(value: unknown): ReduceReducerId {
+  if (typeof value !== 'string') {
+    return DEFAULT_REDUCE_REDUCER;
+  }
+  const lowered = value.toLowerCase();
+  return REDUCE_REDUCER_IDS.find((id) => id === lowered) ?? DEFAULT_REDUCE_REDUCER;
+}
+
+const settingsMemorySchema = z.looseObject({
+  mode: z.enum(ReducerMode).optional(),
+  replaceWithValue: z.number().optional(),
+});
+
+export type ExpressionQuerySettings = KnownFields<z.infer<typeof settingsMemorySchema>>;
+
+export const reduceWireSchema = z.looseObject({
+  ...queryBaseWire,
+  type: z.literal(ExpressionQueryType.reduce),
+  expression: z.string().catch(''),
+  // Kept loose so an unrecognised reducer falls back rather than failing the whole read, and
+  // explicitly optional because a bare z.unknown() still rejects a missing key. The codec narrows
+  // whatever turns up to the real set.
+  reducer: z.unknown().optional(),
+  settings: z
+    .looseObject({
+      mode: z.enum(ReducerMode).optional().catch(undefined),
+      replaceWithValue: z.number().optional().catch(undefined),
+    })
+    .optional()
+    .catch(undefined),
+});
+
+export const reduceMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  type: z.literal(ExpressionQueryType.reduce),
+  expression: z.string(),
+  reducer: z.enum(REDUCE_REDUCER_IDS),
+  settings: settingsMemorySchema.optional(),
+});
+
+export type ReduceExpressionQuery = KnownFields<z.infer<typeof reduceMemorySchema>>;
+
+export const reduceCodec = z.codec(reduceWireSchema, reduceMemorySchema, {
+  decode: (wire) => ({
+    ...wire,
+    expression: stripRefIdPrefix(wire.expression),
+    reducer: toReduceReducerId(wire.reducer),
+  }),
+  encode: ({ settings, ...rest }) => {
+    // `settings: null` is rejected by the backend, and so is any non-object. Leave the key out
+    // entirely when there is nothing to send.
+    return settings ? { ...rest, settings } : rest;
+  },
+});
+
+export const reduceSaveRules = reduceMemorySchema
+  .refine((query) => query.expression.trim() !== '', {
+    error: 'Select a query to reduce.',
+    path: ['expression'],
+  })
+  .refine(
+    (query) =>
+      // The backend only requires a replacement value in `replaceNN` mode; it ignores the field
+      // otherwise.
+      query.settings?.mode !== ReducerMode.ReplaceNonNumbers || typeof query.settings.replaceWithValue === 'number',
+    {
+      error: 'Enter a replacement value.',
+      path: ['settings', 'replaceWithValue'],
+    }
+  );

--- a/public/app/features/expressions/schemas/resample.ts
+++ b/public/app/features/expressions/schemas/resample.ts
@@ -1,0 +1,73 @@
+import * as z from 'zod';
+
+import { ExpressionQueryType } from '../types';
+
+import {
+  type KnownFields,
+  DOWNSAMPLER_IDS,
+  type DownsamplerId,
+  UPSAMPLER_IDS,
+  type UpsamplerId,
+  queryBaseMemory,
+  queryBaseWire,
+  stripRefIdPrefix,
+} from './common';
+
+/**
+ * Re-spaces the timestamps in a series onto a regular interval.
+ *
+ * The backend does not check the sampler names while parsing - it only finds out they are wrong
+ * when the rule runs - so the sets here are narrower than what would be accepted on save.
+ */
+
+export const DEFAULT_DOWNSAMPLER: DownsamplerId = 'mean';
+export const DEFAULT_UPSAMPLER: UpsamplerId = 'fillna';
+
+export function toDownsamplerId(value: unknown): DownsamplerId {
+  return DOWNSAMPLER_IDS.find((id) => id === value) ?? DEFAULT_DOWNSAMPLER;
+}
+
+export function toUpsamplerId(value: unknown): UpsamplerId {
+  return UPSAMPLER_IDS.find((id) => id === value) ?? DEFAULT_UPSAMPLER;
+}
+
+export const resampleWireSchema = z.looseObject({
+  ...queryBaseWire,
+  type: z.literal(ExpressionQueryType.resample),
+  expression: z.string().catch(''),
+  window: z.string().catch(''),
+  // Explicitly optional: a bare z.unknown() still rejects a missing key.
+  downsampler: z.unknown().optional(),
+  upsampler: z.unknown().optional(),
+});
+
+export const resampleMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  type: z.literal(ExpressionQueryType.resample),
+  expression: z.string(),
+  window: z.string(),
+  downsampler: z.enum(DOWNSAMPLER_IDS),
+  upsampler: z.enum(UPSAMPLER_IDS),
+});
+
+export type ResampleExpressionQuery = KnownFields<z.infer<typeof resampleMemorySchema>>;
+
+export const resampleCodec = z.codec(resampleWireSchema, resampleMemorySchema, {
+  decode: (wire) => ({
+    ...wire,
+    expression: stripRefIdPrefix(wire.expression),
+    downsampler: toDownsamplerId(wire.downsampler),
+    upsampler: toUpsamplerId(wire.upsampler),
+  }),
+  encode: (memory) => memory,
+});
+
+export const resampleSaveRules = resampleMemorySchema
+  .refine((query) => query.expression.trim() !== '', {
+    error: 'Select a query to resample.',
+    path: ['expression'],
+  })
+  .refine((query) => query.window.trim() !== '', {
+    error: 'Enter a window duration, for example 10m.',
+    path: ['window'],
+  });

--- a/public/app/features/expressions/schemas/schemas.test.ts
+++ b/public/app/features/expressions/schemas/schemas.test.ts
@@ -1,0 +1,340 @@
+import * as z from 'zod';
+
+import { EvalFunction } from '../../alerting/state/alertDef';
+import { ExpressionQueryType } from '../types';
+
+import {
+  encodeExpressionQuery,
+  expressionQueryCodec,
+  parseExpressionQuery,
+  validateExpressionQuery,
+} from './expressionQuery';
+
+jest.mock('@grafana/runtime', () => ({
+  logWarning: jest.fn(),
+}));
+
+/** Models shaped the way they actually come back from the ruler API. */
+const savedModels = {
+  math: { refId: 'C', type: 'math', expression: '$B * 2', datasource: { type: '__expr__', uid: '__expr__' } },
+  reduce: { refId: 'B', type: 'reduce', reducer: 'last', expression: 'A' },
+  resample: { refId: 'B', type: 'resample', expression: 'A', window: '10m', downsampler: 'mean', upsampler: 'fillna' },
+  threshold: {
+    refId: 'C',
+    type: 'threshold',
+    expression: 'B',
+    conditions: [{ evaluator: { type: 'gt', params: [10] } }],
+  },
+  classic: {
+    refId: 'B',
+    type: 'classic_conditions',
+    conditions: [
+      {
+        type: 'query',
+        evaluator: { type: 'gt', params: [5] },
+        operator: { type: 'and' },
+        query: { params: ['A'] },
+        reducer: { type: 'avg', params: [] },
+      },
+    ],
+  },
+  sql: { refId: 'B', type: 'sql', expression: 'SELECT * FROM A', format: 'alerting' },
+} as const;
+
+describe('reading saved models', () => {
+  it.each(Object.entries(savedModels))('reads a %s model', (_name, model) => {
+    expect(parseExpressionQuery(model)).toMatchObject({ type: model.type });
+  });
+
+  // Guards the rule that every `.catch()` fallback has to satisfy the in-memory schema. Without
+  // this, leniency breaks silently and a bad model throws instead of falling back.
+  it.each(Object.values(ExpressionQueryType))('reads a completely malformed %s model', (type) => {
+    const garbage = {
+      type,
+      refId: null,
+      expression: null,
+      reducer: 42,
+      window: {},
+      downsampler: [],
+      upsampler: false,
+      conditions: 'not an array',
+      settings: 'not an object',
+    };
+
+    const parsed = parseExpressionQuery(garbage);
+
+    expect(parsed).toBeDefined();
+    expect(parsed?.type).toBe(type);
+  });
+
+  // A missing key is different from a malformed one, and Zod treats z.unknown() as required, so
+  // these would otherwise fail the whole read and leave the rule unopenable.
+  it('reads a reduce that has no reducer', () => {
+    expect(parseExpressionQuery({ type: 'reduce', refId: 'B', expression: 'A' })).toMatchObject({
+      reducer: 'mean',
+    });
+  });
+
+  it('reads a resample that has neither sampler', () => {
+    expect(parseExpressionQuery({ type: 'resample', refId: 'B', expression: 'A', window: '10m' })).toMatchObject({
+      downsampler: 'mean',
+      upsampler: 'fillna',
+    });
+  });
+
+  it.each(Object.values(ExpressionQueryType))('reads a %s model carrying only its type', (type) => {
+    expect(parseExpressionQuery({ type })).toMatchObject({ type });
+  });
+
+  it('returns undefined for a model with no type, rather than throwing', () => {
+    expect(parseExpressionQuery({ refId: 'A', expression: 'A' })).toBeUndefined();
+  });
+
+  it('returns undefined for an unrecognised type', () => {
+    expect(parseExpressionQuery({ refId: 'A', type: 'not-a-real-type' })).toBeUndefined();
+  });
+});
+
+describe('unknown fields', () => {
+  it('keeps fields we do not model through a read and write round trip', () => {
+    const model = {
+      ...savedModels.reduce,
+      hide: false,
+      intervalMs: 1000,
+      maxDataPoints: 43200,
+      somethingWeHaveNeverHeardOf: 'keep me',
+    };
+
+    const parsed = parseExpressionQuery(model);
+    const written = encodeExpressionQuery(parsed!);
+
+    expect(written).toMatchObject({
+      hide: false,
+      intervalMs: 1000,
+      maxDataPoints: 43200,
+      somethingWeHaveNeverHeardOf: 'keep me',
+    });
+  });
+
+  it('keeps the per-condition type and reducer params a classic condition carries', () => {
+    const parsed = parseExpressionQuery(savedModels.classic);
+    const written = encodeExpressionQuery(parsed!);
+
+    expect(written).toMatchObject({
+      conditions: [{ type: 'query', reducer: { type: 'avg', params: [] } }],
+    });
+  });
+});
+
+describe('reduce settings', () => {
+  it('leaves settings out entirely rather than writing null, which the backend rejects', () => {
+    const parsed = parseExpressionQuery(savedModels.reduce);
+    const written = encodeExpressionQuery(parsed!);
+
+    // Checking the keys, not the value: an explicit `undefined` still serialises as `null` in some
+    // paths, which is the thing we are guarding against.
+    expect(Object.keys(written as object)).not.toContain('settings');
+  });
+
+  it('keeps settings when there is something to send', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.reduce,
+      settings: { mode: 'replaceNN', replaceWithValue: 0 },
+    });
+
+    expect(encodeExpressionQuery(parsed!)).toMatchObject({
+      settings: { mode: 'replaceNN', replaceWithValue: 0 },
+    });
+  });
+
+  it('treats a missing mode as strict, which the backend spells as an empty string', () => {
+    const parsed = parseExpressionQuery({ ...savedModels.reduce, settings: { mode: '' } });
+
+    expect(encodeExpressionQuery(parsed!)).toMatchObject({ settings: { mode: '' } });
+  });
+});
+
+describe('reducer names', () => {
+  it('lower-cases a reduce reducer, matching what the backend does', () => {
+    expect(parseExpressionQuery({ ...savedModels.reduce, reducer: 'MAX' })).toMatchObject({ reducer: 'max' });
+  });
+
+  it('falls back to mean for a reducer that reduce does not support', () => {
+    // `avg` is a classic-condition reducer; reduce calls the same thing `mean`.
+    expect(parseExpressionQuery({ ...savedModels.reduce, reducer: 'avg' })).toMatchObject({ reducer: 'mean' });
+  });
+
+  it('does not overwrite a classic condition reducer that is already set', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.classic,
+      conditions: [
+        {
+          type: 'query',
+          evaluator: { type: 'gt', params: [5] },
+          query: { params: ['A'] },
+          reducer: { type: 'max', params: [] },
+        },
+      ],
+    });
+
+    expect(parsed).toMatchObject({ conditions: [{ reducer: { type: 'max' } }] });
+  });
+
+  it('fills in only the classic conditions that are missing a reducer', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.classic,
+      conditions: [
+        {
+          type: 'query',
+          evaluator: { type: 'gt', params: [5] },
+          query: { params: ['A'] },
+          reducer: { type: 'sum', params: [] },
+        },
+        { type: 'query', evaluator: { type: 'gt', params: [5] }, query: { params: ['B'] } },
+      ],
+    });
+
+    expect(parsed).toMatchObject({
+      conditions: [{ reducer: { type: 'sum' } }, { reducer: { type: 'avg', params: [] } }],
+    });
+  });
+
+  it('falls back to avg for a classic reducer we do not recognise', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.classic,
+      conditions: [
+        {
+          type: 'query',
+          evaluator: { type: 'gt', params: [5] },
+          query: { params: ['A'] },
+          reducer: { type: 'not-a-reducer', params: [] },
+        },
+      ],
+    });
+
+    expect(parsed).toMatchObject({ conditions: [{ reducer: { type: 'avg' } }] });
+  });
+
+  it('fills in a missing classic condition reducer', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.classic,
+      conditions: [{ type: 'query', evaluator: { type: 'gt', params: [5] }, query: { params: ['A'] } }],
+    });
+
+    expect(parsed).toMatchObject({ conditions: [{ reducer: { type: 'avg', params: [] } }] });
+  });
+});
+
+describe('refId references', () => {
+  it('strips a leading $ for reduce, which the backend also ignores', () => {
+    expect(parseExpressionQuery({ ...savedModels.reduce, expression: '$A' })).toMatchObject({ expression: 'A' });
+  });
+
+  it('strips a leading $ for resample', () => {
+    expect(parseExpressionQuery({ ...savedModels.resample, expression: '$A' })).toMatchObject({ expression: 'A' });
+  });
+
+  it('leaves a threshold expression alone, because rewriting it would change the saved rule', () => {
+    expect(parseExpressionQuery({ ...savedModels.threshold, expression: '$B' })).toMatchObject({ expression: '$B' });
+  });
+});
+
+describe('hysteresis state', () => {
+  it('keeps loadedFingerprints when an unrelated field is edited', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.threshold,
+      conditions: [
+        {
+          evaluator: { type: 'gt', params: [10] },
+          unloadEvaluator: { type: 'lt', params: [5] },
+          loadedFingerprints: ['18446744073709551615', '42'],
+        },
+      ],
+    });
+
+    const edited = { ...parsed!, refId: 'D' };
+
+    expect(encodeExpressionQuery(edited)).toMatchObject({
+      conditions: [{ loadedFingerprints: ['18446744073709551615', '42'] }],
+    });
+  });
+
+  it('treats a null unloadEvaluator as no hysteresis', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.threshold,
+      conditions: [{ evaluator: { type: 'gt', params: [10] }, unloadEvaluator: null }],
+    });
+
+    const written = encodeExpressionQuery(parsed!) as { conditions: Array<Record<string, unknown>> };
+
+    expect(Object.keys(written.conditions[0])).not.toContain('unloadEvaluator');
+  });
+});
+
+describe('read is lenient but saving is not', () => {
+  it('reads a threshold with no conditions, then refuses to save it as-is', () => {
+    const parsed = parseExpressionQuery({ ...savedModels.threshold, conditions: [] });
+
+    // Reading has to work, or the user cannot open their own rule.
+    expect(parsed).toBeDefined();
+
+    // A condition was filled in so the editor has something to show, and that is now valid.
+    expect(validateExpressionQuery(parsed!).success).toBe(true);
+  });
+
+  it('refuses to save a threshold with more than one condition', () => {
+    const twoConditions = {
+      ...savedModels.threshold,
+      conditions: [{ evaluator: { type: 'gt', params: [10] } }, { evaluator: { type: 'lt', params: [1] } }],
+    };
+
+    const parsed = parseExpressionQuery(twoConditions);
+
+    // Both conditions survive the read rather than being silently thrown away.
+    expect(parsed).toMatchObject({ conditions: [{}, {}] });
+    expect(validateExpressionQuery(parsed!).success).toBe(false);
+  });
+
+  it('refuses to save a threshold whose expression still has a $ prefix', () => {
+    const parsed = parseExpressionQuery({ ...savedModels.threshold, expression: '$B' });
+
+    expect(parsed).toBeDefined();
+    expect(validateExpressionQuery(parsed!).success).toBe(false);
+  });
+
+  it('refuses to save a range threshold with only one value', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.threshold,
+      conditions: [{ evaluator: { type: EvalFunction.IsWithinRange, params: [5] } }],
+    });
+
+    expect(validateExpressionQuery(parsed!).success).toBe(false);
+  });
+
+  it('accepts a range threshold with two values', () => {
+    const parsed = parseExpressionQuery({
+      ...savedModels.threshold,
+      conditions: [{ evaluator: { type: EvalFunction.IsWithinRange, params: [5, 10] } }],
+    });
+
+    expect(validateExpressionQuery(parsed!).success).toBe(true);
+  });
+
+  it('refuses to save a reduce in replaceNN mode with no replacement value', () => {
+    const parsed = parseExpressionQuery({ ...savedModels.reduce, settings: { mode: 'replaceNN' } });
+
+    expect(validateExpressionQuery(parsed!).success).toBe(false);
+  });
+
+  it('refuses to save an empty math expression', () => {
+    const parsed = parseExpressionQuery({ ...savedModels.math, expression: '' });
+
+    expect(validateExpressionQuery(parsed!).success).toBe(false);
+  });
+
+  it('rejects a structurally broken write even though reads are forgiving', () => {
+    const broken = { ...savedModels.threshold, conditions: 'nonsense' };
+
+    expect(z.safeEncode(expressionQueryCodec, broken as never).success).toBe(false);
+  });
+});

--- a/public/app/features/expressions/schemas/sql.ts
+++ b/public/app/features/expressions/schemas/sql.ts
@@ -1,0 +1,49 @@
+import * as z from 'zod';
+
+import { ExpressionQueryType } from '../types';
+
+import { type KnownFields, queryBaseMemory, queryBaseWire } from './common';
+
+/**
+ * A SQL query over the results of other queries. `expression` is SQL text (MySQL dialect), not a
+ * refId - the backend works out what this depends on by reading the table names out of the SQL.
+ */
+
+/**
+ * `alerting` makes the backend return a single number per series, which is what an alert rule
+ * needs. Any other value (including an empty one) returns a table instead. The backend accepts any
+ * string here, but only `alerting` means anything.
+ */
+export const SQL_FORMAT_ALERTING = 'alerting';
+
+const shape = {
+  type: z.literal(ExpressionQueryType.sql),
+  expression: z.string(),
+  format: z.literal(SQL_FORMAT_ALERTING).optional(),
+};
+
+export const sqlWireSchema = z.looseObject({
+  ...queryBaseWire,
+  ...shape,
+  expression: z.string().catch(''),
+  // Older or hand-written models can carry a format we do not use; drop it rather than reject.
+  format: z.literal(SQL_FORMAT_ALERTING).optional().catch(undefined),
+});
+
+export const sqlMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  ...shape,
+});
+
+export type SqlExpressionQuery = KnownFields<z.infer<typeof sqlMemorySchema>>;
+
+export const sqlCodec = z.codec(sqlWireSchema, sqlMemorySchema, {
+  decode: (wire) => wire,
+  encode: (memory) => memory,
+});
+
+/** The backend rejects an empty query outright. */
+export const sqlSaveRules = sqlMemorySchema.refine((query) => query.expression.trim() !== '', {
+  error: 'Enter a SQL expression.',
+  path: ['expression'],
+});

--- a/public/app/features/expressions/schemas/threshold.ts
+++ b/public/app/features/expressions/schemas/threshold.ts
@@ -1,0 +1,133 @@
+import * as z from 'zod';
+
+import { EvalFunction } from '../../alerting/state/alertDef';
+import { ExpressionQueryType } from '../types';
+
+import {
+  type KnownFields,
+  THRESHOLD_EVAL_FUNCTIONS,
+  type ThresholdEvalFunction,
+  evaluatorMemory,
+  evaluatorWire,
+  hasEnoughParams,
+  queryBaseMemory,
+  queryBaseWire,
+} from './common';
+
+/**
+ * Checks a series against a threshold.
+ *
+ * Two things about this type are easy to get wrong:
+ *
+ * - `expression` must be a plain refId. `reduce` and `resample` both tolerate a leading `$`, but
+ *   threshold does not, and `$A` ends up looking for a query named `$A`. We do not rewrite it on
+ *   read, because that would silently change a saved rule; the save rules reject it instead so the
+ *   user finds out.
+ * - The backend accepts exactly one condition. We still model the list as "one or more" so nothing
+ *   is thrown away when reading a rule that somehow has more, and catch it on save.
+ */
+
+const conditionWireSchema = z.looseObject({
+  evaluator: evaluatorWire(THRESHOLD_EVAL_FUNCTIONS).catch({
+    type: EvalFunction.IsAbove,
+    params: [],
+  }),
+  // `null` here means "no hysteresis", same as leaving it out.
+  unloadEvaluator: evaluatorWire(THRESHOLD_EVAL_FUNCTIONS).nullish().catch(undefined),
+  /**
+   * Which series are currently firing. The server writes this in when it evaluates the rule; we
+   * never author it, but it has to survive a read/write round trip or hysteresis resets and the
+   * alert re-fires.
+   */
+  loadedFingerprints: z.array(z.string()).optional().catch(undefined),
+  /** Superseded by loadedFingerprints. An encoded data frame, kept as-is. */
+  loadedDimensions: z.unknown().optional(),
+});
+
+const conditionMemorySchema = z.looseObject({
+  evaluator: evaluatorMemory(THRESHOLD_EVAL_FUNCTIONS),
+  unloadEvaluator: evaluatorMemory(THRESHOLD_EVAL_FUNCTIONS).optional(),
+  loadedFingerprints: z.array(z.string()).optional(),
+  loadedDimensions: z.unknown().optional(),
+});
+
+export type ThresholdCondition = KnownFields<z.infer<typeof conditionMemorySchema>>;
+
+/** Turns an evaluator function into one threshold actually supports, falling back to "is above". */
+export function toThresholdEvalFunction(value: unknown): ThresholdEvalFunction {
+  return THRESHOLD_EVAL_FUNCTIONS.find((fn) => fn === value) ?? EvalFunction.IsAbove;
+}
+
+/** Used when a saved rule has no condition at all, so the editor still has something to show. */
+export const defaultThresholdCondition: ThresholdCondition = {
+  evaluator: { type: EvalFunction.IsAbove, params: [0] },
+};
+
+export const thresholdWireSchema = z.looseObject({
+  ...queryBaseWire,
+  type: z.literal(ExpressionQueryType.threshold),
+  expression: z.string().catch(''),
+  conditions: z.array(conditionWireSchema).catch([]),
+});
+
+export const thresholdMemorySchema = z.looseObject({
+  ...queryBaseMemory,
+  type: z.literal(ExpressionQueryType.threshold),
+  expression: z.string(),
+  // One or more, so `conditions[0]` is always there without a check.
+  conditions: z.tuple([conditionMemorySchema], conditionMemorySchema),
+});
+
+export type ThresholdExpressionQuery = KnownFields<z.infer<typeof thresholdMemorySchema>>;
+
+export const thresholdCodec = z.codec(thresholdWireSchema, thresholdMemorySchema, {
+  decode: (wire) => {
+    const conditions = wire.conditions.map((condition) => ({
+      ...condition,
+      // Flatten `null` to missing so callers only have one "no hysteresis" case to handle.
+      unloadEvaluator: condition.unloadEvaluator ?? undefined,
+    }));
+
+    // Split off the head so the type comes out as "one or more" rather than a plain array.
+    const [first, ...rest] = conditions;
+    const nonEmpty: [ThresholdCondition, ...ThresholdCondition[]] = first
+      ? [first, ...rest]
+      : [structuredClone(defaultThresholdCondition)];
+
+    return { ...wire, conditions: nonEmpty };
+  },
+  encode: (memory) => ({
+    ...memory,
+    conditions: memory.conditions.map(({ unloadEvaluator, ...condition }) =>
+      unloadEvaluator ? { ...condition, unloadEvaluator } : condition
+    ),
+  }),
+});
+
+export const thresholdSaveRules = thresholdMemorySchema
+  .refine((query) => query.expression.trim() !== '', {
+    error: 'Select a query to threshold.',
+    path: ['expression'],
+  })
+  .refine((query) => !query.expression.startsWith('$'), {
+    error: 'Reference the query by name only, without a leading "$".',
+    path: ['expression'],
+  })
+  .refine((query) => query.conditions.length === 1, {
+    error: 'A threshold takes exactly one condition.',
+    path: ['conditions'],
+  })
+  .refine((query) => hasEnoughParams(query.conditions[0].evaluator), {
+    error: 'Enter a threshold value.',
+    path: ['conditions', 0, 'evaluator', 'params'],
+  })
+  .refine(
+    (query) => {
+      const unload = query.conditions[0].unloadEvaluator;
+      return !unload || hasEnoughParams(unload);
+    },
+    {
+      error: 'Enter a recovery threshold value.',
+      path: ['conditions', 0, 'unloadEvaluator', 'params'],
+    }
+  );

--- a/public/app/features/expressions/schemas/threshold.ts
+++ b/public/app/features/expressions/schemas/threshold.ts
@@ -15,16 +15,14 @@ import {
 } from './common';
 
 /**
- * Checks a series against a threshold.
+ * Checks a series against a threshold. Two things here are easy to get wrong:
  *
- * Two things about this type are easy to get wrong:
- *
- * - `expression` must be a plain refId. `reduce` and `resample` both tolerate a leading `$`, but
- *   threshold does not, and `$A` ends up looking for a query named `$A`. We do not rewrite it on
- *   read, because that would silently change a saved rule; the save rules reject it instead so the
- *   user finds out.
- * - The backend accepts exactly one condition. We still model the list as "one or more" so nothing
- *   is thrown away when reading a rule that somehow has more, and catch it on save.
+ * - `expression` has to be a plain query name. `reduce` and `resample` ignore a leading `$`, but
+ *   threshold does not and would look for a query called `$A`. We leave it alone when reading,
+ *   since rewriting it would change someone's saved rule behind their back, and reject it on save
+ *   instead so they hear about it.
+ * - Only one condition is allowed. The list is typed as "one or more" anyway, so a rule that
+ *   somehow has more does not lose them on the way in, and saving is what complains.
  */
 
 const conditionWireSchema = z.looseObject({
@@ -32,15 +30,15 @@ const conditionWireSchema = z.looseObject({
     type: EvalFunction.IsAbove,
     params: [],
   }),
-  // `null` here means "no hysteresis", same as leaving it out.
+  // `null` means no recovery threshold, same as leaving it out.
   unloadEvaluator: evaluatorWire(THRESHOLD_EVAL_FUNCTIONS).nullish().catch(undefined),
   /**
-   * Which series are currently firing. The server writes this in when it evaluates the rule; we
-   * never author it, but it has to survive a read/write round trip or hysteresis resets and the
-   * alert re-fires.
+   * Which series are already firing. The server fills this in when it evaluates the rule. We never
+   * set it, but it has to survive being read and written again - lose it and the alert forgets it
+   * was firing and goes off a second time.
    */
   loadedFingerprints: z.array(z.string()).optional().catch(undefined),
-  /** Superseded by loadedFingerprints. An encoded data frame, kept as-is. */
+  /** The older version of the field above. Passed through as-is. */
   loadedDimensions: z.unknown().optional(),
 });
 

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -3,30 +3,12 @@ import { config } from '@grafana/runtime';
 
 import { EvalFunction } from '../alerting/state/alertDef';
 
-import type {
-  ClassicCondition as ClassicConditionSchema,
-  ClassicExpressionQuery as ClassicExpressionQuerySchema,
-} from './schemas/classic';
-import type { ClassicReducerId } from './schemas/common';
-import type { ExpressionQuery as ExpressionQuerySchema } from './schemas/expressionQuery';
-import type { MathExpressionQuery as MathExpressionQuerySchema } from './schemas/math';
-import type {
-  ExpressionQuerySettings as ExpressionQuerySettingsSchema,
-  ReduceExpressionQuery as ReduceExpressionQuerySchema,
-} from './schemas/reduce';
-import type { ResampleExpressionQuery as ResampleExpressionQuerySchema } from './schemas/resample';
-import type { SqlExpressionQuery as SqlExpressionQuerySchema } from './schemas/sql';
-import type { ThresholdExpressionQuery as ThresholdExpressionQuerySchema } from './schemas/threshold';
-
 /**
  * MATCHES a constant in DataSourceWithBackend
  */
 export const ExpressionDatasourceUID = '__expr__';
 
-/**
- * The enums live here rather than in `./schemas` because they are runtime values, and this repo
- * does not allow re-exporting a value from another module. The schemas import them from here.
- */
+/** The kinds of server-side expression. The schemas under `./schemas` describe each one. */
 export enum ExpressionQueryType {
   math = 'math',
   reduce = 'reduce',
@@ -41,26 +23,6 @@ export enum ReducerMode {
   ReplaceNonNumbers = 'replaceNN',
   DropNonNumbers = 'dropNN',
 }
-
-/**
- * The shapes of each expression type are defined by the schemas under `./schemas`, which also
- * handle reading and writing them. These aliases keep the familiar names available from here.
- *
- * Note that reading a field which only some types have is now a compile error until you narrow by
- * `type` first - use the `is*Expression` helpers in `./schemas/expressionQuery`.
- */
-export type ExpressionQuery = ExpressionQuerySchema;
-export type MathExpressionQuery = MathExpressionQuerySchema;
-export type ReduceExpressionQuery = ReduceExpressionQuerySchema;
-export type ResampleExpressionQuery = ResampleExpressionQuerySchema;
-export type ClassicExpressionQuery = ClassicExpressionQuerySchema;
-export type ThresholdExpressionQuery = ThresholdExpressionQuerySchema;
-export type SqlExpressionQuery = SqlExpressionQuerySchema;
-export type ExpressionQuerySettings = ExpressionQuerySettingsSchema;
-export type ClassicCondition = ClassicConditionSchema;
-
-/** The reducers a classic condition accepts. `reduce` expressions use a different, smaller set. */
-export type ReducerType = ClassicReducerId;
 
 export const getExpressionLabel = (type: ExpressionQueryType) => {
   switch (type) {

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -1,13 +1,32 @@
-import { type DataQuery, ReducerID, type SelectableValue } from '@grafana/data';
+import { ReducerID, type SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import { EvalFunction } from '../alerting/state/alertDef';
+
+import type {
+  ClassicCondition as ClassicConditionSchema,
+  ClassicExpressionQuery as ClassicExpressionQuerySchema,
+} from './schemas/classic';
+import type { ClassicReducerId } from './schemas/common';
+import type { ExpressionQuery as ExpressionQuerySchema } from './schemas/expressionQuery';
+import type { MathExpressionQuery as MathExpressionQuerySchema } from './schemas/math';
+import type {
+  ExpressionQuerySettings as ExpressionQuerySettingsSchema,
+  ReduceExpressionQuery as ReduceExpressionQuerySchema,
+} from './schemas/reduce';
+import type { ResampleExpressionQuery as ResampleExpressionQuerySchema } from './schemas/resample';
+import type { SqlExpressionQuery as SqlExpressionQuerySchema } from './schemas/sql';
+import type { ThresholdExpressionQuery as ThresholdExpressionQuerySchema } from './schemas/threshold';
 
 /**
  * MATCHES a constant in DataSourceWithBackend
  */
 export const ExpressionDatasourceUID = '__expr__';
 
+/**
+ * The enums live here rather than in `./schemas` because they are runtime values, and this repo
+ * does not allow re-exporting a value from another module. The schemas import them from here.
+ */
 export enum ExpressionQueryType {
   math = 'math',
   reduce = 'reduce',
@@ -16,6 +35,32 @@ export enum ExpressionQueryType {
   threshold = 'threshold',
   sql = 'sql',
 }
+
+export enum ReducerMode {
+  Strict = '', // backend API wants an empty string to support "strict" mode
+  ReplaceNonNumbers = 'replaceNN',
+  DropNonNumbers = 'dropNN',
+}
+
+/**
+ * The shapes of each expression type are defined by the schemas under `./schemas`, which also
+ * handle reading and writing them. These aliases keep the familiar names available from here.
+ *
+ * Note that reading a field which only some types have is now a compile error until you narrow by
+ * `type` first - use the `is*Expression` helpers in `./schemas/expressionQuery`.
+ */
+export type ExpressionQuery = ExpressionQuerySchema;
+export type MathExpressionQuery = MathExpressionQuerySchema;
+export type ReduceExpressionQuery = ReduceExpressionQuerySchema;
+export type ResampleExpressionQuery = ResampleExpressionQuerySchema;
+export type ClassicExpressionQuery = ClassicExpressionQuerySchema;
+export type ThresholdExpressionQuery = ThresholdExpressionQuerySchema;
+export type SqlExpressionQuery = SqlExpressionQuerySchema;
+export type ExpressionQuerySettings = ExpressionQuerySettingsSchema;
+export type ClassicCondition = ClassicConditionSchema;
+
+/** The reducers a classic condition accepts. `reduce` expressions use a different, smaller set. */
+export type ReducerType = ClassicReducerId;
 
 export const getExpressionLabel = (type: ExpressionQueryType) => {
   switch (type) {
@@ -85,12 +130,6 @@ export const reducerTypes: Array<SelectableValue<string>> = [
   { value: ReducerID.last, label: 'Last', description: 'Get the last value' },
 ];
 
-export enum ReducerMode {
-  Strict = '', // backend API wants an empty string to support "strict" mode
-  ReplaceNonNumbers = 'replaceNN',
-  DropNonNumbers = 'dropNN',
-}
-
 export const reducerModes: Array<SelectableValue<ReducerMode>> = [
   {
     value: ReducerMode.Strict,
@@ -135,67 +174,3 @@ export const thresholdFunctions: Array<SelectableValue<EvalFunction>> = [
   { value: EvalFunction.IsWithinRangeIncluded, label: 'Is within range included' },
   { value: EvalFunction.IsOutsideRangeIncluded, label: 'Is outside range included' },
 ];
-
-/**
- * For now this is a single object to cover all the types.... would likely
- * want to split this up by type as the complexity increases
- */
-export interface ExpressionQuery extends DataQuery {
-  type: ExpressionQueryType;
-  reducer?: string;
-  expression?: string;
-  window?: string;
-  downsampler?: string;
-  upsampler?: string;
-  conditions?: ClassicCondition[];
-  settings?: ExpressionQuerySettings;
-}
-
-export interface SqlExpressionQuery extends ExpressionQuery {
-  /** Format `alerting` is expected when using SQL expressions in alert rules */
-  format?: 'alerting';
-}
-
-export interface ThresholdExpressionQuery extends ExpressionQuery {
-  conditions: ClassicCondition[];
-}
-export interface ExpressionQuerySettings {
-  mode?: ReducerMode;
-  replaceWithValue?: number;
-}
-
-export interface ClassicCondition {
-  evaluator: {
-    params: number[];
-    type: EvalFunction;
-  };
-  unloadEvaluator?: {
-    params: number[];
-    type: EvalFunction;
-  };
-  operator?: {
-    type: string;
-  };
-  query: {
-    params: string[];
-  };
-  reducer?: {
-    params: [];
-    type: ReducerType;
-  };
-  type: 'query';
-}
-
-export type ReducerType =
-  | 'avg'
-  | 'min'
-  | 'max'
-  | 'sum'
-  | 'count'
-  | 'last'
-  | 'median'
-  | 'diff'
-  | 'diff_abs'
-  | 'percent_diff'
-  | 'percent_diff_abs'
-  | 'count_non_null';

--- a/public/app/features/expressions/utils/expressionTypes.test.ts
+++ b/public/app/features/expressions/utils/expressionTypes.test.ts
@@ -1,101 +1,61 @@
 import { EvalFunction } from 'app/features/alerting/state/alertDef';
 
-import { type ClassicCondition, type ExpressionQuery, ExpressionQueryType } from '../types';
+import { makeExpression, makeReduceExpression } from '../schemas/factories';
+import { ExpressionQueryType, ReducerMode } from '../types';
 
-import { defaultCondition, getDefaults } from './expressionTypes';
+import { getReducerType, isRangeEvaluator, isReducerExpression, isStrictReducer } from './expressionTypes';
 
-describe('getDefaults', () => {
-  describe('classic expression type', () => {
-    it('should create default conditions when conditions is undefined', () => {
-      const query = {
-        type: ExpressionQueryType.classic,
-        refId: 'A',
-      } as ExpressionQuery;
-
-      const result = getDefaults(query);
-      expect(result.conditions).toEqual([defaultCondition]);
-    });
-
-    it('should backfill missing reducer in existing conditions', () => {
-      const query = {
-        type: ExpressionQueryType.classic,
-        refId: 'A',
-        conditions: [
-          {
-            type: 'query',
-            evaluator: { params: [0], type: EvalFunction.IsAbove },
-            query: { params: ['A'] },
-          } satisfies ClassicCondition,
-        ],
-      } as ExpressionQuery;
-
-      const result = getDefaults(query);
-      expect(result.conditions![0].reducer).toEqual({ params: [], type: 'avg' });
-    });
-
-    it('should not overwrite an existing reducer', () => {
-      const query = {
-        type: ExpressionQueryType.classic,
-        refId: 'A',
-        conditions: [
-          {
-            type: 'query',
-            evaluator: { params: [0], type: EvalFunction.IsAbove },
-            query: { params: ['A'] },
-            reducer: { params: [], type: 'max' },
-          },
-        ],
-      } as ExpressionQuery;
-
-      const result = getDefaults(query);
-      expect(result.conditions?.[0].reducer?.type).toBe('max');
-    });
-
-    it('should handle a mix of conditions with and without reducer', () => {
-      const query = {
-        type: ExpressionQueryType.classic,
-        refId: 'A',
-        conditions: [
-          {
-            type: 'query',
-            evaluator: { params: [0], type: EvalFunction.IsAbove },
-            query: { params: ['A'] },
-            reducer: { params: [], type: 'sum' },
-          },
-          {
-            type: 'query',
-            evaluator: { params: [0], type: EvalFunction.IsAbove },
-            query: { params: ['B'] },
-          } satisfies ClassicCondition,
-        ],
-      } as ExpressionQuery;
-
-      const result = getDefaults(query);
-      expect(result.conditions?.[0]?.reducer?.type).toBe('sum');
-      expect(result.conditions?.[1]?.reducer).toEqual({ params: [], type: 'avg' });
-    });
+describe('getReducerType', () => {
+  it('accepts a classic condition reducer', () => {
+    expect(getReducerType('percent_diff_abs')).toBe('percent_diff_abs');
   });
 
-  describe('reduce expression type', () => {
-    it('should set default reducer when missing', () => {
-      const query = {
-        type: ExpressionQueryType.reduce,
-        refId: 'A',
-      } as ExpressionQuery;
+  it('returns undefined for something that is not a reducer', () => {
+    expect(getReducerType('not-a-reducer')).toBeUndefined();
+  });
+});
 
-      const result = getDefaults(query);
-      expect(result.reducer).toBe('mean');
-    });
+describe('isStrictReducer', () => {
+  const reduce = makeReduceExpression({ refId: 'B' });
 
-    it('should not overwrite existing reducer', () => {
-      const query = {
-        type: ExpressionQueryType.reduce,
-        refId: 'A',
-        reducer: 'max',
-      } as ExpressionQuery;
+  it('treats a reduce with no settings as strict, which is what the backend does', () => {
+    expect(isStrictReducer(reduce)).toBe(true);
+  });
 
-      const result = getDefaults(query);
-      expect(result.reducer).toBe('max');
-    });
+  it('treats an empty mode as strict, because that is how the backend spells it', () => {
+    expect(isStrictReducer({ ...reduce, settings: { mode: ReducerMode.Strict } })).toBe(true);
+  });
+
+  it('is not strict when non-numeric values are dropped', () => {
+    expect(isStrictReducer({ ...reduce, settings: { mode: ReducerMode.DropNonNumbers } })).toBe(false);
+  });
+
+  it('is not strict for an expression that is not a reduce', () => {
+    expect(isStrictReducer(makeExpression(ExpressionQueryType.threshold, { refId: 'C' }))).toBe(false);
+  });
+});
+
+describe('isReducerExpression', () => {
+  it('narrows a reduce expression', () => {
+    expect(isReducerExpression(makeExpression(ExpressionQueryType.reduce, { refId: 'B' }))).toBe(true);
+  });
+
+  it('rejects the other types', () => {
+    expect(isReducerExpression(makeExpression(ExpressionQueryType.math, { refId: 'B' }))).toBe(false);
+  });
+});
+
+describe('isRangeEvaluator', () => {
+  it.each([
+    EvalFunction.IsWithinRange,
+    EvalFunction.IsOutsideRange,
+    EvalFunction.IsWithinRangeIncluded,
+    EvalFunction.IsOutsideRangeIncluded,
+  ])('treats %s as a range, so it needs two values', (fn) => {
+    expect(isRangeEvaluator(fn)).toBe(true);
+  });
+
+  it.each([EvalFunction.IsAbove, EvalFunction.IsBelow, EvalFunction.IsEqual])('treats %s as a single value', (fn) => {
+    expect(isRangeEvaluator(fn)).toBe(false);
   });
 });

--- a/public/app/features/expressions/utils/expressionTypes.ts
+++ b/public/app/features/expressions/utils/expressionTypes.ts
@@ -1,78 +1,8 @@
-import { ReducerID } from '@grafana/data';
-
 import { EvalFunction } from '../../alerting/state/alertDef';
 import { isReducerType } from '../guards';
-import {
-  type ClassicCondition,
-  type ExpressionQuery,
-  ExpressionQueryType,
-  ReducerMode,
-  type ReducerType,
-} from '../types';
-
-export const getDefaults = (query: ExpressionQuery) => {
-  switch (query.type) {
-    case ExpressionQueryType.reduce:
-      if (!query.reducer) {
-        query.reducer = ReducerID.mean;
-      }
-
-      break;
-
-    case ExpressionQueryType.resample:
-      if (!query.downsampler) {
-        query.downsampler = ReducerID.mean;
-      }
-
-      if (!query.upsampler) {
-        query.upsampler = 'fillna';
-      }
-
-      query.reducer = undefined;
-      break;
-
-    case ExpressionQueryType.math:
-      query.expression = undefined;
-      break;
-
-    case ExpressionQueryType.classic:
-      if (!query.conditions) {
-        query.conditions = [defaultCondition];
-      } else {
-        // API-loaded rules may have conditions without a reducer object (e.g. provisioned
-        // rules or rules created by older versions). Backfill with the default reducer
-        // to prevent downstream components from crashing on undefined access.
-        for (const condition of query.conditions) {
-          if (!condition.reducer) {
-            condition.reducer = { params: [], type: 'avg' };
-          }
-        }
-      }
-
-      break;
-
-    default:
-      query.reducer = undefined;
-  }
-
-  return query;
-};
-
-export const defaultCondition: ClassicCondition = {
-  type: 'query',
-  reducer: {
-    params: [],
-    type: 'avg',
-  },
-  operator: {
-    type: 'and',
-  },
-  query: { params: [] },
-  evaluator: {
-    params: [0, 0],
-    type: EvalFunction.IsAbove,
-  },
-};
+import type { ReduceExpressionQuery } from '../schemas/reduce';
+import type { ThresholdExpressionQuery } from '../schemas/threshold';
+import { type ExpressionQuery, ExpressionQueryType, ReducerMode, type ReducerType } from '../types';
 
 /**
  * Returns the ReducerType if the value is a valid ReducerType, otherwise undefined
@@ -94,11 +24,11 @@ export function isStrictReducer(expressionModel: ExpressionQuery): boolean {
   return mode === ReducerMode.Strict || mode === undefined;
 }
 
-export function isReducerExpression(expressionModel: ExpressionQuery) {
+export function isReducerExpression(expressionModel: ExpressionQuery): expressionModel is ReduceExpressionQuery {
   return expressionModel.type === ExpressionQueryType.reduce;
 }
 
-export function isThresholdExpression(expressionModel: ExpressionQuery) {
+export function isThresholdExpression(expressionModel: ExpressionQuery): expressionModel is ThresholdExpressionQuery {
   return expressionModel.type === ExpressionQueryType.threshold;
 }
 

--- a/public/app/features/expressions/utils/expressionTypes.ts
+++ b/public/app/features/expressions/utils/expressionTypes.ts
@@ -1,14 +1,16 @@
 import { EvalFunction } from '../../alerting/state/alertDef';
 import { isReducerType } from '../guards';
+import type { ClassicReducerId } from '../schemas/common';
+import type { ExpressionQuery } from '../schemas/expressionQuery';
 import type { ReduceExpressionQuery } from '../schemas/reduce';
 import type { ThresholdExpressionQuery } from '../schemas/threshold';
-import { type ExpressionQuery, ExpressionQueryType, ReducerMode, type ReducerType } from '../types';
+import { ExpressionQueryType, ReducerMode } from '../types';
 
 /**
- * Returns the ReducerType if the value is a valid ReducerType, otherwise undefined
+ * Returns the reducer id if the value is one a classic condition accepts, otherwise undefined
  * @param value string
  */
-export function getReducerType(value: string): ReducerType | undefined {
+export function getReducerType(value: string): ClassicReducerId | undefined {
   if (isReducerType(value)) {
     return value;
   }

--- a/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.test.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.test.ts
@@ -166,3 +166,46 @@ describe('alertingAlertRuleFormSchema', () => {
     expect(result.annotations).toBeUndefined();
   });
 });
+
+describe('alertingModelSchema expression handling', () => {
+  it('fills in what an expression left out, so a plugin does not have to know the defaults', () => {
+    const parsed = alertingModelSchema.parse({ refId: 'B', type: 'reduce', expression: 'A' });
+
+    expect(parsed).toMatchObject({ type: 'reduce', reducer: 'mean' });
+  });
+
+  it('gives a threshold with no conditions one to work with', () => {
+    const parsed = alertingModelSchema.parse({ refId: 'C', type: 'threshold', expression: 'B' });
+
+    expect(parsed).toMatchObject({ conditions: [{ evaluator: { type: 'gt' } }] });
+  });
+
+  it('reads an expression through the expression schemas rather than the loose branch', () => {
+    // The loose branch would have left `reducer` exactly as given; the expression branch narrows it
+    // to something reduce actually supports.
+    const parsed = alertingModelSchema.parse({ refId: 'B', type: 'reduce', expression: 'A', reducer: 'AVG' });
+
+    // `avg` is a classic-condition reducer, not a reduce one, so it falls back rather than being
+    // passed along to fail at evaluation time.
+    expect(parsed).toMatchObject({ reducer: 'mean' });
+  });
+
+  it('keeps fields on an expression that we do not describe', () => {
+    const parsed = alertingModelSchema.parse({
+      refId: 'B',
+      type: 'reduce',
+      expression: 'A',
+      reducer: 'last',
+      intervalMs: 1000,
+      maxDataPoints: 43200,
+    });
+
+    expect(parsed).toMatchObject({ intervalMs: 1000, maxDataPoints: 43200 });
+  });
+
+  it('leaves a query model alone when its type is not an expression type', () => {
+    const model = { refId: 'A', type: 'timeSeriesQuery', expr: 'up', editorMode: 'code' };
+
+    expect(alertingModelSchema.parse(model)).toMatchObject(model);
+  });
+});

--- a/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
@@ -13,11 +13,11 @@ const queryModelBase = z.looseObject({
 });
 
 /**
- * A query model, which is either one of Grafana's own expressions or a query for a data source.
+ * Either one of Grafana's own expressions or a query for a data source.
  *
- * Expressions are checked against the real expression schemas, so a plugin passing a malformed one
- * finds out here rather than getting a confusing error from the backend later. Data source query
- * models stay unchecked - there are far too many of them, and they are the data source's business.
+ * Expressions get checked properly, so a plugin sending a broken one finds out here instead of
+ * getting a confusing error from the backend later. Data source queries are left unchecked -
+ * there are far too many of them, and their shape is the data source's business.
  */
 /** Does this model claim to be one of Grafana's expressions? */
 function looksLikeExpression(model: unknown): boolean {

--- a/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
+++ b/public/app/features/plugins/components/restrictedGrafanaApis/alerting/alertRuleFormSchema.ts
@@ -1,14 +1,42 @@
 import * as z from 'zod';
 
 import { RuleFormType } from 'app/features/alerting/unified/types/rule-form';
+import { expressionQueryCodec } from 'app/features/expressions/schemas/expressionQuery';
+import { ExpressionQueryType } from 'app/features/expressions/types';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 
-// Combined schema that supports both regular and expression queries
-export const alertingModelSchema = z.looseObject({
+/** What every query model carries, whatever it is a query for. */
+const queryModelBase = z.looseObject({
   refId: z.string(),
   maxDataPoints: z.number().optional().describe('Maximum number of data points to return'),
   intervalMs: z.number().optional().describe('Interval in milliseconds'),
 });
+
+/**
+ * A query model, which is either one of Grafana's own expressions or a query for a data source.
+ *
+ * Expressions are checked against the real expression schemas, so a plugin passing a malformed one
+ * finds out here rather than getting a confusing error from the backend later. Data source query
+ * models stay unchecked - there are far too many of them, and they are the data source's business.
+ */
+/** Does this model claim to be one of Grafana's expressions? */
+function looksLikeExpression(model: unknown): boolean {
+  if (typeof model !== 'object' || model === null || !('type' in model)) {
+    return false;
+  }
+
+  const type = model.type;
+  return typeof type === 'string' && Object.values(ExpressionQueryType).some((known) => known === type);
+}
+
+export const alertingModelSchema = z.union([
+  expressionQueryCodec.describe('A Grafana expression: math, reduce, resample, threshold, classic_conditions or sql'),
+  // Anything claiming to be an expression has to go through the branch above, or the check there
+  // would be pointless - a bad expression would just fall through to here and be accepted.
+  queryModelBase.describe('A data source query model').refine((model) => !looksLikeExpression(model), {
+    error: 'This looks like a Grafana expression, but it is not a valid one.',
+  }),
+]);
 
 // Main navigate to alert form schema - merged from both alertingSchemaApi and formDefaults
 export const alertingAlertRuleFormSchema = z.object({

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -22,7 +22,7 @@ import { config, isMigrationHandler, migrateRequest, toDataQueryError, isExpress
 import { backendSrv } from 'app/core/services/backend_srv';
 import { queryIsEmpty } from 'app/core/utils/query';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { emitDataRequestEvent } from './queryAnalytics';

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -3,7 +3,7 @@
 import { type MergeExclusive } from 'type-fest';
 
 import { type DataQuery, type RelativeTimeRange } from '@grafana/data';
-import { type ExpressionQuery } from 'app/features/expressions/types';
+import type { ExpressionQuery } from 'app/features/expressions/schemas/expressionQuery';
 
 import { type AlertGroupTotals, type AlertInstanceTotals } from './unified-alerting';
 


### PR DESCRIPTION
**What is this feature?**

Splits the single `ExpressionQuery` interface into one schema per expression type, and uses those schemas to read and write expression models at the alert rule boundary.

`public/app/features/expressions/types.ts` described all six expression types with one interface and every type-specific field optional. The comment above it already admitted the problem: *"For now this is a single object to cover all the types.... would likely want to split this up by type as the complexity increases"*.

Each type now has three layers, in `public/app/features/expressions/schemas/`:

1. a **wire schema** — deliberately forgiving, describing what `pkg/expr` actually accepts
2. a **codec** — wire ⇄ in-memory, carrying shape and normalisation only
3. **save rules** — the stricter checks, applied only when saving

`ExpressionQuery` stays as the name, now a discriminated union on `type`, so existing import paths keep working while the compiler points at every place that reads a field without narrowing first.

Two supporting changes fall out of this:

- The five places that each hand-built their own expression defaults now go through one set of factories (`schemas/factories.ts`). Two of them had already drifted apart — `getDefaultExpressions` and `createSimpleConditionExpressions` disagreed on `datasource.type`, and only one attached a `conditions[]` to its reduce.
- The normalisation of saved rules, previously spread across four places that ran at different times, is now a single parse at the read boundary (`parseExpressionModels` in `utils/rule-form.ts`).

**Why do we need this feature?**

Nothing told you which fields a type needed. A `reduce` with no `reducer`, or a `threshold` with no `conditions`, typechecked fine and then failed at evaluation time in the backend.

The refactor surfaced three latent bugs, each now fixed and covered by a test:

- Classic conditions were saved with `operator: { type: 'when' }`. That is not a valid operator in the frontend's own `evalOperators` list or in the backend's (`and` / `or` / `logic-or`). It was harmless only because the row is labelled "WHEN" from `index === 0` and the backend ignores the first condition's operator — so this was invalid data written into every classic rule.
- Re-picking the expression type you already had rebuilt the expression from scratch, discarding the window, reducer and other settings.
- `z.unknown()` is **not** implicitly optional inside `z.looseObject` in Zod 4. A saved `reduce` with no `reducer` key failed to parse at all, which would have made that rule impossible to open.

**Who is this feature for?**

Anyone working on expressions or the alert rule editor. No user-visible change is intended.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Two things worth your attention.

**1. The payload for newly created rules gets smaller.** New rules stop writing the leftover `conditions` array on a `reduce`, and the classic-only `operator` / `query` / `reducer` / `type` fields on a `threshold` condition. I checked each against the parsers: `UnmarshalReduceCommand` reads only `expression`, `reducer` and `settings`, and `ThresholdConditionJSON` has only `evaluator`, `unloadEvaluator`, `loadedFingerprints` and `loadedDimensions`. Existing rules keep these fields — unknown fields are passed through untouched. This accounts for all 20 updated snapshots, which are pure removals.

**2. Reads are lenient on purpose, writes are not.** A `.refine()` on a codec's in-memory side blocks *decoding* as well as encoding, so the save rules are deliberately kept off the codecs. Moving one onto a codec would stop an already-saved rule that breaks it from opening at all. There is a test pinning that asymmetry, and a comment in `schemas/common.ts` explaining it. Please don't "tidy" the refinements onto the codecs.

**Testing**

- `yarn typecheck`, `yarn eslint`, `yarn prettier --check` — clean
- 400 suites / 4617 tests pass, including new coverage for the schemas, factories, the parse boundary and the save rules

Also verified by hand against a local instance, checking the stored rule via the Ruler API before and after a UI edit:

- a rule carrying fields we do not model round-trips byte-identically, nothing lost or added
- `loadedFingerprints` survives an unrelated edit, so saving a firing rule does not reset hysteresis and re-fire it
- `settings` is written as absent rather than `null`, which the backend rejects outright
- all six types render from parsed models and round-trip unchanged, including `settings.mode: dropNN`, `within_range [1, 100]`, and `format: alerting`
- a reduce+threshold pair is still recognised and collapsed back into the simple condition editor

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. <!-- refactor, no new feature -->
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. <!-- internal refactor, no docs change -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
