### PR TITLE
Graphite: forward scopedVars when interpolating variable queries

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -52,6 +52,20 @@ interface Context {
   ds: GraphiteDatasource;
 }
 
+/**
+ * Mirrors templateSrv.replace() when window.__grafanaSceneContext is unset: only names present
+ * in the scopedVars argument are interpolated.
+ */
+function replaceFromScopedVarsOnly(target?: string, scopedVars?: ScopedVars): string {
+  if (!target) {
+    return target ?? '';
+  }
+  return target.replace(/\$(\w+)/g, (match, name) => {
+    const value = scopedVars?.[name]?.value;
+    return value == null || value === '' ? match : String(value);
+  });
+}
+
 const createFetchResponse = <T>(data: T): FetchResponse<T> => ({
   data,
   status: 200,
@@ -1557,6 +1571,59 @@ describe('graphiteDatasource', () => {
       expect(requestOptions.params).toEqual({});
       expect(requestOptions.data).toEqual('query=app.backend*');
       expect(results).not.toBe(null);
+    });
+
+    it('does not query Graphite with a literal $env.* when chained variable scopedVars are provided', async () => {
+      ctx.templateSrv.replace = jest.fn(replaceFromScopedVarsOnly);
+
+      fetchMock.mockImplementation((options) => {
+        requestOptions = options;
+        return of(createFetchResponse([]));
+      });
+
+      await ctx.ds.metricFindQuery('$env.*', {
+        scopedVars: {
+          env: { text: 'prod', value: 'prod' },
+          __sceneObject: { text: '', value: { name: 'dashboard' } },
+        },
+      });
+
+      // Graphite used to call replace() with only __searchFilter, so $env was left as a literal.
+      // The find API then 200'd an empty list and the variable collapsed to All.
+      expect(requestOptions.data).toBe('query=prod.*');
+      expect(requestOptions.data).not.toBe('query=$env.*');
+    });
+
+    it('sends a literal $env.* when scopedVars are omitted, matching the empty-options failure', async () => {
+      ctx.templateSrv.replace = jest.fn(replaceFromScopedVarsOnly);
+
+      fetchMock.mockImplementation((options) => {
+        requestOptions = options;
+        return of(createFetchResponse([]));
+      });
+
+      const results = await ctx.ds.metricFindQuery('$env.*', {});
+
+      expect(requestOptions.data).toBe('query=$env.*');
+      expect(results).toEqual([]);
+    });
+
+    it('should keep __searchFilter when merging options.scopedVars', async () => {
+      ctx.templateSrv.replace = jest.fn(replaceFromScopedVarsOnly);
+
+      await ctx.ds.metricFindQuery('$env.$__searchFilter', {
+        searchFilter: 'web',
+        scopedVars: { env: { text: 'prod', value: 'prod' } },
+      });
+
+      expect(ctx.templateSrv.replace).toHaveBeenCalledWith(
+        '$env.$__searchFilter',
+        expect.objectContaining({
+          env: { text: 'prod', value: 'prod' },
+          __searchFilter: { value: 'web*', text: '' },
+        })
+      );
+      expect(requestOptions.data).toEqual('query=prod.web*');
     });
 
     it('should interpolate $__searchFilter with default when searchFilter is missing', () => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -17,6 +17,7 @@ import {
   dateTimeAsMoment,
   getFieldDisplayName,
   getSearchFilterScopedVar,
+  type LegacyMetricFindQueryOptions,
   type MetricFindValue,
   type QueryResultMetaStat,
   type ScopedVars,
@@ -686,6 +687,22 @@ export class GraphiteDatasource
     return parsedDate.unix();
   }
 
+  /**
+   * Merge caller-provided scopedVars (including `__sceneObject`) with `__searchFilter`.
+   * Graphite interpolates via templateSrv.replace() and used to pass only the search-filter
+   * vars, so chained queries fell back to window.__grafanaSceneContext.
+   */
+  private getMetricFindScopedVars(
+    query: string,
+    wildcardChar: string,
+    options?: LegacyMetricFindQueryOptions
+  ): ScopedVars {
+    return {
+      ...options?.scopedVars,
+      ...getSearchFilterScopedVar({ query, wildcardChar, options }),
+    };
+  }
+
   metricFindQuery(findQuery: string | GraphiteQuery, optionalOptions?: any): Promise<MetricFindValue[]> {
     const options = optionalOptions || {};
 
@@ -697,10 +714,7 @@ export class GraphiteDatasource
     let query = queryObject.target ?? '';
 
     // First attempt to check for tag-related functions (using empty wildcard for interpolation)
-    let interpolatedQuery = this.templateSrv.replace(
-      query,
-      getSearchFilterScopedVar({ query, wildcardChar: '', options: optionalOptions })
-    );
+    let interpolatedQuery = this.templateSrv.replace(query, this.getMetricFindScopedVars(query, '', optionalOptions));
 
     // special handling for tag_values(<tag>[,<expression>]*), this is used for template variables
     let allParams = interpolatedQuery.match(/^tag_values\((.*)\)$/);
@@ -722,10 +736,7 @@ export class GraphiteDatasource
     let useExpand = query.match(/^expand\((.*)\)$/);
     query = useExpand ? useExpand[1] : query;
 
-    interpolatedQuery = this.templateSrv.replace(
-      query,
-      getSearchFilterScopedVar({ query, wildcardChar: '*', options: optionalOptions })
-    );
+    interpolatedQuery = this.templateSrv.replace(query, this.getMetricFindScopedVars(query, '*', optionalOptions));
 
     let range;
     if (options.range) {


### PR DESCRIPTION
## Summary
- Graphite `metricFindQuery` interpolated through `templateSrv.replace()` with only `__searchFilter` in `scopedVars`.
- `QueryVariable` already passes the calling scene via `options.scopedVars` (`__sceneObject` plus sibling variables). Graphite dropped those, so chained queries like `$env.*` were sent to `/metrics/find` as a literal whenever `window.__grafanaSceneContext` was unset.
- Graphite answers that with HTTP 200 and `[]`, so the variable looks empty / All.
- Merge `options.scopedVars` with the search-filter vars (same pattern as the SQL datasource). `__searchFilter` still wins when both are present.

## Test plan
- [ ] `yarn workspace @grafana-plugins/graphite test:ci datasource.test.ts --watchAll=false`
- [ ] On a dashboard, Graphite chained query variables still populate as before.
- [ ] Variable picker search (`$__searchFilter`) still appends `*`.

## How to reproduce (before this change)

### Unit test
The regression test uses a `replace()` stand-in that only interpolates names from its `scopedVars` argument (no global scene context):

```bash
yarn workspace @grafana-plugins/graphite test:ci datasource.test.ts -t "does not query Graphite with a literal" --watchAll=false
```

Without the datasource change that test fails with:

```
Expected: "query=prod.*"
Received: "query=$env.*"
```

That is the request Graphite receives for a chained variable, which it answers with an empty list.

### UI
1. Run Graphite locally: `make devenv sources=graphite1` (and Grafana as usual).
2. Create a dashboard with the Graphite datasource and two **query** variables:
   - `env` — query `*`
   - `region` — query `$env.*`
3. Open the dashboard. Both variables get option lists; Network shows `POST .../metrics/find` with `query=<interpolated>.` (for example `query=prod.*`).
4. Repeat the same `metricFindQuery` from a scene that does **not** set `window.__grafanaSceneContext` (anything other than `DashboardScene` / `EmbeddedScene`). Before this change, Network shows `query=$env.*` and the `region` picker only has All / no options. After this change it matches step 3.


Made with [Cursor](https://cursor.com)