### PR TITLE
TableNG: Stop passing enableVirtualization in tests

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.safari.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.safari.test.tsx
@@ -30,9 +30,7 @@ const createBasicDataFrame = (): DataFrame =>
 
 describe('TableNG Safari 26 workaround', () => {
   it('wraps the table in a contain:strict container without breaking rendering', () => {
-    const { container } = render(
-      <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-    );
+    const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
     // The grid renders inside an extra wrapper div rather than at the container root.
     const grid = container.querySelector('[role="grid"]');

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -18,12 +18,19 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { TableCellBackgroundDisplayMode } from '@grafana/schema';
+import { mockClientSize } from '@grafana/test-utils';
 
 import { type PanelContext, PanelContextProvider } from '../../PanelChrome';
 import { TableCellDisplayMode } from '../types';
 
 import { TableNG } from './TableNG';
 import { TABLE } from './constants';
+
+// react-data-grid sizes its virtualized viewport from the client box, which jsdom reports as 0 - without
+// this the grid renders no rows at all.
+beforeAll(() => {
+  mockClientSize({ width: 800, height: 600 });
+});
 
 // Shared helpers for test data frame construction
 const withFieldOverrides = (frame: ReturnType<typeof toDataFrame>): DataFrame =>
@@ -435,34 +442,20 @@ describe('TableNG', () => {
 
   describe('initialRowIndex', () => {
     it('should not scroll by default', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createSortingTestDataFrame()} width={100} height={10} />
-      );
+      const { container } = render(<TableNG data={createSortingTestDataFrame()} width={100} height={10} />);
       expect(jestScrollIntoView).not.toHaveBeenCalled();
       expect(container.querySelector('[aria-selected="true"][role="row"]')).not.toBeInTheDocument();
     });
     it('initialRowIndex should scroll', async () => {
       const { container } = render(
-        <TableNG
-          initialRowIndex={4}
-          enableVirtualization={false}
-          data={createSortingTestDataFrame()}
-          width={100}
-          height={10}
-        />
+        <TableNG initialRowIndex={4} data={createSortingTestDataFrame()} width={100} height={10} />
       );
       expect(jestScrollIntoView).toHaveBeenCalledTimes(1);
       expect(container.querySelector('[aria-selected="true"][role="row"]')).toBeVisible();
     });
     it('sorting should not retrigger initialRowIndex scroll', async () => {
       const { container } = render(
-        <TableNG
-          initialRowIndex={4}
-          enableVirtualization={false}
-          data={createSortingTestDataFrame()}
-          width={100}
-          height={10}
-        />
+        <TableNG initialRowIndex={4} data={createSortingTestDataFrame()} width={100} height={10} />
       );
 
       expect(container.querySelector('[aria-selected="true"][role="row"]')).toBeVisible();
@@ -493,7 +486,6 @@ describe('TableNG', () => {
               },
             ]}
             initialRowIndex={5}
-            enableVirtualization={false}
             data={createSortingTestDataFrame(6)}
             width={100}
             height={10}
@@ -520,7 +512,6 @@ describe('TableNG', () => {
               desc,
             },
           ]}
-          enableVirtualization={false}
           data={createBasicDataFrame()}
           width={800}
           height={600}
@@ -539,7 +530,6 @@ describe('TableNG', () => {
               desc: true,
             },
           ]}
-          enableVirtualization={false}
           data={createBasicDataFrame()}
           width={800}
           height={600}
@@ -557,7 +547,6 @@ describe('TableNG', () => {
               desc: false,
             },
           ]}
-          enableVirtualization={false}
           data={createBasicDataFrame()}
           width={800}
           height={600}
@@ -577,7 +566,6 @@ describe('TableNG', () => {
             },
           ]}
           sortByBehavior={'managed'}
-          enableVirtualization={false}
           data={createBasicDataFrame()}
           width={800}
           height={600}
@@ -596,7 +584,6 @@ describe('TableNG', () => {
             },
           ]}
           sortByBehavior={'managed'}
-          enableVirtualization={false}
           data={createBasicDataFrame()}
           width={800}
           height={600}
@@ -610,9 +597,7 @@ describe('TableNG', () => {
 
   describe('Basic TableNG rendering', () => {
     it('renders a simple table with columns and rows', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Check for the data grid container
       const dataGridContainer = container.querySelector('[role="grid"]');
@@ -636,9 +621,7 @@ describe('TableNG', () => {
 
   describe('Nested tables', () => {
     it('renders table with nested data structure', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrame()} width={800} height={600} />);
 
       const expectedContent = ['Column A', 'Column B', 'A1', 'A2'];
       expectedContent.forEach((text) => {
@@ -653,9 +636,7 @@ describe('TableNG', () => {
     });
 
     it('expands nested data when clicking expand button', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrame()} width={800} height={600} />);
 
       // Verify initial state
       const expectedContent = ['Column A', 'Column B', 'A1', 'A2'];
@@ -701,9 +682,7 @@ describe('TableNG', () => {
       // row index — not from the top-level frame (which here has no apply-to-row field at all).
       window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrameWithRowColor()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrameWithRowColor()} width={800} height={600} />);
 
       await user.click(container.querySelector('[aria-label="Expand row"]')!);
 
@@ -716,12 +695,7 @@ describe('TableNG', () => {
 
     it('auto-expands all rows when expandAllRows is set in frame meta', () => {
       const { container } = render(
-        <TableNG
-          enableVirtualization={false}
-          data={createNestedDataFrame({ custom: { expandAllRows: true } })}
-          width={800}
-          height={600}
-        />
+        <TableNG data={createNestedDataFrame({ custom: { expandAllRows: true } })} width={800} height={600} />
       );
 
       const expandedRows = container.querySelectorAll('[aria-expanded="true"]');
@@ -735,9 +709,7 @@ describe('TableNG', () => {
     it('renders the empty state when there are no rows but a nested transform is present', () => {
       // Regression: with zero rows the nested data is empty, so there is no first nested frame
       // to read nested fields from. The table must render its empty state instead of throwing.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createEmptyNestedDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createEmptyNestedDataFrame()} width={800} height={600} />);
 
       expect(container.querySelector('[role="treegrid"]')).toBeInTheDocument();
       expect(screen.getByText('No rows')).toBeInTheDocument();
@@ -747,9 +719,7 @@ describe('TableNG', () => {
     it('gives the columns the full width when there are no rows to expand', () => {
       // With no nested frame to expand into there's no expander column, so its width shouldn't be
       // held back from the real columns — rdg's grid-template-columns shows what they actually got.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createEmptyNestedDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createEmptyNestedDataFrame()} width={800} height={600} />);
 
       const grid = container.querySelector<HTMLElement>('[role="treegrid"]')!;
       expect(grid).toHaveStyle({ gridTemplateColumns: '400px 400px' });
@@ -761,9 +731,7 @@ describe('TableNG', () => {
       // The outer table has no footer reducers. The nested frame fields do.
       // Before the fix, bottomSummaryRows was driven by the top-level hasFooter, so the nested
       // footer never rendered. After the fix, each table controls its own footer independently.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrameWithFooter()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrameWithFooter()} width={800} height={600} />);
 
       // Before expansion: no footer row should be visible at all
       expect(container.querySelector('.rdg-summary-row')).not.toBeInTheDocument();
@@ -778,9 +746,7 @@ describe('TableNG', () => {
     });
 
     it('nested footer displays values computed from the nested fields (sum of Nested B = 30)', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrameWithFooter()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrameWithFooter()} width={800} height={600} />);
 
       await user.click(container.querySelector('[aria-label="Expand row"]')!);
 
@@ -790,9 +756,7 @@ describe('TableNG', () => {
 
     it('does not show a footer row in the nested table when nested fields have no footer reducers', async () => {
       // Uses the plain nested frame (no footer reducers on nested fields)
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createNestedDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createNestedDataFrame()} width={800} height={600} />);
 
       await user.click(container.querySelector('[aria-label="Expand row"]')!);
 
@@ -814,9 +778,7 @@ describe('TableNG', () => {
         })),
       };
 
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={frameWithTopLevelFooter} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={frameWithTopLevelFooter} width={800} height={600} />);
 
       // Top-level footer is visible before expansion
       expect(container.querySelector('.rdg-summary-row')).toBeInTheDocument();
@@ -869,7 +831,7 @@ describe('TableNG', () => {
       };
 
       const { rerender, container } = render(
-        <TableNG enableVirtualization={false} data={makeStableFrame(['key-A', 'key-B'])} width={800} height={600} />
+        <TableNG data={makeStableFrame(['key-A', 'key-B'])} width={800} height={600} />
       );
 
       // Expand the first row (key-A is at index 0)
@@ -880,9 +842,7 @@ describe('TableNG', () => {
       expect(screen.queryByText('nested-B')).not.toBeInTheDocument();
 
       // Re-render with reversed row order: key-B is now at index 0, key-A at index 1
-      rerender(
-        <TableNG enableVirtualization={false} data={makeStableFrame(['key-B', 'key-A'])} width={800} height={600} />
-      );
+      rerender(<TableNG data={makeStableFrame(['key-B', 'key-A'])} width={800} height={600} />);
 
       // key-A is now at index 1 but should still be expanded via its stable key
       expect(screen.getByText('nested-A')).toBeInTheDocument();
@@ -930,9 +890,7 @@ describe('TableNG', () => {
         );
       };
 
-      const { rerender, container } = render(
-        <TableNG enableVirtualization={false} data={makeIndexedFrame(['A', 'B'])} width={800} height={600} />
-      );
+      const { rerender, container } = render(<TableNG data={makeIndexedFrame(['A', 'B'])} width={800} height={600} />);
 
       // Expand the row at index 0 (A's subframe).
       const expandButton = container.querySelector('[aria-label="Expand row"]');
@@ -943,7 +901,7 @@ describe('TableNG', () => {
 
       // Reverse the row order. Without a stable key, expansion sticks to index 0,
       // which now holds B's subframe.
-      rerender(<TableNG enableVirtualization={false} data={makeIndexedFrame(['B', 'A'])} width={800} height={600} />);
+      rerender(<TableNG data={makeIndexedFrame(['B', 'A'])} width={800} height={600} />);
 
       expect(screen.getByText('nested-B')).toBeInTheDocument();
       expect(screen.queryByText('nested-A')).not.toBeInTheDocument();
@@ -952,9 +910,7 @@ describe('TableNG', () => {
 
   describe('Header options', () => {
     it('defaults to showing headers', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Check for column headers
       const headers = container.querySelectorAll('[role="columnheader"]');
@@ -962,9 +918,7 @@ describe('TableNG', () => {
     });
 
     it('hides headers when noHeader is true', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} noHeader={true} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} noHeader={true} />);
 
       // Get the grid container
       const gridContainer = container.querySelector('[role="grid"]');
@@ -983,9 +937,7 @@ describe('TableNG', () => {
     });
 
     it('shows full column name in title attribute for truncated headers', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       const headers = container.querySelectorAll('[role="columnheader"]');
       const firstHeaderSpan = headers[0].querySelector('button');
@@ -1007,7 +959,7 @@ describe('TableNG', () => {
       const frame = createDisplayNameDataFrame('Pretty Name');
       expect(frame.fields[0].state?.displayName).toBeFalsy();
 
-      render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      render(<TableNG data={frame} width={800} height={600} />);
 
       expect(frame.fields[0].state?.displayName).toBe('Pretty Name');
     });
@@ -1020,7 +972,7 @@ describe('TableNG', () => {
         field.state = { ...field.state, displayName: `Already Cached ${i}` };
       });
 
-      render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      render(<TableNG data={frame} width={800} height={600} />);
 
       frame.fields.forEach((field, i) => {
         expect(field.state?.displayName).toBe(`Already Cached ${i}`);
@@ -1033,7 +985,7 @@ describe('TableNG', () => {
       // and fall back to caching the whole frame, so even the "cached" first field gets recomputed.
       frame.fields[0].state = { ...frame.fields[0].state, displayName: 'Already Cached' };
 
-      render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      render(<TableNG data={frame} width={800} height={600} />);
 
       expect(frame.fields[0].state?.displayName).toBe('Pretty Name 0');
       expect(frame.fields[1].state?.displayName).toBe('Pretty Name 1');
@@ -1042,11 +994,11 @@ describe('TableNG', () => {
 
     it('recaches display names when a new data frame instance is passed in', () => {
       const frame1 = createDisplayNameDataFrame('Pretty Name');
-      const { rerender } = render(<TableNG enableVirtualization={false} data={frame1} width={800} height={600} />);
+      const { rerender } = render(<TableNG data={frame1} width={800} height={600} />);
       expect(frame1.fields[0].state?.displayName).toBe('Pretty Name');
 
       const frame2 = createDisplayNameDataFrame('Different Name');
-      rerender(<TableNG enableVirtualization={false} data={frame2} width={800} height={600} />);
+      rerender(<TableNG data={frame2} width={800} height={600} />);
 
       expect(frame2.fields[0].state?.displayName).toBe('Different Name');
       // frame1 is untouched by the later render — proves recaching is keyed off the new frame, not a stale one.
@@ -1086,7 +1038,7 @@ describe('TableNG', () => {
         })
       );
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       const columnHeaders = container.querySelectorAll('[role="columnheader"]');
       const valueColumnButton = columnHeaders[1].querySelector('button') || columnHeaders[1];
@@ -1106,9 +1058,7 @@ describe('TableNG', () => {
 
   describe('Footer options', () => {
     it('defaults to not showing footer', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
       expect(container.querySelector('.rdg-summary-row')).not.toBeInTheDocument();
     });
 
@@ -1127,9 +1077,7 @@ describe('TableNG', () => {
           },
         })),
       };
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={frameWithReducers} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={frameWithReducers} width={800} height={600} />);
 
       // Check for footer row
       const footerRow = container.querySelector('.rdg-summary-row');
@@ -1150,9 +1098,7 @@ describe('TableNG', () => {
           config: { ...field.config, custom: { footer: { reducers: ['sum'] } } },
         })),
       };
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={frameWithReducers} width={800} height={600} tableRefreshEnabled />
-      );
+      const { container } = render(<TableNG data={frameWithReducers} width={800} height={600} tableRefreshEnabled />);
 
       const footerCell = container.querySelector<HTMLElement>('.rdg-bottom-summary-row .rdg-cell')!;
       expect(window.getComputedStyle(footerCell).getPropertyValue('border-block-end')).toBe('none');
@@ -1161,9 +1107,7 @@ describe('TableNG', () => {
 
   describe('Pagination', () => {
     it('defaults to not showing pagination', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
       expect(container.querySelector('.table-ng-pagination')).not.toBeInTheDocument();
     });
 
@@ -1333,13 +1277,7 @@ describe('TableNG', () => {
 
     it('does not show pagination when there are no rows even if pagination is enabled', () => {
       const { container } = render(
-        <TableNG
-          enableVirtualization={false}
-          data={createEmptyDataFrame()}
-          width={800}
-          height={300}
-          enablePagination={true}
-        />
+        <TableNG data={createEmptyDataFrame()} width={800} height={300} enablePagination={true} />
       );
 
       expect(container.querySelector('.table-ng-pagination')).not.toBeInTheDocument();
@@ -1348,7 +1286,7 @@ describe('TableNG', () => {
 
   describe('Geo cells', () => {
     it('renders the geo cell as WKT once the lazy OpenLayers provider loads', async () => {
-      render(<TableNG enableVirtualization={false} data={createGeoDataFrame()} width={800} height={600} />);
+      render(<TableNG data={createGeoDataFrame()} width={800} height={600} />);
 
       // A geo field sends TableNG down the Suspense/LazyOpenLayersProvider branch. Until the
       // provider resolves, GeoCell has no formatGeometry and stringifies the raw geometry (a plain
@@ -1361,36 +1299,20 @@ describe('TableNG', () => {
 
   describe('Empty state', () => {
     it('displays the default no rows message when there are no rows', () => {
-      render(<TableNG enableVirtualization={false} data={createEmptyDataFrame()} width={800} height={600} />);
+      render(<TableNG data={createEmptyDataFrame()} width={800} height={600} />);
 
       expect(screen.getByText('No rows')).toBeInTheDocument();
     });
 
     it('displays the custom noValue message when provided', () => {
-      render(
-        <TableNG
-          enableVirtualization={false}
-          data={createEmptyDataFrame()}
-          width={800}
-          height={600}
-          noValue="Custom empty table message"
-        />
-      );
+      render(<TableNG data={createEmptyDataFrame()} width={800} height={600} noValue="Custom empty table message" />);
 
       expect(screen.getByText('Custom empty table message')).toBeInTheDocument();
       expect(screen.queryByText('No rows')).not.toBeInTheDocument();
     });
 
     it('does not display the noValue message when there is at least one row', () => {
-      render(
-        <TableNG
-          enableVirtualization={false}
-          data={createBasicDataFrame()}
-          width={800}
-          height={600}
-          noValue="Custom empty table message"
-        />
-      );
+      render(<TableNG data={createBasicDataFrame()} width={800} height={600} noValue="Custom empty table message" />);
 
       expect(screen.queryByText('Custom empty table message')).not.toBeInTheDocument();
       expect(screen.queryByText('No rows')).not.toBeInTheDocument();
@@ -1400,9 +1322,7 @@ describe('TableNG', () => {
 
   describe('Sorting', () => {
     it('allows sorting when clicking on column headers', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Ensure there are column headers
       const columnHeader = container.querySelector('[role="columnheader"]');
@@ -1452,9 +1372,7 @@ describe('TableNG', () => {
     });
 
     it('cycles through ascending, descending, and no sort states', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Get the first column header
       const columnHeader = container.querySelector('[role="columnheader"]');
@@ -1481,9 +1399,7 @@ describe('TableNG', () => {
     });
 
     it('supports multi-column sorting with cmd or ctrl key', async () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createSortingTestDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createSortingTestDataFrame()} width={800} height={600} />);
 
       // Get all column headers
       const columnHeaders = container.querySelectorAll('[role="columnheader"]');
@@ -1739,9 +1655,7 @@ describe('TableNG', () => {
         theme: createTheme(),
       })[0];
 
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={processedFrame} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={processedFrame} width={800} height={600} />);
 
       // Get column headers
       const columnHeaders = container.querySelectorAll('[role="columnheader"]');
@@ -1775,13 +1689,7 @@ describe('TableNG', () => {
       const onSortByChange = jest.fn();
 
       const { container } = render(
-        <TableNG
-          enableVirtualization={false}
-          data={createBasicDataFrame()}
-          width={800}
-          height={600}
-          onSortByChange={onSortByChange}
-        />
+        <TableNG data={createBasicDataFrame()} width={800} height={600} onSortByChange={onSortByChange} />
       );
 
       // Ensure there are column headers
@@ -1840,9 +1748,7 @@ describe('TableNG', () => {
         })
       );
 
-      const { container } = render(
-        <TableNG enableVirtualization={false} contentAwareWidthsEnabled={true} data={frame} width={800} height={600} />
-      );
+      const { container } = render(<TableNG contentAwareWidthsEnabled={true} data={frame} width={800} height={600} />);
 
       // rdg lays the grid out with an inline grid-template-columns, so it holds every column width.
       const grid = container.querySelector<HTMLElement>('[role="grid"]');
@@ -1870,9 +1776,7 @@ describe('TableNG', () => {
       };
 
       // First render with unfiltered data
-      const { container, rerender } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container, rerender } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Check initial row count
       const initialRows = container.querySelectorAll('[role="row"]');
@@ -1880,7 +1784,7 @@ describe('TableNG', () => {
       expect(initialRowCount).toBe(3); // Our basic frame has 3 rows
 
       // Rerender with filtered data
-      rerender(<TableNG enableVirtualization={false} data={filteredFrame} width={800} height={600} />);
+      rerender(<TableNG data={filteredFrame} width={800} height={600} />);
 
       // Check filtered row count
       const filteredRows = container.querySelectorAll('[role="row"]');
@@ -1911,9 +1815,7 @@ describe('TableNG', () => {
       };
 
       // First render with unfiltered data
-      const { container, rerender } = render(
-        <TableNG enableVirtualization={false} data={baseFrame} width={800} height={600} />
-      );
+      const { container, rerender } = render(<TableNG data={baseFrame} width={800} height={600} />);
 
       // Check initial row count
       const initialRows = container.querySelectorAll('[role="row"]');
@@ -1921,7 +1823,7 @@ describe('TableNG', () => {
       expect(initialRowCount).toBe(3);
 
       // Rerender with filtered data
-      rerender(<TableNG enableVirtualization={false} data={filteredFrame} width={800} height={600} />);
+      rerender(<TableNG data={filteredFrame} width={800} height={600} />);
 
       // Check filtered row count
       const filteredRows = container.querySelectorAll('[role="row"]');
@@ -1968,9 +1870,7 @@ describe('TableNG', () => {
       };
 
       // Render with unfiltered data and footer options
-      const { container, rerender } = render(
-        <TableNG enableVirtualization={false} data={baseFrameWithReducers} width={800} height={600} />
-      );
+      const { container, rerender } = render(<TableNG data={baseFrameWithReducers} width={800} height={600} />);
 
       // Check initial footer sum (1+2+3=6)
       const initialFooter = container.querySelector('.rdg-summary-row');
@@ -1984,7 +1884,7 @@ describe('TableNG', () => {
       expect(initialFooterTexts[1]).toBe('6');
 
       // Rerender with filtered data
-      rerender(<TableNG enableVirtualization={false} data={filteredFrame} width={800} height={600} />);
+      rerender(<TableNG data={filteredFrame} width={800} height={600} />);
       // Check filtered footer sum (should be 1)
       const filteredFooter = container.querySelector('.rdg-summary-row');
       expect(filteredFooter).toBeInTheDocument();
@@ -2029,7 +1929,7 @@ describe('TableNG', () => {
         })
       );
 
-      render(<TableNG enableVirtualization={false} data={crossFilterFrame} width={800} height={600} />);
+      render(<TableNG data={crossFilterFrame} width={800} height={600} />);
 
       // Two filter buttons: [0]=Category, [1]=Status
       const filterButtons = screen.getAllByTestId(
@@ -2124,7 +2024,7 @@ describe('TableNG', () => {
         })
       );
 
-      render(<TableNG enableVirtualization={false} data={nestedCrossFilterFrame} width={800} height={600} />);
+      render(<TableNG data={nestedCrossFilterFrame} width={800} height={600} />);
 
       // Apply top-level Column A filter to keep only row A1
       const filterButtons = screen.getAllByTestId(
@@ -2152,12 +2052,10 @@ describe('TableNG', () => {
       };
 
       // First render with unfiltered data
-      const { container, rerender } = render(
-        <TableNG enableVirtualization={false} data={baseFrame} width={800} height={600} />
-      );
+      const { container, rerender } = render(<TableNG data={baseFrame} width={800} height={600} />);
 
       // Rerender with filtered data
-      rerender(<TableNG enableVirtualization={false} data={filteredFrame} width={800} height={600} />);
+      rerender(<TableNG data={filteredFrame} width={800} height={600} />);
 
       // Check filtered row count
       const filteredRows = container.querySelectorAll('[role="row"]');
@@ -2174,9 +2072,7 @@ describe('TableNG', () => {
 
   describe('Text wrapping', () => {
     it('defaults to not wrapping text', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       const cellStyles = window.getComputedStyle(cells[0]);
@@ -2194,7 +2090,6 @@ describe('TableNG', () => {
 
       const { container } = render(
         <TableNG
-          enableVirtualization={false}
           data={frame}
           width={800}
           height={600}
@@ -2221,9 +2116,7 @@ describe('TableNG', () => {
       // `pre-line` collapses runs of whitespace, which flattens the indentation displayJsonValue
       // produces. The JSON and auto style classes both declare white-space at the same specificity,
       // so this also guards against the winner coming down to emotion's insertion order.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(true)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(true)} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       const jsonCellStyles = window.getComputedStyle(cells[1]);
@@ -2246,9 +2139,7 @@ describe('TableNG', () => {
         test: () => false,
       });
 
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(true)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(true)} width={800} height={600} />);
 
       // metadata's value ({ region: 'us-east-1', replicas: 3 }) pretty-prints to 4 lines:
       // `{\n "region": "us-east-1",\n "replicas": 3\n}`.
@@ -2265,9 +2156,7 @@ describe('TableNG', () => {
       // moment it's hovered, which un-hovers it, which snaps it back — an infinite flicker. min-width
       // pins the floor to the cell's own size so the cap can only ever grow it, never shrink it.
       const user = userEvent.setup();
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       await user.click(cells[1]);
@@ -2282,9 +2171,7 @@ describe('TableNG', () => {
       // it, so the expanded state hangs off `:focus-within` rather than the selection alone. Without
       // that, clicking away from the table leaves the cell stuck open over its neighbors.
       const user = userEvent.setup();
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       await user.click(cells[1]);
@@ -2301,9 +2188,7 @@ describe('TableNG', () => {
       // selected, and that outlives the grid's focus, so the reset that hides it has to as well —
       // gating it too puts an outline back on the header the moment the user clicks away.
       const user = userEvent.setup();
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       const header = container.querySelector('[role="columnheader"]')!;
       await user.click(header);
@@ -2317,7 +2202,7 @@ describe('TableNG', () => {
       // Both expand over their neighbors, so whichever is on top wins the overlap. A selection
       // outlives the pointer, so ranking it above hover leaves a stale selected cell clipping the
       // overflow of whatever the user hovers next.
-      render(<TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />);
+      render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       // jsdom's selector engine never matches `:hover`, so the two values have to be compared as
       // declared rather than as computed on an element.
@@ -2344,9 +2229,7 @@ describe('TableNG', () => {
       // to the top — pushing the first several lines into the negative-scroll region above scrollTop
       // 0, where they're unreachable no matter how far up you scroll.
       const user = userEvent.setup();
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       await user.click(cells[1]);
@@ -2362,13 +2245,7 @@ describe('TableNG', () => {
       // grow unbounded on hover too, the exact panel-escaping overflow this option exists to stop.
       const user = userEvent.setup();
       const { container } = render(
-        <TableNG
-          enableVirtualization={false}
-          data={createJsonDataFrame(true)}
-          width={800}
-          height={600}
-          maxRowHeight={100}
-        />
+        <TableNG data={createJsonDataFrame(true)} width={800} height={600} maxRowHeight={100} />
       );
 
       const cells = container.querySelectorAll('[role="gridcell"]');
@@ -2402,9 +2279,7 @@ describe('TableNG', () => {
     it('renders an unwrapped JSON cell with the indentation intact in the DOM', () => {
       // the collapsing happens in CSS, so the text node itself must still carry the newlines and
       // indentation for the hover expansion to have anything to reveal.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createJsonDataFrame(false)} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createJsonDataFrame(false)} width={800} height={600} />);
 
       const cells = container.querySelectorAll('[role="gridcell"]');
       // read the raw node rather than using toHaveTextContent, which normalizes away the very
@@ -2433,7 +2308,6 @@ describe('TableNG', () => {
       // Render the component
       const { container } = render(
         <TableNG
-          enableVirtualization={false}
           // fieldConfig={inspectDataFrame.fields[0].config}
           data={inspectDataFrame}
           width={800}
@@ -2464,9 +2338,7 @@ describe('TableNG', () => {
 
   describe('Accessibility', () => {
     it('has proper ARIA attributes for accessibility', () => {
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
-      );
+      const { container } = render(<TableNG data={createBasicDataFrame()} width={800} height={600} />);
 
       // Check that the table has a grid role
       const grid = container.querySelector('[role="grid"]');
@@ -2510,7 +2382,7 @@ describe('TableNG', () => {
         };
       };
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       // Find cells in the first column
       const cells = container.querySelectorAll('[role="gridcell"]');
@@ -2547,7 +2419,7 @@ describe('TableNG', () => {
         };
       };
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       // Find cells in the first column
       const cells = container.querySelectorAll('[role="gridcell"]');
@@ -2588,7 +2460,7 @@ describe('TableNG', () => {
         };
       };
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       // Find rows in the table
       const rows = container.querySelectorAll('[role="row"]');
@@ -2633,7 +2505,7 @@ describe('TableNG', () => {
         color: '#0000ff', // second column: blue, should be ignored in favor of the row color
       });
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       const rows = container.querySelectorAll('[role="row"]');
       const cells = rows[1].querySelectorAll('[role="gridcell"]'); // Skip header row
@@ -2677,7 +2549,7 @@ describe('TableNG', () => {
         color: '#0000ff', // visible column's own color, should defer to the hidden column
       });
 
-      const { container } = render(<TableNG enableVirtualization={false} data={frame} width={800} height={600} />);
+      const { container } = render(<TableNG data={frame} width={800} height={600} />);
 
       const rows = container.querySelectorAll('[role="row"]');
       const cells = rows[1].querySelectorAll('[role="gridcell"]'); // Skip header row
@@ -2724,7 +2596,7 @@ describe('TableNG', () => {
       const data = createTimeDataFrame();
       render(
         <PanelContextProvider value={mockPanelContext}>
-          <TableNG enableVirtualization={false} data={data} width={800} height={600} enableSharedCrosshair />
+          <TableNG data={data} width={800} height={600} enableSharedCrosshair />
         </PanelContextProvider>
       );
 
@@ -2743,13 +2615,7 @@ describe('TableNG', () => {
     it('should not publish DataHoverEvent when enableSharedCrosshair is false', async () => {
       render(
         <PanelContextProvider value={mockPanelContext}>
-          <TableNG
-            enableVirtualization={false}
-            data={createTimeDataFrame()}
-            width={800}
-            height={600}
-            enableSharedCrosshair={false}
-          />
+          <TableNG data={createTimeDataFrame()} width={800} height={600} enableSharedCrosshair={false} />
         </PanelContextProvider>
       );
 
@@ -2761,13 +2627,7 @@ describe('TableNG', () => {
     it('should not publish DataHoverEvent when time field is not present', async () => {
       render(
         <PanelContextProvider value={mockPanelContext}>
-          <TableNG
-            enableVirtualization={false}
-            data={createBasicDataFrame()}
-            width={800}
-            height={600}
-            enableSharedCrosshair
-          />
+          <TableNG data={createBasicDataFrame()} width={800} height={600} enableSharedCrosshair />
         </PanelContextProvider>
       );
 
@@ -2779,13 +2639,7 @@ describe('TableNG', () => {
     it('should publish DataHoverClearEvent when leaving a row', async () => {
       render(
         <PanelContextProvider value={mockPanelContext}>
-          <TableNG
-            enableVirtualization={false}
-            data={createTimeDataFrame()}
-            width={800}
-            height={600}
-            enableSharedCrosshair
-          />
+          <TableNG data={createTimeDataFrame()} width={800} height={600} enableSharedCrosshair />
         </PanelContextProvider>
       );
 
@@ -2802,13 +2656,7 @@ describe('TableNG', () => {
     it('should not publish DataHoverClearEvent when enableSharedCrosshair is false', async () => {
       render(
         <PanelContextProvider value={mockPanelContext}>
-          <TableNG
-            enableVirtualization={false}
-            data={createTimeDataFrame()}
-            width={800}
-            height={600}
-            enableSharedCrosshair={false}
-          />
+          <TableNG data={createTimeDataFrame()} width={800} height={600} enableSharedCrosshair={false} />
         </PanelContextProvider>
       );
 
@@ -2839,7 +2687,7 @@ describe('TableNG', () => {
       dataFrame.fields[0].config.links = links;
       dataFrame.fields[0].getLinks = () => links.map(toLinkModel);
 
-      render(<TableNG enableVirtualization={false} data={dataFrame} width={800} height={600} />);
+      render(<TableNG data={dataFrame} width={800} height={600} />);
 
       const cell = screen.getByText('A1');
       await userEvent.click(cell);
@@ -2859,7 +2707,7 @@ describe('TableNG', () => {
       dataFrame.fields[0].config.links = links;
       dataFrame.fields[0].getLinks = () => links.map(toLinkModel);
 
-      render(<TableNG enableVirtualization={false} data={dataFrame} width={800} height={600} />);
+      render(<TableNG data={dataFrame} width={800} height={600} />);
 
       const cell = screen.getByText('A1');
 
@@ -2928,7 +2776,7 @@ describe('TableNG', () => {
         })
       );
 
-      const { container } = render(<TableNG enableVirtualization={false} data={outerFrame} width={800} height={600} />);
+      const { container } = render(<TableNG data={outerFrame} width={800} height={600} />);
 
       // Expand the second outer row (index 1), which has State='Up'
       const expandButtons = container.querySelectorAll('[aria-label="Expand row"]');
@@ -2983,7 +2831,7 @@ describe('TableNG', () => {
     });
 
     const renderAtWidth = (data: DataFrame, width: number) =>
-      render(<TableNG enableVirtualization={false} data={data} width={width} height={300} />);
+      render(<TableNG data={data} width={width} height={300} />);
 
     it('applies width changes immediately when no auto-sized column is width-sensitive', () => {
       const data = frameWithFields([
@@ -2993,7 +2841,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(data, 400);
       expect(columnTemplate(container)).toBe('200px 200px');
 
-      rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
+      rerender(<TableNG data={data} width={900} height={300} />);
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
@@ -3002,7 +2850,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(data, 400);
       expect(columnTemplate(container)).toBe('200px 200px');
 
-      rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
+      rerender(<TableNG data={data} width={900} height={300} />);
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
@@ -3019,7 +2867,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(data, 400);
       expect(columnTemplate(container)).toBe('200px 200px');
 
-      rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
+      rerender(<TableNG data={data} width={900} height={300} />);
       expect(columnTemplate(container)).toBe('450px 450px');
     });
 
@@ -3041,7 +2889,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(insensitive, 400);
       const gridBefore = gridNode(container);
 
-      rerender(<TableNG enableVirtualization={false} data={sensitive} width={400} height={300} />);
+      rerender(<TableNG data={sensitive} width={400} height={300} />);
       expect(gridNode(container)).toBe(gridBefore);
     });
 
@@ -3050,7 +2898,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(data, 400);
       expect(columnTemplate(container)).toBe('100px 300px');
 
-      rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
+      rerender(<TableNG data={data} width={900} height={300} />);
       expect(columnTemplate(container)).toBe('100px 800px');
     });
 
@@ -3072,7 +2920,7 @@ describe('TableNG', () => {
       const { container, rerender } = renderAtWidth(data, 400);
       const initialTemplate = columnTemplate(container);
 
-      rerender(<TableNG enableVirtualization={false} data={data} width={900} height={300} />);
+      rerender(<TableNG data={data} width={900} height={300} />);
       expect(columnTemplate(container)).not.toBe(initialTemplate);
     });
 
@@ -3095,9 +2943,7 @@ describe('TableNG', () => {
       // Narrow enough that available width can't cover both columns' content width, so there's no
       // leftover to redistribute — each column's measured content width is what actually lands,
       // rather than being masked by growth filling out the panel.
-      const { container } = render(
-        <TableNG enableVirtualization={false} data={data} width={250} height={300} contentAwareWidthsEnabled />
-      );
+      const { container } = render(<TableNG data={data} width={250} height={300} contentAwareWidthsEnabled />);
 
       const [serviceWidth, metadataWidth] = columnTemplate(container)
         .split(' ')

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -146,7 +146,10 @@ interface BaseTableProps {
   initialRowIndex?: number;
   fieldConfig?: FieldConfigSource;
   getActions?: GetActionsFunction;
-  // Used solely for testing as RTL can't correctly render the table otherwise
+  /**
+   * Renders every row into the DOM instead of only the visible window. Needed when the
+   * table is captured as a static image (PDF reporting) rather than scrolled by a user.
+   */
   enableVirtualization?: boolean;
   // for MarkdownCell, this flag disables sanitization of HTML content. Configured via config.ini.
   disableSanitizeHtml?: boolean;

--- a/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.test.tsx
@@ -12,6 +12,7 @@ import {
   toUtc,
 } from '@grafana/data';
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
+import { mockClientSize } from '@grafana/test-utils';
 import { type Options } from 'app/plugins/panel/logstable/options/types';
 
 import { FIELD_SELECTOR_MIN_WIDTH } from '../../logs/components/fieldSelector/FieldSelector';
@@ -20,16 +21,10 @@ import { extractFieldsTransformer } from '../../transformers/extractFields/extra
 import { ExploreLogsTable } from './ExploreLogsTable';
 import { getMockLokiFrame, getMockLokiFrameDataPlane } from './utils/mocks';
 
-// Mock TableNG to disable virtualization, otherwise the lack of viewport in our testing env will cause the table to only render a single column
-jest.mock('@grafana/ui/unstable', () => {
-  const actual = jest.requireActual('@grafana/ui/unstable');
-  const MockTableNG = actual.TableNG;
-  return {
-    ...actual,
-    TableNG: (props: React.ComponentProps<typeof MockTableNG>) => (
-      <MockTableNG {...props} enableVirtualization={false} />
-    ),
-  };
+// react-data-grid sizes its virtualized viewport from the client box, which jsdom reports as 0 - without
+// this the table only renders a single column.
+beforeAll(() => {
+  mockClientSize({ width: 800, height: 600 });
 });
 
 const publishMockFn = jest.fn();

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -19,6 +19,7 @@ import {
 } from '@grafana/data';
 import { mockTransformationsRegistry, organizeFieldsTransformer } from '@grafana/data/internal';
 import { defaultTableOptions } from '@grafana/schema';
+import { mockClientSize } from '@grafana/test-utils';
 import { PanelContextProvider, type PanelContext } from '@grafana/ui';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
 import { DownloadFormat, downloadLogs } from 'app/features/logs/utils';
@@ -50,16 +51,10 @@ const mockEventBus: EventBus = {
   newScopedBus: jest.fn(),
 };
 
-// Mock TableNG to disable virtualization, otherwise the lack of viewport in our testing env will cause the table to only render a single column
-jest.mock('@grafana/ui/unstable', () => {
-  const actual = jest.requireActual('@grafana/ui/unstable');
-  const MockTableNG = actual.TableNG;
-  return {
-    ...actual,
-    TableNG: (props: React.ComponentProps<typeof MockTableNG>) => (
-      <MockTableNG {...props} enableVirtualization={false} />
-    ),
-  };
+// react-data-grid sizes its virtualized viewport from the client box, which jsdom reports as 0 - without
+// this the table only renders a single column.
+beforeAll(() => {
+  mockClientSize({ width: 800, height: 600 });
 });
 
 const publishMockFn = jest.fn();


### PR DESCRIPTION
## What

Stops every test from passing `enableVirtualization={false}` to `TableNG`.

The prop existed because react-data-grid rendered no rows under `@react/testing-library` (RTL), but
"RTL can't render the table" is the symptom, not the cause: react-data-grid sizes its virtualized
viewport from the **client box**, and jsdom always reports `clientWidth`/`clientHeight` as 0, so the
computed row range is empty. Mocking those two properties makes virtualization work in tests, so every
test can now render the table the way a browser does.

- `TableNG.test.tsx`: 92 `enableVirtualization={false}` call sites removed, replaced by one `mockClientSize`
  in a `beforeAll`.
- `ExploreLogsTable.test.tsx` and `LogsTable.test.tsx` no longer mock the whole of `@grafana/ui/unstable`
  just to inject the prop — that `jest.mock` block is gone from both.
- `TableNG.safari.test.tsx` drops the prop and needs no client-box mock at all: `IS_SAFARI_26` already
  disables virtualization on that path.

## The prop itself stays

An earlier revision of this PR deleted `enableVirtualization` from `BaseTableProps` on the assumption that
it was test-only, as its doc comment claimed. It isn't: Enterprise reporting passes it when rendering PDF
tables, which need every row in the DOM rather than the visible window, so the public API is unchanged
here. The only non-test change is that doc comment, which now describes the static-image capture use case
instead of claiming the prop is for tests.

## The `mockClientSize` helper

`mockClientSize` landed in `@grafana/test-utils` with #130618. It's a separate opt-in helper next to
`mockBoundingClientRect` rather than folded into it — ~70 test files call that one, and some legitimately
assert behaviour under a zero client size. It defines the properties on `Element.prototype` rather than
`HTMLElement.prototype`, so a test with its own narrower `clientWidth` mock still wins.

## Verification

- `yarn jest packages/grafana-ui/src/components/Table public/app/features/explore/Logs/ExploreLogsTable public/app/plugins/panel/logstable --no-watch` — exit 0, 1013 passed / 15 skipped / 1 todo across 47 suites.
- `yarn typecheck` — exit 0 (this is the job that caught the Enterprise consumer).
- `yarn eslint` on the touched paths — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
