### PR TITLE
E2E: Cover the FileDropzone and shortcut-modal flows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -474,6 +474,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/dashboards-suite/embedded-dashboard.spec.ts @grafana/dashboards-squad
 /e2e-playwright/dashboards-suite/general-dashboards.spec.ts @grafana/dashboards-squad
 /e2e-playwright/dashboards-suite/import-dashboard.spec.ts @grafana/dashboards-squad
+/e2e-playwright/dashboards-suite/import-dashboard-file-upload.spec.ts @grafana/dashboards-squad
 /e2e-playwright/dashboards-suite/load-options-from-url.spec.ts @grafana/dashboards-squad
 /e2e-playwright/dashboards-suite/new-constant-variable.spec.ts @grafana/dashboards-squad
 /e2e-playwright/dashboards-suite/new-custom-variable.spec.ts @grafana/dashboards-squad
@@ -514,6 +515,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/frontend-sandbox-datasource.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/grafana-datasource-random-walk.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/graph-auto-migrate.spec.ts @grafana/dataviz-squad
+/e2e-playwright/various-suite/help-modal-shortcut.spec.ts @grafana/grafana-frontend-navigation @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/inspect-drawer.spec.ts @grafana/dashboards-squad
 /e2e-playwright/various-suite/keybinds.spec.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/migrate-to-cloud.spec.ts @grafana/grafana-operator-experience-squad

--- a/e2e-playwright/alerting-suite/import-to-gma-notification-templates.spec.ts
+++ b/e2e-playwright/alerting-suite/import-to-gma-notification-templates.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import { DROPZONE_TEST_ID, dragFilesOntoDropzone, dropzoneInput, writeFilesForDrag } from '../utils/dropzone-helpers';
+
+const SLACK_TEMPLATE = '{{ define "slack.title" }}{{ .Status }} alert{{ end }}';
+const EMAIL_TEMPLATE = '{{ define "email.subject" }}{{ .CommonLabels.alertname }}{{ end }}';
+
+test.use({
+  featureToggles: {
+    alertingMigrationWizardUI: true,
+  },
+});
+
+/**
+ * Step 1 of the import wizard uploads the notification templates that the imported Alertmanager
+ * config references. Every file added here becomes a template keyed by its file name, so the file
+ * list and its duplicate-name validation are the only guard against a silently dropped template.
+ */
+test.describe(
+  'Import to Grafana-managed alerting — notification templates',
+  {
+    tag: ['@alerting'],
+  },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/alerting/import-to-gma');
+      // The YAML source is selected by default and is what renders the template dropzone.
+      await expect(page.getByRole('radio', { name: /YAML file/ })).toBeChecked();
+      await expect(page.getByTestId(DROPZONE_TEST_ID)).toBeVisible();
+    });
+
+    test('lists every template file added through the file picker', async ({ page }) => {
+      await dropzoneInput(page).setInputFiles([
+        { name: 'slack.tmpl', mimeType: 'text/plain', buffer: Buffer.from(SLACK_TEMPLATE) },
+        { name: 'email.tmpl', mimeType: 'text/plain', buffer: Buffer.from(EMAIL_TEMPLATE) },
+      ]);
+
+      await expect(page.getByText('slack.tmpl', { exact: true })).toBeVisible();
+      await expect(page.getByText('email.tmpl', { exact: true })).toBeVisible();
+    });
+
+    test('lists template files dragged onto the dropzone', async ({ page }, testInfo) => {
+      const filePaths = writeFilesForDrag(testInfo, [
+        { name: 'slack.tmpl', contents: SLACK_TEMPLATE },
+        { name: 'email.tmpl', contents: EMAIL_TEMPLATE },
+      ]);
+
+      await dragFilesOntoDropzone(page, page.getByTestId(DROPZONE_TEST_ID), filePaths);
+
+      await expect(page.getByText('slack.tmpl', { exact: true })).toBeVisible();
+      await expect(page.getByText('email.tmpl', { exact: true })).toBeVisible();
+    });
+
+    test('removes a single template file and keeps the rest', async ({ page }) => {
+      await dropzoneInput(page).setInputFiles([
+        { name: 'slack.tmpl', mimeType: 'text/plain', buffer: Buffer.from(SLACK_TEMPLATE) },
+        { name: 'email.tmpl', mimeType: 'text/plain', buffer: Buffer.from(EMAIL_TEMPLATE) },
+      ]);
+      await expect(page.getByText('slack.tmpl', { exact: true })).toBeVisible();
+
+      await page.getByRole('button', { name: 'Remove slack.tmpl' }).click();
+
+      await expect(page.getByText('email.tmpl', { exact: true })).toBeVisible();
+      await expect(page.getByText('slack.tmpl', { exact: true })).toBeHidden();
+    });
+
+    test('flags two template files sharing a name', async ({ page }) => {
+      await dropzoneInput(page).setInputFiles([
+        { name: 'slack.tmpl', mimeType: 'text/plain', buffer: Buffer.from(SLACK_TEMPLATE) },
+      ]);
+      await expect(page.getByText('slack.tmpl', { exact: true })).toBeVisible();
+
+      // A second file with the same name would overwrite the first template on import.
+      await dropzoneInput(page).setInputFiles([
+        { name: 'slack.tmpl', mimeType: 'text/plain', buffer: Buffer.from(EMAIL_TEMPLATE) },
+      ]);
+
+      await expect(page.getByText('Duplicate template file name: "slack.tmpl"')).toBeVisible();
+    });
+  }
+);

--- a/e2e-playwright/dashboards-suite/import-dashboard-file-upload.spec.ts
+++ b/e2e-playwright/dashboards-suite/import-dashboard-file-upload.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+import testDashboard from '../dashboards/TestDashboard.json';
+import { DROPZONE_TEST_ID, dragFilesOntoDropzone, dropzoneInput, writeFilesForDrag } from '../utils/dropzone-helpers';
+
+/**
+ * The upload half of /dashboard/import. `import-dashboard.spec.ts` covers pasting JSON into the
+ * textarea, which never touches the `FileDropzone` — reading the file, parsing it and handing the
+ * result to the import form only happens on this path.
+ */
+test.describe(
+  'Import a dashboard from a file',
+  {
+    tag: ['@dashboards'],
+  },
+  () => {
+    let importedUid = '';
+
+    function dashboardFixture(suffix: string) {
+      return { ...testDashboard, uid: `dropzone-${suffix}`, title: `Kubernetes cluster overview ${suffix}` };
+    }
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/dashboard/import');
+      await expect(page.getByTestId(DROPZONE_TEST_ID)).toBeVisible();
+    });
+
+    test.afterEach(async ({ request }) => {
+      if (importedUid) {
+        await request.delete(`/api/dashboards/uid/${importedUid}`);
+        importedUid = '';
+      }
+    });
+
+    test('imports a dashboard chosen through the file picker', async ({ page, selectors }) => {
+      const dashboard = dashboardFixture(crypto.randomUUID().slice(0, 8));
+
+      await dropzoneInput(page).setInputFiles({
+        name: 'kubernetes-cluster-overview.json',
+        mimeType: 'application/json',
+        buffer: Buffer.from(JSON.stringify(dashboard)),
+      });
+
+      // The name field is seeded from the parsed file, so its value proves the FileReader result
+      // reached the import form rather than just that a file was accepted.
+      await expect(page.getByTestId(selectors.components.ImportDashboardForm.name)).toHaveValue(dashboard.title);
+
+      await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
+
+      await page.waitForURL('**/d/**');
+      importedUid = new URL(page.url()).pathname.split('/')[2];
+
+      await expect(page.getByTestId(selectors.components.Breadcrumbs.breadcrumb(dashboard.title))).toBeVisible();
+      await expect(page.getByText('Gauge Example')).toBeVisible();
+      await expect(page.getByText('Time series example')).toBeVisible();
+    });
+
+    test('imports a dashboard dragged onto the dropzone', async ({ page, selectors }, testInfo) => {
+      const dashboard = dashboardFixture(crypto.randomUUID().slice(0, 8));
+      const [filePath] = writeFilesForDrag(testInfo, [
+        { name: 'kubernetes-cluster-overview.json', contents: JSON.stringify(dashboard) },
+      ]);
+
+      await dragFilesOntoDropzone(page, page.getByTestId(DROPZONE_TEST_ID), [filePath]);
+
+      await expect(page.getByTestId(selectors.components.ImportDashboardForm.name)).toHaveValue(dashboard.title);
+
+      await page.getByTestId(selectors.components.ImportDashboardForm.submit).click();
+
+      await page.waitForURL('**/d/**');
+      importedUid = new URL(page.url()).pathname.split('/')[2];
+
+      await expect(page.getByTestId(selectors.components.Breadcrumbs.breadcrumb(dashboard.title))).toBeVisible();
+    });
+
+    test('rejects a file whose type is not accepted', async ({ page, selectors }) => {
+      await dropzoneInput(page).setInputFiles({
+        name: 'screenshot.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from('not-a-dashboard'),
+      });
+
+      const rejection = page
+        .getByTestId(selectors.components.Alert.alertV2('error'))
+        .filter({ hasText: 'File type must be' });
+      await expect(rejection).toBeVisible();
+      await expect(rejection).toContainText('.json');
+
+      await expect(page.getByTestId(selectors.components.ImportDashboardForm.name)).toBeHidden();
+    });
+
+    test('reports a parse failure and still imports a valid file afterwards', async ({ page, selectors }) => {
+      await dropzoneInput(page).setInputFiles({
+        name: 'truncated.json',
+        mimeType: 'application/json',
+        buffer: Buffer.from('{ "title": "Kubernetes cluster overview"'),
+      });
+
+      await expect(
+        page.getByTestId(selectors.components.Alert.alertV2('error')).filter({ hasText: 'Import failed' })
+      ).toBeVisible();
+
+      const dashboard = dashboardFixture(crypto.randomUUID().slice(0, 8));
+      await dropzoneInput(page).setInputFiles({
+        name: 'kubernetes-cluster-overview.json',
+        mimeType: 'application/json',
+        buffer: Buffer.from(JSON.stringify(dashboard)),
+      });
+
+      await expect(page.getByTestId(selectors.components.ImportDashboardForm.name)).toHaveValue(dashboard.title);
+    });
+
+    test('opens the file picker when the dropzone is activated from the keyboard', async ({ page }) => {
+      const dropzone = page.getByTestId(DROPZONE_TEST_ID);
+      await dropzone.focus();
+
+      const fileChooser = page.waitForEvent('filechooser');
+      await page.keyboard.press('Enter');
+
+      // The import page takes a single dashboard file, which the picker has to reflect.
+      expect((await fileChooser).isMultiple()).toBe(false);
+    });
+  }
+);

--- a/e2e-playwright/utils/dropzone-helpers.ts
+++ b/e2e-playwright/utils/dropzone-helpers.ts
@@ -1,0 +1,51 @@
+import { type Locator, type Page, type TestInfo } from '@playwright/test';
+import fs from 'fs';
+
+/** Test id on the root element every `FileDropzone` renders. */
+export const DROPZONE_TEST_ID = 'dropzone';
+
+/**
+ * The hidden react-dropzone file input inside a `FileDropzone`, for `setInputFiles`.
+ * Pass a narrower scope when the page renders more than one dropzone.
+ */
+export function dropzoneInput(scope: Page | Locator): Locator {
+  return scope.getByTestId(DROPZONE_TEST_ID).locator('input[type="file"]');
+}
+
+/** Writes files into the test's output dir and returns their paths, for dragging onto a dropzone. */
+export function writeFilesForDrag(testInfo: TestInfo, files: Array<{ name: string; contents: string }>): string[] {
+  return files.map(({ name, contents }) => {
+    const filePath = testInfo.outputPath(name);
+    fs.writeFileSync(filePath, contents);
+    return filePath;
+  });
+}
+
+/**
+ * Drags files onto a `FileDropzone`, the path `setInputFiles` never exercises.
+ *
+ * This goes through CDP rather than a hand-built `DataTransfer`: react-dropzone reads dropped
+ * files through file-selector, which calls `getFile()` on the drag item's file-system handle, and
+ * items added to a `new DataTransfer()` in page context carry no handle — the drop then throws
+ * "Cannot read properties of undefined (reading 'getFile')" and the dropzone stays empty.
+ * Chromium-only, which is the browser this suite runs in.
+ */
+export async function dragFilesOntoDropzone(page: Page, dropzone: Locator, filePaths: string[]) {
+  const box = await dropzone.boundingBox();
+  if (!box) {
+    throw new Error('Cannot drag onto a dropzone that is not visible');
+  }
+
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  const data = { items: [], files: filePaths, dragOperationsMask: 1 };
+
+  const cdp = await page.context().newCDPSession(page);
+  try {
+    await cdp.send('Input.dispatchDragEvent', { type: 'dragEnter', x, y, data });
+    await cdp.send('Input.dispatchDragEvent', { type: 'dragOver', x, y, data });
+    await cdp.send('Input.dispatchDragEvent', { type: 'drop', x, y, data });
+  } finally {
+    await cdp.detach();
+  }
+}

--- a/e2e-playwright/various-suite/help-modal-shortcut.spec.ts
+++ b/e2e-playwright/various-suite/help-modal-shortcut.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+/**
+ * The `?` shortcut is the only way into the shortcuts dialog — `keybinds.spec.ts` covers the
+ * navigation and time-range bindings, but nothing covers the handler that opens this modal.
+ */
+test.describe(
+  'Shortcuts help modal',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/');
+      await expect(page.getByText('Welcome to Grafana')).toBeVisible();
+    });
+
+    test('shift+/ opens the shortcuts dialog and Escape closes it', async ({ page }) => {
+      await page.keyboard.press('Shift+Slash');
+
+      const dialog = page.getByRole('dialog', { name: 'Shortcuts' });
+      await expect(dialog).toBeVisible();
+      // The listed bindings are the content of the dialog, so assert one of them rather than the frame.
+      await expect(dialog.getByText('Go to Home Dashboard')).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden();
+    });
+
+    test('the dialog close button dismisses it and the shortcut opens it again', async ({ page, selectors }) => {
+      await page.keyboard.press('Shift+Slash');
+
+      const dialog = page.getByRole('dialog', { name: 'Shortcuts' });
+      await expect(dialog).toBeVisible();
+
+      await dialog.getByTestId(selectors.components.Modal.closeButton).click();
+      await expect(dialog).toBeHidden();
+
+      await page.keyboard.press('Shift+Slash');
+      await expect(page.getByRole('dialog', { name: 'Shortcuts' })).toBeVisible();
+    });
+
+    test('repeated shortcut presses leave a single dialog open', async ({ page }) => {
+      await page.keyboard.press('Shift+Slash');
+      await page.keyboard.press('Shift+Slash');
+      await page.keyboard.press('Shift+Slash');
+
+      const dialog = page.getByRole('dialog', { name: 'Shortcuts' });
+      await expect(dialog).toHaveCount(1);
+      await expect(dialog).toBeVisible();
+
+      // One Escape has to be enough — stacked modals would leave one behind.
+      await page.keyboard.press('Escape');
+      await expect(page.getByRole('dialog', { name: 'Shortcuts' })).toHaveCount(0);
+    });
+  }
+);


### PR DESCRIPTION
**What is this feature?**

Playwright coverage for the user flows that run through `FileDropzone` and the shortcuts help modal.

- `e2e-playwright/dashboards-suite/import-dashboard-file-upload.spec.ts` — import a dashboard through the file picker and through a drag; a rejected file type; a JSON parse failure and recovery afterwards; keyboard activation of the picker.
- `e2e-playwright/alerting-suite/import-to-gma-notification-templates.spec.ts` — add notification template files by picker and by drag, remove one, and the duplicate-file-name validation.
- `e2e-playwright/various-suite/help-modal-shortcut.spec.ts` — the shortcut opens exactly one dialog, Escape and the close button dismiss it, and repeated presses do not stack modals.
- `e2e-playwright/utils/dropzone-helpers.ts` — locate a dropzone's file input, and drag real files onto it over CDP.

Tests only; no product code changes.

**Why do we need this feature?**

These flows had no e2e coverage at all. `dashboards-suite/import-dashboard.spec.ts` pastes JSON into the textarea and never touches the dropzone, and `setInputFiles` appears nowhere in the suite — so nothing exercised reading a file, parsing it, or handing the result to a form. The `?` help modal was likewise uncovered (`various-suite/keybinds.spec.ts` covers the navigation and time-range bindings only).

That gap matters right now because #132382 moves `FileDropzone` behind a lazy boundary and a `Suspense` fallback, which changes when these controls appear and when they become usable. This coverage is on `main` and independent of that PR.

Two things worth knowing for anyone writing similar tests:

- A `DataTransfer` built in page context cannot drive react-dropzone. The event arrives with `types: ['Files']` and one file, but file-selector calls `getFile()` on the drag item's file-system handle, which synthetic items do not have — the drop throws `Cannot read properties of undefined (reading 'getFile')` and the dropzone silently stays empty. The helper uses CDP `Input.dispatchDragEvent` with real file paths instead (Chromium-only, which is what this suite runs; `various-suite/perf-test.spec.ts` already uses CDP).
- `keyboard.type('?')` does not trigger the help modal — mousetrap never sees it. `keyboard.press('Shift+Slash')` does.

**Who is this feature for?**

Contributors touching `FileDropzone`, the dashboard import page, the alerting import wizard, or global keybindings.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Verification:

- All 12 tests pass locally against a dev server: `yarn e2e:playwright --project dashboards --project various --project alerting --grep "Import a dashboard from a file|Shortcuts help modal|notification templates"`.
- Mutation-checked two of the picker assertions (wrong expected dashboard title, wrong expected file name) and confirmed both go red, so they are not tautologies.
- `prettier` and `eslint` clean.

Not covered, and why — both are product gaps rather than test gaps, flagged here rather than worked around:

- Image/icon resource uploads. `ResourcePickerPopover` renders only the Folder and URL tab buttons; nothing sets `PickerTabType.Upload`, so the dropzone behind it is unreachable from the UI.
- The legacy `mod+s` save and `p s` share shortcuts. `keybindingSrv.setupDashboardBindings` has no production callers (only its definition and a jest mock), so there is no path to drive those handlers.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
