### PR TITLE
PanelEdit: Conditional field config display & edit context

### DIFF
--- a/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
+++ b/packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts
@@ -3,6 +3,7 @@ import { type ComponentType } from 'react';
 import { type EventBus } from '../events/types';
 import { type DataFrame } from '../types/dataFrame';
 import { type VariableSuggestionsScope, type VariableSuggestion } from '../types/dataLink';
+import { type FieldConfigSource } from '../types/fieldOverrides';
 import { type InterpolateFunction } from '../types/panel';
 import { Registry, type RegistryItem } from '../utils/Registry';
 
@@ -17,6 +18,13 @@ export interface StandardEditorContext<TOptions, TState = any> {
   instanceState?: TState;
   isOverride?: boolean;
   annotations?: DataFrame[];
+  /**
+   * The panel's field config - standard defaults, custom defaults and override rules.
+   *
+   * Undefined outside a panel options pane (transformation editors, canvas inline edit) and while
+   * PanelPlugin collects static defaults, so always guard before reading.
+   */
+  fieldConfig?: FieldConfigSource;
 }
 
 export interface StandardEditorProps<TValue = any, TSettings = any, TOptions = any, TState = any> {

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -4,6 +4,7 @@ import { type ComponentClass, type ComponentType } from 'react';
 import { FieldConfigOptionsRegistry } from '../field/FieldConfigOptionsRegistry';
 import { type StandardEditorContext } from '../field/standardFieldConfigEditorRegistry';
 import { type PanelModel } from '../types/dashboard';
+import { type FieldConfig } from '../types/dataFrame';
 import {
   type FieldConfigProperty,
   type FieldConfigPropertyItem,
@@ -46,7 +47,7 @@ export type StandardOptionConfig = {
    * Only affects the defaults pane - the property is still offered for override rules. Use
    * {@link SetFieldConfigOptionsArgs.disableStandardOptions} to remove it everywhere.
    */
-  showIf?: FieldConfigPropertyItem['showIf'];
+  showIf?: FieldConfigPropertyItem<FieldConfig>['showIf'];
 };
 
 /**

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -36,7 +36,7 @@ import { createFieldConfigRegistry } from './registryFactories';
 import { type PanelDataSummary } from './suggestions/getPanelDataSummary';
 
 /** @beta */
-export type StandardOptionConfig = {
+export type StandardOptionConfig<TContextOptions = unknown> = {
   defaultValue?: any;
   settings?: any;
   hideFromDefaults?: boolean;
@@ -47,7 +47,7 @@ export type StandardOptionConfig = {
    * Only affects the defaults pane - the property is still offered for override rules. Use
    * {@link SetFieldConfigOptionsArgs.disableStandardOptions} to remove it everywhere.
    */
-  showIf?: FieldConfigPropertyItem<FieldConfig>['showIf'];
+  showIf?: FieldConfigPropertyItem<FieldConfig, unknown, {}, TContextOptions>['showIf'];
 };
 
 /**
@@ -77,7 +77,7 @@ export interface PanelScreenshotContext {
 export type PanelScreenshotHandler = (ctx: PanelScreenshotContext) => Promise<Blob | null>;
 
 /** @beta */
-export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
+export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any, TContextOptions = unknown> {
   /**
    * Configuration object of the standard field config properites
    *
@@ -92,7 +92,7 @@ export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
    * }
    * ```
    */
-  standardOptions?: Partial<Record<FieldConfigProperty, StandardOptionConfig>>;
+  standardOptions?: Partial<Record<FieldConfigProperty, StandardOptionConfig<TContextOptions>>>;
 
   /**
    * Array of standard field config properties that should not be available in the panel
@@ -134,7 +134,7 @@ export interface SetFieldConfigOptionsArgs<TFieldConfigOptions = any> {
    * }
    * ```
    */
-  useCustomConfig?: (builder: FieldConfigEditorBuilder<TFieldConfigOptions>) => void;
+  useCustomConfig?: (builder: FieldConfigEditorBuilder<TFieldConfigOptions, TContextOptions>) => void;
 }
 
 /**
@@ -460,7 +460,7 @@ export class PanelPlugin<
    *
    * @public
    */
-  useFieldConfig(config: SetFieldConfigOptionsArgs<TFieldConfigOptions> = {}) {
+  useFieldConfig(config: SetFieldConfigOptionsArgs<TFieldConfigOptions, TOptions> = {}) {
     // builder is applied lazily when custom field configs are accessed
     this._initConfigRegistry = () => createFieldConfigRegistry(config, this.meta.name);
 

--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -4,7 +4,11 @@ import { type ComponentClass, type ComponentType } from 'react';
 import { FieldConfigOptionsRegistry } from '../field/FieldConfigOptionsRegistry';
 import { type StandardEditorContext } from '../field/standardFieldConfigEditorRegistry';
 import { type PanelModel } from '../types/dashboard';
-import { type FieldConfigProperty, type FieldConfigSource } from '../types/fieldOverrides';
+import {
+  type FieldConfigProperty,
+  type FieldConfigPropertyItem,
+  type FieldConfigSource,
+} from '../types/fieldOverrides';
 import {
   type PanelPluginMeta,
   type PanelProps,
@@ -35,6 +39,14 @@ export type StandardOptionConfig = {
   defaultValue?: any;
   settings?: any;
   hideFromDefaults?: boolean;
+  /**
+   * Conditionally hide this standard property in the options pane. Replaces any showIf the property
+   * declares itself, so a panel can force a property visible as well as hide it.
+   *
+   * Only affects the defaults pane - the property is still offered for override rules. Use
+   * {@link SetFieldConfigOptionsArgs.disableStandardOptions} to remove it everywhere.
+   */
+  showIf?: FieldConfigPropertyItem['showIf'];
 };
 
 /**

--- a/packages/grafana-data/src/panel/registryFactories.test.ts
+++ b/packages/grafana-data/src/panel/registryFactories.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../field/standardFieldConfigEditorRegistry';
 import { FieldConfigProperty, type FieldConfigPropertyItem } from '../types/fieldOverrides';
 
+import { type SetFieldConfigOptionsArgs } from './PanelPlugin';
 import { createFieldConfigRegistry } from './registryFactories';
 
 describe('createFieldConfigRegistry', () => {
@@ -62,6 +63,72 @@ describe('createFieldConfigRegistry', () => {
     const otherPlugin = createFieldConfigRegistry({}, 'Other');
 
     expect(otherPlugin.getIfExists('min')?.showIf).toBeUndefined();
+  });
+
+  describe('typing the editor context to the panel options', () => {
+    interface Options {
+      showUnit: boolean;
+    }
+
+    interface CustomConfig {
+      lineWidth: number;
+    }
+
+    // The context options default to `any`, which would satisfy a plain property access even if the
+    // type stopped being threaded through. Collapsing `any` to `never` makes these tests fail to
+    // compile in that case, which is the regression they exist to catch.
+    type NotAny<T> = 0 extends 1 & T ? never : T;
+
+    it('types context.options for a standard property, so a showIf needs no cast', () => {
+      const showIf = jest.fn().mockReturnValue(true);
+      const config: SetFieldConfigOptionsArgs<CustomConfig, Options> = {
+        standardOptions: {
+          [FieldConfigProperty.Min]: {
+            showIf: (defaults, _data, _annotations, ctx) => {
+              const options: NotAny<NonNullable<typeof ctx>['options']> = ctx?.options;
+              return showIf(defaults, options?.showUnit);
+            },
+          },
+        },
+      };
+
+      const registry = createFieldConfigRegistry(config, 'Test');
+      registry
+        .getIfExists('min')
+        ?.showIf?.({ min: 1 }, undefined, undefined, { data: [], options: { showUnit: true } });
+
+      expect(showIf).toHaveBeenCalledWith({ min: 1 }, true);
+    });
+
+    it('types context.options for a custom property, so a showIf needs no cast', () => {
+      const showIf = jest.fn().mockReturnValue(true);
+      const config: SetFieldConfigOptionsArgs<CustomConfig, Options> = {
+        useCustomConfig: (builder) => {
+          // addCustomEditor rather than addNumberInput, so the test does not depend on the
+          // standard editors registry being initialised
+          builder.addCustomEditor({
+            id: 'lineWidth',
+            path: 'lineWidth',
+            name: 'Line width',
+            editor: jest.fn(),
+            override: jest.fn(),
+            process: (value) => value,
+            shouldApply: () => true,
+            showIf: (custom, _data, _annotations, ctx) => {
+              const options: NotAny<NonNullable<typeof ctx>['options']> = ctx?.options;
+              return showIf(custom.lineWidth, options?.showUnit);
+            },
+          });
+        },
+      };
+
+      const registry = createFieldConfigRegistry(config, 'Test');
+      registry
+        .getIfExists('custom.lineWidth')
+        ?.showIf?.({ lineWidth: 2 }, undefined, undefined, { data: [], options: { showUnit: false } });
+
+      expect(showIf).toHaveBeenCalledWith(2, false);
+    });
   });
 
   it('forwards the editor context to a plugin-supplied showIf', () => {

--- a/packages/grafana-data/src/panel/registryFactories.test.ts
+++ b/packages/grafana-data/src/panel/registryFactories.test.ts
@@ -1,0 +1,76 @@
+import {
+  type StandardEditorContext,
+  standardFieldConfigEditorRegistry,
+} from '../field/standardFieldConfigEditorRegistry';
+import { FieldConfigProperty, type FieldConfigPropertyItem } from '../types/fieldOverrides';
+
+import { createFieldConfigRegistry } from './registryFactories';
+
+describe('createFieldConfigRegistry', () => {
+  // `max` ships a showIf of its own, like fieldMinMax does in core, so we can check what a
+  // plugin-supplied showIf does to it.
+  const builtInShowIf = () => true;
+
+  beforeAll(() => {
+    standardFieldConfigEditorRegistry.setInit(
+      () =>
+        [
+          { id: FieldConfigProperty.Min, path: 'min' },
+          { id: FieldConfigProperty.Max, path: 'max', showIf: builtInShowIf },
+        ] as FieldConfigPropertyItem[]
+    );
+  });
+
+  it('attaches a plugin-supplied showIf to a standard property', () => {
+    const showIf = jest.fn().mockReturnValue(false);
+
+    const registry = createFieldConfigRegistry({ standardOptions: { [FieldConfigProperty.Min]: { showIf } } }, 'Test');
+
+    expect(registry.getIfExists('min')?.showIf).toBe(showIf);
+  });
+
+  it('leaves properties the plugin did not configure alone', () => {
+    const registry = createFieldConfigRegistry(
+      { standardOptions: { [FieldConfigProperty.Min]: { showIf: jest.fn() } } },
+      'Test'
+    );
+
+    expect(registry.getIfExists('max')?.showIf).toBe(builtInShowIf);
+  });
+
+  it("replaces a property's own showIf, so a plugin can force it visible", () => {
+    const showIf = jest.fn().mockReturnValue(true);
+
+    const registry = createFieldConfigRegistry({ standardOptions: { [FieldConfigProperty.Max]: { showIf } } }, 'Test');
+
+    expect(registry.getIfExists('max')?.showIf).toBe(showIf);
+  });
+
+  it('keeps the built-in showIf when only other settings are overridden', () => {
+    const registry = createFieldConfigRegistry(
+      { standardOptions: { [FieldConfigProperty.Max]: { defaultValue: 10 } } },
+      'Test'
+    );
+
+    expect(registry.getIfExists('max')?.showIf).toBe(builtInShowIf);
+    expect(registry.getIfExists('max')?.defaultValue).toBe(10);
+  });
+
+  it('does not leak a plugin showIf into other plugins via the shared standard registry', () => {
+    createFieldConfigRegistry({ standardOptions: { [FieldConfigProperty.Min]: { showIf: jest.fn() } } }, 'Test');
+
+    const otherPlugin = createFieldConfigRegistry({}, 'Other');
+
+    expect(otherPlugin.getIfExists('min')?.showIf).toBeUndefined();
+  });
+
+  it('forwards the editor context to a plugin-supplied showIf', () => {
+    const showIf = jest.fn().mockReturnValue(true);
+    const context = { data: [], options: { showValues: true } } as StandardEditorContext<unknown, unknown>;
+
+    const registry = createFieldConfigRegistry({ standardOptions: { [FieldConfigProperty.Min]: { showIf } } }, 'Test');
+    registry.getIfExists('min')?.showIf?.({}, undefined, undefined, context);
+
+    expect(showIf).toHaveBeenCalledWith({}, undefined, undefined, context);
+  });
+});

--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -54,6 +54,14 @@ export function createFieldConfigRegistry<TFieldConfigOptions>(
       const customHideFromDefaults = config.standardOptions[id]?.hideFromDefaults;
       const customDefault = config.standardOptions[id]?.defaultValue;
       const customSettings = config.standardOptions[id]?.settings;
+      const customShowIf = config.standardOptions[id]?.showIf;
+
+      if (customShowIf) {
+        fieldConfigProp = {
+          ...fieldConfigProp,
+          showIf: customShowIf,
+        };
+      }
 
       if (customHideFromDefaults !== undefined) {
         fieldConfigProp = {

--- a/packages/grafana-data/src/panel/registryFactories.ts
+++ b/packages/grafana-data/src/panel/registryFactories.ts
@@ -12,8 +12,8 @@ import { type SetFieldConfigOptionsArgs } from './PanelPlugin';
  * @param pluginName - name of the plugin that will use the registry.
  * @internal
  */
-export function createFieldConfigRegistry<TFieldConfigOptions>(
-  config: SetFieldConfigOptionsArgs<TFieldConfigOptions> = {},
+export function createFieldConfigRegistry<TFieldConfigOptions, TContextOptions = unknown>(
+  config: SetFieldConfigOptionsArgs<TFieldConfigOptions, TContextOptions> = {},
   pluginName: string
 ): FieldConfigOptionsRegistry {
   const registry = new FieldConfigOptionsRegistry();
@@ -22,7 +22,7 @@ export function createFieldConfigRegistry<TFieldConfigOptions>(
 
   // Add custom options
   if (config.useCustomConfig) {
-    const builder = new FieldConfigEditorBuilder<TFieldConfigOptions>();
+    const builder = new FieldConfigEditorBuilder<TFieldConfigOptions, TContextOptions>();
     config.useCustomConfig(builder);
 
     for (const customProp of builder.getRegistry().list()) {

--- a/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
+++ b/packages/grafana-data/src/types/OptionsUIRegistryBuilder.ts
@@ -13,9 +13,9 @@ import { type OptionEditorConfig } from './options';
 /**
  * Option editor registry item
  */
-export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>
+export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue, TContextOptions = unknown>
   extends RegistryItem,
-    OptionEditorConfig<TOptions, TSettings, TValue> {
+    OptionEditorConfig<TOptions, TSettings, TValue, TContextOptions> {
   /**
    * React component used to edit the options property
    */
@@ -35,7 +35,8 @@ export interface OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>
 interface OptionsUIRegistryBuilderAPI<
   TOptions,
   TEditorProps,
-  T extends OptionsEditorItem<TOptions, any, TEditorProps, any>,
+  T extends OptionsEditorItem<TOptions, any, TEditorProps, any, TContextOptions>,
+  TContextOptions = unknown,
 > {
   addNumberInput?<TSettings extends NumberFieldConfigSettings = NumberFieldConfigSettings>(
     config: OptionEditorConfig<TOptions, TSettings, number>
@@ -71,7 +72,9 @@ interface OptionsUIRegistryBuilderAPI<
    * Enables custom editor definition
    * @param config
    */
-  addCustomEditor<TSettings, TValue>(config: OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this;
+  addCustomEditor<TSettings, TValue>(
+    config: OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue, TContextOptions>
+  ): this;
 
   /**
    * Returns registry of option editors
@@ -82,12 +85,15 @@ interface OptionsUIRegistryBuilderAPI<
 export abstract class OptionsUIRegistryBuilder<
   TOptions,
   TEditorProps,
-  T extends OptionsEditorItem<TOptions, any, TEditorProps, any>,
-> implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T>
+  T extends OptionsEditorItem<TOptions, any, TEditorProps, any, TContextOptions>,
+  TContextOptions = unknown,
+> implements OptionsUIRegistryBuilderAPI<TOptions, TEditorProps, T, TContextOptions>
 {
   private properties: T[] = [];
 
-  addCustomEditor<TSettings, TValue>(config: T & OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue>): this {
+  addCustomEditor<TSettings, TValue>(
+    config: T & OptionsEditorItem<TOptions, TSettings, TEditorProps, TValue, TContextOptions>
+  ): this {
     this.properties.push(config);
     return this;
   }

--- a/packages/grafana-data/src/types/fieldOverrides.ts
+++ b/packages/grafana-data/src/types/fieldOverrides.ts
@@ -74,8 +74,8 @@ export type FieldConfigEditorProps<TValue, TSettings extends {}> = StandardEdito
 /** @deprecated Use StandardEditorProps instead */
 export type FieldOverrideEditorProps<TValue, TSettings extends {}> = StandardEditorProps<TValue, TSettings>;
 
-export interface FieldConfigEditorConfig<TOptions, TSettings = any, TValue = any>
-  extends OptionEditorConfig<TOptions, TSettings, TValue> {
+export interface FieldConfigEditorConfig<TOptions, TSettings = any, TValue = any, TContextOptions = unknown>
+  extends OptionEditorConfig<TOptions, TSettings, TValue, TContextOptions> {
   /**
    * Function that allows specifying whether or not this field config should apply to a given field.
    * @param field
@@ -89,8 +89,12 @@ export interface FieldConfigEditorConfig<TOptions, TSettings = any, TValue = any
   hideFromOverrides?: boolean;
 }
 
-export interface FieldConfigPropertyItem<TOptions = any, TValue = any, TSettings extends {} = any>
-  extends OptionsEditorItem<TOptions, TSettings, StandardEditorProps<TValue, TSettings>, TValue> {
+export interface FieldConfigPropertyItem<
+  TOptions = any,
+  TValue = any,
+  TSettings extends {} = any,
+  TContextOptions = unknown,
+> extends OptionsEditorItem<TOptions, TSettings, StandardEditorProps<TValue, TSettings>, TValue, TContextOptions> {
   // An editor that can be filled in with context info (template variables etc)
   override: ComponentType<StandardEditorProps<TValue, TSettings>>;
 

--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -1,3 +1,5 @@
+import { type StandardEditorContext } from '../field/standardFieldConfigEditorRegistry';
+
 import { type DataFrame } from './dataFrame';
 
 /**
@@ -49,7 +51,21 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
   defaultValue?: TValue;
 
   /**
-   * Function that enables configuration of when option editor should be shown based on current panel option properties.
+   * Function that enables configuration of when option editor should be shown.
+   *
+   * `currentOptions` is the object the editor is registered against: the panel options for a panel
+   * option, `fieldConfig.defaults.custom` for a custom field config property, and
+   * `fieldConfig.defaults` for a standard one.
+   *
+   * `context` is the same editor context the editor component receives, so a condition can span
+   * both sides of the pane - `context.options` for the panel options and `context.fieldConfig` for
+   * the whole field config. It is undefined when options are built outside an options pane (for
+   * example while collecting static defaults), so guard before reading it.
    */
-  showIf?: (currentOptions: TOptions, data?: DataFrame[], annotations?: DataFrame[]) => boolean | undefined;
+  showIf?: (
+    currentOptions: TOptions,
+    data?: DataFrame[],
+    annotations?: DataFrame[],
+    context?: StandardEditorContext<unknown>
+  ) => boolean | undefined;
 }

--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -57,15 +57,15 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any, TCo
    * option, `fieldConfig.defaults.custom` for a custom field config property, and
    * `fieldConfig.defaults` for a standard one.
    *
-   * `context` is the same editor context the editor component receives, so a condition can span
-   * both sides of the pane - `context.options` for the panel options and `context.fieldConfig` for
-   * the whole field config. It is undefined when options are built outside an options pane (for
-   * example while collecting static defaults), so guard before reading it.
+   * `context` is the same editor context the editor component receives. `context.fieldConfig` is
+   * the whole field config, which lets a condition span both sides of the pane. `context.options`
+   * mirrors `currentOptions` rather than adding `addNestedOptions`.
+   * The context is undefined when options are built outside an options pane
    */
-  showIf?: (
+  showIf?(
     currentOptions: TOptions,
     data?: DataFrame[],
     annotations?: DataFrame[],
     context?: StandardEditorContext<TContextOptions>
-  ) => boolean | undefined;
+  ): boolean | undefined;
 }

--- a/packages/grafana-data/src/types/options.ts
+++ b/packages/grafana-data/src/types/options.ts
@@ -7,7 +7,7 @@ import { type DataFrame } from './dataFrame';
  *
  * @beta
  */
-export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
+export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any, TContextOptions = unknown> {
   /**
    * Path of the option property to control.
    *
@@ -66,6 +66,6 @@ export interface OptionEditorConfig<TOptions, TSettings = any, TValue = any> {
     currentOptions: TOptions,
     data?: DataFrame[],
     annotations?: DataFrame[],
-    context?: StandardEditorContext<unknown>
+    context?: StandardEditorContext<TContextOptions>
   ) => boolean | undefined;
 }

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -189,10 +189,10 @@ export type PanelOptionEditorsRegistry = Registry<PanelOptionsEditorItem>;
 export interface PanelOptionsEditorProps<TValue> extends StandardEditorProps<TValue> {}
 
 export interface PanelOptionsEditorItem<TOptions = any, TValue = any, TSettings = any>
-  extends OptionsEditorItem<TOptions, TSettings, PanelOptionsEditorProps<TValue>, TValue> {}
+  extends OptionsEditorItem<TOptions, TSettings, PanelOptionsEditorProps<TValue>, TValue, TOptions> {}
 
 export interface PanelOptionsEditorConfig<TOptions, TSettings = any, TValue = any>
-  extends OptionEditorConfig<TOptions, TSettings, TValue> {}
+  extends OptionEditorConfig<TOptions, TSettings, TValue, TOptions> {}
 
 /**
  * @internal

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -29,12 +29,19 @@ import { type PanelOptionsEditorConfig, type PanelOptionsEditorItem } from '../t
 /**
  * Fluent API for declarative creation of field config option editors
  */
-export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder<
+export class FieldConfigEditorBuilder<TOptions, TContextOptions = unknown> extends OptionsUIRegistryBuilder<
   TOptions,
   StandardEditorProps,
-  FieldConfigPropertyItem<TOptions>
+  // The item type has to carry TContextOptions too: the base class intersects it with the config
+  // type, and if only one side is typed the context degrades. The `any`s keep the item permissive so each add*
+  // method below can narrow value and settings, as before.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  FieldConfigPropertyItem<TOptions, any, any, TContextOptions>,
+  TContextOptions
 > {
-  addNumberInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & NumberFieldConfigSettings, number>) {
+  addNumberInput<TSettings>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & NumberFieldConfigSettings, number, TContextOptions>
+  ) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -46,7 +53,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addSliderInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & SliderFieldConfigSettings, number>) {
+  addSliderInput<TSettings>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & SliderFieldConfigSettings, number, TContextOptions>
+  ) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -58,7 +67,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addTextInput<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & StringFieldConfigSettings, string>) {
+  addTextInput<TSettings>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & StringFieldConfigSettings, string, TContextOptions>
+  ) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -71,7 +82,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 
   addSelect<TOption, TSettings extends SelectFieldConfigSettings<TOption>>(
-    config: FieldConfigEditorConfig<TOptions, TSettings, TOption>
+    config: FieldConfigEditorConfig<TOptions, TSettings, TOption, TContextOptions>
   ) {
     return this.addCustomEditor({
       ...config,
@@ -85,7 +96,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addRadio<TOption, TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, TOption>) {
+  addRadio<TOption, TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, TOption, TContextOptions>) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -99,7 +110,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addBooleanSwitch<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, boolean>) {
+  addBooleanSwitch<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, boolean, TContextOptions>) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -111,7 +122,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addColorPicker<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, string>) {
+  addColorPicker<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings, string, TContextOptions>) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -123,7 +134,9 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
     });
   }
 
-  addUnitPicker<TSettings>(config: FieldConfigEditorConfig<TOptions, TSettings & UnitFieldConfigSettings, string>) {
+  addUnitPicker<TSettings>(
+    config: FieldConfigEditorConfig<TOptions, TSettings & UnitFieldConfigSettings, string, TContextOptions>
+  ) {
     return this.addCustomEditor({
       ...config,
       id: config.path,
@@ -136,7 +149,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 
   addFieldNamePicker<TSettings>(
-    config: FieldConfigEditorConfig<TOptions, TSettings & FieldNamePickerConfigSettings, string>
+    config: FieldConfigEditorConfig<TOptions, TSettings & FieldNamePickerConfigSettings, string, TContextOptions>
   ): this {
     return this.addCustomEditor({
       ...config,
@@ -150,7 +163,7 @@ export class FieldConfigEditorBuilder<TOptions> extends OptionsUIRegistryBuilder
   }
 
   addGenericEditor<TSettings>(
-    config: FieldConfigEditorConfig<TOptions, TSettings & any>, // & any... i give up!
+    config: FieldConfigEditorConfig<TOptions, TSettings & any, unknown, TContextOptions>, // & any... i give up!
     editor: (props: StandardEditorProps<TSettings>) => JSX.Element
   ): this {
     return this.addCustomEditor({

--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -257,7 +257,8 @@ export function isNestedPanelOptions(item: unknown): item is NestedPanelOptionsB
 export class PanelOptionsEditorBuilder<TOptions> extends OptionsUIRegistryBuilder<
   TOptions,
   StandardEditorProps,
-  PanelOptionsEditorItem<TOptions>
+  PanelOptionsEditorItem<TOptions>,
+  TOptions
 > {
   addNestedOptions<Sub>(opts: NestedPanelOptions<Sub>) {
     const s = new NestedPanelOptionsBuilder<Sub>(opts);

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -87,6 +87,29 @@ describe('getFieldOverrideCategories', () => {
     });
   });
 
+  describe('field config in the editor context', () => {
+    it('hands the whole panel field config to an override property editor', () => {
+      const registry = makeRegistry([makeItem('custom.lineWidth')]);
+      const fieldConfig: FieldConfigSource = {
+        defaults: { unit: 'bytes', custom: { lineWidth: 2 } },
+        overrides: [
+          { matcher: { id: 'byName', options: 'A-series' }, properties: [{ id: 'custom.lineWidth', value: 5 }] },
+        ],
+      };
+
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', jest.fn());
+
+      const propertyItem = categories[0].items.find((item) => item.props.id?.includes('-property-'));
+      const element = propertyItem?.props.render(propertyItem!) as React.ReactElement<{
+        context: { fieldConfig?: FieldConfigSource; isOverride?: boolean };
+      }>;
+
+      // an editor in an override row can read the defaults it is overriding, not just its own value
+      expect(element.props.context.fieldConfig).toBe(fieldConfig);
+      expect(element.props.context.isOverride).toBe(true);
+    });
+  });
+
   describe('hideFromOverrides', () => {
     it('excludes items with hideFromOverrides:true from the add override property picker', () => {
       const registry = makeRegistry([

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -99,6 +99,7 @@ export function getFieldOverrideCategories(
     const overrideData = getFramesForMatcherScope(data, override.matcher.scope);
     const context = {
       data: overrideData,
+      fieldConfig: currentFieldConfig,
       getSuggestions: (scope?: VariableSuggestionsScope) => getDataLinksVariableSuggestions(overrideData, scope),
       isOverride: true,
     };

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -1,5 +1,6 @@
 import {
   EventBusSrv,
+  type FieldConfig,
   type FieldConfigOptionsRegistry,
   type FieldConfigPropertyItem,
   type FieldConfigSource,
@@ -448,7 +449,9 @@ describe('getVisualizationOptions', () => {
       overrides: [],
     };
 
-    const makeItem = (overrides: Partial<FieldConfigPropertyItem> = {}): FieldConfigPropertyItem => ({
+    const makeItem = <TContextOptions = unknown>(
+      overrides: Partial<FieldConfigPropertyItem<FieldConfig, unknown, {}, TContextOptions>> = {}
+    ): FieldConfigPropertyItem => ({
       id: 'unit',
       path: 'unit',
       name: 'Unit',
@@ -462,45 +465,41 @@ describe('getVisualizationOptions', () => {
     const context = { data: [], options: { showValues: true }, fieldConfig } as StandardEditorContext<unknown, unknown>;
 
     it('shows a property that declares no showIf', () => {
-      expect(isFieldConfigOptionVisible(makeItem(), fieldConfig, undefined, context)).toBe(true);
+      expect(isFieldConfigOptionVisible(makeItem(), undefined, context)).toBe(true);
     });
 
     it('hides a property flagged hideFromDefaults without consulting showIf', () => {
       const showIf = jest.fn().mockReturnValue(true);
 
-      expect(
-        isFieldConfigOptionVisible(makeItem({ hideFromDefaults: true, showIf }), fieldConfig, undefined, context)
-      ).toBe(false);
+      expect(isFieldConfigOptionVisible(makeItem({ hideFromDefaults: true, showIf }), undefined, context)).toBe(false);
       expect(showIf).not.toHaveBeenCalled();
     });
 
     it('hides the property when showIf returns undefined', () => {
       const item = makeItem({ showIf: () => undefined });
 
-      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(false);
+      expect(isFieldConfigOptionVisible(item, undefined, context)).toBe(false);
     });
 
     it('passes the standard defaults to a standard property and the custom defaults to a custom one', () => {
       const standardShowIf = jest.fn().mockReturnValue(true);
       const customShowIf = jest.fn().mockReturnValue(true);
 
-      isFieldConfigOptionVisible(makeItem({ showIf: standardShowIf }), fieldConfig, undefined, context);
-      isFieldConfigOptionVisible(makeItem({ isCustom: true, showIf: customShowIf }), fieldConfig, undefined, context);
+      isFieldConfigOptionVisible(makeItem({ showIf: standardShowIf }), undefined, context);
+      isFieldConfigOptionVisible(makeItem({ isCustom: true, showIf: customShowIf }), undefined, context);
 
       expect(standardShowIf.mock.calls[0][0]).toEqual({ unit: 'bytes', custom: { lineWidth: 2 } });
       expect(customShowIf.mock.calls[0][0]).toEqual({ lineWidth: 2 });
     });
 
     it('lets a standard property condition on a panel option via the editor context', () => {
-      const item = makeItem({
-        showIf: (_defaults, _data, _annotations, ctx) =>
-          (ctx?.options as { showValues?: boolean } | undefined)?.showValues === true,
+      // ctx.options is typed here, not unknown - this stops compiling if that regresses
+      const item = makeItem<{ showValues: boolean }>({
+        showIf: (_defaults, _data, _annotations, ctx) => ctx?.options?.showValues === true,
       });
 
-      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(true);
-      expect(
-        isFieldConfigOptionVisible(item, fieldConfig, undefined, { ...context, options: { showValues: false } })
-      ).toBe(false);
+      expect(isFieldConfigOptionVisible(item, undefined, context)).toBe(true);
+      expect(isFieldConfigOptionVisible(item, undefined, { ...context, options: { showValues: false } })).toBe(false);
     });
 
     it('lets a custom property condition on the standard defaults via the editor context', () => {
@@ -509,12 +508,17 @@ describe('getVisualizationOptions', () => {
         showIf: (_custom, _data, _annotations, ctx) => ctx?.fieldConfig?.defaults.unit === 'bytes',
       });
 
-      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(true);
+      expect(isFieldConfigOptionVisible(item, undefined, context)).toBe(true);
 
       const withoutUnit: FieldConfigSource = { defaults: { custom: { lineWidth: 2 } }, overrides: [] };
-      expect(isFieldConfigOptionVisible(item, withoutUnit, undefined, { ...context, fieldConfig: withoutUnit })).toBe(
-        false
-      );
+      expect(isFieldConfigOptionVisible(item, undefined, { ...context, fieldConfig: withoutUnit })).toBe(false);
+    });
+
+    it('hides a property whose showIf needs the field config when the context has none', () => {
+      // transformation editors and canvas inline edit build a context without a field config
+      const item = makeItem({ showIf: (defaults) => defaults.unit === 'bytes' });
+
+      expect(isFieldConfigOptionVisible(item, undefined, { data: [] })).toBe(false);
     });
 
     it('passes the series and annotations through to showIf', () => {
@@ -524,7 +528,6 @@ describe('getVisualizationOptions', () => {
 
       isFieldConfigOptionVisible(
         makeItem({ showIf }),
-        fieldConfig,
         { series, annotations, state: LoadingState.Done, timeRange: getDefaultTimeRange() },
         context
       );

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -2,16 +2,23 @@ import {
   EventBusSrv,
   type FieldConfigOptionsRegistry,
   type FieldConfigPropertyItem,
+  type FieldConfigSource,
   FieldType,
   getDefaultTimeRange,
   LoadingState,
+  type PanelOptionsEditorBuilder,
   type PanelPlugin,
   Registry,
+  type StandardEditorContext,
   toDataFrame,
 } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 
-import { getStandardEditorContext, getVisualizationOptions2 } from './getVisualizationOptions';
+import {
+  getStandardEditorContext,
+  getVisualizationOptions2,
+  isFieldConfigOptionVisible,
+} from './getVisualizationOptions';
 
 describe('getVisualizationOptions', () => {
   describe('getStandardEditorContext', () => {
@@ -20,6 +27,7 @@ describe('getVisualizationOptions', () => {
         data: undefined,
         replaceVariables: jest.fn(),
         options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
         eventBus: new EventBusSrv(),
         instanceState: {},
       });
@@ -32,6 +40,7 @@ describe('getVisualizationOptions', () => {
         data: undefined,
         replaceVariables: jest.fn(),
         options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
         eventBus: new EventBusSrv(),
         instanceState: {},
       });
@@ -103,6 +112,7 @@ describe('getVisualizationOptions', () => {
         data: panelData,
         replaceVariables: jest.fn(),
         options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
         eventBus: new EventBusSrv(),
         instanceState: {},
       });
@@ -426,6 +436,206 @@ describe('getVisualizationOptions', () => {
       expect(showIfSpy.mock.calls.length).toEqual(1);
       expect(showIfSpy.mock.calls[0][0].displayName).toBe('default');
       expect(showIfSpy.mock.calls[0][2][0].fields[0].config.displayName).toBe('annotation');
+    });
+  });
+
+  describe('isFieldConfigOptionVisible', () => {
+    const fieldConfig: FieldConfigSource = {
+      defaults: {
+        unit: 'bytes',
+        custom: { lineWidth: 2 },
+      },
+      overrides: [],
+    };
+
+    const makeItem = (overrides: Partial<FieldConfigPropertyItem> = {}): FieldConfigPropertyItem => ({
+      id: 'unit',
+      path: 'unit',
+      name: 'Unit',
+      process: (value) => value,
+      shouldApply: () => true,
+      override: jest.fn(),
+      editor: jest.fn(),
+      ...overrides,
+    });
+
+    const context = { data: [], options: { showValues: true }, fieldConfig } as StandardEditorContext<unknown, unknown>;
+
+    it('shows a property that declares no showIf', () => {
+      expect(isFieldConfigOptionVisible(makeItem(), fieldConfig, undefined, context)).toBe(true);
+    });
+
+    it('hides a property flagged hideFromDefaults without consulting showIf', () => {
+      const showIf = jest.fn().mockReturnValue(true);
+
+      expect(
+        isFieldConfigOptionVisible(makeItem({ hideFromDefaults: true, showIf }), fieldConfig, undefined, context)
+      ).toBe(false);
+      expect(showIf).not.toHaveBeenCalled();
+    });
+
+    it('hides the property when showIf returns undefined', () => {
+      const item = makeItem({ showIf: () => undefined });
+
+      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(false);
+    });
+
+    it('passes the standard defaults to a standard property and the custom defaults to a custom one', () => {
+      const standardShowIf = jest.fn().mockReturnValue(true);
+      const customShowIf = jest.fn().mockReturnValue(true);
+
+      isFieldConfigOptionVisible(makeItem({ showIf: standardShowIf }), fieldConfig, undefined, context);
+      isFieldConfigOptionVisible(makeItem({ isCustom: true, showIf: customShowIf }), fieldConfig, undefined, context);
+
+      expect(standardShowIf.mock.calls[0][0]).toEqual({ unit: 'bytes', custom: { lineWidth: 2 } });
+      expect(customShowIf.mock.calls[0][0]).toEqual({ lineWidth: 2 });
+    });
+
+    it('lets a standard property condition on a panel option via the editor context', () => {
+      const item = makeItem({
+        showIf: (_defaults, _data, _annotations, ctx) =>
+          (ctx?.options as { showValues?: boolean } | undefined)?.showValues === true,
+      });
+
+      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(true);
+      expect(
+        isFieldConfigOptionVisible(item, fieldConfig, undefined, { ...context, options: { showValues: false } })
+      ).toBe(false);
+    });
+
+    it('lets a custom property condition on the standard defaults via the editor context', () => {
+      const item = makeItem({
+        isCustom: true,
+        showIf: (_custom, _data, _annotations, ctx) => ctx?.fieldConfig?.defaults.unit === 'bytes',
+      });
+
+      expect(isFieldConfigOptionVisible(item, fieldConfig, undefined, context)).toBe(true);
+
+      const withoutUnit: FieldConfigSource = { defaults: { custom: { lineWidth: 2 } }, overrides: [] };
+      expect(isFieldConfigOptionVisible(item, withoutUnit, undefined, { ...context, fieldConfig: withoutUnit })).toBe(
+        false
+      );
+    });
+
+    it('passes the series and annotations through to showIf', () => {
+      const showIf = jest.fn().mockReturnValue(true);
+      const series = [toDataFrame({ fields: [{ name: 'value', values: [1] }] })];
+      const annotations = [toDataFrame({ fields: [{ name: 'time', values: [1] }] })];
+
+      isFieldConfigOptionVisible(
+        makeItem({ showIf }),
+        fieldConfig,
+        { series, annotations, state: LoadingState.Done, timeRange: getDefaultTimeRange() },
+        context
+      );
+
+      expect(showIf.mock.calls[0][1]).toBe(series);
+      expect(showIf.mock.calls[0][2]).toBe(annotations);
+    });
+  });
+
+  describe('editor context in showIf', () => {
+    const fieldConfig: FieldConfigSource = {
+      defaults: { unit: 'bytes', custom: { lineWidth: 2 } },
+      overrides: [],
+    };
+
+    const vizPanel = new VizPanel({ title: 'Panel A', pluginId: 'timeseries', key: 'panel-12', fieldConfig });
+
+    const getPlugin = (
+      fieldConfigItems: FieldConfigPropertyItem[],
+      optionsSupplier?: (builder: PanelOptionsEditorBuilder<unknown>) => void
+    ) =>
+      ({
+        meta: { skipDataQuery: false, name: 'Timeseries' },
+        getPanelOptionsSupplier: () => optionsSupplier ?? (() => {}),
+        fieldConfigRegistry: new Registry<FieldConfigPropertyItem>(() => fieldConfigItems),
+      }) as unknown as PanelPlugin;
+
+    const buildOptions = (plugin: PanelPlugin, currentOptions: Record<string, unknown>) =>
+      getVisualizationOptions2({
+        panel: vizPanel,
+        eventBus: new EventBusSrv(),
+        plugin,
+        instanceState: {},
+        currentOptions,
+        currentFieldConfig: fieldConfig,
+        reportInteractionUI: 'panel-edit',
+      });
+
+    it('hands a field config showIf the panel options and the whole field config', () => {
+      const showIf = jest.fn().mockReturnValue(true);
+      const plugin = getPlugin([
+        {
+          id: 'custom.property1',
+          path: 'property1',
+          isCustom: true,
+          process: (value) => value,
+          shouldApply: () => true,
+          override: jest.fn(),
+          editor: jest.fn(),
+          name: 'Property 1',
+          showIf,
+        },
+      ]);
+
+      buildOptions(plugin, { showValues: true });
+
+      const context = showIf.mock.calls[0][3];
+      expect(context.options).toEqual({ showValues: true });
+      expect(context.fieldConfig).toEqual(fieldConfig);
+    });
+
+    it('hides a standard field config property when a panel option turns it off', () => {
+      const makePlugin = () =>
+        getPlugin([
+          {
+            id: 'unit',
+            path: 'unit',
+            name: 'Unit',
+            process: (value) => value,
+            shouldApply: () => true,
+            override: jest.fn(),
+            editor: jest.fn(),
+            showIf: (_defaults, _data, _annotations, ctx) =>
+              (ctx?.options as { showUnit?: boolean } | undefined)?.showUnit === true,
+          },
+        ]);
+
+      expect(buildOptions(makePlugin(), { showUnit: true })[0].items.length).toEqual(1);
+      expect(buildOptions(makePlugin(), { showUnit: false })).toEqual([]);
+    });
+
+    it('hides a panel option when its showIf inspects the field config', () => {
+      const supplier = (builder: PanelOptionsEditorBuilder<unknown>) => {
+        builder.addCustomEditor({
+          id: 'lineStyle',
+          path: 'lineStyle',
+          name: 'Line style',
+          editor: jest.fn(),
+          showIf: (_options, _data, _annotations, ctx) =>
+            (ctx?.fieldConfig?.defaults.custom as { lineWidth?: number } | undefined)?.lineWidth === 99,
+        });
+      };
+
+      expect(buildOptions(getPlugin([], supplier), {})).toEqual([]);
+    });
+
+    it('shows a panel option when its showIf matches the field config', () => {
+      const supplier = (builder: PanelOptionsEditorBuilder<unknown>) => {
+        builder.addCustomEditor({
+          id: 'lineStyle',
+          path: 'lineStyle',
+          name: 'Line style',
+          editor: jest.fn(),
+          showIf: (_options, _data, _annotations, ctx) =>
+            (ctx?.fieldConfig?.defaults.custom as { lineWidth?: number } | undefined)?.lineWidth === 2,
+        });
+      };
+
+      const categories = buildOptions(getPlugin([], supplier), {});
+      expect(categories.length).toEqual(1);
+      expect(categories[0].items.length).toEqual(1);
     });
   });
 });

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.test.ts
@@ -542,9 +542,9 @@ describe('getVisualizationOptions', () => {
 
     const vizPanel = new VizPanel({ title: 'Panel A', pluginId: 'timeseries', key: 'panel-12', fieldConfig });
 
-    const getPlugin = (
+    const getPlugin = <TOptions>(
       fieldConfigItems: FieldConfigPropertyItem[],
-      optionsSupplier?: (builder: PanelOptionsEditorBuilder<unknown>) => void
+      optionsSupplier?: (builder: PanelOptionsEditorBuilder<TOptions>) => void
     ) =>
       ({
         meta: { skipDataQuery: false, name: 'Timeseries' },
@@ -619,6 +619,26 @@ describe('getVisualizationOptions', () => {
       };
 
       expect(buildOptions(getPlugin([], supplier), {})).toEqual([]);
+    });
+
+    it('types the editor context to the panel options, so a showIf needs no cast', () => {
+      interface LegendOptions {
+        legend: { showLegend: boolean };
+      }
+
+      const supplier = (builder: PanelOptionsEditorBuilder<LegendOptions>) => {
+        builder.addCustomEditor({
+          id: 'legendValues',
+          path: 'legend.values',
+          name: 'Legend values',
+          editor: jest.fn(),
+          // ctx.options is LegendOptions here, not unknown - this stops compiling if that regresses
+          showIf: (_options, _data, _annotations, ctx) => ctx?.options?.legend.showLegend === true,
+        });
+      };
+
+      expect(buildOptions(getPlugin([], supplier), { legend: { showLegend: true } })[0].items.length).toEqual(1);
+      expect(buildOptions(getPlugin([], supplier), { legend: { showLegend: false } })).toEqual([]);
     });
 
     it('shows a panel option when its showIf matches the field config', () => {

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -66,9 +66,7 @@ export function getStandardEditorContext({
 /**
  * Whether a field config property should appear in the defaults pane.
  *
- * The property's own `showIf` receives the slice it is registered against - `defaults.custom` for a
- * custom property, `defaults` for a standard one - and the editor context, which carries the panel
- * options and the whole field config so a condition can span both.
+ * `data` is a separate argument for backward compatability, but is also contained in the context
  *
  * Overrides are not filtered here: `hideFromOverrides` is the knob for that side, so hiding a
  * property from the defaults pane never hides an override rule that already configures it.
@@ -77,7 +75,6 @@ export function getStandardEditorContext({
  */
 export function isFieldConfigOptionVisible(
   fieldOption: FieldConfigPropertyItem,
-  fieldConfig: FieldConfigSource,
   data: PanelData | undefined,
   context: StandardEditorContext<unknown, unknown>
 ): boolean {
@@ -89,7 +86,9 @@ export function isFieldConfigOptionVisible(
     return true;
   }
 
-  const currentValue = fieldOption.isCustom ? fieldConfig.defaults.custom : fieldConfig.defaults;
+  // A context built outside the options pane carries no field config
+  const defaults = context.fieldConfig?.defaults ?? {};
+  const currentValue = fieldOption.isCustom ? defaults.custom : defaults;
 
   // showIf is typed `boolean | undefined` and an undefined return has always hidden the option.
   return Boolean(fieldOption.showIf(currentValue, data?.series, data?.annotations, context));
@@ -140,7 +139,7 @@ export function getVisualizationOptions(props: OptionPaneRenderProps): OptionsPa
    * Field options
    */
   for (const fieldOption of plugin.fieldConfigRegistry.list()) {
-    if (!isFieldConfigOptionVisible(fieldOption, currentFieldConfig, data, context)) {
+    if (!isFieldConfigOptionVisible(fieldOption, data, context)) {
       continue;
     }
 
@@ -286,7 +285,7 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
 
   // Field options
   for (const fieldOption of plugin.fieldConfigRegistry.list()) {
-    if (!isFieldConfigOptionVisible(fieldOption, currentFieldConfig, data, context)) {
+    if (!isFieldConfigOptionVisible(fieldOption, data, context)) {
       continue;
     }
 

--- a/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getVisualizationOptions.tsx
@@ -11,6 +11,7 @@ import {
   type StandardEditorContext,
   type VariableSuggestionsScope,
   type FieldConfigSource,
+  type FieldConfigPropertyItem,
   PanelOptionsEditorBuilder,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -33,6 +34,7 @@ interface GetStandardEditorContextProps {
   data: PanelData | undefined;
   replaceVariables: InterpolateFunction;
   options: Record<string, unknown>;
+  fieldConfig: FieldConfigSource;
   eventBus: EventBus;
   instanceState: OptionPaneRenderProps['instanceState'];
 }
@@ -41,6 +43,7 @@ export function getStandardEditorContext({
   data,
   replaceVariables,
   options,
+  fieldConfig,
   eventBus,
   instanceState,
 }: GetStandardEditorContextProps): StandardEditorContext<unknown, unknown> {
@@ -50,6 +53,7 @@ export function getStandardEditorContext({
     data: dataSeries,
     replaceVariables,
     options,
+    fieldConfig,
     eventBus,
     getSuggestions: (scope?: VariableSuggestionsScope) => getDataLinksVariableSuggestions(dataSeries, scope),
     instanceState,
@@ -57,6 +61,38 @@ export function getStandardEditorContext({
   };
 
   return context;
+}
+
+/**
+ * Whether a field config property should appear in the defaults pane.
+ *
+ * The property's own `showIf` receives the slice it is registered against - `defaults.custom` for a
+ * custom property, `defaults` for a standard one - and the editor context, which carries the panel
+ * options and the whole field config so a condition can span both.
+ *
+ * Overrides are not filtered here: `hideFromOverrides` is the knob for that side, so hiding a
+ * property from the defaults pane never hides an override rule that already configures it.
+ *
+ * @internal
+ */
+export function isFieldConfigOptionVisible(
+  fieldOption: FieldConfigPropertyItem,
+  fieldConfig: FieldConfigSource,
+  data: PanelData | undefined,
+  context: StandardEditorContext<unknown, unknown>
+): boolean {
+  if (fieldOption.hideFromDefaults) {
+    return false;
+  }
+
+  if (!fieldOption.showIf) {
+    return true;
+  }
+
+  const currentValue = fieldOption.isCustom ? fieldConfig.defaults.custom : fieldConfig.defaults;
+
+  // showIf is typed `boolean | undefined` and an undefined return has always hidden the option.
+  return Boolean(fieldOption.showIf(currentValue, data?.series, data?.annotations, context));
 }
 
 export function getVisualizationOptions(props: OptionPaneRenderProps): OptionsPaneCategoryDescriptor[] {
@@ -69,6 +105,7 @@ export function getVisualizationOptions(props: OptionPaneRenderProps): OptionsPa
     data,
     replaceVariables: panel.replaceVariables,
     options: currentOptions,
+    fieldConfig: currentFieldConfig,
     eventBus: dashboard.events,
     instanceState,
   });
@@ -103,20 +140,7 @@ export function getVisualizationOptions(props: OptionPaneRenderProps): OptionsPa
    * Field options
    */
   for (const fieldOption of plugin.fieldConfigRegistry.list()) {
-    if (fieldOption.isCustom) {
-      if (
-        fieldOption.showIf &&
-        !fieldOption.showIf(currentFieldConfig.defaults.custom, data?.series, data?.annotations)
-      ) {
-        continue;
-      }
-    } else {
-      if (fieldOption.showIf && !fieldOption.showIf(currentFieldConfig.defaults, data?.series, data?.annotations)) {
-        continue;
-      }
-    }
-
-    if (fieldOption.hideFromDefaults) {
+    if (!isFieldConfigOptionVisible(fieldOption, currentFieldConfig, data, context)) {
       continue;
     }
 
@@ -252,6 +276,7 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
     data,
     replaceVariables: panel.interpolate,
     options: currentOptions,
+    fieldConfig: currentFieldConfig,
     eventBus: eventBus,
     instanceState,
   });
@@ -261,12 +286,7 @@ export function getVisualizationOptions2(props: OptionPaneRenderProps2): Options
 
   // Field options
   for (const fieldOption of plugin.fieldConfigRegistry.list()) {
-    const hideOption =
-      fieldOption.showIf &&
-      (fieldOption.isCustom
-        ? !fieldOption.showIf(currentFieldConfig.defaults.custom, data?.series, data?.annotations)
-        : !fieldOption.showIf(currentFieldConfig.defaults, data?.series, data?.annotations));
-    if (fieldOption.hideFromDefaults || hideOption) {
+    if (!isFieldConfigOptionVisible(fieldOption, currentFieldConfig, data, context)) {
       continue;
     }
 
@@ -334,7 +354,7 @@ export function fillOptionsPaneItems(
   supplier(builder, context);
 
   for (const pluginOption of builder.getItems()) {
-    if (pluginOption.showIf && !pluginOption.showIf(context.options, context.data, context.annotations)) {
+    if (pluginOption.showIf && !pluginOption.showIf(context.options, context.data, context.annotations, context)) {
       continue;
     }
 

--- a/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useId, useMemo } from 'react';
 
-import { createFieldConfigRegistry, type SetFieldConfigOptionsArgs } from '@grafana/data';
+import { createFieldConfigRegistry, type SetFieldConfigOptionsArgs, type StandardEditorContext } from '@grafana/data';
 import { type GraphFieldConfig, type TableSparklineCellOptions } from '@grafana/schema';
 import { Field, useStyles2 } from '@grafana/ui';
 import { defaultSparklineCellConfig } from '@grafana/ui/internal';
@@ -49,6 +49,10 @@ export const SparklineCellOptionsEditor = (props: TableCellEditorProps<TableSpar
 
   const style = useStyles2(getStyles);
 
+  // This registry is built outside the options pane, so there are no panel options or field config to
+  // put on the context - a showIf that reads one sees undefined and keeps the option hidden.
+  const context = useMemo<StandardEditorContext<unknown>>(() => ({ data: [] }), []);
+
   const values = { ...defaultSparklineCellConfig, ...cellOptions };
 
   const htmlIdBase = useId();
@@ -56,7 +60,7 @@ export const SparklineCellOptionsEditor = (props: TableCellEditorProps<TableSpar
   return (
     <>
       {registry.list(optionIds.map((id) => `custom.${id}`)).map((item) => {
-        if (item.showIf && !item.showIf(values)) {
+        if (item.showIf && !item.showIf(values, context.data, context.annotations, context)) {
           return null;
         }
         const Editor = item.editor;
@@ -68,7 +72,7 @@ export const SparklineCellOptionsEditor = (props: TableCellEditorProps<TableSpar
               onChange={(val) => onChange({ ...cellOptions, [path]: val })}
               value={(isOptionKey(path, values) ? values[path] : undefined) ?? item.defaultValue}
               item={item}
-              context={{ data: [] }}
+              context={context}
               id={`${htmlIdBase}${item.id}`}
             />
           </Field>


### PR DESCRIPTION
**What is this feature?**

Four additive changes to the panel edit API:
1. Adding `fieldConfig` to `StandardEditorContext` 
[packages/grafana-data/src/field/standardFieldConfigEditorRegistry.ts](https://github.com/grafana/grafana/pull/132398/changes#diff-eba467b52494b54ea54435851ac95e693d774133df1598a685ff85f77ab83918R27)
2. Adding `showIf` to `StandardOptionConfig`
[packages/grafana-data/src/panel/PanelPlugin.ts](https://github.com/grafana/grafana/pull/132398/changes#diff-c15da4cfa365f7a5c844003da0d784bdcd91483806f616ced251e365c55b8558R50)
3. New `context` arg to `showIf` methods (in options and config)
4. `showIf` context is typed to the panel options via a new `TContextOptions` type param

**Why do we need this feature?**

Better panel plugin option DX/UX.

Panel plugin developers might have default field config which are not relevant for specific frames or panel options, and currently the only option is to either hide the field config from the defaults (so it only shows in overrides), or to convert it to a panel option.

More (core) potential use-cases:
* Enabling more context-aware inline documentation
* Standard: Hide filterable (ad-hoc filter display) when tooltips are disabled
* Table
* * hide `Column filter` and `Wrap header text` when show table header is disabled
* * Min / Max / Field min/max when no celltype is gauge cell
* Stat: Min / Max / Field min/max when `graphMode` is none
* Heatmap: retire `yAxis.*` options and use standard options instead hidden by default
* XYChart: show Unit/Decimals in defaults when the frames resolve to a single y field

**Who is this feature for?**

Panel developers and editors.

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana/issues/83970
Enables solution for https://github.com/grafana/grafana/issues/121202, 

**Special notes for your reviewer:**
I've always assumed that this would be a big hairy change because it's such a painful limitation of working with panel plugins editors, but after digging in it looks like this is low-hanging fruit we just never got around to.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
