### PR TITLE
Preferences: Allow non team members to search preferences

### DIFF
--- a/pkg/registry/apis/preferences/register.go
+++ b/pkg/registry/apis/preferences/register.go
@@ -33,8 +33,9 @@ var (
 )
 
 type APIBuilder struct {
-	authorizer  authorizer.Authorizer
-	legacyPrefs grafanarest.Storage
+	authorizer   authorizer.Authorizer
+	accessClient authlib.AccessClient
+	legacyPrefs  grafanarest.Storage
 
 	merger *merger // joins all preferences
 }
@@ -49,7 +50,8 @@ func RegisterAPIService(
 ) (*APIBuilder, error) {
 	sql := legacy.NewLegacySQL(legacysql.NewDatabaseProvider(db))
 	builder := &APIBuilder{
-		merger: newMerger(cfg),
+		merger:       newMerger(cfg),
+		accessClient: accessClient,
 		authorizer: &utils.AuthorizeFromName{
 			OKNames:      []string{"merged"},
 			AccessClient: accessClient, // can i edit a team
@@ -130,7 +132,11 @@ func (b *APIBuilder) storageForVersion(
 			return nil, err
 		}
 	}
-	wrappedStorage := &preferencesStorage{Storage: store, gvk: prefs.GroupVersionKind()}
+	wrappedStorage := &preferencesStorage{
+		Storage:      store,
+		gvk:          prefs.GroupVersionKind(),
+		accessClient: b.accessClient,
+	}
 	storage[prefs.StoragePath()] = wrappedStorage
 
 	apiGroupInfo.VersionedResourcesStorageMap[prefs.GroupVersion().Version] = storage

--- a/pkg/registry/apis/preferences/store.go
+++ b/pkg/registry/apis/preferences/store.go
@@ -32,7 +32,8 @@ var PreferencesTeamLimit = 25
 // This converts the query into explicitly picking the preferences the caller should have access
 type preferencesStorage struct {
 	grafanarest.Storage
-	gvk schema.GroupVersionKind
+	gvk          schema.GroupVersionKind
+	accessClient authlib.AccessClient
 }
 
 func (s *preferencesStorage) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
@@ -192,8 +193,24 @@ func (s *preferencesStorage) appendOwnerPreferences(ctx context.Context, user id
 			return nil
 		}
 	case utils.TeamResourceOwner:
-		if !isUser || !slices.Contains(user.GetGroups(), owner.Identifier) {
+		if !isUser {
 			return nil
+		}
+		// Explicit team lookups must allow the same readers as a single-resource GET.
+		if !slices.Contains(user.GetGroups(), owner.Identifier) {
+			rsp, err := s.accessClient.Check(ctx, user, authlib.CheckRequest{
+				Verb:      "get",
+				Group:     "iam.grafana.app",
+				Resource:  "teams",
+				Namespace: user.GetNamespace(),
+				Name:      owner.Identifier,
+			}, "")
+			if err != nil {
+				return fmt.Errorf("checking team read permission: %w", err)
+			}
+			if !rsp.Allowed {
+				return nil
+			}
 		}
 	default:
 		return nil // skip

--- a/pkg/registry/apis/preferences/store_test.go
+++ b/pkg/registry/apis/preferences/store_test.go
@@ -2,6 +2,7 @@ package preferences
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestListPreferences(t *testing.T) {
 
 	t.Run("returns user, team (sorted), then namespace prefs in inheritance order", func(t *testing.T) {
 		fake := &fakeStorage{items: allItems}
-		store := &preferencesStorage{Storage: fake}
+		store := &preferencesStorage{Storage: fake, accessClient: claims.FixedAccessClient(true)}
 
 		ctx := identity.WithRequester(context.Background(), userABC)
 		list, err := store.ListPreferences(ctx, nil)
@@ -176,7 +177,7 @@ func TestListPreferences_FieldSelector(t *testing.T) {
 			expect:   []string{"team-x"},
 		},
 		{
-			name:     "filters out team the user does not belong to",
+			name:     "filters out team without membership or read permission",
 			selector: fields.OneTermEqualSelector("metadata.name", "team-zzz"),
 			expect:   []string{},
 		},
@@ -200,7 +201,7 @@ func TestListPreferences_FieldSelector(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := &fakeStorage{items: items}
-			store := &preferencesStorage{Storage: fake}
+			store := &preferencesStorage{Storage: fake, accessClient: claims.FixedAccessClient(false)}
 
 			ctx := identity.WithRequester(context.Background(), userABC)
 			list, err := store.ListPreferences(ctx, &internalversion.ListOptions{
@@ -210,6 +211,109 @@ func TestListPreferences_FieldSelector(t *testing.T) {
 			require.Equal(t, tc.expect, names(list))
 		})
 	}
+}
+
+func TestListPreferences_FieldSelector_TeamAccess(t *testing.T) {
+	accessErr := errors.New("access service unavailable")
+	cases := []struct {
+		name         string
+		identityType claims.IdentityType
+		groups       []string
+		allowed      bool
+		checkErr     error
+		wantCheck    bool
+		wantItem     bool
+	}{
+		{
+			name:         "non-member with read permission receives saved preferences",
+			identityType: claims.TypeUser,
+			allowed:      true,
+			wantCheck:    true,
+			wantItem:     true,
+		},
+		{
+			name:         "non-member without read permission cannot read preferences",
+			identityType: claims.TypeUser,
+			wantCheck:    true,
+		},
+		{
+			name:         "permission errors are returned without reading preferences",
+			identityType: claims.TypeUser,
+			checkErr:     accessErr,
+			wantCheck:    true,
+		},
+		{
+			name:         "member reads preferences without an access check",
+			identityType: claims.TypeUser,
+			groups:       []string{"team-uid"},
+			wantItem:     true,
+		},
+		{
+			name:         "non-user remains excluded even with team access",
+			identityType: claims.TypeServiceAccount,
+			groups:       []string{"team-uid"},
+			allowed:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user := &identity.StaticRequester{
+				Type:      tc.identityType,
+				UserUID:   "user-uid",
+				Namespace: "stacks-123",
+				Groups:    tc.groups,
+			}
+			item := newPref("team-team-uid")
+			item.Namespace = user.Namespace
+			item.Spec.HomeDashboardUID = ptr.To("saved-dashboard")
+			fake := &fakeStorage{items: map[string]*preferences.Preferences{item.Name: item}}
+			checked := false
+			client := &testAccessClient{
+				check: func(_ context.Context, caller claims.AuthInfo, req claims.CheckRequest, folder string) (claims.CheckResponse, error) {
+					checked = true
+					require.Same(t, user, caller)
+					require.Equal(t, claims.CheckRequest{
+						Verb:      "get",
+						Group:     "iam.grafana.app",
+						Resource:  "teams",
+						Namespace: "stacks-123",
+						Name:      "team-uid",
+					}, req)
+					require.Empty(t, folder)
+					return claims.CheckResponse{Allowed: tc.allowed}, tc.checkErr
+				},
+			}
+			store := &preferencesStorage{Storage: fake, accessClient: client}
+			ctx := identity.WithRequester(context.Background(), user)
+			ctx = requestK8s.WithNamespace(ctx, user.Namespace)
+			list, err := store.ListPreferences(ctx, &internalversion.ListOptions{
+				FieldSelector: fields.OneTermEqualSelector("metadata.name", item.Name),
+			})
+			require.Equal(t, tc.wantCheck, checked)
+			if tc.checkErr != nil {
+				require.ErrorIs(t, err, tc.checkErr)
+				require.Empty(t, fake.calls)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantItem {
+				require.Equal(t, []preferences.Preferences{*item}, list.Items)
+			} else {
+				require.Empty(t, list.Items)
+				require.Empty(t, fake.calls)
+			}
+		})
+	}
+}
+
+type testAccessClient struct {
+	claims.AccessClient
+	check func(context.Context, claims.AuthInfo, claims.CheckRequest, string) (claims.CheckResponse, error)
+}
+
+func (c *testAccessClient) Check(ctx context.Context, user claims.AuthInfo, req claims.CheckRequest, folder string) (claims.CheckResponse, error) {
+	return c.check(ctx, user, req, folder)
 }
 
 func TestListPreferences_Errors(t *testing.T) {


### PR DESCRIPTION
**Why**:

Team admins who aren’t members can save team preferences, but the settings page shows “Default” after reloading because its LIST endpoint filters out teams the caller doesn’t belong to.

  This change allows explicitly requested team preferences to be returned when the caller has team read permission, matching the direct GET endpoint. Membership-based preference inheritance remains unchanged.