### PR TITLE
Table: Shrink auto columns to fit the panel instead of overflowing with `preventHorizontalOverflow` and wrapped columns

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
@@ -373,36 +373,57 @@ describe('FlameGraphTopTableContainer column widths with useTableNG', () => {
     }
   };
 
+  // jsdom's canvas mock measures every string as zero-width, so content-aware widths would size the
+  // symbol column as if it were empty and never overflow the pane. Give text a width proportional to
+  // its length so the long Go symbols in the fixture stretch the column the way they do in a browser.
+  const CHAR_WIDTH = 8;
+  const mockTextMeasurement = () => {
+    jest.spyOn(CanvasRenderingContext2D.prototype, 'measureText').mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      ((text: string) => ({
+        width: String(text).length * CHAR_WIDTH,
+      })) as typeof CanvasRenderingContext2D.prototype.measureText
+    );
+  };
+
   afterEach(() => {
+    jest.restoreAllMocks();
     for (const { property, target, descriptor } of originalDescriptors) {
       Object.defineProperty(target, property, descriptor);
     }
   });
 
-  it('fits the columns in the space the scrollbar leaves rather than the full width', async () => {
-    mockTableSize({ width: GRID_WIDTH, height: GRID_WIDTH });
-    mockGridScrollbar();
+  // Symbol is the one column left unsized, so whichever way TableNG sizes its auto columns it must
+  // land inside the space the scrollbar leaves — the pane has no room for a horizontal scrollbar.
+  it.each([{ contentAwareWidthsEnabled: undefined }, { contentAwareWidthsEnabled: true }])(
+    'fits the columns in the space the scrollbar leaves with contentAwareWidthsEnabled=$contentAwareWidthsEnabled',
+    async ({ contentAwareWidthsEnabled }) => {
+      mockTableSize({ width: GRID_WIDTH, height: GRID_WIDTH });
+      mockGridScrollbar();
+      mockTextMeasurement();
 
-    const container = new FlameGraphDataContainer(createDataFrame(data), { collapsing: true });
-    render(
-      <FlameGraphTopTableContainer
-        data={container}
-        onSymbolClick={jest.fn()}
-        onSearch={jest.fn()}
-        onSandwich={jest.fn()}
-        colorScheme={ColorScheme.ValueBased}
-        useTableNG={true}
-      />
-    );
+      const container = new FlameGraphDataContainer(createDataFrame(data), { collapsing: true });
+      render(
+        <FlameGraphTopTableContainer
+          data={container}
+          onSymbolClick={jest.fn()}
+          onSearch={jest.fn()}
+          onSandwich={jest.fn()}
+          colorScheme={ColorScheme.ValueBased}
+          useTableNG={true}
+          contentAwareWidthsEnabled={contentAwareWidthsEnabled}
+        />
+      );
 
-    await waitFor(() => {
-      const grid = document.querySelector<HTMLElement>('.rdg')!;
-      // The wrapper the TableNG branch sizes, i.e. the width the table was handed.
-      const handedWidth = parseFloat(grid.parentElement!.style.width);
-      const columnWidths = grid.style.gridTemplateColumns.split(' ').map(parseFloat);
+      await waitFor(() => {
+        const grid = document.querySelector<HTMLElement>('.rdg')!;
+        // The wrapper the TableNG branch sizes, i.e. the width the table was handed.
+        const handedWidth = parseFloat(grid.parentElement!.style.width);
+        const columnWidths = grid.style.gridTemplateColumns.split(' ').map(parseFloat);
 
-      expect(columnWidths).toHaveLength(4);
-      expect(columnWidths.reduce((total, columnWidth) => total + columnWidth, 0)).toBe(handedWidth - SCROLLBAR_WIDTH);
-    });
-  });
+        expect(columnWidths).toHaveLength(4);
+        expect(columnWidths.reduce((total, columnWidth) => total + columnWidth, 0)).toBe(handedWidth - SCROLLBAR_WIDTH);
+      });
+    }
+  );
 });

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -113,6 +113,11 @@ const FlameGraphTopTableContainer = memo(
                     height={height}
                     tableRefreshEnabled={tableRefreshEnabled}
                     contentAwareWidthsEnabled={contentAwareWidthsEnabled}
+                    // The pane's width is already divided up between the three fixed columns and
+                    // Symbol, so a horizontal scrollbar would hide columns rather than reveal them.
+                    // Symbol truncates to fit instead — its full value is a click away in the flame
+                    // graph, and in a narrow split pane it truncates either way.
+                    preventHorizontalOverflow
                   />
                 </div>
               );
@@ -196,9 +201,10 @@ function buildTableDataFrame(
     config: {
       // TableNG lays its columns out inside `width` minus its own vertical scrollbar, so spelling out
       // a width here that fills `width` overflows by the scrollbar and leaves the grid scrolling
-      // sideways a few pixels. Leaving Symbol unsized instead makes it the one column TableNG hands
-      // the leftover space to, which is the same "fill whatever the fixed columns don't use" intent
-      // without having to know the scrollbar's width. The legacy table has no such notion, so it
+      // sideways a few pixels. Leaving Symbol unsized instead makes it the one column TableNG sizes
+      // itself, which is the same "fill whatever the fixed columns don't use" intent without having
+      // to know the scrollbar's width — see `preventHorizontalOverflow` at the call site, which is
+      // what keeps an unsized Symbol inside the pane. The legacy table has no such notion, so it
       // still gets told exactly how wide to make it.
       custom: useTableNG ? {} : { width: width - actionColumnWidth - TOP_TABLE_COLUMN_WIDTH * 2 },
       links: [

--- a/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableFlat.tsx
@@ -87,6 +87,7 @@ export function TableFlat(props: TableNGProps) {
     sortByBehavior = 'initial',
     contentAwareWidthsEnabled = false,
     tableRefreshEnabled = false,
+    preventHorizontalOverflow = false,
   } = props;
 
   const theme = useTheme2();
@@ -189,6 +190,7 @@ export function TableFlat(props: TableNGProps) {
     tableRefreshEnabled,
     filter,
     noPanelPadding,
+    preventHorizontalOverflow,
   });
 
   const [widths, numFrozenColsFullyInView] = useColWidths(

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNested.tsx
@@ -100,6 +100,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
     sortByBehavior = 'initial',
     contentAwareWidthsEnabled = false,
     tableRefreshEnabled = false,
+    preventHorizontalOverflow = false,
   } = props;
 
   const uniqueId = useId();
@@ -250,6 +251,7 @@ export function TableNested(props: TableNGProps & { nestedFramesField: Field<Dat
     getActions: getCellActions,
     tableRefreshEnabled,
     filter,
+    preventHorizontalOverflow,
   });
 
   const [widths] = useColWidths(preparedFields, availableWidth, frozenColumns, widthConfigResetKey, contentAwareWidths);

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -796,6 +796,7 @@ export interface ContentAwareWidths {
   tableRefreshEnabled?: boolean;
   filter?: FilterType;
   noPanelPadding?: boolean;
+  preventHorizontalOverflow?: boolean;
 }
 
 const pickColWidths = (fields: Field[], availWidth: number, contentAware?: ContentAwareWidths): number[] =>
@@ -825,6 +826,7 @@ interface UseContentAwareWidthsOptions {
   tableRefreshEnabled?: boolean;
   filter?: FilterType;
   noPanelPadding?: boolean;
+  preventHorizontalOverflow?: boolean;
 }
 
 /**
@@ -840,6 +842,7 @@ export function useContentAwareWidths({
   tableRefreshEnabled = false,
   filter,
   noPanelPadding = false,
+  preventHorizontalOverflow = false,
 }: UseContentAwareWidthsOptions): ContentAwareWidths | undefined {
   const theme = useTheme2();
   const headerTypographyCtx = useMemo(
@@ -863,6 +866,7 @@ export function useContentAwareWidths({
             tableRefreshEnabled,
             filter,
             noPanelPadding,
+            preventHorizontalOverflow,
           }
         : undefined,
     [
@@ -874,6 +878,7 @@ export function useContentAwareWidths({
       filter,
       tableRefreshEnabled,
       noPanelPadding,
+      preventHorizontalOverflow,
     ]
   );
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -160,6 +160,14 @@ interface BaseTableProps {
   disableKeyboardEvents?: boolean;
   // temporary feature toggle to manage rollout of content-aware auto column widths (table.autoColumnWidths)
   contentAwareWidthsEnabled?: boolean;
+  /**
+   * Set by callers that would rather see a column's content truncated than have the table scroll
+   * sideways — a table embedded in a fixed layout, where a horizontal scrollbar hides columns the
+   * surrounding UI has already reserved room for. Auto columns are then levelled down to fit the
+   * available width, widest first, instead of keeping their content width. Only affects
+   * content-aware widths (`contentAwareWidthsEnabled`).
+   */
+  preventHorizontalOverflow?: boolean;
   // temporary feature toggle to manage rollout of the refreshed table experience (table.refresh)
   tableRefreshEnabled?: boolean;
 }

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1814,11 +1814,12 @@ describe('TableNG utils', () => {
       return typographyCtx;
     };
 
-    const compute = (fields: Field[], availWidth: number, showTypeIcons = false) =>
+    const compute = (fields: Field[], availWidth: number, showTypeIcons = false, preventHorizontalOverflow = false) =>
       computeContentAwareColWidths(fields, availWidth, {
         typographyCtx: makeTypographyCtx(),
         headerTypographyCtx: makeTypographyCtx(),
         showTypeIcons,
+        preventHorizontalOverflow,
       });
 
     afterEach(() => jest.restoreAllMocks());
@@ -1957,6 +1958,68 @@ describe('TableNG utils', () => {
       ];
 
       expect(compute(fields, 100)).toEqual([300]);
+    });
+
+    describe('preventHorizontalOverflow', () => {
+      it('levels an unwrapped column down to fit, truncating its content instead of scrolling', () => {
+        const fields: Field[] = [
+          // 100*8+13+6 = 819, well over the 400 cap; no wrapText, so the content ellipsizes.
+          { name: 'S', type: FieldType.string, values: ['x'.repeat(100)], config: {} },
+          { name: 'N', type: FieldType.number, values: [999], config: {} }, // 37 => floored to 50
+        ];
+
+        // Content totals 450 against a 300px panel. With the option the 150px of overflow comes out
+        // of the text column, which then shows an ellipsis rather than hiding N behind a scrollbar.
+        expect(compute(fields, 300, false, true)).toEqual([250, 50]);
+        // Without it, an unwrapped column keeps its content width and the grid scrolls (the default).
+        expect(compute(fields, 300)).toEqual([COLUMN.MAX_AUTO_WIDTH, 50]);
+      });
+
+      it('still takes the overflow from the widest column first, then levels them together', () => {
+        const fields: Field[] = [
+          { name: 'A', type: FieldType.string, values: ['x'.repeat(40)], config: {} }, // 339
+          { name: 'B', type: FieldType.string, values: ['x'.repeat(20)], config: {} }, // 179
+        ];
+
+        // Same widest-first levelling wrapped columns get: a 40px deficit comes entirely out of A,
+        // which is 160px wider than B...
+        expect(compute(fields, 478, false, true)).toEqual([299, 179]);
+        // ...while a 200px deficit levels A down to B and then splits the last 40px between them.
+        expect(compute(fields, 318, false, true)).toEqual([159, 159]);
+      });
+
+      it('leaves graphical columns at their measured width — there is nothing in them to truncate', () => {
+        const fields: Field[] = [
+          { name: 'S', type: FieldType.string, values: ['x'.repeat(100)], config: {} }, // capped to 400
+          {
+            name: 'g',
+            type: FieldType.number,
+            values: [1],
+            config: { custom: { cellOptions: { type: TableCellDisplayMode.Sparkline } } }, // 150
+          },
+        ];
+
+        // The 300px deficit is more than levelling S down to the sparkline's width would cover, so a
+        // shrinkable sparkline would have been dragged down with it ([125, 125]). Squeezing a
+        // sparkline clips the graphic instead of ellipsizing text, so S absorbs the whole deficit.
+        expect(compute(fields, 250, false, true)).toEqual([100, COLUMN.DEFAULT_WIDTH]);
+      });
+
+      it('still stops at the header label, keeping the residual overflow', () => {
+        const fields: Field[] = [
+          {
+            name: 'A'.repeat(30), // header 30*8 + sort arrow 22 + 13 = 275
+            type: FieldType.string,
+            values: ['x'.repeat(60)], // 499 => capped to 400
+            config: {},
+          },
+          { name: 'N', type: FieldType.number, values: [999], config: {} }, // 50
+        ];
+
+        // Truncating the values is fine; truncating the column's own title isn't. The option gets as
+        // close to fitting as the header allows and the grid scrolls the rest.
+        expect(compute(fields, 200, false, true)).toEqual([275, 50]);
+      });
     });
 
     it('measures the display-formatted string, not the raw value', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1960,6 +1960,24 @@ describe('TableNG utils', () => {
       expect(compute(fields, 100)).toEqual([300]);
     });
 
+    it('leaves a graphical column at its measured width even when wrapText is set on it', () => {
+      const fields: Field[] = [
+        { name: 'S', type: FieldType.string, values: ['x'.repeat(100)], config: { custom: { wrapText: true } } }, // capped to 400
+        {
+          name: 'g',
+          type: FieldType.number,
+          values: [1],
+          // wrapText has no effect on a sparkline's rendering, but a default applied to every column
+          // shouldn't make this one eligible for the level-down either — there's nothing to reflow.
+          config: { custom: { wrapText: true, cellOptions: { type: TableCellDisplayMode.Sparkline } } }, // 150
+        },
+      ];
+
+      // Same 300px deficit as the preventHorizontalOverflow case below: S gives back everything a
+      // wrapped column can (down to its header), the sparkline stays untouched.
+      expect(compute(fields, 250)).toEqual([100, COLUMN.DEFAULT_WIDTH]);
+    });
+
     describe('preventHorizontalOverflow', () => {
       it('levels an unwrapped column down to fit, truncating its content instead of scrolling', () => {
         const fields: Field[] = [

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1899,6 +1899,66 @@ describe('TableNG utils', () => {
       expect(compute(fields, 100)).toEqual([COLUMN.MAX_AUTO_WIDTH]);
     });
 
+    it('levels a wrapped column down to fit the panel rather than overflowing it', () => {
+      const cols = (wrap: boolean): Field[] => [
+        // 100*8+13+6 = 819, well over the 400 cap.
+        { name: 'S', type: FieldType.string, values: ['x'.repeat(100)], config: { custom: { wrapText: wrap } } },
+        { name: 'N', type: FieldType.number, values: [999], config: {} }, // 37 => floored to 50
+      ];
+
+      // Content totals 400 + 50 = 450 against a 300px panel. The wrapped column can trade the 150px
+      // of overflow for extra row height, so it gives all of it back and the table fits exactly.
+      expect(compute(cols(true), 300)).toEqual([250, 50]);
+      // Unwrapped, the same content would be clipped rather than reflowed, so it keeps its width and
+      // the grid scrolls instead.
+      expect(compute(cols(false), 300)).toEqual([COLUMN.MAX_AUTO_WIDTH, 50]);
+    });
+
+    it('takes the overflow from the widest wrapped column first, then levels them together', () => {
+      const fields: Field[] = [
+        // 40*8+13+6 = 339
+        { name: 'A', type: FieldType.string, values: ['x'.repeat(40)], config: { custom: { wrapText: true } } },
+        // 20*8+13+6 = 179
+        { name: 'B', type: FieldType.string, values: ['x'.repeat(20)], config: { custom: { wrapText: true } } },
+      ];
+
+      // Content totals 518. A 40px deficit comes entirely out of A, which is 160px wider than B:
+      // the narrower column gives up nothing while a wider one still has slack.
+      expect(compute(fields, 478)).toEqual([299, 179]);
+      // A 200px deficit first levels A down to B (160px), then splits the remaining 40px between
+      // them (20px each), so they land on a common width instead of A collapsing on its own.
+      expect(compute(fields, 318)).toEqual([159, 159]);
+    });
+
+    it('never levels a wrapped column below its header label, keeping the residual overflow', () => {
+      const fields: Field[] = [
+        {
+          name: 'A'.repeat(30), // header 30*8 + sort arrow 22 + 13 = 275
+          type: FieldType.string,
+          values: ['x'.repeat(60)], // 499 => capped to 400
+          config: { custom: { wrapText: true } },
+        },
+        { name: 'N', type: FieldType.number, values: [999], config: {} }, // 50
+      ];
+
+      // The 250px deficit against a 200px panel is more than the wrapped column can give: the header
+      // label doesn't reflow, so it stops at 275 and the grid still scrolls, just 125px less far.
+      expect(compute(fields, 200)).toEqual([275, 50]);
+    });
+
+    it('never levels a wrapped column below its configured minWidth', () => {
+      const fields: Field[] = [
+        {
+          name: 'S',
+          type: FieldType.string,
+          values: ['x'.repeat(100)], // 819 => capped to 400
+          config: { custom: { wrapText: true, minWidth: 300 } },
+        },
+      ];
+
+      expect(compute(fields, 100)).toEqual([300]);
+    });
+
     it('measures the display-formatted string, not the raw value', () => {
       const fields: Field[] = [
         {
@@ -1996,8 +2056,9 @@ describe('TableNG utils', () => {
       const longestLine = Math.max(...pretty.split('\n').map((line) => line.length));
       const expected = longestLine * CHAR_W + CELL_CHROME;
 
-      // availWidth below the content so it can't grow to fill (which would mask the difference).
-      expect(compute([jsonField(value, true)], 40)).toEqual([expected]);
+      // availWidth exactly at the content width, so the column neither grows to fill (which would
+      // mask the difference) nor levels down to fit (wrapped columns give width back on overflow).
+      expect(compute([jsonField(value, true)], expected)).toEqual([expected]);
       // the widest line is far narrower than the whole blob, which would hit the cap.
       expect(expected).toBeLessThan(COLUMN.MAX_AUTO_WIDTH);
       expect(pretty.length * CHAR_W + CELL_CHROME).toBeGreaterThan(COLUMN.MAX_AUTO_WIDTH);
@@ -2094,11 +2155,13 @@ describe('TableNG utils', () => {
       });
       // Wrapped links stack vertically, so the column follows the widest link ("Open dashboard",
       // 14*8+8=120; +CELL_CHROME 13 = 133) rather than the summed inline run of both links.
-      const wrapped = computeContentAwareColWidths([field(true)], 50, {
+      // availWidth is the wrapped content width, so neither column grows and the wrapped one has no
+      // overflow to level down into.
+      const wrapped = computeContentAwareColWidths([field(true)], 133, {
         typographyCtx: makeTypographyCtx(),
         headerTypographyCtx: makeTypographyCtx(),
       });
-      const inline = computeContentAwareColWidths([field(false)], 50, {
+      const inline = computeContentAwareColWidths([field(false)], 133, {
         typographyCtx: makeTypographyCtx(),
         headerTypographyCtx: makeTypographyCtx(),
       });

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1286,6 +1286,12 @@ export interface ContentAwareColWidthsOptions {
   filter?: FilterType;
   /** The first column carries extra inline-start padding to line up with the panel title. */
   noPanelPadding?: boolean;
+  /**
+   * Truncate rather than scroll: auto columns are levelled down to fit `availWidth` even when their
+   * content doesn't wrap, so an embedding layout that has already reserved room for every column
+   * doesn't lose the last of them behind a horizontal scrollbar.
+   */
+  preventHorizontalOverflow?: boolean;
   /** overridable for testing; otherwise derived from the auto-column count */
   sampleSize?: number;
 }
@@ -1598,6 +1604,20 @@ function isReflowingCol(field: Field, resolvedType: TableCellDisplayMode): boole
   return shouldTextWrap(field) || resolvedType === TableCellDisplayMode.Markdown;
 }
 
+// Cell types whose width is chrome rather than text: a gauge, a sparkline, an image, a row of action
+// buttons. There is nothing in them to ellipsize, so squeezing one clips the control itself — they
+// stay at their measured width even under `preventHorizontalOverflow`.
+const UNSHRINKABLE_CELL_TYPES = new Set<TableCellDisplayMode>([
+  TableCellDisplayMode.Sparkline,
+  TableCellDisplayMode.Gauge,
+  TableCellDisplayMode.BasicGauge,
+  TableCellDisplayMode.GradientGauge,
+  TableCellDisplayMode.LcdGauge,
+  TableCellDisplayMode.Image,
+  TableCellDisplayMode.Geo,
+  TableCellDisplayMode.Actions,
+]);
+
 /**
  * Reclaims up to `deficit` px from `widths` (mutated in place) by levelling its widest entries down:
  * the widest column is cut to the next-widest, then the two are cut together, and so on. The columns
@@ -1648,15 +1668,17 @@ function levelDownColWidths(widths: Map<number, number>, floors: Map<number, num
  *      graphical cells, whichever applies, unioned with its header label width;
  *   2. clamped to `[max(MIN_WIDTH, custom.minWidth), MAX_AUTO_WIDTH]`;
  *   3. then, if the auto columns overflow the available width, the overflow is taken back out of the
- *      columns that wrap, widest first (see {@link levelDownColWidths}) — a wrapped column can trade
- *      width for height, so it absorbs the overflow rather than leaving the grid to scroll sideways;
+ *      columns that can absorb it, widest first (see {@link levelDownColWidths}): a wrapped column
+ *      trades the width for extra row height, and under `preventHorizontalOverflow` every
+ *      text-bearing column trades it for an ellipsis, either being preferable to a horizontal
+ *      scrollbar;
  *   4. or, if the auto columns don't fill the available width, the leftover is distributed by a
  *      growth share of `growthWeight × √(content width)`, so a column with more content still takes
  *      more slack (a busy pill column beats a sparse one) while the √ damps the spread enough that
  *      the widest column doesn't run away from its neighbours; numeric/boolean columns grow only
  *      modestly (see {@link growthWeight}).
- * When the overflow survives step 3 — no wrapped columns, or their floors reached — the remaining
- * content widths are kept and the grid scrolls.
+ * When the overflow survives step 3 — nothing able to absorb it, or the floors reached — the
+ * remaining content widths are kept and the grid scrolls.
  *
  * Every input is independent of the sort and filter state (fields hold the full, unsorted values),
  * so widths stay put when the user sorts or filters. See {@link measureHeaderWidth} for the sort
@@ -1674,6 +1696,7 @@ export function computeContentAwareColWidths(
     filter,
     sampleSize,
     noPanelPadding = false,
+    preventHorizontalOverflow = false,
   }: ContentAwareColWidthsOptions
 ): number[] {
   const autoIdxs: number[] = [];
@@ -1699,8 +1722,8 @@ export function computeContentAwareColWidths(
   // content width per auto column, clamped to [floor, cap]
   const contentWidths = new Map<number, number>();
   let contentTotal = 0;
-  // lower bound per wrapped auto column, for the overflow step below; absent for columns that can't
-  // reflow, or that are already sitting at their bound.
+  // lower bound per shrinkable auto column, for the overflow step below; absent for columns that
+  // can't give width back, or that are already sitting at their bound.
   const shrinkFloors = new Map<number, number>();
 
   const measureCtx: ColWidthMeasureCtx = { typographyCtx, getActions };
@@ -1742,19 +1765,25 @@ export function computeContentAwareColWidths(
     contentWidths.set(i, clamped + extraPadding);
     contentTotal += clamped + extraPadding;
 
-    if (isReflowingCol(field, resolvedType)) {
+    // Two ways a column can give width back rather than push the table into a horizontal scroll: a
+    // wrapped column reflows the content it gives up into extra row height, and under
+    // `preventHorizontalOverflow` the caller has said it would rather see content ellipsized than
+    // scroll, which puts every text-bearing column in play.
+    const canShrink =
+      isReflowingCol(field, resolvedType) || (preventHorizontalOverflow && !UNSHRINKABLE_CELL_TYPES.has(resolvedType));
+    if (canShrink) {
       // Anything the column asked for above its header, footer and configured minimum is width it
-      // can give back as extra row height instead. The header label and footer summary can't reflow
-      // — they'd truncate — so they stay a hard bound even on a wrapped column.
-      const reflowFloor = Math.min(Math.max(headerWidth, footerWidth, floor), cap) + extraPadding;
-      if (reflowFloor < clamped + extraPadding) {
-        shrinkFloors.set(i, reflowFloor);
+      // gives up first. The header label and footer summary can neither reflow nor ellipsize without
+      // costing the column its identity, so they stay a hard bound however it was measured.
+      const shrinkFloor = Math.min(Math.max(headerWidth, footerWidth, floor), cap) + extraPadding;
+      if (shrinkFloor < clamped + extraPadding) {
+        shrinkFloors.set(i, shrinkFloor);
       }
     }
   }
 
-  // Wrapped columns trade width for height, so hand the overflow back to them before letting the
-  // grid scroll sideways.
+  // Hand the overflow back to the columns that can absorb it — as height, or as an ellipsis — before
+  // letting the grid scroll sideways.
   const deficit = definedWidth + contentTotal - availWidth;
   const reclaimed =
     deficit > SHRINK_EPS && shrinkFloors.size > 0 ? levelDownColWidths(contentWidths, shrinkFloors, deficit) : 0;

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1770,7 +1770,7 @@ export function computeContentAwareColWidths(
     // `preventHorizontalOverflow` the caller has said it would rather see content ellipsized than
     // scroll, which puts every text-bearing column in play.
     const canShrink =
-      isReflowingCol(field, resolvedType) || (preventHorizontalOverflow && !UNSHRINKABLE_CELL_TYPES.has(resolvedType));
+      !UNSHRINKABLE_CELL_TYPES.has(resolvedType) && (isReflowingCol(field, resolvedType) || preventHorizontalOverflow);
     if (canShrink) {
       // Anything the column asked for above its header, footer and configured minimum is width it
       // gives up first. The header label and footer summary can neither reflow nor ellipsize without

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1586,6 +1586,60 @@ function growthWeight(type: FieldType): number {
   return GROWTH_WEIGHTS[type] ?? DEFAULT_GROWTH_WEIGHT;
 }
 
+// Below half a pixel there's nothing left worth redistributing, and the accumulated float error is
+// the same order as the gain, so the levelling below stops here rather than chasing an exact fit.
+const SHRINK_EPS = 0.5;
+
+// Cell types that reflow their content into extra row height rather than clipping it. Their measured
+// content width is a preference rather than a requirement, so it's the first thing we give back when
+// the table would otherwise overflow the panel.
+function isReflowingCol(field: Field, resolvedType: TableCellDisplayMode): boolean {
+  // Markdown renders wrapped whatever `wrapText` says (see measureMarkdownColWidth).
+  return shouldTextWrap(field) || resolvedType === TableCellDisplayMode.Markdown;
+}
+
+/**
+ * Reclaims up to `deficit` px from `widths` (mutated in place) by levelling its widest entries down:
+ * the widest column is cut to the next-widest, then the two are cut together, and so on. The columns
+ * responsible for the overflow therefore give the space back before their narrower neighbours give
+ * up any, and a column already narrower than the level we land on is never touched at all. No column
+ * goes below its `floors` entry, so this returns less than `deficit` when the floors are hit first.
+ *
+ * Only columns present in `floors` are candidates.
+ */
+function levelDownColWidths(widths: Map<number, number>, floors: Map<number, number>, deficit: number): number {
+  let pool = Array.from(floors.keys()).filter((i) => widths.get(i)! > floors.get(i)! + SHRINK_EPS);
+  let remaining = deficit;
+
+  while (remaining > SHRINK_EPS && pool.length > 0) {
+    const level = Math.max(...pool.map((i) => widths.get(i)!));
+    const tier: number[] = [];
+    let nextLevel = 0;
+    for (const i of pool) {
+      const width = widths.get(i)!;
+      if (width >= level - SHRINK_EPS) {
+        tier.push(i);
+      } else {
+        nextLevel = Math.max(nextLevel, width);
+      }
+    }
+
+    // How deep the current tier can be cut in one pass: down to the next-widest column, down to the
+    // highest floor in the tier, or just far enough to cover what's left of the deficit — whichever
+    // comes first. Each of those outcomes re-tiers the next pass (a wider tier, a smaller pool, or
+    // done), so the loop always makes progress.
+    const tierFloor = Math.max(...tier.map((i) => floors.get(i)!));
+    const step = Math.min(remaining / tier.length, level - nextLevel, level - tierFloor);
+    for (const i of tier) {
+      widths.set(i, widths.get(i)! - step);
+    }
+    remaining -= step * tier.length;
+    pool = pool.filter((i) => widths.get(i)! > floors.get(i)! + SHRINK_EPS);
+  }
+
+  return deficit - remaining;
+}
+
 /**
  * @internal
  * Content-aware variant of {@link computeColWidths}. Columns with a configured `custom.width` keep
@@ -1593,12 +1647,16 @@ function growthWeight(type: FieldType): number {
  *   1. its cell content (a sampled, display-formatted, measured max) or a per-type default for
  *      graphical cells, whichever applies, unioned with its header label width;
  *   2. clamped to `[max(MIN_WIDTH, custom.minWidth), MAX_AUTO_WIDTH]`;
- *   3. then, if the auto columns don't fill the available width, the leftover is distributed by a
+ *   3. then, if the auto columns overflow the available width, the overflow is taken back out of the
+ *      columns that wrap, widest first (see {@link levelDownColWidths}) — a wrapped column can trade
+ *      width for height, so it absorbs the overflow rather than leaving the grid to scroll sideways;
+ *   4. or, if the auto columns don't fill the available width, the leftover is distributed by a
  *      growth share of `growthWeight × √(content width)`, so a column with more content still takes
  *      more slack (a busy pill column beats a sparse one) while the √ damps the spread enough that
  *      the widest column doesn't run away from its neighbours; numeric/boolean columns grow only
  *      modestly (see {@link growthWeight}).
- * When content overflows the available width the content widths are kept and the grid scrolls.
+ * When the overflow survives step 3 — no wrapped columns, or their floors reached — the remaining
+ * content widths are kept and the grid scrolls.
  *
  * Every input is independent of the sort and filter state (fields hold the full, unsorted values),
  * so widths stay put when the user sorts or filters. See {@link measureHeaderWidth} for the sort
@@ -1641,6 +1699,9 @@ export function computeContentAwareColWidths(
   // content width per auto column, clamped to [floor, cap]
   const contentWidths = new Map<number, number>();
   let contentTotal = 0;
+  // lower bound per wrapped auto column, for the overflow step below; absent for columns that can't
+  // reflow, or that are already sitting at their bound.
+  const shrinkFloors = new Map<number, number>();
 
   const measureCtx: ColWidthMeasureCtx = { typographyCtx, getActions };
   // Filter entries are keyed per parent on nested tables, so match on the display name they carry
@@ -1680,23 +1741,45 @@ export function computeContentAwareColWidths(
 
     contentWidths.set(i, clamped + extraPadding);
     contentTotal += clamped + extraPadding;
+
+    if (isReflowingCol(field, resolvedType)) {
+      // Anything the column asked for above its header, footer and configured minimum is width it
+      // can give back as extra row height instead. The header label and footer summary can't reflow
+      // — they'd truncate — so they stay a hard bound even on a wrapped column.
+      const reflowFloor = Math.min(Math.max(headerWidth, footerWidth, floor), cap) + extraPadding;
+      if (reflowFloor < clamped + extraPadding) {
+        shrinkFloors.set(i, reflowFloor);
+      }
+    }
   }
 
+  // Wrapped columns trade width for height, so hand the overflow back to them before letting the
+  // grid scroll sideways.
+  const deficit = definedWidth + contentTotal - availWidth;
+  const reclaimed =
+    deficit > SHRINK_EPS && shrinkFloors.size > 0 ? levelDownColWidths(contentWidths, shrinkFloors, deficit) : 0;
+  contentTotal -= reclaimed;
+
   // Distribute leftover space by growthWeight × √(content width): a column with more content grows
-  // more, but the √ damps the spread so the widest column doesn't run away from its neighbours. On
-  // overflow content widths are kept (grid scrolls).
+  // more, but the √ damps the spread so the widest column doesn't run away from its neighbours. If
+  // the columns still overflow after the level-down above, their widths are kept and the grid
+  // scrolls.
   const growShare = (i: number) => growthWeight(fields[i].type) * Math.sqrt(contentWidths.get(i)!);
   const growTotal = autoIdxs.reduce((sum, i) => sum + growShare(i), 0);
 
   const leftover = availWidth - definedWidth - contentTotal;
   const shouldGrow = leftover > 0 && growTotal > 0;
+  // A level-down that absorbed the whole deficit leaves the columns summing to availWidth exactly,
+  // so rounding up from there would put them straight back over it. One that ran into the floors
+  // still overflows, and takes the round-up path below like any other overflow.
+  const shrankToFit = reclaimed > 0 && leftover > -SHRINK_EPS;
   // Round cumulatively so the rounded widths sum to the same total as the exact ones. Rounding each
   // independently can push the total past availWidth and trigger a spurious horizontal scrollbar.
   let exactSoFar = 0;
   let roundedSoFar = 0;
   for (const i of autoIdxs) {
     const contentWidth = contentWidths.get(i)!;
-    if (!shouldGrow) {
+    if (!shouldGrow && !shrankToFit) {
       // No leftover to distribute — the columns already fill or overflow availWidth, so the grid
       // scrolls regardless and matching the total exactly no longer matters. Round up instead of
       // cumulatively: a column sitting exactly at its measured content need (canvas measurement is
@@ -1705,8 +1788,8 @@ export function computeContentAwareColWidths(
       widths[i] = Math.ceil(contentWidth);
       continue;
     }
-    const grown = contentWidth + leftover * (growShare(i) / growTotal);
-    exactSoFar += grown;
+    const target = shouldGrow ? contentWidth + leftover * (growShare(i) / growTotal) : contentWidth;
+    exactSoFar += target;
     const rounded = Math.round(exactSoFar) - roundedSoFar;
     roundedSoFar += rounded;
     widths[i] = rounded;


### PR DESCRIPTION
## What

Shrinks content-aware auto columns when a table would otherwise overflow. Wrapped and Markdown columns shrink by default; `preventHorizontalOverflow` lets other text-bearing auto columns shrink with an ellipsis. Graphical and action cells are excluded.

The flame graph table opts into `preventHorizontalOverflow` so its Symbol column gives space back instead of pushing fixed-width columns behind a scrollbar. The prop defaults to off, and the behavior remains behind `tableAutoColumnWidths`.

## Why

Wide content can make horizontal scrolling pointless when the column already wraps, and can hide fixed-width columns in narrow layouts.

## Testing

- Added coverage for shrinking eligible columns and preserving their minimum widths.
- Updated the flame graph scrollbar-fit test to cover both width algorithms.
- Manually verified the [flame graph](http://localhost:3000/d/16f11TZWk/panel-tests-flame-graph?from=now-6h&to=now&timezone=browser) and [table](http://localhost:3000/d/table-auto-col-widths/table-auto-column-widths?from=now-6h&to=now&timezone=browser&var-Filters=&dtab=Kitchen-sink&editPanel=4) examples.

https://github.com/user-attachments/assets/c42f2a2e-85c4-4be4-b928-7db9c73b0a96
