### PR TITLE
CodeMirror: Migrate provisioned dashboard JSON preview

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.test.tsx
@@ -30,10 +30,9 @@ jest.mock(
       children({ width: 1000, height: 1000, scaledWidth: 1, scaledHeight: 1 })
 );
 
-// Monaco can't boot web workers in jsdom
-jest.mock('@grafana/ui', () => ({
-  ...jest.requireActual('@grafana/ui'),
-  CodeEditor: ({ value }: { value: string }) => <textarea data-testid="code-editor" readOnly value={value} />,
+jest.mock('@grafana/ui/unstable', () => ({
+  ...jest.requireActual('@grafana/ui/unstable'),
+  CodeMirrorEditor: ({ value }: { value: string }) => <textarea data-testid="code-editor" readOnly value={value} />,
 }));
 
 jest.mock('app/features/dashboard/api/dashboard_api', () => ({

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   ClipboardButton,
   Stack,
-  CodeEditor,
   Box,
   Label,
   RadioButtonGroup,
@@ -20,6 +19,7 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
+import { CodeMirrorEditor } from '@grafana/ui/unstable';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
@@ -176,14 +176,16 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
           ) : (
             <AutoSizer disableWidth>
               {({ height }) => (
-                <CodeEditor
-                  width="100%"
-                  height={height}
+                <CodeMirrorEditor
+                  height={`${height}px`}
                   language="json"
-                  showLineNumbers={true}
-                  showMiniMap={displayJson.length > 100}
                   value={displayJson}
-                  readOnly={true}
+                  aria-label={t(
+                    'dashboard-scene.save-provisioned-dashboard-form.json-preview-label',
+                    'Provisioned dashboard JSON'
+                  )}
+                  onChange={() => {}}
+                  readOnly
                 />
               )}
             </AutoSizer>

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -221,6 +221,7 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     json: css({
       flexGrow: 1,
+      minHeight: '300px',
       maxHeight: '800px',
     }),
     // Alert's wrapper sets flexGrow: 1, which in this column layout makes it swallow all the

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -85,6 +85,8 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
   const isK8sMode = exportFormat === ExportFormat.V2Resource && hasK8sMeta;
   const displayJson = isK8sMode ? (k8sResource.value ?? '') : classicJson;
   const isLossyClassicModel = !isK8sMode && isDashboardV2Spec(changedSaveModel);
+  const hasCommonOptions =
+    changeInfo.hasTimeChanges || changeInfo.hasVariableValueChanges || changeInfo.hasRefreshChange;
 
   const saveToFile = useCallback(() => {
     const blob = new Blob([displayJson], {
@@ -168,7 +170,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
           </Alert>
         )}
 
-        <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />
+        {hasCommonOptions && <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />}
 
         <div className={styles.json}>
           {isK8sMode && k8sResource.loading ? (

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -85,8 +85,6 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
   const isK8sMode = exportFormat === ExportFormat.V2Resource && hasK8sMeta;
   const displayJson = isK8sMode ? (k8sResource.value ?? '') : classicJson;
   const isLossyClassicModel = !isK8sMode && isDashboardV2Spec(changedSaveModel);
-  const hasCommonOptions =
-    changeInfo.hasTimeChanges || changeInfo.hasVariableValueChanges || changeInfo.hasRefreshChange;
 
   const saveToFile = useCallback(() => {
     const blob = new Blob([displayJson], {
@@ -170,7 +168,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
           </Alert>
         )}
 
-        {hasCommonOptions && <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />}
+        <SaveDashboardFormCommonOptions drawer={drawer} changeInfo={changeInfo} />
 
         <div className={styles.json}>
           {isK8sMode && k8sResource.loading ? (

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -110,7 +110,7 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
 
   return (
     <div className={styles.container}>
-      <Stack direction="column" gap={2} grow={1}>
+      <Stack direction="column" gap={2} grow={1} minWidth={0}>
         <div>
           <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.cannot-be-saved">
             This dashboard cannot be saved from the Grafana UI because it has been provisioned from another source. Copy
@@ -223,6 +223,8 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     json: css({
       flexGrow: 1,
+      width: '100%',
+      minWidth: 0,
       minHeight: '300px',
       maxHeight: '800px',
     }),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7717,6 +7717,7 @@
         "model-label": "Model",
         "v2-resource": "V2 Resource"
       },
+      "json-preview-label": "Provisioned dashboard JSON",
       "label-description": "Description",
       "label-folder-name": "Folder name",
       "label-target-folder": "Target folder",


### PR DESCRIPTION
## Related Issue

Fixes DPRO-378, #132119

## Description

Migrates the provisioned dashboard JSON preview from Monaco to CodeMirror 6 while preserving the existing export behavior.

## Changes

* Replace `CodeEditor` with the unstable `CodeMirrorEditor` in the provisioned dashboard save form
* Keep the preview read-only and JSON-formatted within the existing autosized container
* Give the autosized preview a minimum height so CodeMirror is visible
* Constrain the column and editor wrapper to the drawer width while preserving CodeMirror's internal horizontal scrolling
* Update the existing test mock to use CodeMirror

## Demo
https://github.com/user-attachments/assets/f8e25d43-811e-4d93-9ba6-18bad8b78df7

## Testing Instructions
* Open a provisioned dashboard, enter edit mode, and open the Save drawer
* Verify the JSON preview renders and remains read-only in both Classic and V2 Resource formats
* Scroll through JSON containing long lines and verify the editor remains constrained to the drawer width

## Reviewer Checklist

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
