### PR TITLE
CodeMirror: Migrate JSON inspectors

### DIFF
--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -1,3 +1,6 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { of } from 'rxjs';
 
 import {
@@ -19,6 +22,7 @@ import {
   SceneQueryRunner,
   VizPanel,
 } from '@grafana/scenes';
+import { type CodeMirrorEditorProps } from '@grafana/ui/unstable';
 import * as libpanels from 'app/features/library-panels/state/api';
 import { getStandardTransformers } from 'app/features/transformers/standardTransformers';
 
@@ -32,6 +36,24 @@ import { activateFullSceneTree } from '../utils/test-utils';
 import { findVizPanelByKey } from '../utils/utils';
 
 import { InspectJsonTab } from './InspectJsonTab';
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: AutoSizerProps) => children({ height: 480, scaledHeight: 480, scaledWidth: 800, width: 800 }),
+}));
+
+jest.mock('@grafana/ui/unstable', () => ({
+  ...jest.requireActual('@grafana/ui/unstable'),
+  CodeMirrorEditor: (props: CodeMirrorEditorProps) => (
+    <textarea
+      aria-label={props['aria-label']}
+      readOnly={props.readOnly}
+      value={props.value}
+      onChange={(event) => props.onChange(event.currentTarget.value)}
+      onBlur={(event) => props.onBlur?.(event.currentTarget.value)}
+    />
+  ),
+}));
 
 standardTransformersRegistry.setInit(getStandardTransformers);
 const panelPlugin: PanelPlugin = new PanelPlugin(() => null);
@@ -161,26 +183,25 @@ describe('InspectJsonTab', () => {
     expect(tab.isEditable()).toBe(false);
   });
 
-  it('Can update model', async () => {
+  it('applies the latest editor text when Apply is clicked immediately after editing', async () => {
+    const user = userEvent.setup();
     const { tab, panel, scene } = await buildTestScene();
+    render(<tab.Component model={tab} />);
 
-    tab.onCodeEditorBlur(`{
-      "id": 12,
-      "type": "table",
-      "title": "New title",
-      "gridPos": {
-        "x": 1,
-        "y": 2,
-        "w": 3,
-        "h": 4
-      },
-      "options": {},
-      "fieldConfig": {},
-      "transformations": [],
-      "transparent": false
-    }`);
-
-    tab.onApplyChange();
+    const updatedPanel = {
+      id: 12,
+      type: 'table',
+      title: 'New title',
+      gridPos: { x: 1, y: 2, w: 3, h: 4 },
+      options: {},
+      fieldConfig: {},
+      transformations: [],
+      transparent: false,
+    };
+    const editor = screen.getByRole('textbox', { name: 'JSON content' });
+    await user.clear(editor);
+    await user.paste(JSON.stringify(updatedPanel));
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
 
     const panel2 = findVizPanelByKey(scene, panel.state.key)!;
     expect(panel2.state.title).toBe('New title');
@@ -203,7 +224,7 @@ describe('InspectJsonTab', () => {
     expect(originalGridItem.state.width).toBe(8);
     expect(originalGridItem.state.height).toBe(10);
 
-    tab.onCodeEditorBlur(`{
+    tab.onJsonTextChange(`{
       "id": 12,
       "type": "table",
       "title": "Panel A",
@@ -259,7 +280,7 @@ describe('InspectJsonTab', () => {
       const grid = layoutManager.state.grid as SceneGridLayout;
       const forceRenderSpy = jest.spyOn(grid, 'forceRender');
 
-      tab.onCodeEditorBlur(`{
+      tab.onJsonTextChange(`{
         "kind": "GridLayoutItem",
         "spec": {
           "x": 5,
@@ -289,7 +310,7 @@ describe('InspectJsonTab', () => {
       const { tab } = await buildTestSceneWithV2Spec();
       tab.onChangeSource({ value: 'panel-layout' });
 
-      tab.onCodeEditorBlur(`{
+      tab.onJsonTextChange(`{
         "kind": "GridLayoutItem",
         "spec": {
           "x": "not a number"

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -18,7 +18,8 @@ import {
   type VizPanel,
 } from '@grafana/scenes';
 import { type LibraryPanel } from '@grafana/schema';
-import { Alert, Button, CodeEditor, Field, Select, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, Select, useStyles2 } from '@grafana/ui';
+import { CodeMirrorEditor } from '@grafana/ui/unstable';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { getPanelDataFrames } from 'app/features/dashboard/components/HelpWizard/utils';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -281,7 +282,7 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
     this.state.onClose();
   }
 
-  public onCodeEditorBlur = (value: string) => {
+  public onJsonTextChange = (value: string) => {
     this.setState({ jsonText: value });
   };
 
@@ -341,15 +342,15 @@ function InspectJsonTabComponent({ model }: SceneComponentProps<InspectJsonTab>)
       <div className={styles.content}>
         <AutoSizer disableWidth>
           {({ height }) => (
-            <CodeEditor
-              width="100%"
-              height={height}
+            <CodeMirrorEditor
+              height={`${height}px`}
               language="json"
-              showLineNumbers={true}
-              showMiniMap={jsonText.length > 100}
+              aria-label={t('dashboard.inspect-json.editor-label', 'JSON content')}
+              basicSetup={{ lineNumbers: true }}
               value={jsonText}
               readOnly={!model.isEditable()}
-              onBlur={model.onCodeEditorBlur}
+              onChange={model.onJsonTextChange}
+              onBlur={model.onJsonTextChange}
             />
           )}
         </AutoSizer>

--- a/public/app/features/inspector/InspectJSONTab.test.tsx
+++ b/public/app/features/inspector/InspectJSONTab.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
+
+import { getDefaultTimeRange, LoadingState, type PanelData } from '@grafana/data';
+import { type CodeMirrorEditorProps } from '@grafana/ui/unstable';
+
+import { InspectJSONTab } from './InspectJSONTab';
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: AutoSizerProps) => children({ height: 480, scaledHeight: 480, scaledWidth: 800, width: 800 }),
+}));
+
+jest.mock('@grafana/ui/unstable', () => ({
+  ...jest.requireActual('@grafana/ui/unstable'),
+  CodeMirrorEditor: (props: CodeMirrorEditorProps) => (
+    <textarea
+      aria-label={props['aria-label']}
+      readOnly={props.readOnly}
+      value={props.value}
+      onChange={(event) => props.onChange(event.currentTarget.value)}
+      onBlur={(event) => props.onBlur?.(event.currentTarget.value)}
+    />
+  ),
+}));
+
+jest.mock('../search/page/reporting', () => ({
+  reportPanelInspectInteraction: jest.fn(),
+}));
+
+const data = {
+  state: LoadingState.Done,
+  timeRange: getDefaultTimeRange(),
+  series: [],
+} satisfies PanelData;
+
+describe('InspectJSONTab', () => {
+  it('switches read-only Explore JSON sources', async () => {
+    const user = userEvent.setup();
+    render(<InspectJSONTab data={data} onClose={jest.fn()} />);
+
+    const editor = await screen.findByRole('textbox', { name: 'JSON content' });
+    expect(editor).toHaveValue('[]');
+    expect(editor).toHaveAttribute('readonly');
+
+    await user.click(screen.getByRole('combobox', { name: 'Select source' }));
+    await user.click(screen.getByText('Panel data'));
+
+    await waitFor(() => expect(editor).toHaveValue(JSON.stringify(data, null, 2)));
+    expect(editor).toHaveAttribute('readonly');
+  });
+});

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -8,7 +8,8 @@ import { AppEvents, type PanelData, type SelectableValue, LoadingState } from '@
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
-import { Button, CodeEditor, Field, Select, useStyles2 } from '@grafana/ui';
+import { Button, Field, Select, useStyles2 } from '@grafana/ui';
+import { CodeMirrorEditor } from '@grafana/ui/unstable';
 import { appEvents } from 'app/core/app_events';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { type PanelModel } from 'app/features/dashboard/state/PanelModel';
@@ -148,14 +149,14 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
       <div className={styles.content}>
         <AutoSizer disableWidth>
           {({ height }) => (
-            <CodeEditor
-              width="100%"
-              height={height}
+            <CodeMirrorEditor
+              height={`${height}px`}
               language="json"
-              showLineNumbers={true}
-              showMiniMap={text.length > 100}
+              aria-label={t('dashboard.inspect-json.editor-label', 'JSON content')}
+              basicSetup={{ lineNumbers: true }}
               value={text || ''}
               readOnly={!isPanelJSON}
+              onChange={setText}
               onBlur={setText}
             />
           )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5947,6 +5947,7 @@
     "inspect-json": {
       "dataframe-description": "Raw data without transformations and field config applied. ",
       "dataframe-label": "DataFrame JSON (from Query)",
+      "editor-label": "JSON content",
       "panel-data-description": "The raw model passed to the panel visualization",
       "panel-data-label": "Panel data",
       "panel-json-description": "The model saved in the dashboard JSON that configures how everything works.",


### PR DESCRIPTION
## Related Issue
Fixes DPRO-375, #132116

## Description
Migrates the shared and Scenes dashboard JSON inspectors from the Monaco-backed `CodeEditor` to `CodeMirrorEditor` while preserving existing behavior.

## Changes
* Replaced `CodeEditor` with `CodeMirrorEditor` in both JSON inspectors
* Preserved AutoSizer height, JSON language support, line numbers, source changes, and existing read-only rules
* Kept the draft current so an immediate Apply uses the latest editor text
* Added minimal focused component coverage and extracted the editor label translation

## Risks
The most likely regressions are panel JSON Apply behavior and the read-only Explore query inspector. Existing validation and editability logic is unchanged.

## Demo
<img width="1194" height="1716" alt="CleanShot 2026-09-16 at 1 31 24 PM@2x" src="https://github.com/user-attachments/assets/090ad98e-d2d7-4e7a-a792-736e00b7b335" />

## Testing Instructions
* Open a dashboard panel's JSON inspector, edit valid JSON, and immediately click Apply; verify the panel updates and the drawer closes
* Open Explore Query inspector > JSON, switch sources, and verify the content remains read-only

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
