### PR TITLE
Provisioning: show repository status errors

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -30,6 +30,7 @@ import { formatTimestamp } from '../utils/time';
 
 import { RepositoryHealthCard } from './RepositoryHealthCard';
 import { RepositoryPullStatusCard } from './RepositoryPullStatusCard';
+import { RepositoryStatusAlert } from './RepositoryStatusAlert';
 
 type StatCell<T extends keyof ResourceCount = keyof ResourceCount> = CellProps<ResourceCount, ResourceCount[T]>;
 
@@ -99,6 +100,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
   return (
     <Box padding={2}>
       <Stack direction="column" gap={2}>
+        <RepositoryStatusAlert repository={repo} />
         {showFolderMetadataCheck && hasMissingFolderMetadata(conditions) && (
           <MissingFolderMetadataBanner repositoryName={repoName} variant="repo" />
         )}

--- a/public/app/features/provisioning/Repository/RepositoryStatusAlert.test.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusAlert.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from 'test/test-utils';
+
+import { type Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+import { RepositoryStatusAlert } from './RepositoryStatusAlert';
+
+const repository = {
+  metadata: { name: 'test-repo' },
+  spec: {
+    title: 'Test repository',
+    type: 'git',
+    sync: { target: 'folder', enabled: true },
+    workflows: [],
+  },
+  status: {
+    health: { healthy: true },
+    sync: { state: 'success', message: [] },
+    observedGeneration: 1,
+    webhook: {},
+  },
+} as Repository;
+
+describe('RepositoryStatusAlert', () => {
+  it('does not render for a healthy repository', () => {
+    const { container } = render(<RepositoryStatusAlert repository={repository} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows field error details for an unhealthy repository', () => {
+    const detail = 'The repository returned 404 Not Found';
+    render(
+      <RepositoryStatusAlert
+        repository={{
+          ...repository,
+          status: {
+            ...repository.status!,
+            health: { healthy: false, error: 'health', message: [detail] },
+            fieldErrors: [{ type: 'FieldValueInvalid', field: 'secure.token', detail }],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Repository error')).toBeInTheDocument();
+    expect(screen.getByText(detail)).toBeInTheDocument();
+  });
+
+  it('shows the deletion error', () => {
+    const deleteError = 'Repository cleanup could not delete non-empty folder shared-folder.';
+    render(
+      <RepositoryStatusAlert
+        repository={{
+          ...repository,
+          metadata: { ...repository.metadata, deletionTimestamp: '2026-09-11T00:00:00Z' },
+          status: { ...repository.status!, deleteError },
+        }}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Repository deletion error')).toBeInTheDocument();
+    expect(screen.getByText(deleteError)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/provisioning/Repository/RepositoryStatusAlert.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusAlert.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/css';
+
+import { t } from '@grafana/i18n';
+import { Alert, Stack } from '@grafana/ui';
+import { type Repository } from 'app/api/clients/provisioning/v0alpha1';
+
+const preserveNewlines = css({ whiteSpace: 'pre-line' });
+
+export function RepositoryStatusAlert({ repository }: { repository: Repository }) {
+  const deleteError = repository.status?.deleteError;
+  const errors = [
+    ...(deleteError ? [deleteError] : []),
+    ...(repository.status?.fieldErrors?.flatMap((error) => (error.detail ? [error.detail] : [])) ?? []),
+  ];
+
+  if (errors.length) {
+    return (
+      <Alert
+        severity="error"
+        title={
+          deleteError
+            ? t('provisioning.repository-status-alert.deletion-title', 'Repository deletion error')
+            : t('provisioning.repository-status-alert.error-title', 'Repository error')
+        }
+      >
+        <Stack direction="column" gap={1}>
+          {errors.map((error, index) => (
+            <div className={preserveNewlines} key={index}>
+              {error}
+            </div>
+          ))}
+        </Stack>
+      </Alert>
+    );
+  }
+
+  return null;
+}

--- a/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryStatusPage.tsx
@@ -105,7 +105,7 @@ export default function RepositoryStatusPage() {
                   ))}
                 </TabsBar>
                 <TabContent>
-                  {data?.metadata?.deletionTimestamp && (
+                  {data.metadata?.deletionTimestamp && !data.status?.deleteError && (
                     <Alert
                       title={t('provisioning.repository-status-page.title-queued-for-deletion', 'Queued for deletion')}
                       severity="warning"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14696,6 +14696,10 @@
     "repository-status": {
       "error": "Failed to load repository"
     },
+    "repository-status-alert": {
+      "deletion-title": "Repository deletion error",
+      "error-title": "Repository error"
+    },
     "repository-status-page": {
       "back-to-repositories": "Back to repositories",
       "cleaning-up-resources": "Cleaning up repository resources",


### PR DESCRIPTION
**What is this feature?**

The repository Overview displays backend-supplied deletion errors and field errors in a prominent alert. Multiline deletion details keep their formatting.

The queued-for-deletion warning remains visible while cleanup is pending and disappears when the backend reports a deletion error. The Health card continues to display `status.health.message` unchanged.

<img width="1469" height="861" alt="Screenshot 2026-09-12 at 9 44 14 PM" src="https://github.com/user-attachments/assets/8096bc07-9f20-4cec-b9a4-956d1c1ceec2" />

**Why do we need this feature?**

Repository deletion failures were available in `status.deleteError` but were not shown to users. A repository could remain in `Terminating` with only a spinner and no actionable details.

Backend PR: https://github.com/grafana/grafana/pull/132221

**Who is this feature for?**

Git Sync users diagnosing repository configuration or deletion failures.

**Which issue(s) does this PR fix?**:

Frontend for https://github.com/grafana/git-ui-sync-project/issues/1338

**Special notes for your reviewer:**

- The UI renders backend status directly; it does not derive deletion state.
- The alert supports `status.deleteError` and `status.fieldErrors`.
- Unit tests cover healthy, field-error, and deletion-error states.

_<sub>PR description generated with openai-codex:gpt-5.6-sol</sub>_

