### PR TITLE
FieldOverrides: Don't write panel field config onto shared source frames

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -350,6 +350,58 @@ describe('applyFieldOverrides', () => {
       expect(withOverrides[0].fields[1].values[0].fields[1].config.max).toBe(30);
     });
 
+    it('will not write the panel config onto the frames it was given', () => {
+      // The "Time series to table" transformation builds its sparkline frames out of the source
+      // query's own field objects, so the nested frame's config is the same object the query
+      // runner still holds. Applying this panel's config must not reach back into it.
+      const sourceFrame = createDataFrame({
+        name: 'source',
+        refId: 'A',
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1752170223000, 1752170224000] },
+          { name: 'value', type: FieldType.number, values: [10, 20] },
+        ],
+      });
+      const nested: DataFrame = {
+        name: 'nested',
+        length: 2,
+        fields: sourceFrame.fields.map((field) => ({ ...field })),
+      };
+
+      const f0 = createDataFrame({
+        name: 'A',
+        fields: [
+          { name: 'message', type: FieldType.string, values: ['foo'] },
+          { name: 'frame', type: FieldType.frame, values: [nested] },
+        ],
+      });
+
+      const withOverrides = applyFieldOverrides({
+        data: [f0],
+        fieldConfig: {
+          defaults: { unit: 'percent' },
+          overrides: [
+            {
+              matcher: { id: FieldMatcherID.byName, options: 'frame' },
+              properties: [{ id: 'displayName', value: 'Trend' }],
+            },
+          ],
+        },
+        replaceVariables: (value) => value,
+        theme: createTheme(),
+        fieldConfigRegistry: customFieldRegistry,
+      });
+
+      // the config still reaches the fields inside the frame
+      expect(withOverrides[0].fields[1].values[0].fields[1].config).toMatchObject({
+        unit: 'percent',
+        displayName: 'Trend',
+      });
+      // ...without touching the frames handed in
+      expect(nested.fields[1].config).toEqual({});
+      expect(sourceFrame.fields[1].config).toEqual({});
+    });
+
     it('will not crash when some of the nested frames are undefined', () => {
       const f0 = createDataFrame({
         name: 'A',

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -285,11 +285,17 @@ export function applyFieldOverrides(
         const newValues: DataFrame[] = Array(field.values.length);
         for (let idx = 0; idx < field.values.length; idx++) {
           const nestedFrame: DataFrame = field.values[idx] ?? createDataFrame({ fields: [] });
+          // Nested frames share field objects with the source query, so merging in place
+          // would write this panel's config onto data other panels read.
+          const newFields = Array(nestedFrame.fields.length);
           for (let fieldIndex = 0; fieldIndex < nestedFrame.fields.length; fieldIndex++) {
             const valueField = nestedFrame.fields[fieldIndex];
-            valueField.config = defaultsDeep(valueField.config || {}, config);
+            newFields[fieldIndex] = {
+              ...valueField,
+              config: defaultsDeep(cloneDeep(valueField.config) || {}, config),
+            };
           }
-          newValues[idx] = nestedFrame;
+          newValues[idx] = { ...nestedFrame, fields: newFields };
         }
         // @todo should this be scoped?
         field.values = applyFieldOverrides(options, newValues);


### PR DESCRIPTION
**What is this feature?**

`applyFieldOverrides` no longer mutates the frames it is given. For a `FieldType.frame` field it merged the parent config into each nested field with `defaultsDeep`, which mutates its first argument. Those nested frames share `config` objects with the source query's fields, so the panel's config was written into shared data. This copies the fields before merging.

**Why do we need this feature?**

A table panel using "Time series to table" overwrote the field config of its own raw query results. A panel reading it through the `-- Dashboard --` datasource with `withTransforms: false` then inherited the table's `displayName`, `unit`, `color`, `thresholds` and `custom.cellOptions`, so every series rendered with the table column's display name.

**Who is this feature for?**

Users whose dashboards feed a "Time series to table" panel into another panel through the `-- Dashboard --` datasource. Not datasource-specific.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/24078

**Special notes for your reviewer:**

Introduced by #115030, first released in v12.4.0 (`v12.3.7` has no `defaultsDeep` here).

@fastfrwrd — this touches a line #119118 optimised. The copy adds a `cloneDeep` per nested field, on top of the one the recursive call already does. Best of 5, 60 points per sparkline:

| table rows | before | after |
| --- | --- | --- |
| 100 | 1.0 ms | 1.1 ms |
| 1000 | 6.0 ms | 6.8 ms |
| 5000 | 28.7 ms | 34.0 ms |

A shallow copy is not safe: `defaultsDeep` recurses, so it would still mutate a shared `custom` or `thresholds` object.

New test in `fieldOverrides.test.ts` fails on main, passes here. Also verified in a running build: before, all five consumer series carry `displayName=Trend`; after, clean, with the source table's sparklines intact.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
