### PR TITLE
Query Editor: Clear the scroll target when the pinned row unmounts

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { of, map } from 'rxjs';
 
@@ -443,6 +443,69 @@ describe('PanelDataQueriesTab', () => {
       const queries = queriesTab.queryRunner.state.queries;
       expect(refId).toBe('B');
       expect(queries[queries.length - 1].refId).toBe('B');
+    });
+  });
+
+  describe('scrolling a new query row into view', () => {
+    let scrollIntoViewSpy: jest.Mock;
+    let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+
+    beforeEach(() => {
+      // jsdom doesn't implement scrollIntoView, so patch the prototype rather than spy on it.
+      originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+      scrollIntoViewSpy = jest.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+    });
+
+    afterEach(() => {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    });
+
+    // The tab renders nothing until the query runner has data, and these tests need the real
+    // (unmocked) query state so adding and removing rows is observable.
+    async function setupTabWithData() {
+      const { queriesTab } = await setupScene('panel-1');
+      queriesTab.queryRunner.setState({
+        data: { state: LoadingState.Done, series: [], timeRange: {} as TimeRange },
+      });
+      return queriesTab;
+    }
+
+    it('clears scrollToRefId as soon as the row starts scrolling, even if the tab unmounts mid-scroll', async () => {
+      const queriesTab = await setupTabWithData();
+      await queriesTab.addQueryClick();
+      queriesTab.setState({ scrollToRefId: 'B' });
+
+      const { unmount } = render(<PanelDataQueriesTabRendered model={queriesTab} />);
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+
+      // PanelDataPane renders only the active tab, so leaving the Queries tab unmounts the row
+      // while it is still pinned. Nothing reports back on that path.
+      unmount();
+
+      expect(queriesTab.state.scrollToRefId).toBeUndefined();
+    });
+
+    it('does not scroll a new query that inherits the refId of the deleted pinned row', async () => {
+      const queriesTab = await setupTabWithData();
+      await queriesTab.addQueryClick();
+      queriesTab.setState({ scrollToRefId: 'B' });
+
+      const { unmount } = render(<PanelDataQueriesTabRendered model={queriesTab} />);
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      unmount();
+
+      // getNextRefId recycles freed refIds, so an unrelated query added later gets 'B' back and
+      // would inherit a stale scroll target.
+      queriesTab.onQueriesChange(queriesTab.queryRunner.state.queries.filter((query) => query.refId !== 'B'));
+      await queriesTab.addQueryClick();
+      expect(queriesTab.queryRunner.state.queries.map((query) => query.refId)).toEqual(['A', 'B']);
+
+      scrollIntoViewSpy.mockClear();
+      render(<PanelDataQueriesTabRendered model={queriesTab} />);
+      await waitFor(() => expect(screen.getAllByTestId(selectors.components.QueryEditorRows.rows)).toHaveLength(2));
+
+      expect(scrollIntoViewSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { type PropsWithChildren } from 'react';
 
 import { CoreApp, type DataQueryRequest, dateTime, LoadingState, type PanelData, toDataFrame } from '@grafana/data';
@@ -452,6 +452,8 @@ describe('QueryEditorRow', () => {
   describe('scroll into view', () => {
     let scrollIntoViewSpy: jest.Mock;
     let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView;
+    let originalResizeObserver: typeof ResizeObserver;
+    let resizeCallbacks: ResizeObserverCallback[];
 
     const data: PanelData = {
       state: LoadingState.Done,
@@ -459,78 +461,107 @@ describe('QueryEditorRow', () => {
       timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
     };
 
+    // Growing the container is the only way to observe that a pin is still live, and the
+    // jest-setup ResizeObserver only ever emits one observation per observe(). Take it over so
+    // resizes are deterministic and re-pin counts are exact.
+    function growContainer() {
+      resizeCallbacks.forEach((callback) =>
+        callback([{ contentRect: { height: 500 } } as ResizeObserverEntry], {} as ResizeObserver)
+      );
+    }
+
     beforeEach(() => {
       // jsdom doesn't implement scrollIntoView, so patch the prototype rather than spy on it.
       originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
       scrollIntoViewSpy = jest.fn();
       HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
       jest.mocked(pinScrollIntoView).mockClear();
+
+      resizeCallbacks = [];
+      originalResizeObserver = global.ResizeObserver;
+      global.ResizeObserver = class {
+        constructor(private callback: ResizeObserverCallback) {}
+        observe() {
+          resizeCallbacks.push(this.callback);
+        }
+        disconnect() {
+          resizeCallbacks = resizeCallbacks.filter((callback) => callback !== this.callback);
+        }
+        unobserve() {}
+      } as unknown as typeof ResizeObserver;
     });
 
     afterEach(() => {
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      global.ResizeObserver = originalResizeObserver;
     });
 
     it('scrolls the row into view once it renders (after the datasource loads)', async () => {
       render(<QueryEditorRow {...props(data)} scrollIntoView />);
 
       // The row renders nothing until its datasource resolves, so the scroll must wait for that.
-      // The jest-setup ResizeObserver mock may fire an extra re-pin, so assert on the first
-      // (deliberate) call rather than the total count.
-      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1));
       expect(scrollIntoViewSpy.mock.instances[0]).toBe(screen.getByTestId(selectors.components.QueryEditorRows.rows));
-      expect(scrollIntoViewSpy).toHaveBeenNthCalledWith(1, { behavior: 'smooth', block: 'start' });
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
     });
 
-    it('keeps pinning after the scroll and reports back when the user takes over', async () => {
+    it('reports the scroll as soon as the pin starts, so unmounting cannot leave the flag set', async () => {
       const onScrollIntoView = jest.fn();
-      render(<QueryEditorRow {...props(data)} scrollIntoView onScrollIntoView={onScrollIntoView} />);
+      const { unmount } = render(
+        <QueryEditorRow {...props(data)} scrollIntoView onScrollIntoView={onScrollIntoView} />
+      );
 
-      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
-      // The row stays pinned until the layout settles or the user scrolls, so the flag isn't
-      // cleared right after the first scroll.
-      expect(onScrollIntoView).not.toHaveBeenCalled();
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1));
+      // Reported in the same tick as the scroll rather than after the pin's settle window.
+      expect(onScrollIntoView).toHaveBeenCalledTimes(1);
 
-      fireEvent.wheel(window);
+      // Switching tabs unmounts the row mid-pin, and nothing reports back on that path — which is
+      // why the report has to happen at pin start.
+      unmount();
 
       expect(onScrollIntoView).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps pinning after the owner clears the flag, so growing siblings cannot push the row away', async () => {
+      const onScrollIntoView = jest.fn();
+      const initialProps = props(data);
+      const { rerender } = render(
+        <QueryEditorRow {...initialProps} scrollIntoView onScrollIntoView={onScrollIntoView} />
+      );
+      await waitFor(() => expect(onScrollIntoView).toHaveBeenCalledTimes(1));
+
+      // The owner clears its one-shot flag in response to that report. The render that follows
+      // must not be mistaken for a retarget and cancel the pin.
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView={false} onScrollIntoView={onScrollIntoView} />);
+      growContainer();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+      expect(scrollIntoViewSpy.mock.instances[1]).toBe(screen.getByTestId(selectors.components.QueryEditorRows.rows));
     });
 
     it('starts the pin only once, even as the row keeps re-rendering', async () => {
       const initialProps = props(data);
       const { rerender } = render(<QueryEditorRow {...initialProps} scrollIntoView />);
-      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1));
 
       rerender(<QueryEditorRow {...initialProps} scrollIntoView data={{ ...data }} />);
 
       expect(pinScrollIntoView).toHaveBeenCalledTimes(1);
     });
 
-    it('cancels the pin when the scroll is retargeted at another row', async () => {
+    it('pins again when the owner points the scroll back at this row', async () => {
       const onScrollIntoView = jest.fn();
       const initialProps = props(data);
       const { rerender } = render(
         <QueryEditorRow {...initialProps} scrollIntoView onScrollIntoView={onScrollIntoView} />
       );
-      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
+      await waitFor(() => expect(onScrollIntoView).toHaveBeenCalledTimes(1));
 
       rerender(<QueryEditorRow {...initialProps} scrollIntoView={false} onScrollIntoView={onScrollIntoView} />);
-      fireEvent.wheel(window);
-
-      // The pin is gone, so the row neither re-scrolls nor reports back — reporting would clear the
-      // owner's new scroll target.
-      expect(onScrollIntoView).not.toHaveBeenCalled();
-    });
-
-    it('pins again if the row is retargeted later', async () => {
-      const initialProps = props(data);
-      const { rerender } = render(<QueryEditorRow {...initialProps} scrollIntoView />);
-      await waitFor(() => expect(scrollIntoViewSpy).toHaveBeenCalled());
-
-      rerender(<QueryEditorRow {...initialProps} scrollIntoView={false} />);
-      rerender(<QueryEditorRow {...initialProps} scrollIntoView />);
+      rerender(<QueryEditorRow {...initialProps} scrollIntoView onScrollIntoView={onScrollIntoView} />);
 
       expect(pinScrollIntoView).toHaveBeenCalledTimes(2);
+      expect(onScrollIntoView).toHaveBeenCalledTimes(2);
     });
 
     it('does not scroll when the flag is not set', async () => {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -93,7 +93,7 @@ export interface Props<TQuery extends DataQuery> {
    * a fixed delay.
    */
   scrollIntoView?: boolean;
-  /** Called after the scroll happens so the owner can clear the flag. */
+  /** Called as soon as the scroll starts so the owner can clear the one-shot flag. */
   onScrollIntoView?: () => void;
 }
 
@@ -136,10 +136,11 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       this.hasStartedScrollIntoView = true;
       // A single scroll is not enough: the other rows' editors load asynchronously and push this
       // row away as they grow, so keep it pinned until the layout settles or the user scrolls.
-      this.cancelScrollPin = pinScrollIntoView(this.editorRef.current, () => {
-        this.cancelScrollPin = undefined;
-        this.props.onScrollIntoView?.();
-      });
+      this.cancelScrollPin = pinScrollIntoView(this.editorRef.current);
+      // Report as soon as the pin starts. The owner's flag is one-shot and it has no use for pin
+      // completion, so reporting at the end would leave the flag set for good whenever the pin is
+      // cancelled instead of finishing — which is what unmounting the row does.
+      this.props.onScrollIntoView?.();
     }
   }
 
@@ -199,12 +200,9 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       this.setState({ data: dataFilteredByRefId });
     }
 
-    // The owner retargeted the scroll (e.g. a second expression added before this pin settled).
-    // Drop this row's pin so it stops fighting the new target — cancelling rather than finishing,
-    // since finishing would report back and clear the target the owner just set.
-    if (prevProps.scrollIntoView && !this.props.scrollIntoView) {
-      this.cancelScrollPin?.();
-      this.cancelScrollPin = undefined;
+    // The owner pointed the scroll back at this row after we cleared the flag at pin start, so
+    // this is a new request rather than the render that follows our own report.
+    if (!prevProps.scrollIntoView && this.props.scrollIntoView) {
       this.hasStartedScrollIntoView = false;
     }
 

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -54,7 +54,7 @@ export interface Props {
   panelRef?: SceneObjectRef<VizPanel>;
   /** refId of a row to scroll into view once it renders (e.g. a freshly added query). */
   scrollToRefId?: string;
-  /** Called after the row identified by scrollToRefId has been scrolled into view. */
+  /** Called as soon as the row identified by scrollToRefId starts scrolling into view. */
   onScrollIntoView?: () => void;
 }
 

--- a/public/app/features/query/components/pinScrollIntoView.test.ts
+++ b/public/app/features/query/components/pinScrollIntoView.test.ts
@@ -19,6 +19,17 @@ class MockResizeObserver implements ResizeObserver {
   }
 
   unobserve() {}
+
+  /**
+   * Delivers an observation. Real observers stop delivering after disconnect(), so mirror that —
+   * it's what lets a test prove pinning actually stopped rather than only that disconnect() ran.
+   */
+  fire(height: number) {
+    if (this.disconnected) {
+      return;
+    }
+    this.callback([{ contentRect: { height } } as ResizeObserverEntry], this);
+  }
 }
 
 describe('pinScrollIntoView', () => {
@@ -44,25 +55,22 @@ describe('pinScrollIntoView', () => {
     global.ResizeObserver = originalResizeObserver;
   });
 
+  // jsdom's getBoundingClientRect returns 0, so the baseline height measured at pin start is 0.
   function setup() {
     const parent = document.createElement('div');
     const element = document.createElement('div');
     parent.appendChild(element);
     document.body.appendChild(parent);
 
-    const onDone = jest.fn();
-    const cancel = pinScrollIntoView(element, onDone);
-    const observer = MockResizeObserver.instances[0];
+    const cancel = pinScrollIntoView(element);
+    const observer = MockResizeObserver.instances[MockResizeObserver.instances.length - 1];
 
     return {
       element,
       parent,
-      onDone,
       cancel,
       observer,
-      // Simulates a ResizeObserver callback reporting the observed target at `height`. jsdom's
-      // getBoundingClientRect returns 0, so the baseline height measured at pin start is 0.
-      fireResize: (height: number) => observer.callback([{ contentRect: { height } } as ResizeObserverEntry], observer),
+      fireResize: (height: number) => observer.fire(height),
     };
   }
 
@@ -116,52 +124,76 @@ describe('pinScrollIntoView', () => {
     expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('reports done once the layout stays quiet for the settle window', () => {
-    const { onDone, observer } = setup();
+  it('keeps re-pinning right up to the end of the settle window, then stops', () => {
+    const { fireResize, observer } = setup();
 
     jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
-    expect(onDone).not.toHaveBeenCalled();
-
-    jest.advanceTimersByTime(1);
-    expect(onDone).toHaveBeenCalledTimes(1);
-    expect(observer.disconnected).toBe(true);
-  });
-
-  it('restarts the settle window on every height change', () => {
-    const { onDone, fireResize } = setup();
-
+    expect(observer.disconnected).toBe(false);
     fireResize(100);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
+
+    // The re-pin restarted the window, so the pin only ends a full window after the last growth.
     jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
-    fireResize(200);
-    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS - 1);
-    expect(onDone).not.toHaveBeenCalled();
+    expect(observer.disconnected).toBe(false);
 
     jest.advanceTimersByTime(1);
-    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+    fireResize(200);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('stops pinning and reports done on the first user scroll gesture', () => {
-    const { onDone, observer } = setup();
+  it('stops pinning on the first user scroll gesture, leaving deliberate navigation alone', () => {
+    const { fireResize, observer } = setup();
 
     window.dispatchEvent(new Event('wheel'));
 
-    expect(onDone).toHaveBeenCalledTimes(1);
     expect(observer.disconnected).toBe(true);
-
-    // The settle timer must not report done a second time.
+    // Content that grows after the handover must not drag the viewport back to the element.
+    fireResize(400);
     jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS);
-    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('cancel stops pinning without reporting done', () => {
-    const { onDone, cancel, observer } = setup();
+  it('cancel stops pinning', () => {
+    const { cancel, fireResize, observer } = setup();
 
     cancel();
 
-    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS);
-    window.dispatchEvent(new Event('wheel'));
-
-    expect(onDone).not.toHaveBeenCalled();
     expect(observer.disconnected).toBe(true);
+    fireResize(400);
+    jest.advanceTimersByTime(SCROLL_PIN_SETTLE_MS);
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('supersedes an outstanding pin, so two pins never fight over the viewport', () => {
+    const first = setup();
+    const second = setup();
+
+    expect(first.observer.disconnected).toBe(true);
+    expect(second.observer.disconnected).toBe(false);
+
+    // Growth now moves the viewport to the newest target only.
+    first.fireResize(300);
+    second.fireResize(300);
+
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(3);
+    expect(scrollIntoViewSpy.mock.instances[2]).toBe(second.element);
+  });
+
+  it('a superseded pin cancelling late leaves the live pin, and the next pin still supersedes it', () => {
+    const first = setup();
+    const second = setup();
+
+    // The superseded row cleaning up late (its row unmounting) must neither stop the pin that
+    // replaced it nor detach that pin from the viewport.
+    first.cancel();
+    expect(second.observer.disconnected).toBe(false);
+
+    const third = setup();
+
+    expect(second.observer.disconnected).toBe(true);
+    expect(third.observer.disconnected).toBe(false);
+    third.fireResize(300);
+    expect(scrollIntoViewSpy.mock.instances[3]).toBe(third.element);
   });
 });

--- a/public/app/features/query/components/pinScrollIntoView.ts
+++ b/public/app/features/query/components/pinScrollIntoView.ts
@@ -5,41 +5,47 @@
 export const SCROLL_PIN_SETTLE_MS = 1500;
 
 /**
+ * Stops the pin that currently owns the viewport. Only one pin can be active at a time: two pins
+ * scrolling the same viewport fight each other, so starting a new one supersedes the old.
+ */
+let cancelActivePin: (() => void) | undefined;
+
+/**
  * Scrolls an element into view and keeps it pinned there while surrounding content finishes
  * loading. A single scroll is not enough when siblings render asynchronously (e.g. query rows
  * loading their datasource editors): content above the element grows after the scroll and pushes
  * it away, leaving the viewport at a stale offset.
  *
- * Re-pinning is driven by a ResizeObserver on the element's parent and ends — calling `onDone` —
- * once the layout has been quiet for a settle window, or immediately on the first user scroll
- * gesture, so we never fight deliberate navigation.
+ * Re-pinning is driven by a ResizeObserver on the element's parent and ends once the layout has
+ * been quiet for a settle window, on the first user scroll gesture (so we never fight deliberate
+ * navigation), or when a newer pin takes over the viewport.
  *
- * Returns a cancel function that stops pinning without calling `onDone` (for unmount).
+ * Returns a cancel function that stops pinning early (for unmount).
  */
-export function pinScrollIntoView(element: HTMLElement, onDone?: () => void): () => void {
+export function pinScrollIntoView(element: HTMLElement): () => void {
+  cancelActivePin?.();
+
   element.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
   let settleTimer: ReturnType<typeof setTimeout> | undefined;
   let resizeObserver: ResizeObserver | undefined;
 
   const stop = () => {
+    if (cancelActivePin === stop) {
+      cancelActivePin = undefined;
+    }
     clearTimeout(settleTimer);
     resizeObserver?.disconnect();
     window.removeEventListener('wheel', onUserScroll);
     window.removeEventListener('touchmove', onUserScroll);
   };
 
-  const finish = () => {
-    stop();
-    onDone?.();
-  };
-
   // User-intent events only — not 'scroll', which our own programmatic scrolls would trigger.
-  const onUserScroll = () => finish();
+  const onUserScroll = () => stop();
 
   const restartSettleTimer = () => {
     clearTimeout(settleTimer);
-    settleTimer = setTimeout(finish, SCROLL_PIN_SETTLE_MS);
+    settleTimer = setTimeout(stop, SCROLL_PIN_SETTLE_MS);
   };
 
   restartSettleTimer();
@@ -71,6 +77,8 @@ export function pinScrollIntoView(element: HTMLElement, onDone?: () => void): ()
 
   window.addEventListener('wheel', onUserScroll, { passive: true });
   window.addEventListener('touchmove', onUserScroll, { passive: true });
+
+  cancelActivePin = stop;
 
   return stop;
 }


### PR DESCRIPTION
**What is this feature?**

Fires `onScrollIntoView` when the scroll pin starts rather than when it ends, so the owner's
one-shot `scrollToRefId` is always cleared. Reduces the helper to `pinScrollIntoView(element) => cancel`.

**Why do we need this feature?**

`componentWillUnmount` cancels the pin, and cancelling skips `onDone`, so `scrollToRefId` is never
cleared. `PanelDataPane` renders only the active tab, so switching tabs unmounts the row mid-pin.
The flag then stays set for the rest of the session: every return to the Queries tab re-scrolls,
and because `getNextRefId` recycles freed refIds, deleting the pinned row lets an unrelated query
inherit the scroll.

**Who is this feature for?**

Users adding a SQL expression from the Transformations tab. Classic data pane only —
`PanelDataPaneNext` does not use this code.

**Which issue(s) does this PR fix?**:

Fixes #129618

**Special notes for your reviewer:**

Clearing the flag at pin start makes #129524's `cancels the pin when the scroll is retargeted at
another row` obsolete — the report now happens before any retarget can occur. Two helper tests
cover the behaviour it protected instead.

Both repro paths have regression tests that fail without the fix.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Existing behaviour fix; entry
      point is already behind `sqlExpressions`.
- [x] The docs are updated. Not applicable.