### PR TITLE
TimeComparison: Time settings support for fiscal

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
@@ -259,6 +259,73 @@ describe('PanelTimeRange', () => {
     });
   });
 
+  describe('fiscal year start month', () => {
+    // April fiscal year: on 2019-02-11 the current fiscal year started 2018-04-01, so anything
+    // resolving to 2019-01-01 means the panel fell back to a January fiscal year.
+    const APRIL = 3;
+
+    function buildAprilFiscalSceneFor(panelTime: PanelTimeRange) {
+      const sceneTimeRange = new SceneTimeRange({
+        from: 'now-6h',
+        to: 'now',
+        timeZone: 'utc',
+        fiscalYearStartMonth: APRIL,
+      });
+      const panel = new SceneCanvasText({ text: 'Hello', $timeRange: panelTime });
+      const scene = new SceneFlexLayout({
+        $timeRange: sceneTimeRange,
+        children: [new SceneFlexItem({ body: panel })],
+      });
+      activateFullSceneTree(scene);
+
+      return sceneTimeRange;
+    }
+
+    it('should round a fiscal timeFrom to the dashboard fiscal year start', () => {
+      const panelTime = new PanelTimeRange({ timeFrom: 'now/fy' });
+
+      buildAprilFiscalSceneFor(panelTime);
+
+      expect(panelTime.state.value.from.toISOString()).toBe('2018-04-01T00:00:00.000Z');
+      expect(panelTime.state.value.to.toISOString()).toBe(fakeCurrentDate.toISOString());
+    });
+
+    it('should round a fiscal timeFrom to the dashboard fiscal year start before applying the timeShift', () => {
+      const panelTime = new PanelTimeRange({ timeFrom: 'now/fy', timeShift: '1d' });
+
+      buildAprilFiscalSceneFor(panelTime);
+
+      expect(panelTime.state.value.from.toISOString()).toBe('2018-03-31T00:00:00.000Z');
+      expect(panelTime.state.value.to.toISOString()).toBe('2019-02-10T19:00:00.000Z');
+    });
+
+    it('should offset the time comparison range from the fiscal-rounded panel range', () => {
+      const panelTime = new PanelTimeRange({ timeFrom: 'now/fy', compareWith: '1d' });
+
+      buildAprilFiscalSceneFor(panelTime);
+
+      const extraQueries = panelTime.getExtraQueries({
+        targets: [{ refId: 'A' }],
+        range: panelTime.state.value,
+      } as DataQueryRequest);
+
+      // 2018-04-01 fiscal start minus the 1d compare offset, not 2019-01-01 minus 1d.
+      expect(extraQueries[0].req.range.from.toISOString()).toBe('2018-03-31T00:00:00.000Z');
+      expect(extraQueries[0].req.range.to.toISOString()).toBe('2019-02-10T19:00:00.000Z');
+      expect(extraQueries[0].req.rangeRaw).toEqual({ from: 'now/fy-1d', to: 'now-1d' });
+    });
+
+    it('should re-round a fiscal timeFrom when the dashboard fiscal year start month changes', () => {
+      const panelTime = new PanelTimeRange({ timeFrom: 'now/fy' });
+      const sceneTimeRange = buildAprilFiscalSceneFor(panelTime);
+
+      // July fiscal year: the current fiscal year on 2019-02-11 started 2018-07-01.
+      sceneTimeRange.setState({ fiscalYearStartMonth: 6 });
+
+      expect(panelTime.state.value.from.toISOString()).toBe('2018-07-01T00:00:00.000Z');
+    });
+  });
+
   describe('onTimeRangeChange', () => {
     it('should reverse timeShift when updating time range', () => {
       const oneHourShift = '1h';

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -116,15 +116,24 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
     return shouldRerunCompare(prev.compareWith, next.compareWith, queries);
   }
 
+  /**
+   * The panel never owns a fiscal year start; it always rounds against the dashboard's setting.
+   * Mirrors how the base class resolves the time zone from the ancestor time range.
+   */
+  private getFiscalYearStartMonth(): number | undefined {
+    return this.getAncestorTimeRange().state.fiscalYearStartMonth;
+  }
+
   public onTimeRangeChange(timeRange: TimeRange): void {
     const { timeShift } = this.state;
 
     if (timeShift) {
       const timeShiftInterpolated = sceneGraph.interpolate(this, timeShift);
       const reverseShift = '+' + timeShiftInterpolated;
+      const fiscalYearStartMonth = this.getFiscalYearStartMonth();
 
-      const from = dateMath.parseDateMath(reverseShift, timeRange.from, false);
-      const to = dateMath.parseDateMath(reverseShift, timeRange.to, true);
+      const from = dateMath.parseDateMath(reverseShift, timeRange.from, false, fiscalYearStartMonth);
+      const to = dateMath.parseDateMath(reverseShift, timeRange.to, true, fiscalYearStartMonth);
 
       if (from && to) {
         this.getAncestorTimeRange().onTimeRangeChange({
@@ -157,9 +166,10 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
       // Only evaluate if the timeFrom if parent time is relative
       if (rangeUtil.isRelativeTimeRange(parentTimeRange.raw)) {
         const timezone = this.getTimeZone();
+        const fiscalYearStartMonth = this.getFiscalYearStartMonth();
         newTimeData.timeRange = {
-          from: dateMath.toDateTime(timeFromInfo.from, { timezone })!,
-          to: dateMath.toDateTime(timeFromInfo.to, { timezone })!,
+          from: dateMath.toDateTime(timeFromInfo.from, { timezone, fiscalYearStartMonth })!,
+          to: dateMath.toDateTime(timeFromInfo.to, { timezone, fiscalYearStartMonth })!,
           raw: { from: timeFromInfo.from, to: timeFromInfo.to },
         };
         infoBlocks.push(timeFromInfo.display);
@@ -180,12 +190,13 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
 
       if (rangeUtil.isRelativeTimeRange(newTimeData.timeRange.raw)) {
         const timezone = this.getTimeZone();
+        const fiscalYearStartMonth = this.getFiscalYearStartMonth();
 
         const rawFromShifted = `${newTimeData.timeRange.raw.from}${shift}`;
         const rawToShifted = `${newTimeData.timeRange.raw.to}${shift}`;
 
-        const from = dateMath.toDateTime(rawFromShifted, { timezone });
-        const to = dateMath.toDateTime(rawToShifted, { timezone, roundUp: true });
+        const from = dateMath.toDateTime(rawFromShifted, { timezone, fiscalYearStartMonth });
+        const to = dateMath.toDateTime(rawToShifted, { timezone, fiscalYearStartMonth, roundUp: true });
 
         if (!from || !to) {
           newTimeData.timeInfo = 'invalid timeshift';
@@ -198,8 +209,9 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
           raw: { from: rawFromShifted, to: rawToShifted },
         };
       } else {
-        const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false);
-        const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true);
+        const fiscalYearStartMonth = this.getFiscalYearStartMonth();
+        const from = dateMath.parseDateMath(shift, newTimeData.timeRange.from, false, fiscalYearStartMonth);
+        const to = dateMath.parseDateMath(shift, newTimeData.timeRange.to, true, fiscalYearStartMonth);
 
         if (!from || !to) {
           newTimeData.timeInfo = 'invalid timeshift';


### PR DESCRIPTION
**What is this feature?**
`PanelTimeRange` now reads `fiscalYearStartMonth` from the ancestor (dashboard) time range and
threads it into every `dateMath` call it makes, the same way the base class already resolves the
time zone. Previously the panel had no access to the setting, so `parseDateMath` fell back to its
`fiscalYearStartMonth = 0` default.

Five call sites needed it, not just the two named in the issue:
- both `toDateTime` calls in the `timeFrom` branch
- both `toDateTime` calls in the `timeShift` branch — this one concatenates onto the raw string, so
  a `now/fy` override becomes `now/fy-1d` and still needs fiscal rounding
- the `parseDateMath` calls in the absolute `timeShift` branch and in `onTimeRangeChange`, since a
  shift expression can itself carry a `/fy` suffix

Reading from the ancestor rather than passing the value in at construction keeps it correct when the
user changes the setting in the time picker, and avoids having to touch the eight separate places
that construct a `PanelTimeRange`.

**Why do we need this feature?**
Fiscal-relative panel time overrides (`now/fy`, `now-1y/fy`) always rounded to January regardless of
the dashboard's **Fiscal year start month**, so a panel silently disagreed with its own dashboard.
With an April fiscal year, a `now/fy` override resolved to Jan 1 instead of Apr 1.

Time comparison was affected too, though the compare code itself needed no change:
`getCompareTimeRange` derives its window by subtracting a millisecond offset from the already
resolved panel range, so it inherited the wrong base. A `now/fy` override with a 1-day comparison
produced a compare window starting `2018-12-31` instead of `2018-03-31`. Fixing the primary range
fixes the compare window.

Before (note default to January):
<img width="1432" height="734" alt="image" src="https://github.com/user-attachments/assets/a7fbda4e-31dd-4b12-9fca-cc4844d28792" />


After (properly set to April):
<img width="1433" height="694" alt="image" src="https://github.com/user-attachments/assets/86600555-bb83-4be1-a9a3-3101ed05987e" />

Fixes #132297