### PR TITLE
Docs: Clarify 401 Unauthorized troubleshooting for Azure managed identity

### DIFF
--- a/docs/sources/datasources/prometheus/configure/azure-authentication.md
+++ b/docs/sources/datasources/prometheus/configure/azure-authentication.md
@@ -19,7 +19,7 @@ labels:
 menuTitle: Azure authentication (deprecated)
 title: Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
 weight: 200
-review_date: 2026-08-04
+review_date: 2026-09-11
 ---
 
 # Migrate from Prometheus Azure AD to Azure Monitor Managed Service for Prometheus
@@ -127,12 +127,32 @@ The following sections cover common issues you may encounter during or after the
 
 ### "401 Unauthorized" after migration
 
-**Symptom:** The migrated data source returns authentication errors.
+**Symptoms:**
 
-**Solution:**
+- The migrated data source returns `401 Unauthorized` errors on **Save & test** or when running queries.
+- The data source uses **Managed Identity** or **Workload Identity**, and the identity has the correct Azure role assignments.
 
-1. **Self-managed Grafana:** Verify that `grafana-azureprometheus-datasource` is included in `forward_settings_to_plugins` under the `[azure]` heading in your `.ini` configuration file.
-1. **Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
+**Cause:** The Azure Monitor Managed Service for Prometheus plugin doesn't receive the Azure authentication settings from the Grafana server. Either the `[azure]` section of your `.ini` configuration file is missing the options required by your authentication method, or `forward_settings_to_plugins` doesn't include the `grafana-azureprometheus-datasource` plugin.
+
+**Solution for self-managed Grafana:**
+
+Set the options required by your authentication method in the `[azure]` section of your `.ini` configuration file. For a full description of each option, refer to the [`[azure]` configuration reference](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#azure).
+
+- **Managed Identity:** Set `managed_identity_enabled = true`. For a user-assigned identity, also set `managed_identity_client_id` to the identity's client ID. Leave it empty for a system-assigned identity.
+- **Workload Identity:** Set `workload_identity_enabled = true`.
+- **Current User:** Set `user_identity_enabled = true`.
+
+By default, `forward_settings_to_plugins` includes all Grafana Labs Azure plugins, so the Prometheus plugin already receives these settings. If you've customized `forward_settings_to_plugins`, make sure `grafana-azureprometheus-datasource` is listed. For example:
+
+```ini
+[azure]
+managed_identity_enabled = true
+forward_settings_to_plugins = grafana-azureprometheus-datasource
+```
+
+Verify that the identity has the required Azure role, such as **Monitoring Data Reader**, on the target Azure Monitor workspace. Restart Grafana after you change the server configuration.
+
+**Solution for Grafana Cloud:** Contact [Grafana Support](https://grafana.com/profile/org#support).
 
 ### Rollback the migration
 


### PR DESCRIPTION
## What this PR does

Expands the **"401 Unauthorized" after migration** troubleshooting section in the Prometheus Azure authentication (deprecated) guide so it documents the Grafana server options actually required to authenticate the Azure Monitor Managed Service for Prometheus data source.

Previously the section only mentioned `forward_settings_to_plugins`, which support flagged as misleading/incomplete for users authenticating with Azure managed resources (managed identity).

### Changes

- Restructures the section into **Symptoms / Cause / Solution** (matching the Azure Monitor troubleshooting page pattern).
- Documents the `[azure]` options required by each authentication method: `managed_identity_enabled`, `managed_identity_client_id` (user-assigned), `workload_identity_enabled`, and `user_identity_enabled`.
- Clarifies that `forward_settings_to_plugins` includes all Grafana Labs Azure plugins by default, and only customized values need `grafana-azureprometheus-datasource` added explicitly.
- Adds the required Azure role (**Monitoring Data Reader**) and the restart-Grafana step.
- Links to the `[azure]` configuration reference.
- Updates `review_date`.

### Related

Addresses support escalation https://github.com/grafana/support-escalations/issues/23235.

### Verification

- `vale docs/sources/datasources/prometheus/configure/azure-authentication.md` → 0 errors, 0 warnings, 0 suggestions.

Made with [Cursor](https://cursor.com)