### PR TITLE
docs: remove duplicate 'the' in foundation SDK key concepts

### DIFF
--- a/docs/sources/as-code/observability-as-code/foundation-sdk/foundation-sdk-key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/foundation-sdk/foundation-sdk-key-concepts.md
@@ -80,7 +80,7 @@ Most builder methods accept simple values like strings or numbers, but others ex
 
 - `ReduceDataOptions` - How to reduce time series data into single values (e.g. last, avg).
 - `VizLegendOptions` - Configure how the legend of a panel is displayed.
-- `CanvasElementOptions` - Define how the the various components of a Canvas panel should be displayed.
+- `CanvasElementOptions` - Define how the various components of a Canvas panel should be displayed.
 
 Example using options:
 


### PR DESCRIPTION
Tiny docs fix: remove duplicate `the` in the CanvasElementOptions description.