### PR TITLE
docs: fix 'allows to' grammar in Grafana-managed alert rules

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -209,7 +209,7 @@ Define a query to get the data you want to measure and a condition that needs to
 
 Depending on the data source, the query editor offers a **Builder** and a **Code** option. **Builder** helps you construct a query with a visual interface. The **Builder** option is useful if you have limited experience with the query language, while **Code** lets you write the query directly for more control. Switch between them using the **Builder** and **Code** tabs on the query editor toolbar.
 
-The **Default** option allows to configure one query and one alert condition. The **Advanced** option allows multiple queries and expressions for more complex rule definitions.
+The **Default** option allows you to configure one query and one alert condition. The **Advanced** option allows multiple queries and expressions for more complex rule definitions.
 
 {{< collapse title="Default options" >}}
 


### PR DESCRIPTION
Tiny docs fix: change `allows to configure` to `allows you to configure` in the Grafana-managed alert rule docs.