### PR TITLE
docs: fix 'allows to' grammar in alert contact point option

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-grafana-managed-rule.md
@@ -320,7 +320,7 @@ To do this, you need to make sure that your alert rule is in the right evaluatio
 
 Configure who receives notifications when the alert rule fires.
 
-The **Default** option allows to select a [contact point](ref:contact-points) to handle notifications for this alert rule. The **Advanced** option routes notifications through [notification policies](ref:notification-policies).
+The **Default** option allows you to select a [contact point](ref:contact-points) to handle notifications for this alert rule. The **Advanced** option routes notifications through [notification policies](ref:notification-policies).
 
 {{< collapse title="Default options" >}}
 


### PR DESCRIPTION
Tiny docs fix: change `allows to select` to `allows you to select` in the Grafana-managed alert rule notification options.