### PR TITLE
Prevent dashboard browser recursion on cyclic folder data

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -10,6 +10,8 @@ import * as useFolderReadmeModule from 'app/features/provisioning/hooks/useFolde
 import { type DashboardViewItem } from 'app/features/search/types';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { fullyLoadedViewItemCollection } from '../fixtures/state.fixtures';
+
 import { BrowseView } from './BrowseView';
 
 const [mockTree, { folderA, folderA_folderA, folderA_folderB, folderA_folderB_dashbdB, dashbdD, folderB_empty }] =
@@ -56,6 +58,31 @@ describe('browse-dashboards BrowseView', () => {
 
     await userEvent.click(checkbox);
     expect(checkbox).toBeChecked();
+  });
+
+  it('renders a dashboard whose UID matches its parent folder', async () => {
+    const folder: DashboardViewItem = { kind: 'folder', uid: 'same-uid', title: 'Folder same-uid' };
+    const dashboard: DashboardViewItem = {
+      kind: 'dashboard',
+      uid: 'same-uid',
+      title: 'Dashboard same-uid',
+      parentUID: 'same-uid',
+    };
+
+    render(<BrowseView permissions={mockPermissions} folderUID={undefined} width={WIDTH} height={HEIGHT} />, {
+      preloadedState: {
+        browseDashboards: {
+          rootItems: fullyLoadedViewItemCollection([folder]),
+          childrenByParentUID: { 'same-uid': fullyLoadedViewItemCollection([dashboard]) },
+          openFolders: { 'same-uid': true },
+          selectedItems: { $all: false, dashboard: {}, folder: {}, panel: {} },
+        },
+      },
+    });
+
+    expect(await screen.findByText(folder.title)).toBeInTheDocument();
+    expect(screen.getByText(dashboard.title)).toBeInTheDocument();
+    expect(screen.getAllByTestId(selectors.pages.BrowseDashboards.table.checkbox('same-uid'))).toHaveLength(2);
   });
 
   it('checks all descendants when a folder is selected', async () => {

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -252,6 +252,10 @@ function hasSelectedDescendants(
   childrenByParentUID: BrowseDashboardsState['childrenByParentUID'],
   selectedItems: DashboardTreeSelection
 ): boolean {
+  if (item.kind !== 'folder') {
+    return false;
+  }
+
   const collection = childrenByParentUID[item.uid];
   if (!collection) {
     return false;

--- a/public/app/features/browse-dashboards/state/hooks.test.ts
+++ b/public/app/features/browse-dashboards/state/hooks.test.ts
@@ -1,10 +1,11 @@
+import { type DashboardViewItem } from 'app/features/search/types';
 import { configureStore } from 'app/store/configureStore';
 import { useSelector } from 'app/types/store';
 
 import { fullyLoadedViewItemCollection } from '../fixtures/state.fixtures';
 import { type BrowseDashboardsState } from '../types';
 
-import { useBrowseLoadingStatus } from './hooks';
+import { useBrowseLoadingStatus, useFlatTreeState } from './hooks';
 
 jest.mock('app/types/store', () => {
   const original = jest.requireActual('app/types/store');
@@ -75,6 +76,33 @@ describe('browse-dashboards state hooks', () => {
 
       const status = useBrowseLoadingStatus(folderUID);
       expect(status).toEqual('fulfilled');
+    });
+  });
+
+  describe('useFlatTreeState', () => {
+    it('renders a dashboard whose UID matches its parent folder', () => {
+      const folder: DashboardViewItem = { kind: 'folder', uid: 'same-uid', title: 'Folder' };
+      const dashboard: DashboardViewItem = {
+        kind: 'dashboard',
+        uid: 'same-uid',
+        title: 'Dashboard',
+        parentUID: 'same-uid',
+      };
+
+      mockState(
+        createInitialState({
+          rootItems: fullyLoadedViewItemCollection([folder]),
+          childrenByParentUID: { 'same-uid': fullyLoadedViewItemCollection([dashboard]) },
+          openFolders: { 'same-uid': true },
+        })
+      );
+
+      const tree = useFlatTreeState(undefined);
+
+      expect(tree.map(({ item, level }) => `${level}:${item.kind}:${item.uid}`)).toEqual([
+        '0:folder:same-uid',
+        '1:dashboard:same-uid',
+      ]);
     });
   });
 });

--- a/public/app/features/browse-dashboards/state/hooks.ts
+++ b/public/app/features/browse-dashboards/state/hooks.ts
@@ -149,21 +149,16 @@ function createFlatTree(
   excludeUIDs: string[] = []
 ): DashboardsTreeItem[] {
   function mapItem(item: DashboardViewItem, parentUID: string | undefined, level: number): DashboardsTreeItem[] {
+    const isFolder = item.kind === 'folder';
     if (excludeKinds.includes(item.kind) || excludeUIDs.includes(item.uid)) {
       return [];
     }
 
-    const mappedChildren = createFlatTree(
-      item.uid,
-      rootCollection,
-      childrenByUID,
-      openFolders,
-      level + 1,
-      excludeKinds,
-      excludeUIDs
-    );
+    const mappedChildren = isFolder
+      ? createFlatTree(item.uid, rootCollection, childrenByUID, openFolders, level + 1, excludeKinds, excludeUIDs)
+      : [];
 
-    const isOpen = Boolean(openFolders[item.uid]);
+    const isOpen = isFolder && Boolean(openFolders[item.uid]);
     const emptyFolder = childrenByUID[item.uid]?.items.length === 0;
     if (isOpen && emptyFolder && !excludeKinds.includes('empty-folder')) {
       mappedChildren.push({


### PR DESCRIPTION
Fixes #131927.

The dashboard browser flattens nested folders recursively. A dashboard is allowed to have the same UID as its parent folder in unified storage, so recursing into every item can re-enter the folder's own child collection and overflow the call stack.

This change only recurses into items whose kind is `folder`, and the selection-state traversal now does the same. The regression coverage includes a render-level case where a folder and child dashboard share the same UID.

This continues the previously reviewed #131942 changes; the original PR was closed and GitHub does not allow it to be reopened after its head was force-updated.