### PR TITLE
Canvas: Prevent inline text editor freeze on rerender

### DIFF
--- a/public/app/features/canvas/elements/text.tsx
+++ b/public/app/features/canvas/elements/text.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import * as React from 'react';
 import { of } from 'rxjs';
 
@@ -48,13 +48,32 @@ const TextEdit = (props: CanvasElementProps<TextConfig, TextData>) => {
   panelData = context.instanceState?.scene?.data.series;
 
   const textRef = useRef<string>(config.text?.fixed ?? '');
+  const contextRef = useRef(context);
+  contextRef.current = context;
 
   // Save text on TextEdit unmount
   useEffect(() => {
     return () => {
-      saveText(textRef.current);
+      const currentContext = contextRef.current;
+      const selectedElement: ElementState | undefined = currentContext.instanceState?.selected[0];
+      if (selectedElement) {
+        const options = selectedElement.options;
+        selectedElement.onChange({
+          ...options,
+          config: {
+            ...options.config,
+            text: { ...selectedElement.options.config.text, fixed: textRef.current },
+          },
+        });
+
+        // Force a re-render (update scene data after config update)
+        const scene = currentContext.instanceState?.scene;
+        if (scene) {
+          scene.updateData(scene.data);
+        }
+      }
     };
-  });
+  }, []);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
@@ -69,30 +88,6 @@ const TextEdit = (props: CanvasElementProps<TextConfig, TextData>) => {
   const onKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
     textRef.current = event.currentTarget.value;
   };
-
-  const saveText = useCallback(
-    (textValue: string) => {
-      let selectedElement: ElementState;
-      selectedElement = context.instanceState?.selected[0];
-      if (selectedElement) {
-        const options = selectedElement.options;
-        selectedElement.onChange({
-          ...options,
-          config: {
-            ...options.config,
-            text: { ...selectedElement.options.config.text, fixed: textValue },
-          },
-        });
-
-        // Force a re-render (update scene data after config update)
-        const scene = context.instanceState?.scene;
-        if (scene) {
-          scene.updateData(scene.data);
-        }
-      }
-    },
-    [context.instanceState?.scene, context.instanceState?.selected]
-  );
 
   const styles = useStyles2(getStyles(data));
   return (

--- a/public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx
@@ -900,6 +900,11 @@ describe('Canvas', () => {
       await user.keyboard('can only edit fields with no mapping');
       expect(input).toHaveValue('can only edit fields with no mapping');
 
+      // Rerender while editing should not invoke save before edit completion
+      const prevCallsCount = onOptionsChange.mock.calls.length;
+      rerender(canvasPanelElement({ renderCounter: 2 }, eventBus));
+      expect(onOptionsChange.mock.calls.length).toBe(prevCallsCount);
+
       // TextEdit exits edit mode on Enter
       await user.keyboard('{Enter}');
 


### PR DESCRIPTION
**What is this feature?**

Saves Canvas inline text only when the editor unmounts, instead of running the save cleanup before every rerender. The editor keeps refs to the latest text and panel context so edit completion still persists the current value. A regression assertion covers rerenders while typing and the final Enter-to-save path.

**Why do we need this feature?**

The cleanup effect previously had no dependency array, so each rerender saved the text and triggered another Canvas options update. That feedback loop could freeze the panel while a user typed or data refreshed.

**Who is this feature for?**

Users who edit text inline in Canvas panels.

**Which issue(s) does this PR fix?**:

Fixes #132369

**Validation**

- `corepack yarn jest public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx --runInBand` (31 passed, 6 todo)
- `corepack yarn jest public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx -t "Double click edit" --runInBand --no-cache` (1 passed)
- `corepack yarn jest public/app/plugins/panel/canvas/utils.test.ts public/app/plugins/panel/canvas/migrations.test.ts` (45 passed)
- `corepack yarn eslint public/app/features/canvas/elements/text.tsx public/app/plugins/panel/canvas/CanvasPanel.integration.test.tsx`
- `corepack yarn typecheck`

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] No feature toggle is needed because this is a focused bug fix.
- [x] No documentation update is needed because user-facing behavior is unchanged.