### PR TITLE
Live: support single-query math expressions

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -23,12 +23,19 @@ export { StreamingFrameAction, type StreamingFrameOptions } from '@grafana/data'
 /**
  * @alpha
  */
+export interface LiveMathExpressionOptions {
+  sourceRefId: string;
+  resultRefId: string;
+  expression: string;
+}
+
 export interface LiveDataStreamOptions {
   addr: LiveChannelAddress;
   frame?: DataFrameJSON; // initial results
   key?: string;
   buffer?: Partial<StreamingFrameOptions>;
   filter?: LiveDataFilter;
+  mathExpression?: LiveMathExpressionOptions;
 }
 
 /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -124,6 +124,17 @@ function toHealthCheckResult(v: DatasourcesV0HealthCheckResult): HealthCheckResu
   };
 }
 
+const liveMathReferenceIds = (expression: string): string[] => {
+  const refs = new Set<string>();
+  const pattern = /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+  for (const match of expression.matchAll(pattern)) {
+    refs.add(match[1] ?? match[2]);
+  }
+
+  return [...refs];
+};
+
 interface PreparedQuery {
   query: DataQuery;
   /** Absent for expression queries, which are not backed by a data source instance. */
@@ -527,12 +538,55 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     return of(rsp); // add warning?
   }
 
+  const liveSourceRefIds = new Set<string>();
+  for (const f of rsp.data) {
+    const addr = parseLiveChannelAddress(f.meta?.channel);
+    if (!addr) {
+      continue;
+    }
+
+    const sourceRefId = f.refId ?? '';
+    const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
+    if (sourceRefId) {
+      liveSourceRefIds.add(sourceRefId);
+    }
+  }
+
+  const liveMathResultRefIds = new Set<string>();
+  for (const target of req.targets) {
+    if (
+      target.hide ||
+      !target.refId ||
+      !target.expression ||
+      target.type !== 'math' ||
+      !isExpressionReference(target.datasource)
+    ) {
+      continue;
+    }
+
+    const refs = liveMathReferenceIds(target.expression);
+    if (refs.length === 1 && liveSourceRefIds.has(refs[0])) {
+      liveMathResultRefIds.add(target.refId);
+    }
+  }
+
   const staticdata: DataFrame[] = [];
   const streams: Array<Observable<DataQueryResponse>> = [];
   for (const f of rsp.data) {
     const addr = parseLiveChannelAddress(f.meta?.channel);
-    if (addr) {
-      const frame: DataFrame = f;
+    if (!addr) {
+      if (!liveMathResultRefIds.has(f.refId ?? '')) {
+        staticdata.push(f);
+      }
+      continue;
+    }
+
+    const frame: DataFrame = f;
+    const sourceRefId = frame.refId ?? '';
+    const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
+
+    // Preserve the normal live stream unless the source query itself is hidden.
+    if (!sourceQuery?.hide) {
       streams.push(
         live.getDataStream({
           addr,
@@ -540,8 +594,39 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
           frame: dataFrameToJSON(f),
         })
       );
-    } else {
-      staticdata.push(f);
+    }
+
+    // Live Math support is intentionally limited to expressions referencing
+    // exactly one live query. Multi-query expressions continue through the
+    // existing expression path.
+    for (const target of req.targets) {
+      if (
+        target.hide ||
+        !target.refId ||
+        !target.expression ||
+        target.type !== 'math' ||
+        !isExpressionReference(target.datasource)
+      ) {
+        continue;
+      }
+
+      const refs = liveMathReferenceIds(target.expression);
+      if (refs.length !== 1 || refs[0] !== sourceRefId) {
+        continue;
+      }
+
+      streams.push(
+        live.getDataStream({
+          addr,
+          buffer: getter(req, frame),
+          frame: dataFrameToJSON(f),
+          mathExpression: {
+            sourceRefId,
+            resultRefId: target.refId,
+            expression: target.expression,
+          },
+        })
+      );
     }
   }
   if (staticdata.length) {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -97,7 +97,12 @@ export interface HealthCheckResult {
   details: HealthCheckResultDetails;
 }
 
-// Internal for now
+/**
+ * Response shape from the /apis/{group}/v0alpha1/.../datasources/{uid}/health endpoint.
+ * Used when datasourcesApiServerEnableHealthEndpointFrontend is enabled.
+ *
+ * @internal
+ */
 interface DatasourcesV0HealthCheckResult {
   kind?: string;
   apiVersion?: string;
@@ -139,6 +144,12 @@ interface PreparedQuery {
   };
 }
 
+/**
+ * Extend this class to implement a data source plugin that is depending on the Grafana
+ * backend API.
+ *
+ * @public
+ */
 class DataSourceWithBackend<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData,
@@ -173,6 +184,7 @@ class DataSourceWithBackend<
           };
         }
 
+        // if there is no per-query datasource, we use the implicit datasource
         let settings: DataSourceInstanceSettings = this.datasourceInstanceSettings;
 
         if (q.datasource) {
@@ -189,6 +201,8 @@ class DataSourceWithBackend<
           if (dsRef.uid !== datasource.uid || datasourceId !== dsId) {
             datasource = dsRef;
             datasourceId = dsId;
+            // If the query is using a different datasource, we would need to retrieve the datasource
+            // instance (async) and apply the template variables but it seems it's not necessary for now.
             shouldApplyTemplateVariables = false;
           }
         }
@@ -197,7 +211,7 @@ class DataSourceWithBackend<
           query: {
             ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
             datasource,
-            datasourceId,
+            datasourceId, // deprecated!
             intervalMs,
             maxDataPoints,
             queryCachingTTL,
@@ -207,6 +221,9 @@ class DataSourceWithBackend<
       })
     );
 
+    // Collected after the fan-out rather than inside it: the settings lookups resolve in an
+    // arbitrary order, so accumulating from within the callbacks would make the routing header
+    // values and the query-service decision depend on resolution order instead of query order.
     const pluginIDs = new Set<string>();
     const dsUIDs = new Set<string>();
     const datasources: DataSourceInstanceSettings[] = [];
@@ -215,6 +232,7 @@ class DataSourceWithBackend<
     for (const { query, resolved } of prepared) {
       queries.push(query);
       if (!resolved) {
+        // an expression query is not backed by a datasource instance
         continue;
       }
       datasources.push(resolved.settings);
@@ -238,6 +256,7 @@ class DataSourceWithBackend<
 
     let url = '/api/ds/query?ds_type=' + this.type;
 
+    // Use the new query service
     if (config.featureToggles.queryServiceFromUI) {
       // @ts-expect-error featuremgmt/registry.go does not support object feature flags yet
       const allowedTypes = getFeatureFlagClient().getObjectValue('datasources.querier.fe-allowed-types', {
@@ -257,6 +276,7 @@ class DataSourceWithBackend<
       url += '&expression=true';
     }
 
+    // Appending request ID to url to facilitate client-side performance metrics. See #65244 for more context.
     if (requestId) {
       url += `&requestId=${requestId}`;
     }
@@ -296,6 +316,9 @@ class DataSourceWithBackend<
     ];
   }
 
+  /**
+   * Ideally final -- any other implementation may not work as expected
+   */
   query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
     if (config.publicDashboardAccessToken) {
       return publicDashboardQueryHandler(request);
@@ -305,6 +328,9 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
+    // defer keeps the observable cold: without it the request preparation would start when
+    // query() is called rather than when it is subscribed to, and a rejection (e.g. an unknown
+    // datasource) on a never-subscribed observable would surface as an unhandled rejection.
     return defer(() => this.createBackendRequest(request)).pipe(
       switchMap(([req, queries]) =>
         getBackendSrv()
@@ -312,11 +338,16 @@ class DataSourceWithBackend<
           .pipe(
             switchMap((raw) => {
               const rsp = toDataQueryResponse(raw, queries);
+              // Check if any response should subscribe to a live stream
               if (rsp.data?.length && rsp.data.find((f: DataFrame) => f.meta?.channel)) {
                 return toStreamingDataResponse(rsp, request, this.streamOptionsProvider);
               }
               return of(rsp);
             }),
+            // Scoped to the fetch chain on purpose: toDataQueryResponse can only map fetch-shaped
+            // errors, and would turn a plain thrown Error (e.g. the unknown-datasource throw in
+            // createBackendRequest) into a silent empty success. Those errors are left to reach the
+            // subscriber, where runRequest turns them into a query error.
             catchError((err) => {
               return of(toDataQueryResponse(err));
             })
@@ -325,6 +356,7 @@ class DataSourceWithBackend<
     );
   }
 
+  /** Get request headers with plugin ID+UID set */
   protected getRequestHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
     headers[PluginRequestHeaders.PluginID] = this.type;
@@ -332,16 +364,34 @@ class DataSourceWithBackend<
     return headers;
   }
 
+  /**
+   * Apply template variables for explore
+   */
   interpolateVariablesInQueries(queries: TQuery[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery[] {
     return queries.map((q) => this.applyTemplateVariables(q, scopedVars, filters));
   }
 
+  /**
+   * Override to apply template variables and adhoc filters.  The result is usually also `TQuery`, but sometimes this can
+   * be used to modify the query structure before sending to the backend.
+   *
+   * NOTE: if you do modify the structure or use template variables, alerting queries may not work
+   * as expected
+   *
+   * @virtual
+   */
   applyTemplateVariables(query: TQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
     return query;
   }
 
+  /**
+   * Optionally override the streaming behavior
+   */
   streamOptionsProvider: StreamOptionsProvider<TQuery> = standardStreamOptionsProvider;
 
+  /**
+   * Make a GET request to the datasource resource path
+   */
   async getResource<T = any>(
     path: string,
     params?: BackendSrvRequest['params'],
@@ -360,6 +410,9 @@ class DataSourceWithBackend<
     return result.data;
   }
 
+  /**
+   * Send a POST request to the datasource resource path
+   */
   async postResource<T = unknown>(
     path: string,
     data?: BackendSrvRequest['data'],
@@ -378,18 +431,26 @@ class DataSourceWithBackend<
     return result.data;
   }
 
+  /**
+   * Internal function to build the datasource URL based on the feature toggle
+   */
   buildResourcesDatasourceUrl(path: string): string {
     const enabledRedirect = getFeatureFlagClient().getBooleanValue(
       'datasources.apiserver.useNewAPIsForDatasourceResources',
       false
     );
     if (enabledRedirect) {
+      // example:
+      // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
       return `/apis/${this.meta?.id ?? this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }
     return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }
 
+  /**
+   * Run the datasource healthcheck
+   */
   async callHealthCheck(): Promise<HealthCheckResult> {
     const useNewApi = getFeatureFlagClient().getBooleanValue(
       FlagKeys.DatasourcesApiServerEnableHealthEndpointFrontend,
@@ -442,6 +503,10 @@ class DataSourceWithBackend<
       });
   }
 
+  /**
+   * Checks the plugin health
+   * see public/app/features/datasources/state/actions.ts for what needs to be returned here
+   */
   async testDatasource(): Promise<TestDataSourceResponse> {
     return this.callHealthCheck().then((res) => {
       if (res.status === HealthStatus.OK) {
@@ -460,6 +525,9 @@ class DataSourceWithBackend<
   }
 }
 
+/**
+ * @internal exported for tests
+ */
 export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
   rsp: DataQueryResponse,
   req: DataQueryRequest<TQuery>,
@@ -467,7 +535,7 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
 ): Observable<DataQueryResponse> {
   const live = getGrafanaLiveSrv();
   if (!live) {
-    return of(rsp);
+    return of(rsp); // add warning?
   }
 
   const liveSourceRefIds = new Set<string>();
@@ -518,6 +586,7 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     const sourceRefId = frame.refId ?? '';
     const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
 
+    // Preserve the normal live stream unless the source query itself is hidden.
     if (!sourceQuery?.hide) {
       streams.push(
         live.getDataStream({
@@ -528,6 +597,9 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
       );
     }
 
+    // Live Math support is intentionally limited to expressions referencing
+    // exactly one live query. Multi-query expressions continue through the
+    // existing expression path.
     for (const target of req.targets) {
       if (
         target.hide ||
@@ -564,22 +636,31 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     streams.push(of({ ...rsp, data: staticdata }));
   }
   if (streams.length === 1) {
-    return streams[0];
+    return streams[0]; // avoid merge wrapper
   }
   return merge(...streams);
 }
 
+/**
+ * This allows data sources to customize the streaming connection query
+ *
+ * @public
+ */
 export type StreamOptionsProvider<TQuery extends DataQuery = DataQuery> = (
   request: DataQueryRequest<TQuery>,
   frame: DataFrame
 ) => Partial<StreamingFrameOptions>;
 
+/**
+ * @public
+ */
 export const standardStreamOptionsProvider: StreamOptionsProvider = (request: DataQueryRequest, frame: DataFrame) => {
   const opts: Partial<StreamingFrameOptions> = {
     maxLength: request.maxDataPoints ?? 500,
     action: StreamingFrameAction.Append,
   };
 
+  // For recent queries, clamp to the current time range
   if (request.rangeRaw?.to === 'now') {
     opts.maxDelta = request.range.to.valueOf() - request.range.from.valueOf();
   }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -97,12 +97,7 @@ export interface HealthCheckResult {
   details: HealthCheckResultDetails;
 }
 
-/**
- * Response shape from the /apis/{group}/v0alpha1/.../datasources/{uid}/health endpoint.
- * Used when datasourcesApiServerEnableHealthEndpointFrontend is enabled.
- *
- * @internal
- */
+// Internal for now
 interface DatasourcesV0HealthCheckResult {
   kind?: string;
   apiVersion?: string;
@@ -144,12 +139,6 @@ interface PreparedQuery {
   };
 }
 
-/**
- * Extend this class to implement a data source plugin that is depending on the Grafana
- * backend API.
- *
- * @public
- */
 class DataSourceWithBackend<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData,
@@ -184,7 +173,6 @@ class DataSourceWithBackend<
           };
         }
 
-        // if there is no per-query datasource, we use the implicit datasource
         let settings: DataSourceInstanceSettings = this.datasourceInstanceSettings;
 
         if (q.datasource) {
@@ -201,8 +189,6 @@ class DataSourceWithBackend<
           if (dsRef.uid !== datasource.uid || datasourceId !== dsId) {
             datasource = dsRef;
             datasourceId = dsId;
-            // If the query is using a different datasource, we would need to retrieve the datasource
-            // instance (async) and apply the template variables but it seems it's not necessary for now.
             shouldApplyTemplateVariables = false;
           }
         }
@@ -211,7 +197,7 @@ class DataSourceWithBackend<
           query: {
             ...(shouldApplyTemplateVariables ? this.applyTemplateVariables(q, request.scopedVars, request.filters) : q),
             datasource,
-            datasourceId, // deprecated!
+            datasourceId,
             intervalMs,
             maxDataPoints,
             queryCachingTTL,
@@ -221,9 +207,6 @@ class DataSourceWithBackend<
       })
     );
 
-    // Collected after the fan-out rather than inside it: the settings lookups resolve in an
-    // arbitrary order, so accumulating from within the callbacks would make the routing header
-    // values and the query-service decision depend on resolution order instead of query order.
     const pluginIDs = new Set<string>();
     const dsUIDs = new Set<string>();
     const datasources: DataSourceInstanceSettings[] = [];
@@ -232,7 +215,6 @@ class DataSourceWithBackend<
     for (const { query, resolved } of prepared) {
       queries.push(query);
       if (!resolved) {
-        // an expression query is not backed by a datasource instance
         continue;
       }
       datasources.push(resolved.settings);
@@ -256,7 +238,6 @@ class DataSourceWithBackend<
 
     let url = '/api/ds/query?ds_type=' + this.type;
 
-    // Use the new query service
     if (config.featureToggles.queryServiceFromUI) {
       // @ts-expect-error featuremgmt/registry.go does not support object feature flags yet
       const allowedTypes = getFeatureFlagClient().getObjectValue('datasources.querier.fe-allowed-types', {
@@ -276,7 +257,6 @@ class DataSourceWithBackend<
       url += '&expression=true';
     }
 
-    // Appending request ID to url to facilitate client-side performance metrics. See #65244 for more context.
     if (requestId) {
       url += `&requestId=${requestId}`;
     }
@@ -316,9 +296,6 @@ class DataSourceWithBackend<
     ];
   }
 
-  /**
-   * Ideally final -- any other implementation may not work as expected
-   */
   query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
     if (config.publicDashboardAccessToken) {
       return publicDashboardQueryHandler(request);
@@ -328,9 +305,6 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
-    // defer keeps the observable cold: without it the request preparation would start when
-    // query() is called rather than when it is subscribed to, and a rejection (e.g. an unknown
-    // datasource) on a never-subscribed observable would surface as an unhandled rejection.
     return defer(() => this.createBackendRequest(request)).pipe(
       switchMap(([req, queries]) =>
         getBackendSrv()
@@ -338,16 +312,11 @@ class DataSourceWithBackend<
           .pipe(
             switchMap((raw) => {
               const rsp = toDataQueryResponse(raw, queries);
-              // Check if any response should subscribe to a live stream
               if (rsp.data?.length && rsp.data.find((f: DataFrame) => f.meta?.channel)) {
                 return toStreamingDataResponse(rsp, request, this.streamOptionsProvider);
               }
               return of(rsp);
             }),
-            // Scoped to the fetch chain on purpose: toDataQueryResponse can only map fetch-shaped
-            // errors, and would turn a plain thrown Error (e.g. the unknown-datasource throw in
-            // createBackendRequest) into a silent empty success. Those errors are left to reach the
-            // subscriber, where runRequest turns them into a query error.
             catchError((err) => {
               return of(toDataQueryResponse(err));
             })
@@ -356,7 +325,6 @@ class DataSourceWithBackend<
     );
   }
 
-  /** Get request headers with plugin ID+UID set */
   protected getRequestHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
     headers[PluginRequestHeaders.PluginID] = this.type;
@@ -364,34 +332,16 @@ class DataSourceWithBackend<
     return headers;
   }
 
-  /**
-   * Apply template variables for explore
-   */
   interpolateVariablesInQueries(queries: TQuery[], scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): TQuery[] {
     return queries.map((q) => this.applyTemplateVariables(q, scopedVars, filters));
   }
 
-  /**
-   * Override to apply template variables and adhoc filters.  The result is usually also `TQuery`, but sometimes this can
-   * be used to modify the query structure before sending to the backend.
-   *
-   * NOTE: if you do modify the structure or use template variables, alerting queries may not work
-   * as expected
-   *
-   * @virtual
-   */
   applyTemplateVariables(query: TQuery, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]) {
     return query;
   }
 
-  /**
-   * Optionally override the streaming behavior
-   */
   streamOptionsProvider: StreamOptionsProvider<TQuery> = standardStreamOptionsProvider;
 
-  /**
-   * Make a GET request to the datasource resource path
-   */
   async getResource<T = any>(
     path: string,
     params?: BackendSrvRequest['params'],
@@ -410,9 +360,6 @@ class DataSourceWithBackend<
     return result.data;
   }
 
-  /**
-   * Send a POST request to the datasource resource path
-   */
   async postResource<T = unknown>(
     path: string,
     data?: BackendSrvRequest['data'],
@@ -431,26 +378,18 @@ class DataSourceWithBackend<
     return result.data;
   }
 
-  /**
-   * Internal function to build the datasource URL based on the feature toggle
-   */
   buildResourcesDatasourceUrl(path: string): string {
     const enabledRedirect = getFeatureFlagClient().getBooleanValue(
       'datasources.apiserver.useNewAPIsForDatasourceResources',
       false
     );
     if (enabledRedirect) {
-      // example:
-      // /apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/stacks-1/datasources/local-prometheus/resources/api/v1/labels
       const apiVersion = 'v0alpha1';
       return `/apis/${this.meta?.id ?? this.type}.datasource.grafana.app/${apiVersion}/namespaces/${config.namespace}/datasources/${this.uid}/resources/${path}`;
     }
     return `/api/datasources/uid/${this.uid}/resources/${path}`;
   }
 
-  /**
-   * Run the datasource healthcheck
-   */
   async callHealthCheck(): Promise<HealthCheckResult> {
     const useNewApi = getFeatureFlagClient().getBooleanValue(
       FlagKeys.DatasourcesApiServerEnableHealthEndpointFrontend,
@@ -503,10 +442,6 @@ class DataSourceWithBackend<
       });
   }
 
-  /**
-   * Checks the plugin health
-   * see public/app/features/datasources/state/actions.ts for what needs to be returned here
-   */
   async testDatasource(): Promise<TestDataSourceResponse> {
     return this.callHealthCheck().then((res) => {
       if (res.status === HealthStatus.OK) {
@@ -525,9 +460,6 @@ class DataSourceWithBackend<
   }
 }
 
-/**
- * @internal exported for tests
- */
 export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
   rsp: DataQueryResponse,
   req: DataQueryRequest<TQuery>,
@@ -535,7 +467,7 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
 ): Observable<DataQueryResponse> {
   const live = getGrafanaLiveSrv();
   if (!live) {
-    return of(rsp); // add warning?
+    return of(rsp);
   }
 
   const liveSourceRefIds = new Set<string>();
@@ -546,7 +478,6 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     }
 
     const sourceRefId = f.refId ?? '';
-    const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
     if (sourceRefId) {
       liveSourceRefIds.add(sourceRefId);
     }
@@ -557,8 +488,10 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     if (
       target.hide ||
       !target.refId ||
-      !target.expression ||
+      !('expression' in target) ||
+      !('type' in target) ||
       target.type !== 'math' ||
+      typeof target.expression !== 'string' ||
       !isExpressionReference(target.datasource)
     ) {
       continue;
@@ -585,7 +518,6 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     const sourceRefId = frame.refId ?? '';
     const sourceQuery = req.targets.find((q) => q.refId === sourceRefId);
 
-    // Preserve the normal live stream unless the source query itself is hidden.
     if (!sourceQuery?.hide) {
       streams.push(
         live.getDataStream({
@@ -596,15 +528,14 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
       );
     }
 
-    // Live Math support is intentionally limited to expressions referencing
-    // exactly one live query. Multi-query expressions continue through the
-    // existing expression path.
     for (const target of req.targets) {
       if (
         target.hide ||
         !target.refId ||
-        !target.expression ||
+        !('expression' in target) ||
+        !('type' in target) ||
         target.type !== 'math' ||
+        typeof target.expression !== 'string' ||
         !isExpressionReference(target.datasource)
       ) {
         continue;
@@ -633,31 +564,22 @@ export function toStreamingDataResponse<TQuery extends DataQuery = DataQuery>(
     streams.push(of({ ...rsp, data: staticdata }));
   }
   if (streams.length === 1) {
-    return streams[0]; // avoid merge wrapper
+    return streams[0];
   }
   return merge(...streams);
 }
 
-/**
- * This allows data sources to customize the streaming connection query
- *
- * @public
- */
 export type StreamOptionsProvider<TQuery extends DataQuery = DataQuery> = (
   request: DataQueryRequest<TQuery>,
   frame: DataFrame
 ) => Partial<StreamingFrameOptions>;
 
-/**
- * @public
- */
 export const standardStreamOptionsProvider: StreamOptionsProvider = (request: DataQueryRequest, frame: DataFrame) => {
   const opts: Partial<StreamingFrameOptions> = {
     maxLength: request.maxDataPoints ?? 500,
     action: StreamingFrameAction.Append,
   };
 
-  // For recent queries, clamp to the current time range
   if (request.rangeRaw?.to === 'now') {
     opts.maxDelta = request.range.to.valueOf() - request.range.from.valueOf();
   }

--- a/public/app/features/expressions/liveMath.test.ts
+++ b/public/app/features/expressions/liveMath.test.ts
@@ -1,0 +1,23 @@
+import { expect, describe, it } from 'vitest';
+
+import { createLiveMathTransform, referencedRefIds } from './liveMath';
+
+describe('live math expressions', () => {
+  it('evaluates arithmetic against a single live field', () => {
+    const transform = createLiveMathTransform(
+      { sourceRefId: 'A', resultRefId: 'B', expression: '$A * 2 + 1' },
+      [1]
+    );
+
+    expect(transform.values([[1000, 2000], [2, 3]])).toEqual([[1000, 2000], [5, 7]]);
+  });
+
+  it('extracts grafana expression references', () => {
+    expect(referencedRefIds('($A * 2) + ${B}')).toEqual(['A', 'B']);
+  });
+
+  it('supports function calls', () => {
+    const transform = createLiveMathTransform({ sourceRefId: 'A', resultRefId: 'B', expression: 'abs($A) + floor(2.9)' }, [0]);
+    expect(transform.values([[-4, 5]])).toEqual([[6, 7]]);
+  });
+});

--- a/public/app/features/expressions/liveMath.ts
+++ b/public/app/features/expressions/liveMath.ts
@@ -1,0 +1,144 @@
+type SerializedLiveField = {
+  values?: unknown[];
+  [key: string]: unknown;
+};
+
+type SerializedLiveFrame = {
+  fields: SerializedLiveField[];
+  refId?: string;
+  [key: string]: unknown;
+};
+
+export type LiveMathExpression = {
+  sourceRefId: string;
+  resultRefId: string;
+  expression: string;
+};
+
+type Token = { kind: 'number' | 'identifier' | 'variable' | 'operator'; value: string } | { kind: 'paren' | 'comma'; value: '(' | ')' | ',' };
+
+const refs = /\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/g;
+
+export function referencedRefIds(expression: string): string[] {
+  const result = new Set<string>();
+  for (const match of expression.matchAll(refs)) {
+    result.add(match[1] ?? match[2]);
+  }
+  return [...result];
+}
+
+function tokenize(expression: string): Token[] {
+  const out: Token[] = [];
+  let i = 0;
+  while (i < expression.length) {
+    if (/\s/.test(expression[i])) {
+      i++;
+      continue;
+    }
+    const variable = expression.slice(i).match(/^\$(?:\{([^}]+)\}|([A-Za-z_][A-Za-z0-9_]*))/);
+    if (variable) {
+      out.push({ kind: 'variable', value: variable[1] ?? variable[2] });
+      i += variable[0].length;
+      continue;
+    }
+    const number = expression.slice(i).match(/^(?:0[xX][0-9a-fA-F]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)/);
+    if (number) {
+      out.push({ kind: 'number', value: number[0] });
+      i += number[0].length;
+      continue;
+    }
+    const identifier = expression.slice(i).match(/^[A-Za-z_][A-Za-z0-9_]*/);
+    if (identifier) {
+      out.push({ kind: 'identifier', value: identifier[0] });
+      i += identifier[0].length;
+      continue;
+    }
+    const op = expression.slice(i).match(/^(?:\*\*|>=|<=|==|!=|&&|\|\||[+\-*/%<>()!,])/);
+    if (!op) {
+      throw new Error(`unsupported character ${expression[i]}`);
+    }
+    const value = op[0];
+    out.push(value === '(' || value === ')' ? { kind: 'paren', value } : value === ',' ? { kind: 'comma', value } : { kind: 'operator', value });
+    i += value.length;
+  }
+  return out;
+}
+
+class Parser {
+  private index = 0;
+  constructor(private readonly tokens: Token[], private readonly value: unknown) {}
+  parse() {
+    const result = this.logicalOr();
+    if (this.index !== this.tokens.length) {
+      throw new Error(`unexpected token ${this.tokens[this.index].value}`);
+    }
+    return result;
+  }
+  private peek(value: string) { return this.tokens[this.index]?.value === value; }
+  private take(value: string) { if (this.peek(value)) { this.index++; return true; } return false; }
+  private number(v: unknown) { return v == null ? NaN : Number(v); }
+  private truthy(v: unknown) { return v != null && v !== false && Number(v) !== 0 && !Number.isNaN(Number(v)); }
+  private logicalOr() {
+    let v = this.logicalAnd();
+    while (this.take('||')) {
+      const r = this.logicalAnd();
+      v = this.truthy(v) || this.truthy(r) ? 1 : 0;
+    }
+    return v;
+  }
+  private logicalAnd() {
+    let v = this.equality();
+    while (this.take('&&')) {
+      const r = this.equality();
+      v = this.truthy(v) && this.truthy(r) ? 1 : 0;
+    }
+    return v;
+  }
+  private equality() { let v = this.relational(); while (this.peek('==') || this.peek('!=')) { const op = this.tokens[this.index++].value; const r = this.relational(); v = op === '==' ? (v === r ? 1 : 0) : (v !== r ? 1 : 0); } return v; }
+  private relational() { let v = this.additive(); while (this.peek('<') || this.peek('>') || this.peek('<=') || this.peek('>=')) { const op = this.tokens[this.index++].value; const a = this.number(v), b = this.number(this.additive()); v = op === '<' ? (a < b ? 1 : 0) : op === '>' ? (a > b ? 1 : 0) : op === '<=' ? (a <= b ? 1 : 0) : (a >= b ? 1 : 0); } return v; }
+  private additive() { let v = this.multiplicative(); while (this.peek('+') || this.peek('-')) { const op = this.tokens[this.index++].value; const r = this.number(this.multiplicative()); v = op === '+' ? this.number(v) + r : this.number(v) - r; } return v; }
+  private multiplicative() { let v = this.power(); while (this.peek('*') || this.peek('/') || this.peek('%')) { const op = this.tokens[this.index++].value; const a = this.number(v), b = this.number(this.power()); v = op === '*' ? a * b : op === '/' ? a / b : a % b; } return v; }
+  private power() { const v = this.unary(); return this.take('**') ? Math.pow(this.number(v), this.number(this.power())) : v; }
+  private unary() { if (this.take('!')) {return this.truthy(this.unary()) ? 0 : 1;} if (this.take('-')) {return -this.number(this.unary());} if (this.take('+')) {return this.number(this.unary());} return this.primary(); }
+  private primary(): unknown {
+    const token = this.tokens[this.index++];
+    if (!token) {throw new Error('unexpected end of expression');}
+    if (token.kind === 'number') {return token.value.startsWith(('0x')) || token.value.startsWith('0X') ? Number.parseInt(token.value, 16) : Number(token.value);}
+    if (token.kind === 'variable') {return this.value;}
+    if (token.kind === 'paren' && token.value === '(') { const v = this.logicalOr(); if (!this.take(')')) {throw new Error('missing closing parenthesis');} return v; }
+    if (token.kind === 'identifier') {
+      if (!this.take('(')) {throw new Error(`unknown identifier ${token.value}`);}
+      const args: unknown[] = [];
+      if (!this.peek(')')) { do {args.push(this.logicalOr());} while (this.take(',')); }
+      if (!this.take(')')) {throw new Error(`missing closing parenthesis for ${token.value}`);}
+      const n = (x = args[0]) => this.number(x);
+      switch (token.value) {
+        case 'abs': return Math.abs(n()); case 'ceil': return Math.ceil(n()); case 'floor': return Math.floor(n()); case 'round': return Math.round(n());
+        case 'exp': return Math.exp(n()); case 'log': return Math.log(n()); case 'log10': return Math.log10(n()); case 'sqrt': return Math.sqrt(n());
+        case 'sin': return Math.sin(n()); case 'cos': return Math.cos(n()); case 'tan': return Math.tan(n()); case 'pow': return Math.pow(n(), this.number(args[1]));
+        case 'min': return Math.min(...args.map((v) => n(v))); case 'max': return Math.max(...args.map((v) => n(v)));
+        case 'is_inf': return typeof args[0] === 'number' && Number.isFinite(args[0]) === false && Number.isNaN(args[0]) === false ? 1 : 0;
+        case 'is_nan': return typeof args[0] === 'number' && Number.isNaN(args[0]) ? 1 : 0; case 'is_null': return args[0] == null ? 1 : 0;
+        case 'is_number': return typeof args[0] === 'number' && Number.isFinite(args[0]) ? 1 : 0; case 'inf': return Infinity; case 'infn': return -Infinity; case 'nan': return NaN; case 'null': return null;
+        default: throw new Error(`unsupported live math function ${token.value}`);
+      }
+    }
+    throw new Error(`unexpected token ${token.value}`);
+  }
+}
+
+export function createLiveMathTransform(expression: LiveMathExpression, fieldIndexes: number[]) {
+  const tokens = tokenize(expression.expression);
+  const evaluate = (value: unknown) => new Parser(tokens, value).parse();
+  const values = (input: unknown[][]) => input.map((column, index) => fieldIndexes.includes(index) ? column.map(evaluate) : column);
+  return {
+    frame: (input: SerializedLiveFrame): SerializedLiveFrame => ({
+      ...input,
+      refId: expression.resultRefId,
+      fields: input.fields.map((field, index) =>
+        fieldIndexes.includes(index) ? { ...field, values: field.values?.map(evaluate) } : field
+      ),
+    }),
+    values,
+  };
+}

--- a/public/app/features/expressions/liveMath.ts
+++ b/public/app/features/expressions/liveMath.ts
@@ -127,18 +127,24 @@ class Parser {
   }
 }
 
-export function createLiveMathTransform(expression: LiveMathExpression, fieldIndexes: number[]) {
+export function createLiveMathTransform(expression: LiveMathExpression, fieldIndexes: number[] = []) {
   const tokens = tokenize(expression.expression);
   const evaluate = (value: unknown) => new Parser(tokens, value).parse();
-  const values = (input: unknown[][]) => input.map((column, index) => fieldIndexes.includes(index) ? column.map(evaluate) : column);
+  const values = (input: unknown[][], indexes: number[] = fieldIndexes) =>
+    input.map((column, index) => indexes.includes(index) ? column.map(evaluate) : column);
   return {
-    frame: (input: SerializedLiveFrame): SerializedLiveFrame => ({
-      ...input,
-      refId: expression.resultRefId,
-      fields: input.fields.map((field, index) =>
-        fieldIndexes.includes(index) ? { ...field, values: field.values?.map(evaluate) } : field
-      ),
-    }),
+    frame: (input: SerializedLiveFrame): SerializedLiveFrame => {
+      const indexes = input.fields
+        .map((field, index) => (field.type === 'number' ? index : -1))
+        .filter((index) => index >= 0);
+      return {
+        ...input,
+        refId: expression.resultRefId,
+        fields: input.fields.map((field, index) =>
+          indexes.includes(index) ? { ...field, values: field.values?.map(evaluate) } : field
+        ),
+      };
+    },
     values,
   };
 }

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -20,6 +20,7 @@ import {
   toDataQueryError,
 } from '@grafana/runtime';
 
+import { createLiveMathTransform } from '../../expressions/liveMath';
 import { StreamingResponseDataType } from '../data/utils';
 
 import { type DataStreamSubscriptionKey, type StreamingDataQueryResponse } from './service';
@@ -237,6 +238,16 @@ export class LiveDataStream<T = unknown> {
     this.prepareInternalStreamForNewSubscription(options);
 
     const shouldSendLastPacketOnly = options?.buffer?.action === StreamingFrameAction.Replace;
+
+    const mathTransform = options.mathExpression
+      ? createLiveMathTransform(
+          options.mathExpression,
+          this.frameBuffer.fields
+            .map((field, index) => (field.type === 'number' ? index : -1))
+            .filter((index) => index >= 0)
+        )
+      : undefined;
+
     const fieldsNamesFilter = options.filter?.fields;
     const dataNeedsFiltering = fieldsNamesFilter?.length;
     const fieldFilterPredicate = dataNeedsFiltering ? ({ name }: Field) => fieldsNamesFilter.includes(name) : undefined;
@@ -257,7 +268,10 @@ export class LiveDataStream<T = unknown> {
           data: [
             {
               type: StreamingResponseDataType.FullFrame,
-              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer),
+              frame: (() => {
+                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer);
+                return mathTransform?.frame(serialized) ?? serialized;
+              })(),
             },
           ],
           error,
@@ -320,6 +334,7 @@ export class LiveDataStream<T = unknown> {
           : reduceNewValuesSameSchemaMessages(messages).values;
 
       const filteredValues = matchingFieldIndexes ? values.filter((v, i) => matchingFieldIndexes?.includes(i)) : values;
+      const transformedValues = mathTransform?.values(filteredValues) ?? filteredValues;
 
       return {
         key: subKey,
@@ -327,7 +342,7 @@ export class LiveDataStream<T = unknown> {
         data: [
           {
             type: StreamingResponseDataType.NewValuesSameSchema,
-            values: filteredValues,
+            values: transformedValues,
           },
         ],
       };

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -239,14 +239,7 @@ export class LiveDataStream<T = unknown> {
 
     const shouldSendLastPacketOnly = options?.buffer?.action === StreamingFrameAction.Replace;
 
-    const mathTransform = options.mathExpression
-      ? createLiveMathTransform(
-          options.mathExpression,
-          this.frameBuffer.fields
-            .map((field, index) => (field.type === 'number' ? index : -1))
-            .filter((index) => index >= 0)
-        )
-      : undefined;
+    const mathTransform = options.mathExpression ? createLiveMathTransform(options.mathExpression) : undefined;
 
     const fieldsNamesFilter = options.filter?.fields;
     const dataNeedsFiltering = fieldsNamesFilter?.length;
@@ -261,63 +254,20 @@ export class LiveDataStream<T = unknown> {
         ? this.frameBuffer.getMatchingFieldIndexes(fieldFilterPredicate)
         : undefined;
 
-      if (!shouldSendLastPacketOnly) {
-        return {
-          key: subKey,
-          state: error ? LoadingState.Error : LoadingState.Streaming,
-          data: [
-            {
-              type: StreamingResponseDataType.FullFrame,
-              frame: (() => {
-                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer);
-                return mathTransform?.frame(serialized) ?? serialized;
-              })(),
-            },
-          ],
-          error,
-        };
-      }
-
-      if (error) {
-        // send empty frame with error
-        return {
-          key: subKey,
-          state: LoadingState.Error,
-          data: [
-            {
-              type: StreamingResponseDataType.FullFrame,
-              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 }),
-            },
-          ],
-          error,
-        };
-      }
-
-      if (!messages.length) {
-        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
-        // send empty frame
-        return {
-          key: subKey,
-          state: LoadingState.Streaming,
-          data: [
-            {
-              type: StreamingResponseDataType.FullFrame,
-              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 }),
-            },
-          ],
-          error,
-        };
-      }
+      const serialized = this.frameBuffer.serialize(
+        fieldFilterPredicate,
+        buffer,
+        shouldSendLastPacketOnly && !error && messages.length ? { maxLength: this.frameBuffer.packetInfo.length } : error || !messages.length ? { maxLength: 0 } : undefined
+      );
+      const transformed = mathTransform?.frame(serialized) ?? serialized;
 
       return {
         key: subKey,
-        state: LoadingState.Streaming,
+        state: error ? LoadingState.Error : LoadingState.Streaming,
         data: [
           {
             type: StreamingResponseDataType.FullFrame,
-            frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, {
-              maxLength: this.frameBuffer.packetInfo.length,
-            }),
+            frame: transformed,
           },
         ],
         error,
@@ -333,8 +283,13 @@ export class LiveDataStream<T = unknown> {
           ? lastMessage.values
           : reduceNewValuesSameSchemaMessages(messages).values;
 
-      const filteredValues = matchingFieldIndexes ? values.filter((v, i) => matchingFieldIndexes?.includes(i)) : values;
-      const transformedValues = mathTransform?.values(filteredValues) ?? filteredValues;
+      const currentNumericFieldIndexes = this.frameBuffer.fields
+        .map((field, index) => (field.type === 'number' ? index : -1))
+        .filter((index) => index >= 0);
+      const transformedValues = mathTransform?.values(values, currentNumericFieldIndexes) ?? values;
+      const filteredValues = matchingFieldIndexes
+        ? transformedValues.filter((v, i) => matchingFieldIndexes?.includes(i))
+        : transformedValues;
 
       return {
         key: subKey,
@@ -342,7 +297,7 @@ export class LiveDataStream<T = unknown> {
         data: [
           {
             type: StreamingResponseDataType.NewValuesSameSchema,
-            values: transformedValues,
+            values: filteredValues,
           },
         ],
       };

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -254,20 +254,72 @@ export class LiveDataStream<T = unknown> {
         ? this.frameBuffer.getMatchingFieldIndexes(fieldFilterPredicate)
         : undefined;
 
-      const serialized = this.frameBuffer.serialize(
-        fieldFilterPredicate,
-        buffer,
-        shouldSendLastPacketOnly && !error && messages.length ? { maxLength: this.frameBuffer.packetInfo.length } : error || !messages.length ? { maxLength: 0 } : undefined
-      );
-      const transformed = mathTransform?.frame(serialized) ?? serialized;
+      if (!shouldSendLastPacketOnly) {
+        return {
+          key: subKey,
+          state: error ? LoadingState.Error : LoadingState.Streaming,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: (() => {
+                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer);
+                return mathTransform?.frame(serialized) ?? serialized;
+              })(),
+            },
+          ],
+          error,
+        };
+      }
+
+      if (error) {
+        // send empty frame with error
+        return {
+          key: subKey,
+          state: LoadingState.Error,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: (() => {
+                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 });
+                return mathTransform?.frame(serialized) ?? serialized;
+              })(),
+            },
+          ],
+          error,
+        };
+      }
+
+      if (!messages.length) {
+        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        // send empty frame
+        return {
+          key: subKey,
+          state: LoadingState.Streaming,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: (() => {
+                const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 });
+                return mathTransform?.frame(serialized) ?? serialized;
+              })(),
+            },
+          ],
+          error,
+        };
+      }
 
       return {
         key: subKey,
-        state: error ? LoadingState.Error : LoadingState.Streaming,
+        state: LoadingState.Streaming,
         data: [
           {
             type: StreamingResponseDataType.FullFrame,
-            frame: transformed,
+            frame: (() => {
+              const serialized = this.frameBuffer.serialize(fieldFilterPredicate, buffer, {
+                maxLength: this.frameBuffer.packetInfo.length,
+              });
+              return mathTransform?.frame(serialized) ?? serialized;
+            })(),
           },
         ],
         error,


### PR DESCRIPTION
Fixes #131854.

Adds support for single-query Math expressions on Grafana Live streams.

The implementation intentionally supports Math expressions referencing exactly one live query; multi-query expressions continue through the existing expression path. It includes arithmetic, Grafana reference parsing, function-call coverage, and applies Live Math transformations to Replace-mode full frames as well as streaming updates.

This is a new clean PR following the maintainer guidance on #131957 after the previous branch history picked up unrelated changes and subscribed unrelated reviewers.