### PR TITLE
TimeComparison: Align comparison-only series to the current time range

### DIFF
--- a/packages/grafana-data/src/dataframe/timeCompare.test.ts
+++ b/packages/grafana-data/src/dataframe/timeCompare.test.ts
@@ -387,16 +387,54 @@ describe('shouldAlignTimeCompare', () => {
     expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(false);
   });
 
-  it('should return false when original frame is not found', () => {
+  // A comparison-only response must still be shifted onto the visible range, otherwise the panel
+  // reports "data outside time range" instead of drawing the compare series (#132370).
+  it('should return true when the original frame is not found', () => {
     const compareFrame = toDataFrame({
       refId: 'A-compare',
       fields: [
         { name: 'time', type: FieldType.time, values: TIME_VALUES_A },
-        { name: 'value', type: FieldType.number, values: ORIGINAL_VALUES },
+        { name: 'value', type: FieldType.number, values: COMPARE_VALUES },
       ],
     });
 
     const allFrames = [compareFrame]; // No original frame with refId 'A'
+    expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(true);
+  });
+
+  it('should return true when the original frame has no values', () => {
+    const originalFrame = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'time', type: FieldType.time, values: [] },
+        { name: 'value', type: FieldType.number, values: [] },
+      ],
+    });
+
+    const compareFrame = toDataFrame({
+      refId: 'A-compare',
+      fields: [
+        { name: 'time', type: FieldType.time, values: TIME_VALUES_A },
+        { name: 'value', type: FieldType.number, values: COMPARE_VALUES },
+      ],
+    });
+
+    const allFrames = [originalFrame, compareFrame];
+    expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(true);
+  });
+
+  it('should return false when the compare frame is already inside the time range', () => {
+    const compareFrame = toDataFrame({
+      refId: 'A-compare',
+      fields: [
+        { name: 'time', type: FieldType.time, values: TIME_VALUES_B },
+        { name: 'value', type: FieldType.number, values: COMPARE_VALUES },
+      ],
+    });
+
+    // No original frame, so the guard against shifting an aligned frame twice has to come from the
+    // compare frame's own timestamps.
+    const allFrames = [compareFrame];
     expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(false);
   });
 
@@ -418,7 +456,7 @@ describe('shouldAlignTimeCompare', () => {
     expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(false);
   });
 
-  it('should return false when original frame has no time field', () => {
+  it('should return true when original frame has no time field', () => {
     const originalFrame = toDataFrame({
       refId: 'A',
       fields: [{ name: 'value', type: FieldType.number, values: ORIGINAL_VALUES }],
@@ -433,10 +471,10 @@ describe('shouldAlignTimeCompare', () => {
     });
 
     const allFrames = [originalFrame, compareFrame];
-    expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(false);
+    expect(shouldAlignTimeCompare(compareFrame, allFrames, mockTimeRange)).toBe(true);
   });
 
-  it('should return false when time fields have empty values', () => {
+  it('should return false when the compare frame has empty values', () => {
     const EMPTY_VALUES: number[] = [];
 
     const originalFrame = toDataFrame({

--- a/packages/grafana-data/src/dataframe/timeCompare.ts
+++ b/packages/grafana-data/src/dataframe/timeCompare.ts
@@ -118,41 +118,39 @@ export function alignTimeRangeCompareData(series: DataFrame, diff: number, theme
 /**
  * Checks if a time comparison frame needs alignment based on whether its first time is before the current time range.
  * Returns true if the first time in compare is before timeRange.from, indicating it needs shifting.
+ *
+ * The decision rests only on the compare frame's own timestamps, so a comparison-only response - the
+ * current period returned no data, or no frame at all - is still shifted onto the visible range
+ * instead of being left in its historical window.
  * @param compareFrame - The frame with time comparison data
- * @param allFrames - Array of all frames to find the matching original frame
+ * @param allFrames - Unused; retained so existing callers keep working
  * @param timeRange - The current panel time range
  * @returns true if alignment is needed
  */
-export function shouldAlignTimeCompare(compareFrame: DataFrame, allFrames: DataFrame[], timeRange: TimeRange): boolean {
-  // Find the matching original frame by removing '-compare' from refId
+export function shouldAlignTimeCompare(
+  compareFrame: DataFrame,
+  allFrames: DataFrame[] | undefined,
+  timeRange: TimeRange
+): boolean {
   const compareRefId = compareFrame.refId;
   if (!compareRefId || !compareRefId.endsWith('-compare')) {
     return false;
   }
 
-  const originalRefId = compareRefId.replace('-compare', '');
-  const originalFrame = allFrames.find((frame) => frame.refId === originalRefId && !isTimeCompareFrame(frame));
-
-  if (!originalFrame) {
-    return false;
-  }
-
-  // Find time fields
   const compareTimeField = compareFrame.fields.find((field) => field.type === FieldType.time);
-  const originalTimeField = originalFrame.fields.find((field) => field.type === FieldType.time);
 
-  if (!compareTimeField?.values.length || !originalTimeField?.values.length) {
+  if (!compareTimeField?.values.length) {
     return false;
   }
 
-  // Find first non-null time value from each frame
+  // Find first non-null time value
   const compareFirstTime = compareTimeField.values.find((value) => value != null);
-  const originalFirstTime = originalTimeField.values.find((value) => value != null);
 
-  if (compareFirstTime == null || originalFirstTime == null) {
+  if (compareFirstTime == null) {
     return false;
   }
 
-  // Check if first non-null time value is before timeRange.from
+  // Check if first non-null time value is before timeRange.from. Once shifted the compare frame sits
+  // inside the range, so this also keeps an already aligned frame from being shifted twice.
   return compareFirstTime < timeRange.from.valueOf();
 }

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
@@ -249,5 +249,19 @@ describe('TimeSeriesPanel', () => {
       expect(currentIcon.style.borderRadius).toBeTruthy();
       expect(compareIcon.style.backgroundSize).toBe('6px 4px');
     });
+
+    it('aligns compare series that have no current-period counterpart (#132370)', () => {
+      // The current period returned nothing, so the compare frames arrive on their own. They still
+      // have to be shifted onto the visible range - the dashed icon is the visible marker that
+      // alignment ran, and without it the panel would only offer "zoom to data".
+      renderPanel(undefined, [makePodFrame('a', { compare: true }), makePodFrame('b', { compare: true })]);
+
+      for (const label of ['a (comparison)', 'b (comparison)']) {
+        const icon = within(screen.getByTestId(selectors.components.VizLegend.seriesName(label))).getByTestId(
+          'series-icon'
+        );
+        expect(icon.style.backgroundSize).toBe('6px 4px');
+      }
+    });
   });
 });

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -90,8 +90,8 @@ export const TimeSeriesPanel = ({
       });
 
       if (diffMs !== 0) {
-        // Check if the compared frame needs time alignment
-        // Apply alignment when time ranges match (no shift applied yet)
+        // Only shift a compare frame that still sits in its historical window, so repeated
+        // preparation of already aligned frames doesn't shift them again
         const needsAlignment = shouldAlignTimeCompare(frame, originalFrames, timeRange);
 
         if (needsAlignment) {


### PR DESCRIPTION
**Fixes #132370**

When the current period returned no data but the comparison period did, the comparison series stayed in its historical window and the panel showed "Data outside time range" instead of rendering it.

`shouldAlignTimeCompare()` returned `false` when it couldn't find the primary frame for a refId, so`alignTimeRangeCompareData()` never ran. The primary frame's timestamp was read into `originalFirstTime` and never used — the decision was only ever `compareFirstTime < timeRange.from`, so the primary frame gated alignment without informing it.

Alignment now rests solely on the compare frame's own timestamps. Where a primary frame with time values exists the result is unchanged, so the two-series path is untouched.

### Before 

<!-- attach before-fix-panel.png and after-fix-panel.png -->
<img width="592" height="372" alt="before-fix-panel" src="https://github.com/user-attachments/assets/6b88c4af-fa97-44de-8736-1920a36e749e" />

### After
<img width="592" height="372" alt="after-fix-panel" src="https://github.com/user-attachments/assets/a0eb3c50-b978-4026-b63d-d6052dd593fb" />


Same dashboard, range and build; only `timeCompare.ts` differed. The comparison series now renders across the current window, dashed and suffixed "(comparison)".

### Testing

- Unit tests for the three previously blocked shapes — no primary frame, primary with empty values, primary with no time field — plus a case pinning the guard against double-shifting.
- A panel test asserting comparison-only frames get the dashed legend icon that only `alignTimeRangeCompareData` applies; it fails without this change.
- Verified against a local instance. No Docker for a Postgres devenv, so the empty primary was produced with a `filterByRefId` transformation excluding refId `A` — transformations run before the panel, so it receives only the `A-compare` frame. A control panel without the transformation was unchanged.

### One question for reviewers

`shouldAlignTimeCompare` no longer needs its `allFrames` argument. I left the parameter in place (widened to `DataFrame[] | undefined`) rather than change the signature of a published `@grafana/data` export. Happy to drop it and update the single in-tree caller if you'd rather not carry a dead parameter.
