### PR TITLE
Alerting: Fix dispatcher blocking in alert broadcast

### DIFF
--- a/pkg/services/ngalert/notifier/alert_broadcast.go
+++ b/pkg/services/ngalert/notifier/alert_broadcast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -56,10 +57,14 @@ func (s *alertBroadcast) Merge(b []byte) error {
 		return nil
 	}
 
-	if err := am.PutAlerts(context.Background(), payload.Alerts); err != nil {
-		s.logger.Warn("Failed to accept received broadcast alerts", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts), "error", err)
-	} else {
-		s.logger.Debug("Received broadcast alerts from peer", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts))
-	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := am.PutAlerts(ctx, payload.Alerts); err != nil {
+			s.logger.Warn("Failed to accept received broadcast alerts", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts), "error", err)
+		} else {
+			s.logger.Debug("Received broadcast alerts from peer", "orgID", payload.OrgID, "alerts", len(payload.Alerts.PostableAlerts))
+		}
+	}()
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

This PR offloads the processing of incoming alert payloads in `alertBroadcast.Merge` into a non-blocking asynchronous goroutine, wrapped in a 5-second timeout. 

**Why do we need this feature?**

Currently, when a peer node receives an incoming broadcast payload, the cluster delegate responsible for merging the remote state (`alertBroadcast.Merge`) executes synchronously on the underlying memberlist gossip network event loop.

Inside this merge delegate, the payload is validated and injected directly into the local alerting dispatcher pipeline via `am.PutAlerts()`. If the Alertmanager pipeline is backlogged (e.g., due to bounded dispatcher queues being full, or slow upstream webhooks), `PutAlerts()` blocks.

Because this blocking occurs directly inside the state-merge delegate, it freezes the entire network event loop for the gossip protocol on that node. The node stops processing all cluster communications (including mandatory heartbeat pings). As a result, the rest of the cluster falsely detects the node as dead, fracturing the cluster into a split-brain state and causing uncoordinated, duplicate alerting.

HashiCorp's `memberlist` API explicitly warns that `Merge` and `NotifyMsg` delegates must be non-blocking. This PR enforces that contract.

**Who is this feature for?**

Administrators and operators running Grafana in High Availability (HA) cluster modes with Unified Alerting enabled.

**Which issue(s) does this PR fix?**:
Fixes #131977

**Special notes for your reviewer:**

To ensure we don't leak goroutines indefinitely in the event that the dispatcher is permanently locked up, the asynchronous `am.PutAlerts()` execution is bounded by a `context.WithTimeout` of 5 seconds. This prioritizes the health and stability of the gossip protocol network thread above all else.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.
