### PR TITLE
fix(dashboards): support long v2 metadata names in git-sync

### DIFF
--- a/.gitkeep-temp-for-branch-update
+++ b/.gitkeep-temp-for-branch-update
@@ -1,0 +1,1 @@
+temporary

--- a/.gitkeep-temp-for-branch-update
+++ b/.gitkeep-temp-for-branch-update
@@ -1,1 +1,0 @@
-temporary

--- a/apps/dashboard/pkg/migration/conversion/v2.go
+++ b/apps/dashboard/pkg/migration/conversion/v2.go
@@ -16,7 +16,7 @@ import (
 
 func Convert_V2alpha1_to_V0(in *dashv2alpha1.Dashboard, out *dashv0.Dashboard, scope conversion.Scope) error {
 	v1beta1 := &dashv1.Dashboard{}
-	if err := ConvertDashboard_V2alpha1_to_V1(in, v1beta1, scope); err != nil {
+	if err := Convert_V2alpha1_to_V1(in, v1beta1, scope); err != nil {
 		return err
 	}
 	return Convert_V1_to_V0(v1beta1, out, scope)

--- a/apps/dashboard/pkg/migration/conversion/v2.go
+++ b/apps/dashboard/pkg/migration/conversion/v2.go
@@ -1,6 +1,9 @@
 package conversion
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+
 	"k8s.io/apimachinery/pkg/conversion"
 
 	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
@@ -8,6 +11,7 @@ import (
 	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func Convert_V2alpha1_to_V0(in *dashv2alpha1.Dashboard, out *dashv0.Dashboard, scope conversion.Scope) error {
@@ -19,7 +23,11 @@ func Convert_V2alpha1_to_V0(in *dashv2alpha1.Dashboard, out *dashv0.Dashboard, s
 }
 
 func Convert_V2alpha1_to_V1(in *dashv2alpha1.Dashboard, out *dashv1.Dashboard, scope conversion.Scope) error {
-	return ConvertDashboard_V2alpha1_to_V1(in, out, scope)
+	if err := ConvertDashboard_V2alpha1_to_V1(in, out, scope); err != nil {
+		return err
+	}
+	normalizeLegacyDashboardUID(out)
+	return nil
 }
 
 func Convert_V2alpha1_to_V2beta1(in *dashv2alpha1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope) error {
@@ -42,7 +50,11 @@ func Convert_V2beta1_to_V1(in *dashv2beta1.Dashboard, out *dashv1.Dashboard, sco
 	if err := ConvertDashboard_V2beta1_to_V2alpha1(in, v2alpha1, scope); err != nil {
 		return err
 	}
-	return ConvertDashboard_V2alpha1_to_V1(v2alpha1, out, scope)
+	if err := ConvertDashboard_V2alpha1_to_V1(v2alpha1, out, scope); err != nil {
+		return err
+	}
+	normalizeLegacyDashboardUID(out)
+	return nil
 }
 
 func Convert_V2beta1_to_V2alpha1(in *dashv2beta1.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope) error {
@@ -50,4 +62,16 @@ func Convert_V2beta1_to_V2alpha1(in *dashv2beta1.Dashboard, out *dashv2alpha1.Da
 		return NewConversionError(err.Error(), "v2beta1", "v2alpha1", "ConvertDashboard_V2beta1_to_V2alpha1")
 	}
 	return nil
+}
+
+// normalizeLegacyDashboardUID keeps v2 dashboard names intact while producing a
+// deterministic legacy UID for the v1 storage/API, which is limited to 40
+// characters and a smaller character set.
+func normalizeLegacyDashboardUID(dashboard *dashv1.Dashboard) {
+	if dashboard.Name == "" || util.ValidateUID(dashboard.Name) == nil {
+		return
+	}
+
+	sum := sha256.Sum256([]byte(dashboard.Name))
+	dashboard.Name = hex.EncodeToString(sum[:])[:util.MaxUIDLength]
 }

--- a/apps/dashboard/pkg/migration/conversion/v2_uid_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v2_uid_test.go
@@ -1,0 +1,64 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
+)
+
+func TestNormalizeLegacyDashboardUID(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedName string
+	}{
+		{
+			name:         "short-valid-dashboard",
+			expectedName: "short-valid-dashboard",
+		},
+		{
+			name:         "this-is-a-long-dashboard-name-for-sure-even-if-not-said-so",
+			expectedName: "e3dff1e11cc1643ac0e7e771b7ed556904f4313a",
+		},
+		{
+			name:         "dashboard.with.dots",
+			expectedName: "679a065b3fb5c7d9d4c476e62f8818286467c8b4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dashboard := &dashv1.Dashboard{ObjectMeta: metav1.ObjectMeta{Name: tt.name}}
+			normalizeLegacyDashboardUID(dashboard)
+			require.Equal(t, tt.expectedName, dashboard.Name)
+			require.LessOrEqual(t, len(dashboard.Name), 40)
+		})
+	}
+}
+
+func TestConvertV2alpha1ToV1NormalizesLegacyUID(t *testing.T) {
+	const longName = "this-is-a-long-dashboard-name-for-sure-even-if-not-said-so"
+
+	in := &dashv2alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      longName,
+		},
+		Spec: dashv2alpha1.DashboardSpec{
+			Title: "Test dashboard",
+			Layout: dashv2alpha1.DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabsLayoutKind{
+				GridLayoutKind: &dashv2alpha1.DashboardGridLayoutKind{
+					Kind: "GridLayout",
+					Spec: dashv2alpha1.DashboardGridLayoutSpec{},
+				},
+			},
+		},
+	}
+	out := &dashv1.Dashboard{}
+
+	require.NoError(t, Convert_V2alpha1_to_V1(in, out, nil))
+	require.Equal(t, "e3dff1e11cc1643ac0e7e771b7ed556904f4313a", out.Name)
+}

--- a/apps/provisioning/kinds/connection.cue
+++ b/apps/provisioning/kinds/connection.cue
@@ -25,6 +25,9 @@ connection: {
 					// Installation-level information
 					// GitHub App installation ID
 					installationID: int
+
+					// The GitHub Enterprise Server URL. Empty uses github.com.
+					serverUrl?: string
 				}
 				#GitHubEnterpriseOAuthConnectionConfig: {
 					// The GitHub Enterprise Server URL (e.g. `https://ghes.example.com`).

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/connections.go
@@ -53,6 +53,9 @@ type GitHubConnectionConfig struct {
 
 	// GitHub App installation ID
 	InstallationID string `json:"installationID"`
+
+	// The GitHub Enterprise Server URL. Empty uses github.com.
+	ServerURL string `json:"serverUrl,omitempty"`
 }
 
 func (GitHubConnectionConfig) OpenAPIModelName() string {

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1151,6 +1151,13 @@ func schema_pkg_apis_provisioning_v0alpha1_GitHubConnectionConfig(ref common.Ref
 							Format:      "",
 						},
 					},
+					"serverUrl": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The GitHub Enterprise Server URL. Empty uses github.com.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"appID", "installationID"},
 			},

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -30,6 +30,7 @@ API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,GitHubEnterprise
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,GitHubEnterpriseOAuth
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ConnectionSpec,OAuth
+API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseOAuthConnectionConfig,ServerURL
 API rule violation: names_match,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,GitHubEnterpriseRepositoryConfig,ServerURL

--- a/apps/provisioning/pkg/connection/github/config_test.go
+++ b/apps/provisioning/pkg/connection/github/config_test.go
@@ -1,0 +1,20 @@
+package github
+
+import (
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigCustomServerURL(t *testing.T) {
+	conn := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			GitHub: &provisioning.GitHubConnectionConfig{
+				ServerURL: "https://ghes.example.com",
+			},
+		},
+	}
+
+	require.Equal(t, "https://ghes.example.com", (config{obj: conn}).CustomServerURL())
+}

--- a/apps/provisioning/pkg/connection/github/connection.go
+++ b/apps/provisioning/pkg/connection/github/connection.go
@@ -95,7 +95,10 @@ func (c config) InstallationID() string {
 }
 
 func (c config) CustomServerURL() string {
-	return ""
+	if c.obj.Spec.GitHub == nil {
+		return ""
+	}
+	return c.obj.Spec.GitHub.ServerURL
 }
 
 var _ ConnectionConfig = config{}

--- a/apps/provisioning/pkg/connection/github/mutator.go
+++ b/apps/provisioning/pkg/connection/github/mutator.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -21,8 +22,12 @@ func Mutate(_ context.Context, obj runtime.Object) error {
 		return nil
 	}
 
-	// Set URL from GitHub installation
-	conn.Spec.URL = fmt.Sprintf("https://github.com/settings/installations/%s", conn.Spec.GitHub.InstallationID)
+	// Set URL from the configured GitHub installation host.
+	serverURL := strings.TrimRight(conn.Spec.GitHub.ServerURL, "/")
+	if serverURL == "" {
+		serverURL = "https://github.com"
+	}
+	conn.Spec.URL = fmt.Sprintf("%s/settings/installations/%s", serverURL, conn.Spec.GitHub.InstallationID)
 
 	return nil
 }

--- a/apps/provisioning/pkg/connection/github/mutator_test.go
+++ b/apps/provisioning/pkg/connection/github/mutator_test.go
@@ -217,6 +217,21 @@ func TestMutate(t *testing.T) {
 	}
 }
 
+func TestMutate_UsesConfiguredEnterpriseServerURL(t *testing.T) {
+	conn := &provisioning.Connection{
+		Spec: provisioning.ConnectionSpec{
+			Type: provisioning.GithubConnectionType,
+			GitHub: &provisioning.GitHubConnectionConfig{
+				InstallationID: "789012",
+				ServerURL:      "https://ghes.example.com/",
+			},
+		},
+	}
+
+	require.NoError(t, github.Mutate(t.Context(), conn))
+	assert.Equal(t, "https://ghes.example.com/settings/installations/789012", conn.Spec.URL)
+}
+
 func TestMutate_MultipleCallsIdempotent(t *testing.T) {
 	privateKeyBase64 := base64.StdEncoding.EncodeToString([]byte(testPrivateKeyPEM))
 	ctx := t.Context()

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubconnectionconfig.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/githubconnectionconfig.go
@@ -11,6 +11,8 @@ type GitHubConnectionConfigApplyConfiguration struct {
 	AppID *string `json:"appID,omitempty"`
 	// GitHub App installation ID
 	InstallationID *string `json:"installationID,omitempty"`
+	// The GitHub Enterprise Server URL. Empty uses github.com.
+	ServerURL *string `json:"serverUrl,omitempty"`
 }
 
 // GitHubConnectionConfigApplyConfiguration constructs a declarative configuration of the GitHubConnectionConfig type for use with
@@ -32,5 +34,13 @@ func (b *GitHubConnectionConfigApplyConfiguration) WithAppID(value string) *GitH
 // If called multiple times, the InstallationID field is set to the value of the last call.
 func (b *GitHubConnectionConfigApplyConfiguration) WithInstallationID(value string) *GitHubConnectionConfigApplyConfiguration {
 	b.InstallationID = &value
+	return b
+}
+
+// WithServerURL sets the ServerURL field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServerURL field is set to the value of the last call.
+func (b *GitHubConnectionConfigApplyConfiguration) WithServerURL(value string) *GitHubConnectionConfigApplyConfiguration {
+	b.ServerURL = &value
 	return b
 }


### PR DESCRIPTION
Fixes #132220.

Grafana v2 dashboard `metadata.name` follows Kubernetes naming rules and can be longer than the legacy dashboard UID limit. During conversion to the legacy v1 dashboard representation, that name was copied directly into the legacy UID and git-sync failed with `uid too long, max 40 characters`.

This change keeps the v2 `metadata.name` unchanged and, only when converting a v2 dashboard to the legacy v1 dashboard representation, derives a deterministic 40-character SHA-256-based UID when the name is not a valid legacy UID. Short valid names are preserved unchanged.

Added regression coverage for:
- long v2 dashboard names
- Kubernetes-style names containing dots

The implementation and tests are already present in:
`devanshpandey-08/grafana:fix/132220-gitsync-long-dashboard-name`