### PR TITLE
Fix Alert aria-label for string buttonContent and add missing HTTP methods to httpMethodOptions

### DIFF
--- a/packages/grafana-data/src/types/action.ts
+++ b/packages/grafana-data/src/types/action.ts
@@ -65,7 +65,10 @@ export enum HttpRequestMethod {
 
 export const httpMethodOptions: SelectableValue[] = [
   { label: HttpRequestMethod.POST, value: HttpRequestMethod.POST },
+  { label: HttpRequestMethod.PUT, value: HttpRequestMethod.PUT },
   { label: HttpRequestMethod.GET, value: HttpRequestMethod.GET },
+  { label: HttpRequestMethod.DELETE, value: HttpRequestMethod.DELETE },
+  { label: HttpRequestMethod.PATCH, value: HttpRequestMethod.PATCH },
 ];
 
 export const contentTypeOptions: SelectableValue[] = [

--- a/packages/grafana-ui/src/components/Alert/Alert.tsx
+++ b/packages/grafana-ui/src/components/Alert/Alert.tsx
@@ -95,7 +95,12 @@ export const Alert = React.forwardRef<HTMLDivElement, Props>(
             <Stack alignItems="center" wrap="wrap">
               {action}
               {onRemove && buttonContent && (
-                <Button aria-label={closeLabel} variant="secondary" onClick={onRemove} type="button">
+                <Button
+                  aria-label={typeof buttonContent === 'string' ? undefined : closeLabel}
+                  variant="secondary"
+                  onClick={onRemove}
+                  type="button"
+                >
                   {buttonContent}
                 </Button>
               )}

--- a/public/app/features/dashboard-scene/settings/variables/utils.ts
+++ b/public/app/features/dashboard-scene/settings/variables/utils.ts
@@ -211,8 +211,10 @@ export function getVariableTypeSelectOptions({ standalone }: VariableTypeSelectO
     if (!config.featureToggles.groupByVariable && option.value === 'groupby') {
       return false;
     }
-    if (option.value === 'adhoc' && unifiedDrilldown && !standalone) {
+    if (option.value === 'adhoc' && unifiedDrilldown && standalone === false) {
       // Dashboards have a dedicated "Filter and Group by" entry point instead.
+      // Only hide when standalone is explicitly false (edit-pane context);
+      // undefined (Settings > Variables page) should still show the adhoc type.
       return false;
     }
 

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -142,6 +142,7 @@ export class LogListModel implements LogRowModel {
 
   get body(): string {
     if (this._body === undefined) {
+      let displayRaw = this.raw;
       try {
         const parsed = parse(this.raw, undefined, {
           onDuplicateKey: ({ newValue }) => newValue,
@@ -151,18 +152,17 @@ export class LogListModel implements LogRowModel {
         }
         const reStringified = this._wrapLogMessage && this._prettifyJSON ? stringify(parsed, undefined, 2) : this.raw;
         if (reStringified) {
-          this.raw = reStringified;
+          displayRaw = reStringified;
         }
       } catch (error) {}
 
       // always escape for literal \n, \t, \r sequences so "Escape newlines" works for all log types.
       if (this._escapeUnescapedString) {
-        this.raw = escapeUnescapedString(this.raw);
+        displayRaw = escapeUnescapedString(displayRaw);
       }
-      const raw = this.raw;
       this._body = this.collapsed
-        ? raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
-        : raw;
+        ? displayRaw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
+        : displayRaw;
       if (!this._wrapLogMessage) {
         this._body = this._body.replace(NEWLINES_REGEX, '');
       }

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -135,4 +135,5 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TablePanel)
   .setPanelOptions((builder) => {
     addTableCustomPanelOptions(builder);
   })
-  .setSuggestionsSupplier(tableSuggestionsSupplier);
+  .setSuggestionsSupplier(tableSuggestionsSupplier)
+  .setNoPadding();


### PR DESCRIPTION
## Summary

Two independent bug fixes:

**1. Alert: `aria-label` incorrectly applied when `buttonContent` is a string**

When `buttonContent` is a plain string, the button already has visible text. Adding `aria-label="Close alert"` on top violates WCAG 2.5.3 (Label in Name) for any caller passing content other than "Close alert". When `buttonContent` is a ReactNode (icon), `aria-label` is still needed since there's no visible text. Fix passes `undefined` when `buttonContent` is a string so the button's own text acts as its accessible name.

Fixes #129954

**2. `httpMethodOptions` missing PUT, DELETE, PATCH**

`httpMethodOptions` only listed POST and GET even though `HttpRequestMethod` defines five values (POST, PUT, GET, DELETE, PATCH). The Data Actions UI never offered PUT, DELETE or PATCH as selectable methods. All five enum values are now exposed.

Fixes #128915

**3. fix(logs): avoid mutating `this.raw` in body getter to fix filter selection**

**4. fix(variables): restore adhoc type in dashboard Settings > Variables editor**

`getVariableTypeSelectOptions` filters out the adhoc type when `dashboardUnifiedDrilldownControls` is enabled and `standalone` is falsy. `standalone` defaults to `undefined` when `VariablesEditView` renders `VariableEditorForm` without the prop — so adhoc was hidden in Settings > Variables where no dedicated toolbar entry exists. Changed the guard to `standalone === false` (explicit boolean) so `undefined` keeps adhoc visible.

Fixes #129433

**5. fix(table): remove default panel padding to eliminate gap below panel header**